### PR TITLE
[#379] Show alert before follow a Block explorer link

### DIFF
--- a/secant/Features/WalletEventsFlow/WalletEventsFlowView.swift
+++ b/secant/Features/WalletEventsFlow/WalletEventsFlowView.swift
@@ -31,7 +31,7 @@ struct WalletEventsFlowView: View {
             )
             .onDisappear(perform: { viewStore.send(.onDisappear) })
             .navigationLinkEmpty(isActive: viewStore.bindingForSelectedWalletEvent(viewStore.selectedWalletEvent)) {
-                viewStore.selectedWalletEvent?.detailView(viewStore)
+                viewStore.selectedWalletEvent?.detailView(store)
             }
         }
     }

--- a/secant/Models/TransactionState.swift
+++ b/secant/Models/TransactionState.swift
@@ -34,7 +34,7 @@ struct TransactionState: Equatable, Identifiable {
     var date: Date { Date(timeIntervalSince1970: timestamp) }
     var totalAmount: Zatoshi { Zatoshi(zecAmount.amount + fee.amount) }
     var viewOnlineURL: URL? {
-        URL(string: "https://blockchair.com/zcash/transaction/\(id)")
+        URL(string: "https://zcashblockexplorer.com/transactions/\(id)")
     }
 
     func confirmationsWith(_ latestMinedHeight: BlockHeight?) -> BlockHeight {

--- a/secant/Models/WalletEvent.swift
+++ b/secant/Models/WalletEvent.swift
@@ -52,13 +52,13 @@ extension WalletEvent {
 // MARK: - Details
 
 extension WalletEvent {
-    @ViewBuilder func detailView(_ viewStore: WalletEventsFlowViewStore) -> some View {
+    @ViewBuilder func detailView(_ store: WalletEventsFlowStore) -> some View {
         switch state {
         case .send(let transaction),
             .pending(let transaction),
             .received(let transaction),
             .failed(let transaction):
-            TransactionDetailView(transaction: transaction, viewStore: viewStore)
+            TransactionDetailView(transaction: transaction, store: store)
         case .shielded(let zatoshi):
             // TODO: implement design once shielding is supported, issue 390
             // https://github.com/zcash/secant-ios-wallet/issues/390

--- a/secantTests/SnapshotTests/WalletEventsSnapshotTests/WalletEventsSnapshotTests.swift
+++ b/secantTests/SnapshotTests/WalletEventsSnapshotTests/WalletEventsSnapshotTests.swift
@@ -116,7 +116,7 @@ class WalletEventsSnapshotTests: XCTestCase {
         
         addAttachments(
             name: "\(#function)_WalletEventDetail",
-            TransactionDetailView(transaction: transaction, viewStore: ViewStore(walletEventsStore))
+            TransactionDetailView(transaction: transaction, store: walletEventsStore)
         )
     }
     
@@ -173,7 +173,7 @@ class WalletEventsSnapshotTests: XCTestCase {
         
         addAttachments(
             name: "\(#function)_WalletEventDetail",
-            TransactionDetailView(transaction: transaction, viewStore: ViewStore(walletEventsStore))
+            TransactionDetailView(transaction: transaction, store: walletEventsStore)
         )
     }
     
@@ -235,7 +235,7 @@ class WalletEventsSnapshotTests: XCTestCase {
         
         addAttachments(
             name: "\(#function)_WalletEventDetail",
-            TransactionDetailView(transaction: transaction, viewStore: ViewStore(walletEventsStore))
+            TransactionDetailView(transaction: transaction, store: walletEventsStore)
         )
     }
     
@@ -293,7 +293,7 @@ class WalletEventsSnapshotTests: XCTestCase {
         
         addAttachments(
             name: "\(#function)_WalletEventDetail",
-            TransactionDetailView(transaction: transaction, viewStore: ViewStore(walletEventsStore))
+            TransactionDetailView(transaction: transaction, store: walletEventsStore)
         )
     }
 }


### PR DESCRIPTION
Closes #379

- `TransactionDetailView` is updated and instead of `ViewStore` it now has `Store`. `Store` is required to show alert. It's not possible with `ViewStore`.
- There are three more actions added to `WalletEventsFlowAction`. These are used to handle the new alert.
- Block explorer URL is changed to https://zcashblockexplorer.com. New URL scheme is derived from how URLs looks now when some transaction is opened.

This is how the screen looks. When user taps here on "View online" button then user is redirected to website right away.
<img width="405" alt="Screenshot 2022-09-22 at 18 58 56" src="https://user-images.githubusercontent.com/506376/191807824-013c6585-40de-4977-a0fb-272ed2edc327.png">

And this is new alert that is presented before user is redirected to block explorer website.
<img width="402" alt="Screenshot 2022-09-22 at 18 59 04" src="https://user-images.githubusercontent.com/506376/191807969-0b0d62c9-b9e2-4eb9-afd8-fd062b11274a.png">



This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.