### PR TITLE
Onboarding: Skip Functionality

### DIFF
--- a/secant/Features/Onboarding/OnboardingStore.swift
+++ b/secant/Features/Onboarding/OnboardingStore.swift
@@ -11,38 +11,54 @@ import ComposableArchitecture
 
 struct OnboardingStep: Equatable, Identifiable {
     let id: UUID
+    let title: String
     let description: String
-    let imageName: String
 }
 
 struct OnboardingState: Equatable {
     var steps: IdentifiedArrayOf<OnboardingStep> = Self.onboardingSteps
     var index = 0
     var offset: CGFloat = .zero
+    var skippedAtindex: Int?
     
     var currentStep: OnboardingStep { steps[index] }
-    var nextButtonDisabled: Bool { steps.count == index + 1 }
+    var skipButtonDisabled: Bool { steps.count == index + 1 }
     var backButtonDisabled: Bool { index == 0 }
-    var progress: Int {
-        ((index + 1) * 100) / (steps.count)
-    }
+    var progress: Int { ((index + 1) * 100) / (steps.count) }
 }
 
 enum OnboardingAction: Equatable {
-    case nextPressed
-    case backPressed
+    case next
+    case back
+    case skip
+    case createNewWallet
 }
 
 let onboardingReducer = Reducer<OnboardingState, OnboardingAction, Void> { state, action, _ in
     switch action {
-    case .backPressed:
-        state.index -= 1
-        state.offset += 20.0
+    case .back:
+        guard state.index > 0 else { return .none }
+        if let skippedFrom = state.skippedAtindex {
+            state.index = skippedFrom
+            state.skippedAtindex = nil
+        } else {
+            state.index -= 1
+            state.offset += 20.0
+        }
         return .none
         
-    case .nextPressed:
+    case .next:
+        guard state.index < state.steps.count - 1 else { return .none }
         state.index += 1
         state.offset -= 20.0
+        return .none
+        
+    case .skip:
+        state.skippedAtindex = state.index
+        state.index = state.steps.count - 1
+        return .none
+        
+    case .createNewWallet:
         return .none
     }
 }

