### PR TITLE
[#434] Fix circural image

### DIFF
--- a/secant/UI Components/CircularFrame/CircularFrameBackground.swift
+++ b/secant/UI Components/CircularFrame/CircularFrameBackground.swift
@@ -22,7 +22,7 @@ struct CircularFrameBackgroundImages: Animatable, ViewModifier {
                 ForEach(0..<viewStore.images.count - 1, id: \.self) { imageIndex in
                     viewStore.images[imageIndex]
                         .resizable()
-                        .aspectRatio(1.3, contentMode: .fill)
+                        .aspectRatio(1, contentMode: .fill)
                         .opacity(imageIndex == viewStore.index ? 1 : 0)
                         .offset(x: imageIndex <= viewStore.index ? 0 : 25)
                         .mask(Circle())
@@ -42,7 +42,7 @@ struct CircularFrameBackgroundImage: Animatable, ViewModifier {
         ZStack {
             image
                 .resizable()
-                .aspectRatio(1.3, contentMode: .fill)
+                .aspectRatio(1, contentMode: .fill)
                 .mask(Circle())
                 .neumorphic()
             


### PR DESCRIPTION
Closes #434

<img width="365" alt="Screenshot 2022-10-07 at 17 29 28" src="https://user-images.githubusercontent.com/506376/194592675-543d5a79-4bf2-42f0-9fe4-c43c0a98792c.png"><img width="359" alt="Screenshot 2022-10-07 at 17 29 39" src="https://user-images.githubusercontent.com/506376/194592692-2f9631e4-e272-487b-8903-ec4cc7f9ee07.png">
<img width="357" alt="Screenshot 2022-10-07 at 17 29 58" src="https://user-images.githubusercontent.com/506376/194592702-89f9a163-8f8c-4137-9786-0f3601c21485.png"><img width="366" alt="Screenshot 2022-10-07 at 17 30 07" src="https://user-images.githubusercontent.com/506376/194592714-f394cdf1-ad05-4123-aca9-8e31cf4fda4b.png">
<img width="368" alt="Screenshot 2022-10-07 at 17 30 45" src="https://user-images.githubusercontent.com/506376/194592720-908c4f89-acd0-4140-9689-4d1bd91b15a6.png"><img width="363" alt="Screenshot 2022-10-07 at 17 30 56" src="https://user-images.githubusercontent.com/506376/194592727-8b3c536a-2ee1-4fa1-9df8-4e9a603953ed.png">


This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.