### PR TITLE
Add deep link support for the Receive screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Added
+- Deep link support for the Receive screen (`zcash:///home/receive`), enabling external apps and webpages to open Zodl directly to the receive flow.
+
 ## 3.2.0 build 5 (2026-03-09)
 
 ### Changed

--- a/modules/Sources/Dependencies/Deeplink/Deeplink.swift
+++ b/modules/Sources/Dependencies/Deeplink/Deeplink.swift
@@ -13,6 +13,7 @@ import ZcashLightClientKit
 public struct Deeplink {
     public enum Destination: Equatable {
         case home
+        case receive
         case send(amount: Int, address: String, memo: String)
     }
     
@@ -39,6 +40,11 @@ public struct Deeplink {
                 Path { "home" }
             }
 
+            // GET /home/receive
+            Route(.case(Destination.receive)) {
+                Path { "home"; "receive" }
+            }
+
             // GET /home/send?amount=:amount&address=:address&memo=:memo
             Route(.case(Destination.send(amount:address:memo:))) {
                 Path { "home"; "send" }
@@ -53,6 +59,9 @@ public struct Deeplink {
         switch try appRouter.match(url: url) {
         case .home:
             return .home
+
+        case .receive:
+            return .receive
 
         case let .send(amount, address, memo):
             return .send(amount: amount, address: address, memo: memo)

--- a/modules/Sources/Features/Root/RootDestination.swift
+++ b/modules/Sources/Features/Root/RootDestination.swift
@@ -44,6 +44,7 @@ extension Root {
     public enum DestinationAction {
         case deeplink(URL)
         case deeplinkHome
+        case deeplinkReceive
         case deeplinkSend(Zatoshi, String, String)
         case deeplinkFailed(URL, ZcashError)
         case updateDestination(Root.DestinationState.Destination)
@@ -67,9 +68,21 @@ extension Root {
                     // The deeplink is some zip321, we ignore it and let users know in a warning screen
                     return .send(.destination(.updateDestination(.deeplinkWarning)))
                 }
-                return .none
+                return .run { [deeplink, derivationTool] send in
+                    do {
+                        let action = try await process(url: url, deeplink: deeplink, derivationTool: derivationTool)
+                        await send(action)
+                    } catch {
+                        await send(.destination(.deeplinkFailed(url, error.toZcashError())))
+                    }
+                }
 
             case .destination(.deeplinkHome):
+                return .none
+
+            case .destination(.deeplinkReceive):
+                state.receiveState = .initial
+                state.path = .receive
                 return .none
 
             case .destination(.deeplinkSend):
@@ -156,6 +169,8 @@ private extension Root {
         switch deeplink {
         case .home:
             return .destination(.deeplinkHome)
+        case .receive:
+            return .destination(.deeplinkReceive)
         case let .send(amount, address, memo):
             return .destination(.deeplinkSend(Zatoshi(Int64(amount)), address, memo))
         }

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -75,6 +75,24 @@ class DeeplinkTests: XCTestCase {
         await store.finish()
     }
 
+    func testActionDeeplinkReceive() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .welcome
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        await store.send(.destination(.deeplinkReceive)) { state in
+            state.receiveState = .initial
+            state.path = .receive
+        }
+
+        await store.finish()
+    }
+
     func testHomeURLParsing() throws {
         guard let url = URL(string: "zcash:///home") else {
             return XCTFail("Deeplink: 'testDeeplinkRequest_homeURL' URL is expected to be valid.")
@@ -118,6 +136,52 @@ class DeeplinkTests: XCTestCase {
             state.destinationState.destination = .home
         }
         
+        await store.finish()
+    }
+
+    func testReceiveURLParsing() throws {
+        guard let url = URL(string: "zcash:///home/receive") else {
+            return XCTFail("Deeplink: 'testReceiveURLParsing' URL is expected to be valid.")
+        }
+
+        let result = try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false })
+
+        XCTAssertEqual(result, Deeplink.Destination.receive)
+    }
+
+    func testDeeplinkRequest_Received_Receive() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .welcome
+        appState.appInitializationState = .initialized
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        store.dependencies.deeplink = DeeplinkClient(
+            resolveDeeplinkURL: { _, _, _ in Deeplink.Destination.receive }
+        )
+        store.dependencies.sdkSynchronizer = SDKSynchronizerClient.mocked(
+            latestState: {
+                var state = SynchronizerState.zero
+                state.syncStatus = .upToDate
+                return state
+            }
+        )
+
+        guard let url = URL(string: "zcash:///home/receive") else {
+            return XCTFail("Deeplink: 'testDeeplinkRequest_Received_Receive' URL is expected to be valid.")
+        }
+
+        await store.send(.destination(.deeplink(url)))
+
+        await store.receive(.destination(.deeplinkReceive)) { state in
+            state.receiveState = .initial
+            state.path = .receive
+        }
+
         await store.finish()
     }
 


### PR DESCRIPTION
## Summary

This PR adds a new `zcash:///home/receive` deep link destination that allows external apps and webpages to open Zodl directly to the Receive screen. This mirrors the existing `zcash:///home/send` deep link pattern.

### Changes
- Added `.receive` case to `Deeplink.Destination` enum with `/home/receive` URL route
- Added `.deeplinkReceive` action to `Root.DestinationAction`
- Connected the existing `process()` pipeline to the `.deeplink(url)` handler so parsed deep link URLs dispatch the appropriate actions
- Navigate to the Receive screen when `.deeplinkReceive` is processed
- Added URL parsing and integration tests following existing test patterns
- Updated CHANGELOG

### Deep Link Format
```
zcash:///home/receive
```

---

### Author checklist
- [x] I have performed a self-review in GitHub's web interface
- [x] Code abides by [Coding Guidelines](docs/CODING_GUIDELINES.md)
- [x] Appropriate automated tests have been added
- [ ] Code coverage report checked
- [x] Documentation updated (CHANGELOG)
- [ ] Tried running the app locally with the changes
- [ ] Before/after screenshots provided (UI changes only)
- [ ] Rebased and squashed before assigning a reviewer

### Reviewer checklist
- [ ] [Code Review Guidelines](CODE_REVIEW_GUIDELINES.md) checklist followed
- [ ] Ad hoc review (second pass with best judgement)
- [ ] Automated tests reviewed
- [ ] Manual tests reviewed (per `docs/testing/manual_testing`)
- [ ] Code coverage impact assessed
- [ ] Docs/README/LICENSE/Architecture reviewed
- [ ] App run locally by the reviewer