--- a/secant/Features/Onboarding/Views/Onboarding.swift
+++ b/secant/Features/Onboarding/Views/Onboarding.swift
@@ -15,26 +15,20 @@ struct OnboardingView: View {
         WithViewStore(self.store) { viewStore in
             VStack(spacing: 50) {
                 HStack(spacing: 50) {
-                    Button(
-                        action: { viewStore.send(.backPressed) },
-                        label: { Text("Previous") }
-                    )
-                    .disabled(viewStore.backButtonDisabled)
+                    Button("Back") { viewStore.send(.back) }
+                        .disabled(viewStore.backButtonDisabled)
                     
                     Spacer()
                     
-                    Button(
-                        action: { viewStore.send(.nextPressed) },
-                        label: { Text("Next") }
-                    )
-                    .disabled(viewStore.nextButtonDisabled)
+                    Button("Skip") { viewStore.send(.skip) }
+                        .disabled(viewStore.skipButtonDisabled)
                 }
                 .frame(height: 100)
                 .padding(.horizontal, 50)
                 
                 Spacer()
                 
-                Text(viewStore.currentStep.imageName)
+                Text(viewStore.currentStep.title)
                     .frame(maxWidth: .infinity)
                     .offset(y: viewStore.offset)
                     .animation(.easeOut(duration: 0.4))
@@ -58,23 +52,29 @@ struct OnboardingView: View {
     }
 }
 
+// swiftlint:disable line_length
 extension OnboardingState {
     static let onboardingSteps = IdentifiedArray(
         uniqueElements: [
             OnboardingStep(
                 id: UUID(),
-                description: "This is the description of the first onboarding step, please read it carefully.",
-                imageName: "Image"
+                title: "Shielded by Default",
+                description: "Tired of worrying about which wallet you used last? US TOO! Now you don't have to, as all funds will automatically be moved to your shielded wallet (and migrated for you)."
             ),
             OnboardingStep(
                 id: UUID(),
-                description: "The second step is even more important, have to pay attention to the details here.",
-                imageName: "Image"
+                title: "Unified Addresses",
+                description: "Tired of worrying about which wallet you used last? US TOO! Now you don't have to, as all funds will automatically be moved to your shielded wallet (and migrated for you)."
             ),
             OnboardingStep(
                 id: UUID(),
-                description: "Congratulations you made it all the way through to the end, you can use the app now!",
-                imageName: "Image"
+                title: "And so much more...",
+                description: "Faster reverse syncing (yes it's a thing).  Liberated Payments, Social Payments, Address Books, in-line ZEC requests, wrapped Bitcoin, fractionalize NFTs, you providing liquidity for anything you want, getting that Defi, and going to Mexico."
+            ),
+            OnboardingStep(
+                id: UUID(),
+                title: "Ready for the Future",
+                description: "Lets get you set up!"
             )
         ]
     )

--- a/secantTests/OnboardingTests/OnboardingStoreTests.swift
+++ b/secantTests/OnboardingTests/OnboardingStoreTests.swift
@@ -17,23 +17,33 @@ class OnboardingStoreTests: XCTestCase {
             environment: ()
         )
         
-        store.send(.nextPressed) {
+        store.send(.next) {
             $0.index += 1
             $0.offset -= 20.0
             
-            XCTAssertFalse($0.nextButtonDisabled)
+            XCTAssertFalse($0.skipButtonDisabled)
             XCTAssertFalse($0.backButtonDisabled)
             XCTAssertEqual($0.currentStep, $0.steps[1])
-            XCTAssertEqual($0.progress, 66)
+            XCTAssertEqual($0.progress, 50)
         }
                 
-        store.send(.nextPressed) {
+        store.send(.next) {
             $0.index += 1
             $0.offset -= 20.0
             
-            XCTAssertTrue($0.nextButtonDisabled)
+            XCTAssertFalse($0.skipButtonDisabled)
             XCTAssertFalse($0.backButtonDisabled)
             XCTAssertEqual($0.currentStep, $0.steps[2])
+            XCTAssertEqual($0.progress, 75)
+        }
+        
+        store.send(.next) {
+            $0.index += 1
+            $0.offset -= 20.0
+            
+            XCTAssertTrue($0.skipButtonDisabled)
+            XCTAssertFalse($0.backButtonDisabled)
+            XCTAssertEqual($0.currentStep, $0.steps[3])
             XCTAssertEqual($0.progress, 100)
         }
     }
@@ -48,24 +58,60 @@ class OnboardingStoreTests: XCTestCase {
             environment: ()
         )
         
-        store.send(.backPressed) {
+        store.send(.back) {
             $0.index -= 1
             $0.offset += 20.0
             
-            XCTAssertFalse($0.nextButtonDisabled)
+            XCTAssertFalse($0.skipButtonDisabled)
             XCTAssertFalse($0.backButtonDisabled)
             XCTAssertEqual($0.currentStep, $0.steps[1])
-            XCTAssertEqual($0.progress, 66)
+            XCTAssertEqual($0.progress, 50)
         }
                 
-        store.send(.backPressed) {
+        store.send(.back) {
             $0.index -= 1
             $0.offset += 20.0
             
-            XCTAssertFalse($0.nextButtonDisabled)
+            XCTAssertFalse($0.skipButtonDisabled)
             XCTAssertTrue($0.backButtonDisabled)
             XCTAssertEqual($0.currentStep, $0.steps[0])
-            XCTAssertEqual($0.progress, 33)
+            XCTAssertEqual($0.progress, 25)
+        }
+    }
+    
+    func testSkipOnboarding() {
+        let initialIndex = 1
+        let initialOffset: CGFloat = .zero - 20.0
+        
+        let store = TestStore(
+            initialState: OnboardingState(
+                index: initialIndex,
+                offset: initialOffset
+            ),
+            reducer: onboardingReducer,
+            environment: ()
+        )
+        
+        store.send(.skip) {
+            $0.index = $0.steps.count - 1
+            $0.offset = initialOffset
+            $0.skippedAtindex = initialIndex
+            
+            XCTAssertTrue($0.skipButtonDisabled)
+            XCTAssertFalse($0.backButtonDisabled)
+            XCTAssertEqual($0.currentStep, $0.steps[3])
+            XCTAssertEqual($0.progress, 100)
+        }
+                
+        store.send(.back) {
+            $0.skippedAtindex = nil
+            $0.index = initialIndex
+            $0.offset = initialOffset
+            
+            XCTAssertFalse($0.skipButtonDisabled)
+            XCTAssertFalse($0.backButtonDisabled)
+            XCTAssertEqual($0.currentStep, $0.steps[1])
+            XCTAssertEqual($0.progress, 50)
         }
     }
 }


### PR DESCRIPTION
This PR adds the Skip capability to Onboarding.

The user can go forward and backward through the onboarding steps but can at any time press Skip, which puts the user to the end of onboarding.  When you are on the last screen, there is still a back button.  The behavior of this PR makes it so that the previously known onboarding step is preserved if someone presses skip, such that if you are on the first page and skip to the end, but press Back from there, the user is landed back on the first page.  The assumption here is that pressing the skip button may be incidental, and the user should be taken back to their last known position.

This PR includes the state changes in the SMA store, updates to the current onboarding example/testing screen, and unit tests.  It also updates the onboarding step data to reflect the current verbiage in the design better.

![Skip](https://user-images.githubusercontent.com/680770/140315955-ab51790a-e750-4f0d-a5ca-ef6ad3db610f.gif)

This code review checklist is intended to serve as a starting point for the author and reviewer. However, it may not be appropriate for all types of changes (e.g., fixing a spelling typo in the documentation).  For a more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use your best judgment when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgment and experience, which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and, when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.