### PR TITLE
Tca nav add send

### DIFF
--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		F9C165C22740403600592F76 /* CreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C165BB2740403600592F76 /* CreateView.swift */; };
 		F9C165C42740403600592F76 /* SentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C165BD2740403600592F76 /* SentView.swift */; };
 		F9EEB8162742C2210032EEB8 /* WithStateBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9EEB8152742C2210032EEB8 /* WithStateBinding.swift */; };
+		F9C165CB2741AB5D00592F76 /* SendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C165CA2741AB5D00592F76 /* SendView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -224,6 +225,7 @@
 		F9C165BB2740403600592F76 /* CreateView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateView.swift; sourceTree = "<group>"; };
 		F9C165BD2740403600592F76 /* SentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentView.swift; sourceTree = "<group>"; };
 		F9EEB8152742C2210032EEB8 /* WithStateBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithStateBinding.swift; sourceTree = "<group>"; };
+		F9C165CA2741AB5D00592F76 /* SendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -720,6 +722,7 @@
 		F9C165B82740403600592F76 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				F9C165CA2741AB5D00592F76 /* SendView.swift */,
 				F9C165BB2740403600592F76 /* CreateView.swift */,
 				F9C165B92740403600592F76 /* ApproveView.swift */,
 				F9C165BD2740403600592F76 /* SentView.swift */,
@@ -994,6 +997,7 @@
 				0DA13CA226C1955600E3B610 /* HomeScreenViewModel.swift in Sources */,
 				0D32282926C586E000262533 /* RequestZcashScreenViewModel.swift in Sources */,
 				0D32281926C5864B00262533 /* ProfileScreen.swift in Sources */,
+				F9C165CB2741AB5D00592F76 /* SendView.swift in Sources */,
 				6654C7412715A47300901167 /* Onboarding.swift in Sources */,
 				0D32282426C586A800262533 /* HistoryScreenViewModel.swift in Sources */,
 				F9C165C42740403600592F76 /* SentView.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -98,6 +98,10 @@
 		F96B41E9273B501F0021B49A /* TransactionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96B41E6273B501F0021B49A /* TransactionHistoryView.swift */; };
 		F96B41EB273B50520021B49A /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96B41EA273B50520021B49A /* Strings.swift */; };
 		F9C165B4274031F600592F76 /* Bindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C165B3274031F600592F76 /* Bindings.swift */; };
+		F9C165BF2740403600592F76 /* SendStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C165B72740403600592F76 /* SendStore.swift */; };
+		F9C165C02740403600592F76 /* ApproveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C165B92740403600592F76 /* ApproveView.swift */; };
+		F9C165C22740403600592F76 /* CreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C165BB2740403600592F76 /* CreateView.swift */; };
+		F9C165C42740403600592F76 /* SentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C165BD2740403600592F76 /* SentView.swift */; };
 		F9EEB8162742C2210032EEB8 /* WithStateBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9EEB8152742C2210032EEB8 /* WithStateBinding.swift */; };
 /* End PBXBuildFile section */
 
@@ -215,6 +219,10 @@
 		F96B41E6273B501F0021B49A /* TransactionHistoryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionHistoryView.swift; sourceTree = "<group>"; };
 		F96B41EA273B50520021B49A /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		F9C165B3274031F600592F76 /* Bindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bindings.swift; sourceTree = "<group>"; };
+		F9C165B72740403600592F76 /* SendStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendStore.swift; sourceTree = "<group>"; };
+		F9C165B92740403600592F76 /* ApproveView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApproveView.swift; sourceTree = "<group>"; };
+		F9C165BB2740403600592F76 /* CreateView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateView.swift; sourceTree = "<group>"; };
+		F9C165BD2740403600592F76 /* SentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentView.swift; sourceTree = "<group>"; };
 		F9EEB8152742C2210032EEB8 /* WithStateBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithStateBinding.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -607,6 +615,7 @@
 			isa = PBXGroup;
 			children = (
 				F93874EC273C4DE200F0E875 /* Home */,
+				F9C165B62740403600592F76 /* Send */,
 				F96B41E2273B501F0021B49A /* TransactionHistory */,
 				6654C73C2715A3FA00901167 /* Onboarding */,
 			);
