### PR TITLE
[#1665] Add deep link support for the Receive screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Added
+- Deep link support for the Receive screen (`zcash:///home/receive`), enabling external apps and webpages to open Zodl directly to the receive flow.
+
+### Fixed
+- Non-ZIP321 deep links (`zcash:///home`, `zcash:///home/send?...`) were silently ignored instead of being processed.
+
 ## 3.2.0 build 5 (2026-03-09)
 
 ### Changed

--- a/modules/Sources/Dependencies/Deeplink/Deeplink.swift
+++ b/modules/Sources/Dependencies/Deeplink/Deeplink.swift
@@ -13,6 +13,7 @@ import ZcashLightClientKit
 public struct Deeplink {
     public enum Destination: Equatable {
         case home
+        case receive
         case send(amount: Int, address: String, memo: String)
     }
     
@@ -39,6 +40,11 @@ public struct Deeplink {
                 Path { "home" }
             }
 
+            // GET /home/receive
+            Route(.case(Destination.receive)) {
+                Path { "home"; "receive" }
+            }
+
             // GET /home/send?amount=:amount&address=:address&memo=:memo
             Route(.case(Destination.send(amount:address:memo:))) {
                 Path { "home"; "send" }
@@ -53,6 +59,9 @@ public struct Deeplink {
         switch try appRouter.match(url: url) {
         case .home:
             return .home
+
+        case .receive:
+            return .receive
 
         case let .send(amount, address, memo):
             return .send(amount: amount, address: address, memo: memo)

--- a/modules/Sources/Features/Root/RootDestination.swift
+++ b/modules/Sources/Features/Root/RootDestination.swift
@@ -44,6 +44,7 @@ extension Root {
     public enum DestinationAction {
         case deeplink(URL)
         case deeplinkHome
+        case deeplinkReceive
         case deeplinkSend(Zatoshi, String, String)
         case deeplinkFailed(URL, ZcashError)
         case updateDestination(Root.DestinationState.Destination)
@@ -67,9 +68,34 @@ extension Root {
                     // The deeplink is some zip321, we ignore it and let users know in a warning screen
                     return .send(.destination(.updateDestination(.deeplinkWarning)))
                 }
-                return .none
+                return .run { [deeplink, derivationTool] send in
+                    do {
+                        let action = try await process(url: url, deeplink: deeplink, derivationTool: derivationTool)
+                        await send(action)
+                    } catch {
+                        await send(.destination(.deeplinkFailed(url, error.toZcashError())))
+                    }
+                }
 
             case .destination(.deeplinkHome):
+                return .none
+
+            case .destination(.deeplinkReceive):
+                guard state.destinationState.destination != .deeplinkWarning else {
+                    return .none
+                }
+                state.receiveState = .initial
+                state.path = .receive
+                let isKeystone = state.selectedWalletAccount?.vendor == .keystone
+                if let uuid = state.selectedWalletAccount?.id {
+                    return .run { send in
+                        let privateUA = try? await sdkSynchronizer.getCustomUnifiedAddress(
+                            uuid,
+                            isKeystone ? [.orchard] : [.sapling, .orchard]
+                        )
+                        await send(.home(.updatePrivateUA(privateUA)))
+                    }
+                }
                 return .none
 
             case .destination(.deeplinkSend):
@@ -156,6 +182,8 @@ private extension Root {
         switch deeplink {
         case .home:
             return .destination(.deeplinkHome)
+        case .receive:
+            return .destination(.deeplinkReceive)
         case let .send(amount, address, memo):
             return .destination(.deeplinkSend(Zatoshi(Int64(amount)), address, memo))
         }

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -75,6 +75,39 @@ class DeeplinkTests: XCTestCase {
         await store.finish()
     }
 
+    func testActionDeeplinkReceive() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .welcome
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        await store.send(.destination(.deeplinkReceive)) { state in
+            state.receiveState = .initial
+            state.path = .receive
+        }
+
+        await store.finish()
+    }
+
+    func testActionDeeplinkReceive_BlockedByDeeplinkWarning() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .deeplinkWarning
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        await store.send(.destination(.deeplinkReceive))
+
+        await store.finish()
+    }
+
     func testHomeURLParsing() throws {
         guard let url = URL(string: "zcash:///home") else {
             return XCTFail("Deeplink: 'testDeeplinkRequest_homeURL' URL is expected to be valid.")
@@ -119,6 +152,63 @@ class DeeplinkTests: XCTestCase {
         }
         
         await store.finish()
+    }
+
+    func testReceiveURLParsing() throws {
+        guard let url = URL(string: "zcash:///home/receive") else {
+            return XCTFail("Deeplink: 'testReceiveURLParsing' URL is expected to be valid.")
+        }
+
+        let result = try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false })
+
+        XCTAssertEqual(result, Deeplink.Destination.receive)
+    }
+
+    func testDeeplinkRequest_Received_Receive() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .welcome
+        appState.appInitializationState = .initialized
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        store.dependencies.deeplink = DeeplinkClient(
+            resolveDeeplinkURL: { _, _, _ in Deeplink.Destination.receive }
+        )
+        store.dependencies.sdkSynchronizer = SDKSynchronizerClient.mocked(
+            latestState: {
+                var state = SynchronizerState.zero
+                state.syncStatus = .upToDate
+                return state
+            }
+        )
+        store.dependencies.walletConfigProvider = .noOp
+
+        guard let url = URL(string: "zcash:///home/receive") else {
+            return XCTFail("Deeplink: 'testDeeplinkRequest_Received_Receive' URL is expected to be valid.")
+        }
+
+        await store.send(.destination(.deeplink(url)))
+
+        await store.receive(.destination(.deeplinkReceive)) { state in
+            state.receiveState = .initial
+            state.path = .receive
+        }
+
+        await store.finish()
+    }
+
+    func testInvalidReceiveURLParsing() throws {
+        guard let url = URL(string: "zcash:///home/receive/extra") else {
+            return XCTFail("Deeplink: 'testInvalidReceiveURLParsing' URL is expected to be valid.")
+        }
+
+        XCTAssertThrowsError(
+            try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false })
+        )
     }
 
     func testsendURLParsing() throws {


### PR DESCRIPTION
Closes #1665

- Added `.receive` case to `Deeplink.Destination` with `/home/receive` URL route
- Added `.deeplinkReceive` action to `Root.DestinationAction`
- Fetches Keystone custom unified addresses before navigating to the Receive screen, matching the in-app flow in `HomeStore.receiveScreenRequested`
- Guards against navigating while a `deeplinkWarning` is displayed
- Connected the existing `process()` pipeline to the `.deeplink(url)` handler — this also **restores processing for all non-ZIP321 deep links** (`zcash:///home`, `zcash:///home/send?...`) which were previously silently ignored after the ZIP-321 check
- Added URL parsing, integration, edge case (deeplinkWarning guard), and negative (`/home/receive/extra`) tests
- Updated CHANGELOG with both the new feature and the deep link fix

### Deep link format
```
zcash:///home/receive
```

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [x] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.
