### PR TITLE
Improve Profile feature reusability by applying Interface Segregation Principle

### DIFF
--- a/secant/Features/Home/HomeStore.swift
+++ b/secant/Features/Home/HomeStore.swift
@@ -265,7 +265,7 @@ extension HomeReducer {
             ProfileEnvironment(
                 appVersionHandler: .live,
                 mnemonic: environment.mnemonic,
-                SDKSynchronizer: environment.SDKSynchronizer,
+                shieldedAddress: environment.SDKSynchronizer.getShieldedAddress,
                 scheduler: environment.scheduler,
                 walletStorage: environment.walletStorage,
                 zcashSDKEnvironment: environment.zcashSDKEnvironment

--- a/secantTests/ProfileTests/ProfileTests.swift
+++ b/secantTests/ProfileTests/ProfileTests.swift
@@ -12,11 +12,12 @@ import ComposableArchitecture
 class ProfileTests: XCTestCase {
     func testSynchronizerStateChanged_AnyButSynced() throws {
         let testScheduler = DispatchQueue.test
+        let shieldedAddress = "ff3927e1f83df9b1b0dc75540ddc59ee435eecebae914d2e6dfe8576fbedc9a8"
 
         let testEnvironment = ProfileEnvironment(
             appVersionHandler: .test,
             mnemonic: .mock,
-            SDKSynchronizer: TestWrappedSDKSynchronizer(),
+            shieldedAddress: { shieldedAddress },
             scheduler: testScheduler.eraseToAnyScheduler(),
             walletStorage: .throwing,
             zcashSDKEnvironment: .testnet
@@ -29,7 +30,7 @@ class ProfileTests: XCTestCase {
         )
         
         store.send(.onAppear) { state in
-            state.address = "ff3927e1f83df9b1b0dc75540ddc59ee435eecebae914d2e6dfe8576fbedc9a8"
+            state.address = shieldedAddress
             state.appVersion = "0.0.1"
             state.appBuild = "31"
             state.sdkVersion = "0.14.0-beta"

--- a/secantTests/SnapshotTests/ProfileSnapshotTests/ProfileSnapshotTests.swift
+++ b/secantTests/SnapshotTests/ProfileSnapshotTests/ProfileSnapshotTests.swift
@@ -17,7 +17,7 @@ class ProfileSnapshotTests: XCTestCase {
         let testEnvironment = ProfileEnvironment(
             appVersionHandler: .test,
             mnemonic: .mock,
-            SDKSynchronizer: TestWrappedSDKSynchronizer(),
+            shieldedAddress: { "ff3927e1f83df9b1b0dc75540ddc59ee435eecebae914d2e6dfe8576fbedc9a8" },
             scheduler: testScheduler.eraseToAnyScheduler(),
             walletStorage: .throwing,
             zcashSDKEnvironment: .testnet


### PR DESCRIPTION
This PR improves robustness of the code by applying ISP at one place inside `ProfileEnvironment`.

## Summary
Recently I've come across your code and spotted some things I thought I could bring to the light.
I know you accept only PRs fixing some existing issue. If you think this PR is not relevant, feel free to abandon it.

In Profile feature, I've spotted some places violating [ISP principle](https://en.wikipedia.org/wiki/Interface_segregation_principle) (one of the SOLID principles) and thought I might give a suggestion for improvement in for of Pull request.

## Problem

The `ProfileEnvironment` is strongly coupled to whole `WrappedSDKSynchronizer` even though it actually needs to use only one of its methods.
This strong coupling makes the code more difficult to reuse and change in the future.

## Solution

Inside the `ProfileEnvironment` we define only what it really needs - a method that returns Shielded Address.

I've solved it by introducing `typealias ShieldedAddressSource`, representing only functionality of getting the address. And replaced it with `WrappedSDKSynchronizer` dependency.

## Benefits of ISP
- Not being dependent on changes to `WrappedSDKSynchronizer` - before, if `WrappedSDKSynchronizer` would change, it would require to change (or at least recompile) Profile feature too. It's not the case any more

- Flexible for future changes - Imagine a situation that we'd want to compose the address from `WrappedSDKSynchronizer` plus some other component, making operation on it, before we display it inside Profile. In current situation we'd have to add new dependency to `ProfileEnvironment` for the other component, and do the logic inside Profile. With this suggested solution, the logic could be performed outside of Profile (perhaps reused for other places) and result passed to `ProfileEnvironment`, without any changes to Profile feature itself.

- Profile Feature is now easier to reason about, because its' Enironment has now more straightforward dependencies.

- Avoiding situation that someone would accidentally call methods of `WrappedSDKSynchronizer` that are not intended to be called inside Profile feature.

- When removed this strong coupling, it makes it much easier to split code to separate packages / frameworks

- Easier unit testing - no need to mock stuff which is not used.

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [x] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
       _(Authors note: Sorry, I'm unable to run the app and verify the changes, since I have no Zcash account yet.  I'm relying on passing unit tests.)_
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.