### PR TITLE
[#1678] Add birthday height picker to Keystone import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Added
+- Wallet birthday picker added to Keystone hardware wallet import flow, allowing users to enter a block height or estimate from a date.
+
 ## 3.2.0 build 5 (2026-03-09)
 
 ### Changed

--- a/modules/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
+++ b/modules/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
@@ -38,7 +38,7 @@ public struct SDKSynchronizerClient {
     public let stop: () -> Void
     public let isSyncing: () -> Bool
     public let isInitialized: () -> Bool
-    public let importAccount: (String, [UInt8]?, Zip32AccountIndex?, AccountPurpose, String, String?) async throws -> AccountUUID?
+    public let importAccount: (String, [UInt8]?, Zip32AccountIndex?, AccountPurpose, String, String?, BlockHeight?) async throws -> AccountUUID?
     
     public let rewind: (RewindPolicy) -> AnyPublisher<Void, Error>
     

--- a/modules/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/modules/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -77,14 +77,15 @@ extension SDKSynchronizerClient: DependencyKey {
             stop: { synchronizer.stop() },
             isSyncing: { synchronizer.latestState.syncStatus.isSyncing },
             isInitialized: { synchronizer.latestState.syncStatus != SyncStatus.unprepared },
-            importAccount: { ufvk, seedFingerprint, zip32AccountIndex, purpose, name, keySource in
+            importAccount: { ufvk, seedFingerprint, zip32AccountIndex, purpose, name, keySource, walletBirthday in
                 try await synchronizer.importAccount(
                     ufvk: ufvk,
                     seedFingerprint: seedFingerprint,
                     zip32AccountIndex: zip32AccountIndex,
                     purpose: purpose,
                     name: name,
-                    keySource: keySource
+                    keySource: keySource,
+                    walletBirthday: walletBirthday
                 )
             },
             rewind: { synchronizer.rewind($0) },

--- a/modules/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
+++ b/modules/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
@@ -90,7 +90,7 @@ extension SDKSynchronizerClient {
         stop: { },
         isSyncing: { false },
         isInitialized: { false },
-        importAccount: { _, _, _, _, _, _ in nil },
+        importAccount: { _, _, _, _, _, _, _ in nil },
         rewind: { _ in Empty<Void, Error>().eraseToAnyPublisher() },
         getAllTransactions: { _ in [] },
         transactionStatesFromZcashTransactions: { _, _ in [] },
@@ -146,7 +146,7 @@ extension SDKSynchronizerClient {
         stop: @escaping () -> Void = { },
         isSyncing: @escaping () -> Bool = { false },
         isInitialized: @escaping () -> Bool = { false },
-        importAccount: @escaping (String, [UInt8]?, Zip32AccountIndex?, AccountPurpose, String, String?) async throws -> AccountUUID? = { _, _, _, _, _, _ in nil },
+        importAccount: @escaping (String, [UInt8]?, Zip32AccountIndex?, AccountPurpose, String, String?, BlockHeight?) async throws -> AccountUUID? = { _, _, _, _, _, _, _ in nil },
         rewind: @escaping (RewindPolicy) -> AnyPublisher<Void, Error> = { _ in return Empty<Void, Error>().eraseToAnyPublisher() },
         getAllTransactions: @escaping (AccountUUID?) -> IdentifiedArrayOf<TransactionState> = { _ in
             let mockedCleared: [TransactionStateMockHelper] = [

--- a/modules/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
+++ b/modules/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
@@ -58,6 +58,7 @@ public struct AddKeystoneHWWallet {
         case backToHomeTapped
         case binding(BindingAction<AddKeystoneHWWallet.State>)
         case forgetThisDeviceTapped
+        case importAccount(BlockHeight?)
         case loadedWalletAccounts([WalletAccount], AccountUUID)
         case onAppear
         case readyToScanTapped
@@ -95,6 +96,10 @@ public struct AddKeystoneHWWallet {
                 return .none
 
             case .unlockTapped:
+                // Intercepted by the coordinator to navigate to the birthday picker
+                return .none
+
+            case .importAccount(let birthday):
                 guard let account = state.zcashAccounts, let firstAccount = account.accounts.first else {
                     return .none
                 }
@@ -106,7 +111,8 @@ public struct AddKeystoneHWWallet {
                             Zip32AccountIndex(firstAccount.index),
                             AccountPurpose.spending,
                             String(localizable: .accountsKeystone),
-                            String(localizable: .accountsKeystone).lowercased()
+                            String(localizable: .accountsKeystone).lowercased(),
+                            birthday
                         )
                         if let uuid {
                             await send(.accountImported(uuid))

--- a/modules/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
+++ b/modules/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
@@ -12,25 +12,78 @@ import AudioServices
 // Path
 import AddKeystoneHWWallet
 import Scan
+import WalletBirthday
 
 extension AddKeystoneHWWalletCoordFlow {
     public func coordinatorReduce() -> Reduce<AddKeystoneHWWalletCoordFlow.State, AddKeystoneHWWalletCoordFlow.Action> {
         Reduce { state, action in
             switch action {
-                
+
                 // MARK: - Scan
-                
+
             case .path(.element(id: _, action: .scan(.foundAccounts(let account)))):
                 var addKeystoneHWWalletState = AddKeystoneHWWallet.State.initial
                 addKeystoneHWWalletState.zcashAccounts = account
                 state.path.append(.accountHWWalletSelection(addKeystoneHWWalletState))
                 audioServices.systemSoundVibrate()
                 return .none
-                
+
             case .path(.element(id: _, action: .scan(.cancelTapped))):
                 let _ = state.path.popLast()
                 return .none
-                
+
+                // MARK: - Account Selection -> Birthday
+
+            case .path(.element(id: _, action: .accountHWWalletSelection(.unlockTapped))):
+                state.path.append(.walletBirthday(WalletBirthday.State.initial))
+                return .none
+
+                // MARK: - Wallet Birthday
+
+            case .path(.element(id: _, action: .walletBirthday(.helpSheetRequested))):
+                state.isHelpSheetPresented.toggle()
+                return .none
+
+            case .path(.element(id: _, action: .walletBirthday(.estimateHeightTapped))):
+                state.path.append(.estimateBirthdaysDate(WalletBirthday.State.initial))
+                return .none
+
+            case .path(.element(id: _, action: .walletBirthday(.restoreTapped))):
+                for element in state.path {
+                    if case .walletBirthday(let walletBirthdayState) = element {
+                        state.birthday = walletBirthdayState.estimatedHeight
+                    }
+                }
+                return performKeystoneImport(&state)
+
+                // MARK: - Estimate Birthday Date
+
+            case .path(.element(id: _, action: .estimateBirthdaysDate(.helpSheetRequested))):
+                state.isHelpSheetPresented.toggle()
+                return .none
+
+            case .path(.element(id: _, action: .estimateBirthdaysDate(.estimateHeightReady))):
+                for element in state.path {
+                    if case .estimateBirthdaysDate(let estimateState) = element {
+                        state.path.append(.estimatedBirthday(estimateState))
+                    }
+                }
+                return .none
+
+                // MARK: - Estimated Birthday Height
+
+            case .path(.element(id: _, action: .estimatedBirthday(.helpSheetRequested))):
+                state.isHelpSheetPresented.toggle()
+                return .none
+
+            case .path(.element(id: _, action: .estimatedBirthday(.restoreTapped))):
+                for element in state.path {
+                    if case .estimatedBirthday(let estimatedBirthdayState) = element {
+                        state.birthday = estimatedBirthdayState.estimatedHeight
+                    }
+                }
+                return performKeystoneImport(&state)
+
                 // MARK: - Self
 
             case .addKeystoneHWWallet(.readyToScanTapped):
@@ -41,8 +94,23 @@ extension AddKeystoneHWWalletCoordFlow {
                 state.path.append(.scan(scanState))
                 return .none
 
+            case .helpSheetRequested:
+                state.isHelpSheetPresented.toggle()
+                return .none
+
             default: return .none
             }
         }
+    }
+
+    private func performKeystoneImport(_ state: inout AddKeystoneHWWalletCoordFlow.State) -> Effect<AddKeystoneHWWalletCoordFlow.Action> {
+        let birthday = state.birthday
+        // Find the accountHWWalletSelection in the path and send importAccount
+        for (id, element) in zip(state.path.ids, state.path) {
+            if case .accountHWWalletSelection = element {
+                return .send(.path(.element(id: id, action: .accountHWWalletSelection(.importAccount(birthday)))))
+            }
+        }
+        return .none
     }
 }

--- a/modules/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
+++ b/modules/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
@@ -14,6 +14,7 @@ import AudioServices
 // Path
 import AddKeystoneHWWallet
 import Scan
+import WalletBirthday
 
 @Reducer
 public struct AddKeystoneHWWalletCoordFlow {
@@ -21,11 +22,16 @@ public struct AddKeystoneHWWalletCoordFlow {
     public enum Path {
         case accountHWWalletSelection(AddKeystoneHWWallet)
         case scan(Scan)
+        case walletBirthday(WalletBirthday)
+        case estimateBirthdaysDate(WalletBirthday)
+        case estimatedBirthday(WalletBirthday)
     }
-    
+
     @ObservableState
     public struct State {
         public var addKeystoneHWWalletState = AddKeystoneHWWallet.State.initial
+        public var birthday: BlockHeight? = nil
+        public var isHelpSheetPresented = false
         public var path = StackState<Path.State>()
 
         public init() { }
@@ -33,11 +39,12 @@ public struct AddKeystoneHWWalletCoordFlow {
 
     public enum Action {
         case addKeystoneHWWallet(AddKeystoneHWWallet.Action)
+        case helpSheetRequested
         case path(StackActionOf<Path>)
     }
 
     @Dependency(\.audioServices) var audioServices
-    
+
     public init() { }
 
     public var body: some Reducer<State, Action> {
@@ -46,7 +53,7 @@ public struct AddKeystoneHWWalletCoordFlow {
         Scope(state: \.addKeystoneHWWalletState, action: \.addKeystoneHWWallet) {
             AddKeystoneHWWallet()
         }
-        
+
         Reduce { state, action in
             switch action {
             default: return .none

--- a/modules/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
+++ b/modules/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
@@ -14,6 +14,7 @@ import Generated
 // Path
 import AddKeystoneHWWallet
 import Scan
+import WalletBirthday
 
 public struct AddKeystoneHWWalletCoordFlowView: View {
     @Environment(\.colorScheme) var colorScheme
@@ -25,7 +26,7 @@ public struct AddKeystoneHWWalletCoordFlowView: View {
         self.store = store
         self.tokenName = tokenName
     }
-    
+
     public var body: some View {
         WithPerceptionTracking {
             NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
@@ -42,11 +43,54 @@ public struct AddKeystoneHWWalletCoordFlowView: View {
                     AccountsSelectionView(store: store)
                 case let .scan(store):
                     ScanView(store: store)
+                case let .walletBirthday(store):
+                    WalletBirthdayView(store: store)
+                case let .estimateBirthdaysDate(store):
+                    WalletBirthdayEstimateDateView(store: store)
+                case let .estimatedBirthday(store):
+                    WalletBirthdayEstimatedHeightView(store: store)
                 }
             }
         }
         .applyScreenBackground()
         .zashiBack()
+        .zashiSheet(
+            isPresented: Binding(
+                get: { store.isHelpSheetPresented },
+                set: { _ in store.send(.helpSheetRequested) }
+            )
+        ) {
+            helpSheetContent()
+        }
+    }
+
+    @ViewBuilder private func helpSheetContent() -> some View {
+        VStack(spacing: 0) {
+            Text(L10n.RestoreWallet.Help.title)
+                .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                .padding(.top, 24)
+                .padding(.bottom, 12)
+
+            HStack(alignment: .top, spacing: 8) {
+                Asset.Assets.infoCircle.image
+                    .zImage(size: 20, style: Design.Text.primary)
+
+                if let attrText = try? AttributedString(
+                    markdown: L10n.RestoreWallet.Help.birthday,
+                    including: \.zashiApp
+                ) {
+                    ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
+                        .zFont(size: 14, style: Design.Text.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.bottom, 32)
+
+            ZashiButton(L10n.RestoreInfo.gotIt) {
+                store.send(.helpSheetRequested)
+            }
+            .padding(.bottom, Design.Spacing.sheetBottomSpace)
+        }
     }
 }
 

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		9E34519D29C8484D00177D16 /* HomeFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341B30BA29B78D1000697081 /* HomeFeatureFlagTests.swift */; };
 		9E34519E29C849B400177D16 /* WalletConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F039B229ABCE8500CF0053 /* WalletConfigProviderTests.swift */; };
 		9E34519F29C849D300177D16 /* ImportWalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E391123283E4CAC0073DD9A /* ImportWalletTests.swift */; };
+		C847492D3A53CE435F3FDA11 /* AddKeystoneHWWalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F401AF195D85F482AA43CA1 /* AddKeystoneHWWalletTests.swift */; };
 		9E3451A029C84A2D00177D16 /* MultiLineTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6713F02897F81B00A6796F /* MultiLineTextFieldTests.swift */; };
 		9E3451A629C84B6600177D16 /* RootTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAFEB812805793200199FC9 /* RootTests.swift */; };
 		9E3451A729C84E9900177D16 /* AppInitializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E391131284644580073DD9A /* AppInitializationTests.swift */; };
@@ -189,6 +190,7 @@
 		9E207C382966EF87003E2C9B /* ReceiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveTests.swift; sourceTree = "<group>"; };
 		9E2706662AFF99F5000DA6EC /* TransactionReadUnreadM.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TransactionReadUnreadM.xcdatamodel; sourceTree = "<group>"; };
 		9E2F1C8B280ED6A7004E65FE /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		8F401AF195D85F482AA43CA1 /* AddKeystoneHWWalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddKeystoneHWWalletTests.swift; sourceTree = "<group>"; };
 		9E391123283E4CAC0073DD9A /* ImportWalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportWalletTests.swift; sourceTree = "<group>"; };
 		9E39112D283F91600073DD9A /* ZatoshiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZatoshiTests.swift; sourceTree = "<group>"; };
 		9E391131284644580073DD9A /* AppInitializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInitializationTests.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				9E207C372966EF6E003E2C9B /* ReceiveTests */,
 				0DFE93DD272C6D4B000FCCA5 /* BackupFlowTests */,
 				9E94C61E28AA7DD5008256E9 /* BalanceBreakdownTests */,
+				8729C4D6B05B6B2BC85C3CD1 /* AddKeystoneHWWalletTests */,
 				9EAB4674285B5C68002904A0 /* DeeplinkTests */,
 				9E3911372848AD3A0073DD9A /* HomeTests */,
 				9E391122283E4C970073DD9A /* ImportWalletTests */,
@@ -500,6 +503,14 @@
 				9E89DF752CD2B2E8002E5317 /* Localizable.strings */,
 			);
 			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		8729C4D6B05B6B2BC85C3CD1 /* AddKeystoneHWWalletTests */ = {
+			isa = PBXGroup;
+			children = (
+				8F401AF195D85F482AA43CA1 /* AddKeystoneHWWalletTests.swift */,
+			);
+			path = AddKeystoneHWWalletTests;
 			sourceTree = "<group>";
 		};
 		9E391122283E4C970073DD9A /* ImportWalletTests */ = {
@@ -1500,6 +1511,7 @@
 				9E3451AF29C855B200177D16 /* SensitiveDataTests.swift in Sources */,
 				9E3451A729C84E9900177D16 /* AppInitializationTests.swift in Sources */,
 				9E3451B029C855E600177D16 /* SettingsTests.swift in Sources */,
+				C847492D3A53CE435F3FDA11 /* AddKeystoneHWWalletTests.swift in Sources */,
 				9E34519F29C849D300177D16 /* ImportWalletTests.swift in Sources */,
 				9E74CCD029DC0628003D6E32 /* ReviewRequestTests.swift in Sources */,
 				9E3451A029C84A2D00177D16 /* MultiLineTextFieldTests.swift in Sources */,

--- a/secantTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
+++ b/secantTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
@@ -1,0 +1,165 @@
+//
+//  AddKeystoneHWWalletTests.swift
+//  secantTests
+//
+//  Created by Adam Tucker on 2026-04-04.
+//
+
+import XCTest
+import ComposableArchitecture
+import KeystoneSDK
+import ZcashLightClientKit
+import AddKeystoneHWWallet
+import CoordFlows
+import WalletBirthday
+@testable import secant_testnet
+
+@MainActor
+final class AddKeystoneHWWalletTests: XCTestCase {
+
+    private func makeZcashAccounts() throws -> ZcashAccounts {
+        let json = """
+        {
+            "seedFingerprint": "aabb",
+            "accounts": [{"ufvk": "utest1fakefvk", "index": 0, "name": "Test"}]
+        }
+        """
+        return try JSONDecoder().decode(ZcashAccounts.self, from: Data(json.utf8))
+    }
+
+    // Verifies that .unlockTapped produces no state changes or effects in the reducer.
+    // The coordinator intercepts this action to navigate to the birthday picker instead.
+    func testUnlockTapped_isNoOp() async throws {
+        let store = TestStore(
+            initialState: .initial
+        ) {
+            AddKeystoneHWWallet()
+        }
+
+        store.dependencies.keystoneHandler = .noOp
+
+        await store.send(.unlockTapped)
+
+        await store.finish()
+    }
+
+    // Verifies that when .importAccount is called with a specific birthday height,
+    // that exact value is forwarded to sdkSynchronizer.importAccount as the walletBirthday parameter.
+    func testImportAccount_withBirthday_forwardsBirthdayToSDK() async throws {
+        let expectedBirthday = BlockHeight(1_700_000)
+        let capturedBirthday = ActorIsolated<BlockHeight?>(nil)
+
+        var state = AddKeystoneHWWallet.State.initial
+        state.zcashAccounts = try makeZcashAccounts()
+
+        let store = TestStore(
+            initialState: state
+        ) {
+            AddKeystoneHWWallet()
+        }
+
+        store.dependencies.keystoneHandler = .noOp
+        store.dependencies.sdkSynchronizer = .mocked(
+            importAccount: { _, _, _, _, _, _, birthday in
+                await capturedBirthday.setValue(birthday)
+                return nil
+            }
+        )
+
+        await store.send(.importAccount(expectedBirthday))
+
+        await store.finish()
+
+        let captured = await capturedBirthday.value
+        XCTAssertEqual(captured, expectedBirthday, "Birthday should be forwarded to sdkSynchronizer.importAccount")
+    }
+
+    // Verifies that when .importAccount is called with a nil birthday,
+    // nil is forwarded to sdkSynchronizer.importAccount (letting the SDK use its default).
+    func testImportAccount_withNilBirthday_forwardsNilToSDK() async throws {
+        let capturedBirthday = ActorIsolated<BlockHeight?>(BlockHeight(999))
+
+        var state = AddKeystoneHWWallet.State.initial
+        state.zcashAccounts = try makeZcashAccounts()
+
+        let store = TestStore(
+            initialState: state
+        ) {
+            AddKeystoneHWWallet()
+        }
+
+        store.dependencies.keystoneHandler = .noOp
+        store.dependencies.sdkSynchronizer = .mocked(
+            importAccount: { _, _, _, _, _, _, birthday in
+                await capturedBirthday.setValue(birthday)
+                return nil
+            }
+        )
+
+        await store.send(.importAccount(nil))
+
+        await store.finish()
+
+        let captured = await capturedBirthday.value
+        XCTAssertNil(captured, "Nil birthday should be forwarded as nil to sdkSynchronizer.importAccount")
+    }
+
+    // Verifies the guard clause: when no zcashAccounts are set on state,
+    // .importAccount produces no effects and does not call the SDK.
+    func testImportAccount_withNoAccounts_isNoOp() async throws {
+        let store = TestStore(
+            initialState: .initial
+        ) {
+            AddKeystoneHWWallet()
+        }
+
+        store.dependencies.keystoneHandler = .noOp
+
+        await store.send(.importAccount(BlockHeight(1_700_000)))
+
+        await store.finish()
+    }
+
+    // End-to-end coordinator test: simulates the full birthday picker flow.
+    // Sets up the navigation path with an account selection and a wallet birthday (estimatedHeight = 1_700_000),
+    // then sends .restoreTapped. Verifies the coordinator reads the birthday from the path,
+    // calls performKeystoneImport, and the birthday value reaches sdkSynchronizer.importAccount.
+    func testCoordinator_restoreTapped_forwardsBirthdayToImportAccount() async throws {
+        let expectedBirthday = BlockHeight(1_700_000)
+        let capturedBirthday = ActorIsolated<BlockHeight?>(nil)
+
+        var accountSelectionState = AddKeystoneHWWallet.State.initial
+        accountSelectionState.zcashAccounts = try makeZcashAccounts()
+
+        var walletBirthdayState = WalletBirthday.State.initial
+        walletBirthdayState.estimatedHeight = expectedBirthday
+
+        var state = AddKeystoneHWWalletCoordFlow.State()
+        state.path.append(.accountHWWalletSelection(accountSelectionState))
+        state.path.append(.walletBirthday(walletBirthdayState))
+
+        let walletBirthdayID = state.path.ids.last!
+
+        let store = Store(
+            initialState: state
+        ) {
+            AddKeystoneHWWalletCoordFlow()
+        } withDependencies: {
+            $0.keystoneHandler = .noOp
+            $0.sdkSynchronizer = .mocked(
+                importAccount: { _, _, _, _, _, _, birthday in
+                    await capturedBirthday.setValue(birthday)
+                    return nil
+                }
+            )
+        }
+
+        await store.send(.path(.element(id: walletBirthdayID, action: .walletBirthday(.restoreTapped))))
+
+        // Give the effect time to run
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        let captured = await capturedBirthday.value
+        XCTAssertEqual(captured, expectedBirthday, "Coordinator should forward birthday into account import")
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/zodl-inc/zodl-ios/issues/1678

## Summary
- Adds wallet birthday picker to the Keystone hardware wallet import flow, matching the existing hot wallet restore UX
- Users can enter a block height manually or estimate from a date before the account is imported
- TODO: Updates SDK dependency to use `importAccount(walletBirthday:)` from https://github.com/zcash/zcash-swift-wallet-sdk/pull/1670 once tagged

## Motivation
Previously, adding a Keystone had no way to specify a birthday height. The SDK hardcoded it to the chain tip, causing the wallet to miss all historical notes/transactions. The only workaround was importing a hot wallet first and adding the keystone mid-sync.

## Testing
Manual testing with my keystone on my personal device

<table>
  <tr>
    <td><img width="330" alt="IMG_0664" src="https://github.com/user-attachments/assets/622e276f-37d1-4d29-924f-01c1ee4b4e81" /></td>
    <td><img width="330" alt="IMG_0665" src="https://github.com/user-attachments/assets/07e0ef48-1472-468a-8a85-e926d6986bb5" /></td>
  </tr>
</table>

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [x] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes?
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.

# Reviewer
- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.