@@ -695,6 +704,25 @@
 			children = (
 				F96B41E5273B501F0021B49A /* TransactionDetailView.swift */,
 				F96B41E6273B501F0021B49A /* TransactionHistoryView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		F9C165B62740403600592F76 /* Send */ = {
+			isa = PBXGroup;
+			children = (
+				F9C165B72740403600592F76 /* SendStore.swift */,
+				F9C165B82740403600592F76 /* Views */,
+			);
+			path = Send;
+			sourceTree = "<group>";
+		};
+		F9C165B82740403600592F76 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				F9C165BB2740403600592F76 /* CreateView.swift */,
+				F9C165B92740403600592F76 /* ApproveView.swift */,
+				F9C165BD2740403600592F76 /* SentView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -939,12 +967,14 @@
 				0DA13C9726C186FF00E3B610 /* RestoreWalletScreen.swift in Sources */,
 				0DACFA8127208D940039EEA5 /* UInt+SuperscriptText.swift in Sources */,
 				0DF2DC51272344E400FA31E2 /* EmptyChip.swift in Sources */,
+				F9C165BF2740403600592F76 /* SendStore.swift in Sources */,
 				0D1922EA26BDD96A00052649 /* ViewModel.swift in Sources */,
 				0D4E7A0926B364170058B01E /* SecantApp.swift in Sources */,
 				66DC733F271D88CC0053CBB6 /* StandardButtonStyle.swift in Sources */,
 				0D864A0926E154FD00A61879 /* InitFailedScreen.swift in Sources */,
 				663FABA0271D876200E495F8 /* PrimaryButton.swift in Sources */,
 				663FAB9C271D874D00E495F8 /* ActiveButton.swift in Sources */,
+				F9C165C02740403600592F76 /* ApproveView.swift in Sources */,
 				0DF2DC5427235E3E00FA31E2 /* View+InnerShadow.swift in Sources */,
 				0D32281A26C5864B00262533 /* ProfileScreenViewModel.swift in Sources */,
 				0D185819272723FF0046B928 /* BlueChip.swift in Sources */,
@@ -954,6 +984,7 @@
 				66A0807B271993C500118B79 /* OnboardingProgressIndicator.swift in Sources */,
 				663FAB9E271D875700E495F8 /* CreateButton.swift in Sources */,
 				0D7DF08C271DCC0E00530046 /* ScreenBackground.swift in Sources */,
+				F9C165C22740403600592F76 /* CreateView.swift in Sources */,
 				0DA13C8F26C15D1D00E3B610 /* WelcomeScreen.swift in Sources */,
 				F9C165B4274031F600592F76 /* Bindings.swift in Sources */,
 				0D32282826C586E000262533 /* RequestZcashScreen.swift in Sources */,
@@ -965,6 +996,7 @@
 				0D32281926C5864B00262533 /* ProfileScreen.swift in Sources */,
 				6654C7412715A47300901167 /* Onboarding.swift in Sources */,
 				0D32282426C586A800262533 /* HistoryScreenViewModel.swift in Sources */,
+				F9C165C42740403600592F76 /* SentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/secant/Features/Home/HomeStore.swift
+++ b/secant/Features/Home/HomeStore.swift
@@ -89,4 +89,13 @@ extension HomeViewStore {
             }
         )
     }
+
+    var showSendBinding: Binding<Bool> {
+        self.binding(
+            get: { $0.route == .send },
+            send: { isActive in
+                return .updateRoute(isActive ? .send : nil)
+            }
+        )
+    }
 }

--- a/secant/Features/Home/Views/HomeView.swift
+++ b/secant/Features/Home/Views/HomeView.swift
@@ -46,7 +46,7 @@ struct HomeView: View {
             .navigationLinkEmpty(
                 isActive: viewStore.showSendBinding,
                 destination: {
-                    Create(
+                    SendView(
                         store: .init(
                             initialState: .init(
                                 transaction: .demo,

--- a/secant/Features/Home/Views/HomeView.swift
+++ b/secant/Features/Home/Views/HomeView.swift
@@ -52,7 +52,10 @@ struct HomeView: View {
                                 transaction: .demo,
                                 route: nil
                             ),
-                            reducer: .default.debug(),
+                            reducer: SendReducer.default(
+                                whenDone: { viewStore.send(.updateRoute(nil)) }
+                            )
+                            .debug(),
                             environment: ()
                         )
                     )

--- a/secant/Features/Home/Views/HomeView.swift
+++ b/secant/Features/Home/Views/HomeView.swift
@@ -21,6 +21,13 @@ struct HomeView: View {
                 .primaryButtonStyle
                 .frame(height: 50)
 
+                Button(
+                    action: { viewStore.send(.updateRoute(.send)) },
+                    label: { Text("Go to Send") }
+                )
+                .primaryButtonStyle
+                .frame(height: 50)
+
                 Spacer()
 
                 HStack {
@@ -36,6 +43,21 @@ struct HomeView: View {
             }
             .padding(.horizontal, 30)
             .navigationBarTitle("Home", displayMode: .inline)
+            .navigationLinkEmpty(
+                isActive: viewStore.showSendBinding,
+                destination: {
+                    Create(
+                        store: .init(
+                            initialState: .init(
+                                transaction: .demo,
+                                route: nil
+                            ),
+                            reducer: .default.debug(),
+                            environment: ()
+                        )
+                    )
+                }
+            )
             .fullScreenCover(
                 isPresented: viewStore.showHistoryBinding,
                 content: {

--- a/secant/Features/Send/SendStore.swift
+++ b/secant/Features/Send/SendStore.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import ComposableArchitecture
+
+struct SendState: Equatable {
+    var transaction: Transaction
+    var route: Create.Route?
+}
+
+enum SendAction: Equatable {
+    case updateTransaction(Transaction)
+    case updateRoute(Create.Route?)
+}
+
+// Mark: - SendReducer
+
+typealias SendReducer = Reducer<SendState, SendAction, Void>
+
+extension SendReducer {
+    private struct SyncStatusUpdatesID: Hashable {}
+
+    static let `default` = Reducer<SendState, SendAction, Void> { state, action, _ in
+        switch action {
+        case let .updateTransaction(transaction):
+            state.transaction = transaction
+            return .none
+        case let .updateRoute(route):
+            state.route = route
+            return .none
+        }
+    }
+}
+
+// Mark: - SendStore
+
+typealias SendStore = Store<SendState, SendAction>
+
+// Mark: - SendViewStore
+
+typealias SendViewStore = ViewStore<SendState, SendAction>
+
+extension SendViewStore {
+
+    var bindingForTransaction: Binding<Transaction> {
+        self.binding(
+            get: \.transaction,
+            send: SendAction.updateTransaction
+        )
+    }
+
+    var routeBinding: Binding<Create.Route?> {
+        self.binding(
+            get: \.route,
+            send: SendAction.updateRoute
+        )
+    }
+}
+

--- a/secant/Features/Send/SendStore.swift
+++ b/secant/Features/Send/SendStore.swift
@@ -28,6 +28,17 @@ extension SendReducer {
             return .none
         }
     }
+
+    static func `default`(whenDone: @escaping () -> Void) -> SendReducer {
+        SendReducer { state, action, _ in
+            switch action {
+            case let .updateRoute(route) where route == .showApprove(route: .showSent(route: .done)):
+                return Effect.fireAndForget(whenDone)
+            default:
+                return Self.default.run(&state, action, ())
+            }
+        }
+    }
 }
 
 // Mark: - SendStore

--- a/secant/Features/Send/Views/ApproveView.swift
+++ b/secant/Features/Send/Views/ApproveView.swift
@@ -2,17 +2,13 @@ import SwiftUI
 import ComposableArchitecture
 
 struct Approve: View {
-    enum Route: Equatable {
-        case showSent(route: Sent.Route?)
-    }
-
     let transaction: Transaction
-    @Binding var route: Route?
+    @Binding var isComplete: Bool
 
     var body: some View {
         VStack {
             Button(
-                action: { route = .showSent(route: nil) },
+                action: { isComplete = true },
                 label: { Text("Go to sent") }
             )
             .primaryButtonStyle
@@ -20,42 +16,21 @@ struct Approve: View {
             .padding()
 
             Text("\(String(dumping: transaction))")
-            Text("\(String(dumping: route))")
+            Text("\(String(dumping: isComplete))")
 
             Spacer()
         }
         .navigationTitle(Text("2. Approve"))
-        .navigationLinkEmpty(
-            isActive: $route.map(
-                extract: {
-                    if case .showSent = $0 {
-                        return true
-                    } else {
-                        return false
-                    }
-                },
-                embed: { $0 ? .showSent(route: (/Route.showSent).extract(from: route)) : nil }
-            ),
-            destination: {
-                Sent(
-                    transaction: transaction,
-                    route:  $route.map(
-                        extract: /Route.showSent,
-                        embed: Route.showSent
-                    )
-                )
-            }
-        )
     }
 }
 
 struct Approve_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            StateContainer(initialState: (Transaction.demo, Approve.Route?.none)) {
+            StateContainer(initialState: (Transaction.demo, false)) {
                 Approve(
                     transaction: $0.0.wrappedValue,
-                    route: $0.1
+                    isComplete: $0.1
                 )
             }
         }

--- a/secant/Features/Send/Views/ApproveView.swift
+++ b/secant/Features/Send/Views/ApproveView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import ComposableArchitecture
+
+struct Approve: View {
+    enum Route: Equatable {
+        case showSent(route: Sent.Route?)
+    }
+
+    let transaction: Transaction
+    @Binding var route: Route?
+
+    var body: some View {
+        VStack {
+            Button(
+                action: { route = .showSent(route: nil) },
+                label: { Text("Go to sent") }
+            )
+            .primaryButtonStyle
+            .frame(height: 50)
+            .padding()
+
+            Text("\(String(dumping: transaction))")
+            Text("\(String(dumping: route))")
+
+            Spacer()
+        }
+        .navigationTitle(Text("2. Approve"))
+        .navigationLinkEmpty(
+            isActive: $route.map(
+                extract: {
+                    if case .showSent = $0 {
+                        return true
+                    } else {
+                        return false
+                    }
+                },
+                embed: { $0 ? .showSent(route: (/Route.showSent).extract(from: route)) : nil }
+            ),
+            destination: {
+                Sent(
+                    transaction: transaction,
+                    route:  $route.map(
+                        extract: /Route.showSent,
+                        embed: Route.showSent
+                    )
+                )
+            }
+        )
+    }
+}
+
+struct Approve_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            StateContainer(initialState: (Transaction.demo, Approve.Route?.none)) {
+                Approve(
+                    transaction: $0.0.wrappedValue,
+                    route: $0.1
+                )
+            }
+        }
+    }
+}

--- a/secant/Features/Send/Views/CreateView.swift
+++ b/secant/Features/Send/Views/CreateView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import ComposableArchitecture
+
+struct Create: View {
+    enum Route: Equatable {
+        case showApprove(route: Approve.Route?)
+    }
+
+    let store: Store<SendState, SendAction>
+
+    var body: some View {
+        WithViewStore(store) { viewStore in
+            VStack {
+                Button(
+                    action: { viewStore.send(.updateRoute(.showApprove(route: nil))) },
+                    label: { Text("Go To Approve") }
+                )
+                .primaryButtonStyle
+                .frame(height: 50)
+                .padding()
+
+                TextField(
+                    "Amount",
+                    text: viewStore
+                        .bindingForTransaction
+                        .amount
+                        .compactMap(
+                            extract: String.init,
+                            embed: UInt.init
+                        )
+                )
+                .padding()
+
+                TextField(
+                    "Address",
+                    text: viewStore.bindingForTransaction.toAddress
+                )
+
+                Text("\(String(dumping: viewStore.transaction))")
+                Text("\(String(dumping: viewStore.route))")
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle(Text("1. Create"))
+            .navigationLinkEmpty(
+                isActive: viewStore.routeBinding.map(
+                    extract: { $0.map(/Route.showApprove) != nil },
+                    embed: { $0 ? .showApprove(route: (/Route.showApprove).extract(from: viewStore.route)) : nil }
+                ),
+                destination: {
+                    Approve(
+                        transaction: viewStore.transaction,
+                        route: viewStore.routeBinding.map(
+                            extract: /Route.showApprove,
+                            embed: Route.showApprove
+                        )
+                    )
+                }
+            )
+        }
+    }
+}
+
+// MARK: - Previews
+
+struct Create_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            Create(store: .demo)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+#if DEBUG
+extension SendStore {
+    static var demo: SendStore {
+        return SendStore(
+            initialState: .init(
+                transaction: .demo,
+                route: nil
+            ),
+            reducer: .default,
+            environment: ()
+        )
+    }
+}
+#endif

--- a/secant/Features/Send/Views/CreateView.swift
+++ b/secant/Features/Send/Views/CreateView.swift
@@ -2,63 +2,42 @@ import SwiftUI
 import ComposableArchitecture
 
 struct Create: View {
-    enum Route: Equatable {
-        case showApprove(route: Approve.Route?)
-    }
-
-    let store: Store<SendState, SendAction>
+    @Binding var transaction: Transaction
+    @Binding var isComplete: Bool
 
     var body: some View {
-        WithViewStore(store) { viewStore in
-            VStack {
-                Button(
-                    action: { viewStore.send(.updateRoute(.showApprove(route: nil))) },
-                    label: { Text("Go To Approve") }
-                )
-                .primaryButtonStyle
-                .frame(height: 50)
-                .padding()
-
-                TextField(
-                    "Amount",
-                    text: viewStore
-                        .bindingForTransaction
-                        .amount
-                        .compactMap(
-                            extract: String.init,
-                            embed: UInt.init
-                        )
-                )
-                .padding()
-
-                TextField(
-                    "Address",
-                    text: viewStore.bindingForTransaction.toAddress
-                )
-
-                Text("\(String(dumping: viewStore.transaction))")
-                Text("\(String(dumping: viewStore.route))")
-
-                Spacer()
-            }
-            .padding()
-            .navigationTitle(Text("1. Create"))
-            .navigationLinkEmpty(
-                isActive: viewStore.routeBinding.map(
-                    extract: { $0.map(/Route.showApprove) != nil },
-                    embed: { $0 ? .showApprove(route: (/Route.showApprove).extract(from: viewStore.route)) : nil }
-                ),
-                destination: {
-                    Approve(
-                        transaction: viewStore.transaction,
-                        route: viewStore.routeBinding.map(
-                            extract: /Route.showApprove,
-                            embed: Route.showApprove
-                        )
-                    )
-                }
+        VStack {
+            Button(
+                action: { isComplete = true },
+                label: { Text("Go To Approve") }
             )
+            .primaryButtonStyle
+            .frame(height: 50)
+            .padding()
+
+            TextField(
+                "Amount",
+                text: $transaction
+                    .amount
+                    .compactMap(
+                        extract: String.init,
+                        embed: UInt.init
+                    )
+            )
+            .padding()
+
+            TextField(
+                "Address",
+                text: $transaction.toAddress
+            )
+
+            Text("\(String(dumping: transaction))")
+            Text("\(String(dumping: isComplete))")
+
+            Spacer()
         }
+        .padding()
+        .navigationTitle(Text("1. Create"))
     }
 }
 
@@ -67,7 +46,12 @@ struct Create: View {
 struct Create_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            Create(store: .demo)
+            StateContainer(initialState: (Transaction.demo, false)) {
+                Create(
+                    transaction: $0.0,
+                    isComplete: $0.1
+                )
+            }
             .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/secant/Features/Send/Views/SendView.swift
+++ b/secant/Features/Send/Views/SendView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import ComposableArchitecture
+
+struct SendView: View {
+    enum Route: Equatable {
+        case showApprove
+        case showSent
+        case done
+    }
+
+    let store: Store<SendState, SendAction>
+
+    var body: some View {
+        WithViewStore(store) { viewStore in
+            Create(
+                transaction: viewStore.bindingForTransaction,
+                isComplete: viewStore.bindingForApprove
+            )
+            .navigationLinkEmpty(
+                isActive: viewStore.bindingForApprove,
+                destination: {
+                    Approve(
+                        transaction: viewStore.transaction,
+                        isComplete: viewStore.bindingForSent
+                    )
+                    .navigationLinkEmpty(
+                        isActive: viewStore.bindingForSent,
+                        destination: {
+                            Sent(
+                                transaction: viewStore.transaction,
+                                isComplete: viewStore.bindingForDone
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    }
+}
+
+struct SendView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            SendView(
+                store: .init(
+                    initialState: .init(
+                        transaction: .demo,
+                        route: nil
+                    ),
+                    reducer: .default,
+                    environment: ()
+                )
+            )
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationViewStyle(StackNavigationViewStyle())
+        }
+    }
+}

--- a/secant/Features/Send/Views/SentView.swift
+++ b/secant/Features/Send/Views/SentView.swift
@@ -2,17 +2,14 @@ import SwiftUI
 import ComposableArchitecture
 
 struct Sent: View {
-    enum Route {
-        case done
-    }
-    @State var transaction: Transaction
-    @Binding var route: Route?
+    var transaction: Transaction
+    @Binding var isComplete: Bool
 
     var body: some View {
         VStack {
             Button(
                 action: {
-                    route = .done
+                    isComplete = true
                 },
                 label: { Text("Done") }
             )
@@ -22,7 +19,7 @@ struct Sent: View {
 
 
             Text("\(String(dumping: transaction))")
-            Text("\(String(dumping: route))")
+            Text("\(String(dumping: isComplete))")
 
             Spacer()
         }
@@ -32,6 +29,6 @@ struct Sent: View {
 
 struct Done_Previews: PreviewProvider {
     static var previews: some View {
-        Sent(transaction: .demo, route: .constant(nil))
+        Sent(transaction: .demo, isComplete: .constant(false))
     }
 }

--- a/secant/Features/Send/Views/SentView.swift
+++ b/secant/Features/Send/Views/SentView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import ComposableArchitecture
+
+struct Sent: View {
+    enum Route {
+        case done
+    }
+    @State var transaction: Transaction
+    @Binding var route: Route?
+
+    var body: some View {
+        VStack {
+            Button(
+                action: {
+                    route = .done
+                },
+                label: { Text("Done") }
+            )
+            .primaryButtonStyle
+            .frame(height: 50)
+            .padding()
+
+
+            Text("\(String(dumping: transaction))")
+            Text("\(String(dumping: route))")
+
+            Spacer()
+        }
+        .navigationTitle(Text("3. Sent"))
+    }
+}
+
+struct Done_Previews: PreviewProvider {
+    static var previews: some View {
+        Sent(transaction: .demo, route: .constant(nil))
+    }
+}

--- a/secant/SecantApp.swift
+++ b/secant/SecantApp.swift
@@ -15,6 +15,7 @@ struct SecantApp: App {
             NavigationView {
                 HomeView(store: homeStore)
             }
+            .navigationViewStyle(StackNavigationViewStyle()) 
         }
     }
 }

--- a/secant/Util/Bindings.swift
+++ b/secant/Util/Bindings.swift
@@ -74,7 +74,14 @@ extension Binding {
         )
     }
 
-    func map<T>(extract: @escaping (Value) -> T, embed: @escaping (T) -> Value?) -> Binding<T> {
+    func map<T>(extract: @escaping (Value) -> T, embed: @escaping (T) -> Value) -> Binding<T> {
+        Binding<T>(
+            get: { extract(wrappedValue) },
+            set: { wrappedValue = embed($0) }
+        )
+    }
+
+    func compactMap<T>(extract: @escaping (Value) -> T, embed: @escaping (T) -> Value?) -> Binding<T> {
         Binding<T>(
             get: { extract(wrappedValue) },
             set: {


### PR DESCRIPTION
Putting this up to see if we have a preference on how to go about handling the construction of connected views. (Though any other comments and suggestions are also welcome.)

The main diff is 780dd0f which goes from the original implementation where the "next" view is encoded in the view itself, to one where the connection between the views is handled by a "Parent" view... or something that acts much like a "coordinator".

There is no "correct" answer here, and it's possible that both are equally good in _this_ example, but one might shine over the other in different set ups.

I'll throw out my thoughts here is that I probably slightly prefer the "coordinator" style one, and something like this would be _necessary_ if we intended to use these views individually / in different combinations. However a big drawback is that for nested navigationLinks, you can see that this can start to make the indentation go further and further down.

I had two ideas on "fixing this". One is just creating intermediate computed views that would only go one navigationLink deep. Two is, I _think_ this can be solved by using a `ViewModifier` and doing the nesting in here when we see that the view we are modifying is already being modified by a "navigation modifier". This would allow us to "stack" the modifiers at the same level of indentation. I haven't got an implementation for this yet, it's just a thought 😅.

Please have a look at the [Commits](https://github.com/zcash/secant-ios-wallet/pull/121/commits) for some more context on all the other commits.

(This should address #12  and #13)

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [x] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.