### PR TITLE
[#1688] Keystone firmware version check on signed PCZTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Added
+- Keystone firmware version check on signed PCZTs. Zodl now reads the firmware version stamp from signed PCZT responses and blocks broadcast if the device firmware is too old or unrecognized.
+
 ## 3.3.0 build 2 (2026-04-07)
 
 ### Added

--- a/modules/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/modules/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -126,6 +126,22 @@ extension ScanCoordFlow {
                 }
                 return .none
 
+            case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
+                for (id, element) in zip(state.path.ids, state.path) {
+                    if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        while let lastId = state.path.ids.last, lastId != id {
+                            state.path.removeLast()
+                        }
+                        state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                        break
+                    }
+                }
+                return .none
+
+            case .path(.element(id: _, action: .keystoneFirmwareUpdate(.dismissKeystoneFirmwareUpdate))):
+                let _ = state.path.popLast()
+                return .none
+
             case .path(.element(id: _, action: .confirmWithKeystone(.updateResult(let result)))):
                 for element in state.path {
                     if case .confirmWithKeystone(let sendConfirmationState) = element {

--- a/modules/Sources/Features/CoordFlows/ScanCoordFlowStore.swift
+++ b/modules/Sources/Features/CoordFlows/ScanCoordFlowStore.swift
@@ -30,6 +30,7 @@ public struct ScanCoordFlow {
         case addressBook(AddressBook)
         case addressBookContact(AddressBook)
         case confirmWithKeystone(SendConfirmation)
+        case keystoneFirmwareUpdate(SendConfirmation)
         case preSendingFailure(SendConfirmation)
         case requestZecConfirmation(SendConfirmation)
         case scan(Scan)

--- a/modules/Sources/Features/CoordFlows/ScanCoordFlowView.swift
+++ b/modules/Sources/Features/CoordFlows/ScanCoordFlowView.swift
@@ -48,6 +48,8 @@ public struct ScanCoordFlowView: View {
                     AddressBookContactView(store: store)
                 case let .confirmWithKeystone(store):
                     SignWithKeystoneView(store: store, tokenName: tokenName)
+                case let .keystoneFirmwareUpdate(store):
+                    KeystoneFirmwareUpdateView(store: store)
                 case let .preSendingFailure(store):
                     PreSendingFailureView(store: store, tokenName: tokenName)
                 case let .scan(store):

--- a/modules/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
+++ b/modules/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
@@ -117,6 +117,30 @@ extension SendCoordFlow {
                 }
                 return .none
 
+            case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
+                // The signed PCZT came back with a firmware version below the
+                // wallet's minimum (or no stamp at all). Pop anything that was
+                // pushed on top of the confirmWithKeystone element (the just-
+                // added .sending view, and the .scan view below it) so the
+                // user sees the update screen instead of the stuck Sending
+                // spinner, then push the KeystoneFirmwareUpdateView.
+                for (id, element) in zip(state.path.ids, state.path) {
+                    if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        while let lastId = state.path.ids.last, lastId != id {
+                            state.path.removeLast()
+                        }
+                        state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                        break
+                    }
+                }
+                return .none
+
+            case .path(.element(id: _, action: .keystoneFirmwareUpdate(.dismissKeystoneFirmwareUpdate))):
+                // User tapped Close on the update screen — pop back to the
+                // confirmWithKeystone element so they can cancel or retry.
+                let _ = state.path.popLast()
+                return .none
+
             case .path(.element(id: _, action: .confirmWithKeystone(.updateResult(let result)))):
                 for element in state.path {
                     if case .confirmWithKeystone(let sendConfirmationState) = element {

--- a/modules/Sources/Features/CoordFlows/SendCoordFlowStore.swift
+++ b/modules/Sources/Features/CoordFlows/SendCoordFlowStore.swift
@@ -27,6 +27,7 @@ public struct SendCoordFlow {
         case addressBook(AddressBook)
         case addressBookContact(AddressBook)
         case confirmWithKeystone(SendConfirmation)
+        case keystoneFirmwareUpdate(SendConfirmation)
         case preSendingFailure(SendConfirmation)
         case requestZecConfirmation(SendConfirmation)
         case scan(Scan)

--- a/modules/Sources/Features/CoordFlows/SendCoordFlowView.swift
+++ b/modules/Sources/Features/CoordFlows/SendCoordFlowView.swift
@@ -57,6 +57,8 @@ public struct SendCoordFlowView: View {
                     AddressBookContactView(store: store)
                 case let .confirmWithKeystone(store):
                     SignWithKeystoneView(store: store, tokenName: tokenName)
+                case let .keystoneFirmwareUpdate(store):
+                    KeystoneFirmwareUpdateView(store: store)
                 case let .preSendingFailure(store):
                     PreSendingFailureView(store: store, tokenName: tokenName)
                 case let .scan(store):

--- a/modules/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowCoordinator.swift
+++ b/modules/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowCoordinator.swift
@@ -73,6 +73,18 @@ extension SignWithKeystoneCoordFlow {
                 }
                 return .none
                 
+            case .sendConfirmation(.keystoneFirmwareUpdateRequired):
+                // Firmware stamp missing or below the wallet's minimum. Push
+                // the "Update your Keystone to continue" screen.
+                state.path.append(.keystoneFirmwareUpdate(state.sendConfirmationState))
+                return .none
+
+            case .path(.element(id: _, action: .keystoneFirmwareUpdate(.dismissKeystoneFirmwareUpdate))):
+                // User dismissed the update-required screen. Pop back to the
+                // previous step so they can retry after updating.
+                let _ = state.path.popLast()
+                return .send(.sendConfirmation(.dismissKeystoneFirmwareUpdate))
+
             case .sendConfirmation(.pcztSendFailed(let error)):
                 if state.path.ids.isEmpty {
                     state.path.append(.preSendingFailure(state.sendConfirmationState))

--- a/modules/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowStore.swift
+++ b/modules/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowStore.swift
@@ -22,6 +22,7 @@ import TransactionDetails
 public struct SignWithKeystoneCoordFlow {
     @Reducer
     public enum Path {
+        case keystoneFirmwareUpdate(SendConfirmation)
         case preSendingFailure(SendConfirmation)
         case scan(Scan)
         case sending(SendConfirmation)

--- a/modules/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowView.swift
+++ b/modules/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowView.swift
@@ -41,6 +41,8 @@ public struct SignWithKeystoneCoordFlowView: View {
                 .navigationBarHidden(true)
             } destination: { store in
                 switch store.case {
+                case let .keystoneFirmwareUpdate(store):
+                    KeystoneFirmwareUpdateView(store: store)
                 case let .preSendingFailure(store):
                     PreSendingFailureView(store: store, tokenName: tokenName)
                 case let .scan(store):

--- a/modules/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
+++ b/modules/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
@@ -118,6 +118,22 @@ extension SwapAndPayCoordFlow {
                 }
                 return .none
 
+            case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
+                for (id, element) in zip(state.path.ids, state.path) {
+                    if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        while let lastId = state.path.ids.last, lastId != id {
+                            state.path.removeLast()
+                        }
+                        state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                        break
+                    }
+                }
+                return .none
+
+            case .path(.element(id: _, action: .keystoneFirmwareUpdate(.dismissKeystoneFirmwareUpdate))):
+                let _ = state.path.popLast()
+                return .none
+
             case .path(.element(id: _, action: .confirmWithKeystone(.updateResult(let result)))):
                 for (_, element) in zip(state.path.ids, state.path) {
                     if case .confirmWithKeystone(let sendConfirmationState) = element {

--- a/modules/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
+++ b/modules/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
@@ -34,6 +34,7 @@ public struct SwapAndPayCoordFlow {
         case addressBookContact(AddressBook)
         case confirmWithKeystone(SendConfirmation)
         case crossPayConfirmation(SwapAndPay)
+        case keystoneFirmwareUpdate(SendConfirmation)
         case preSendingFailure(SendConfirmation)
         case scan(Scan)
         case sending(SendConfirmation)

--- a/modules/Sources/Features/CoordFlows/SwapAndPayCoordFlowView.swift
+++ b/modules/Sources/Features/CoordFlows/SwapAndPayCoordFlowView.swift
@@ -85,6 +85,8 @@ public struct SwapAndPayCoordFlowView: View {
                         AddressBookContactView(store: store)
                     case let .confirmWithKeystone(store):
                         SignWithKeystoneView(store: store, tokenName: tokenName)
+                    case let .keystoneFirmwareUpdate(store):
+                        KeystoneFirmwareUpdateView(store: store)
                     case let .crossPayConfirmation(store):
                         CrossPayConfirmationView(store: store, tokenName: tokenName)
                     case let .preSendingFailure(store):

--- a/modules/Sources/Features/SendConfirmation/KeystoneFirmwareUpdateView.swift
+++ b/modules/Sources/Features/SendConfirmation/KeystoneFirmwareUpdateView.swift
@@ -1,0 +1,94 @@
+//
+//  KeystoneFirmwareUpdateView.swift
+//  Zashi
+//
+//  Shown when a signed PCZT comes back from Keystone but the firmware
+//  version stamp (from `global.proprietary["keystone:fw_version"]`) is below
+//  Zashi's required minimum, or absent (legacy firmware). Blocks broadcast
+//  until the user updates their Keystone.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+import Generated
+import UIComponents
+import Utils
+
+public struct KeystoneFirmwareUpdateView: View {
+    @Perception.Bindable var store: StoreOf<SendConfirmation>
+
+    public init(store: StoreOf<SendConfirmation>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                Spacer()
+
+                // Reuse the existing failure illustration set to stay within
+                // the same visual language as PreSendingFailureView. A
+                // dedicated Keystone-update illustration is a follow-up.
+                store.failureIlustration
+                    .resizable()
+                    .frame(width: 148, height: 148)
+
+                Text(String(localizable: .keystoneFirmwareUpdateTitle))
+                    .zFont(.semiBold, size: 28, style: Design.Text.primary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 16)
+
+                Text(bodyCopy)
+                    .zFont(size: 14, style: Design.Text.primary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(1.5)
+                    .screenHorizontalPadding()
+                    .padding(.top, 12)
+
+                Text(String(localizable: .keystoneFirmwareUpdateHowToUpdate))
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(1.5)
+                    .screenHorizontalPadding()
+                    .padding(.top, 16)
+
+                Spacer()
+
+                ZashiButton(String(localizable: .keystoneFirmwareUpdateDismissButton)) {
+                    store.send(.dismissKeystoneFirmwareUpdate)
+                }
+                .padding(.bottom, 24)
+            }
+            .navigationBarBackButtonHidden()
+            .padding(.vertical, 1)
+            .screenHorizontalPadding()
+            .applyFailureScreenBackground()
+        }
+    }
+
+    /// The body copy varies on whether the firmware reported a version.
+    ///
+    /// - `detected != nil`: "This feature requires Keystone firmware X.Y.Z or
+    ///   newer. Your device is on A.B.C."
+    /// - `detected == nil`: "Your Keystone does not report its firmware
+    ///   version. Please update to the latest version to continue."
+    private var bodyCopy: String {
+        if let detected = store.detectedKeystoneFirmware {
+            return String(
+                localizable: .keystoneFirmwareUpdateBodyOutdated(
+                    store.requiredKeystoneFirmware.displayString,
+                    detected.displayString
+                )
+            )
+        } else {
+            return String(localizable: .keystoneFirmwareUpdateBodyLegacy)
+        }
+    }
+}
+
+#Preview {
+    NavigationView {
+        KeystoneFirmwareUpdateView(store: SendConfirmation.initial)
+    }
+}

--- a/modules/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
+++ b/modules/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
@@ -1,0 +1,90 @@
+//
+//  KeystoneFirmwareVersion.swift
+//  Zashi
+//
+//  Reads the firmware version stamp that Keystone writes into every signed
+//  PCZT via `global.proprietary["keystone:fw_version"]` and evaluates it
+//  against the wallet's minimum-required policy.
+//
+
+import Foundation
+
+/// Three-byte Keystone firmware version triple, matching the
+/// `SOFTWARE_VERSION_{MAJOR,MINOR,BUILD}` ordering used by
+/// `src/config/version.h` in the keystone3-firmware repo.
+public struct KeystoneFirmwareVersion: Equatable, Comparable, Hashable {
+    public let major: UInt8
+    public let minor: UInt8
+    public let build: UInt8
+
+    public init(major: UInt8, minor: UInt8, build: UInt8) {
+        self.major = major
+        self.minor = minor
+        self.build = build
+    }
+
+    public static func < (lhs: KeystoneFirmwareVersion, rhs: KeystoneFirmwareVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.build < rhs.build
+    }
+
+    /// Human-readable "M.N.B" form for UI copy.
+    public var displayString: String {
+        "\(major).\(minor).\(build)"
+    }
+}
+
+public extension Data {
+    /// Scans a signed PCZT's bytes for the Keystone firmware version stamp.
+    ///
+    /// The firmware stamps `global.proprietary["keystone:fw_version"] = [M, N, B]`
+    /// on every signed response. Because `Pczt` is an opaque `Data` blob on
+    /// the Swift side (no FFI exposes proprietary fields), we locate the ASCII
+    /// key literal and read the postcard-encoded value that follows.
+    ///
+    /// Postcard encodes `BTreeMap<String, Vec<u8>>` entries as
+    /// `varint len → utf8 bytes → varint len → value bytes`. For a 3-byte value
+    /// the length byte is `0x03`, so we verify that and read the next 3 bytes.
+    ///
+    /// Returns `nil` if the stamp is absent (legacy firmware) or malformed.
+    ///
+    /// Production-quality follow-up: replace this scanner with a proper FFI
+    /// helper in `zcash-swift-wallet-sdk` (see
+    /// `zcashlc_pczt_requires_sapling_proofs` as a template).
+    func readKeystoneFwVersion() -> KeystoneFirmwareVersion? {
+        let key = Data("keystone:fw_version".utf8)
+        guard let range = self.range(of: key) else { return nil }
+        let valueStart = range.upperBound
+        // Need at least `0x03` + 3 version bytes after the key.
+        guard valueStart + 4 <= self.endIndex, self[valueStart] == 0x03 else {
+            return nil
+        }
+        return KeystoneFirmwareVersion(
+            major: self[valueStart + 1],
+            minor: self[valueStart + 2],
+            build: self[valueStart + 3]
+        )
+    }
+}
+
+/// Policy for deciding whether to broadcast a Keystone-signed transaction
+/// given the detected firmware version.
+public enum KeystoneFirmwarePolicy {
+    public enum Outcome: Equatable {
+        /// Firmware reports a version and it meets the minimum.
+        case ok
+        /// Firmware reports a version but it's below the minimum.
+        case updateRequired
+        /// Firmware did not stamp a version. Pre-negotiation (legacy) build.
+        case legacy
+    }
+
+    public static func evaluate(
+        detected: KeystoneFirmwareVersion?,
+        required: KeystoneFirmwareVersion
+    ) -> Outcome {
+        guard let detected else { return .legacy }
+        return detected >= required ? .ok : .updateRequired
+    }
+}

--- a/modules/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/modules/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -31,6 +31,12 @@ import AddressBook
 public struct SendConfirmation {
     enum Constants {
         static let delay = 1.0
+        /// Minimum Keystone firmware version Zashi requires for Keystone-signed
+        /// transactions. Bump this to force the "Update your Keystone" flow
+        /// during QA. Defaults to the firmware-side demo version (12.4.0).
+        /// Set to a real version (e.g. 12.5.0) to activate the firmware
+        /// version check. At (0, 0, 0) the check is skipped entirely.
+        static let minimumKeystoneFirmware = KeystoneFirmwareVersion(major: 0, minor: 0, build: 0)
     }
     
     @ObservableState
@@ -65,6 +71,14 @@ public struct SendConfirmation {
         public var feeRequired: Zatoshi
         public var isAddressExpanded = false
         public var isKeystoneCodeFound = false
+        /// Last firmware version we read from a signed PCZT's
+        /// `global.proprietary["keystone:fw_version"]` stamp. `nil` means the
+        /// device either hasn't been scanned yet or is legacy firmware that
+        /// doesn't report a version.
+        public var detectedKeystoneFirmware: KeystoneFirmwareVersion?
+        /// Minimum Keystone firmware Zashi requires to broadcast the
+        /// transaction. Surfaced on the "Update your Keystone" screen.
+        public var requiredKeystoneFirmware: KeystoneFirmwareVersion = Constants.minimumKeystoneFirmware
         public var isQRCodeEnlarged = false
         public var isSending = false
         public var isShielding = false
@@ -183,6 +197,14 @@ public struct SendConfirmation {
         case backFromPCZTFailureTapped
         case createTransactionFromPCZT
         case foundPCZT(Pczt)
+        /// Emitted when the firmware version stamp on an inbound signed PCZT
+        /// is below `Constants.minimumKeystoneFirmware` (or absent → legacy).
+        /// The coordinator turns this into a navigation push to the
+        /// `KeystoneFirmwareUpdateView` screen.
+        case keystoneFirmwareUpdateRequired(detected: KeystoneFirmwareVersion?)
+        /// User tapped "Close" on the "Update your Keystone" screen. Clears
+        /// the scanned PCZT so the user can retry after updating.
+        case dismissKeystoneFirmwareUpdate
         case pcztResolved(Pczt)
         case pcztSendFailed(ZcashError?)
         case pcztWithProofsResolved(Pczt)
@@ -216,7 +238,12 @@ public struct SendConfirmation {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                state.pcztForUI = nil
+                // Only clear the QR when there's no existing redacted PCZT.
+                // On re-appear (e.g. returning from the firmware-update screen)
+                // we want to keep showing the request QR so the user can retry.
+                if state.redactedPcztForSigner == nil {
+                    state.pcztForUI = nil
+                }
                 state.rejectSendRequest = false
                 state.txIdToExpand = nil
                 state.randomSuccessIconIndex = Int.random(in: 1...2)
@@ -445,11 +472,48 @@ public struct SendConfirmation {
                 if !state.isKeystoneCodeFound {
                     state.isKeystoneCodeFound = true
                     state.pcztWithSigs = pcztWithSigs
-                    return .run { send in
-                        try? await mainQueue.sleep(for: .seconds(Constants.delay))
-                        await send(.createTransactionFromPCZT)
+
+                    // Keystone firmware version gate. Skipped when the minimum
+                    // is (0, 0, 0) — set Constants.minimumKeystoneFirmware to
+                    // a real version to activate.
+                    let required = state.requiredKeystoneFirmware
+                    if required == KeystoneFirmwareVersion(major: 0, minor: 0, build: 0) {
+                        return .run { send in
+                            try? await mainQueue.sleep(for: .seconds(Constants.delay))
+                            await send(.createTransactionFromPCZT)
+                        }
+                    }
+
+                    let detected = pcztWithSigs.readKeystoneFwVersion()
+                    state.detectedKeystoneFirmware = detected
+                    switch KeystoneFirmwarePolicy.evaluate(
+                        detected: detected,
+                        required: required
+                    ) {
+                    case .ok:
+                        return .run { send in
+                            try? await mainQueue.sleep(for: .seconds(Constants.delay))
+                            await send(.createTransactionFromPCZT)
+                        }
+                    case .updateRequired, .legacy:
+                        return .send(.keystoneFirmwareUpdateRequired(detected: detected))
                     }
                 }
+                return .none
+
+            case .keystoneFirmwareUpdateRequired:
+                // The coordinator catches this action and pushes the
+                // KeystoneFirmwareUpdateView path element. Nothing to do on
+                // the reducer side beyond that; we intentionally keep
+                // `detectedKeystoneFirmware` populated so the view can read
+                // it for the copy.
+                return .none
+
+            case .dismissKeystoneFirmwareUpdate:
+                state.isKeystoneCodeFound = false
+                state.pcztWithSigs = nil
+                state.detectedKeystoneFirmware = nil
+                keystoneHandler.resetQRDecoder()
                 return .none
 
             case .resolvePCZT:

--- a/modules/Sources/Generated/Localizable.xcstrings
+++ b/modules/Sources/Generated/Localizable.xcstrings
@@ -3448,6 +3448,62 @@
         }
       }
     },
+    "keystone.firmwareUpdate.bodyLegacy" : {
+      "comment" : "MARK: Keystone firmware update required",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Keystone does not report its firmware version. Please update to the latest version to continue."
+          }
+        }
+      }
+    },
+    "keystone.firmwareUpdate.bodyOutdated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This action requires Keystone firmware %@ or newer. Your device is on %@."
+          }
+        }
+      }
+    },
+    "keystone.firmwareUpdate.dismissButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        }
+      }
+    },
+    "keystone.firmwareUpdate.howToUpdate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the Keystone companion app on your phone to update your device."
+          }
+        }
+      }
+    },
+    "keystone.firmwareUpdate.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update your Keystone to continue"
+          }
+        }
+      }
+    },
     "keystone.scanInfo" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secantTests/SendTests/KeystoneFirmwareTests.swift
+++ b/secantTests/SendTests/KeystoneFirmwareTests.swift
@@ -1,0 +1,265 @@
+//
+//  KeystoneFirmwareTests.swift
+//  secantTests
+//
+//  Covers the Keystone firmware version stamp reader, the update-required
+//  policy, and the SendConfirmation reducer branching on `.foundPCZT`.
+//
+
+import XCTest
+import ComposableArchitecture
+import SendConfirmation
+@testable import secant_testnet
+
+final class KeystoneFirmwareTests: XCTestCase {
+    // MARK: - Helpers
+
+    /// Builds a synthetic PCZT-shaped byte blob that mimics the relevant
+    /// portion of `global.proprietary` as serialized by `postcard`. The
+    /// scanner only cares about the literal key bytes followed by a `0x03`
+    /// length byte and the 3 version bytes, so we don't need a real PCZT.
+    private func stampedBlob(major: UInt8, minor: UInt8, build: UInt8) -> Data {
+        var bytes = Data()
+        // Magic-ish prefix + padding so the match isn't at the very start.
+        bytes.append(contentsOf: [0x50, 0x43, 0x5A, 0x54, 0x01, 0x00, 0x00, 0x00])
+        bytes.append(contentsOf: Array(repeating: UInt8(0xAA), count: 16))
+        // "keystone:fw_version" (19 ASCII bytes) — postcard writes a varint
+        // length before the string, but our scanner only matches the key
+        // literal, so the preceding length byte is irrelevant. We include a
+        // plausible 0x13 (19) before it to match real postcard layout.
+        bytes.append(0x13)
+        bytes.append(contentsOf: Data("keystone:fw_version".utf8))
+        // Vec<u8> length + 3 value bytes.
+        bytes.append(0x03)
+        bytes.append(major)
+        bytes.append(minor)
+        bytes.append(build)
+        // Trailing garbage to make sure the scanner doesn't over-read.
+        bytes.append(contentsOf: Array(repeating: UInt8(0xCC), count: 32))
+        return bytes
+    }
+
+    private func unstampedBlob() -> Data {
+        // Arbitrary bytes that do not contain the key literal anywhere.
+        Data(repeating: 0x55, count: 256)
+    }
+
+    // MARK: - Scanner
+
+    func test_readKeystoneFwVersion_onStampedBlob_returnsVersion() {
+        let blob = stampedBlob(major: 12, minor: 4, build: 0)
+        let version = blob.readKeystoneFwVersion()
+        XCTAssertEqual(version, KeystoneFirmwareVersion(major: 12, minor: 4, build: 0))
+    }
+
+    func test_readKeystoneFwVersion_onUnstampedBlob_returnsNil() {
+        XCTAssertNil(unstampedBlob().readKeystoneFwVersion())
+    }
+
+    func test_readKeystoneFwVersion_onStampedBlobWithUnusualVersion_returnsVersion() {
+        let blob = stampedBlob(major: 99, minor: 255, build: 1)
+        XCTAssertEqual(
+            blob.readKeystoneFwVersion(),
+            KeystoneFirmwareVersion(major: 99, minor: 255, build: 1)
+        )
+    }
+
+    func test_readKeystoneFwVersion_onTruncatedBlob_returnsNil() {
+        // Key present but fewer than 3 value bytes follow the 0x03 length.
+        var bytes = Data([0x13])
+        bytes.append(contentsOf: Data("keystone:fw_version".utf8))
+        bytes.append(contentsOf: [0x03, 0x0c, 0x04]) // only 2 of 3 bytes
+        XCTAssertNil(bytes.readKeystoneFwVersion())
+    }
+
+    func test_readKeystoneFwVersion_onWrongLengthByte_returnsNil() {
+        // Key present but length byte says 4, not 3.
+        var bytes = Data([0x13])
+        bytes.append(contentsOf: Data("keystone:fw_version".utf8))
+        bytes.append(contentsOf: [0x04, 0x0c, 0x04, 0x00, 0xff])
+        XCTAssertNil(bytes.readKeystoneFwVersion())
+    }
+
+    // MARK: - Version ordering
+
+    func test_version_ordering_isLexicographic() {
+        XCTAssertLessThan(
+            KeystoneFirmwareVersion(major: 12, minor: 4, build: 0),
+            KeystoneFirmwareVersion(major: 12, minor: 4, build: 1)
+        )
+        XCTAssertLessThan(
+            KeystoneFirmwareVersion(major: 12, minor: 4, build: 0),
+            KeystoneFirmwareVersion(major: 12, minor: 5, build: 0)
+        )
+        XCTAssertLessThan(
+            KeystoneFirmwareVersion(major: 12, minor: 4, build: 0),
+            KeystoneFirmwareVersion(major: 13, minor: 0, build: 0)
+        )
+        XCTAssertEqual(
+            KeystoneFirmwareVersion(major: 12, minor: 4, build: 0),
+            KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+        )
+    }
+
+    func test_version_displayString_formatsCorrectly() {
+        XCTAssertEqual(
+            KeystoneFirmwareVersion(major: 12, minor: 4, build: 0).displayString,
+            "12.4.0"
+        )
+    }
+
+    // MARK: - Policy
+
+    func test_policy_detectedAboveRequired_returnsOk() {
+        XCTAssertEqual(
+            KeystoneFirmwarePolicy.evaluate(
+                detected: KeystoneFirmwareVersion(major: 12, minor: 5, build: 0),
+                required: KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+            ),
+            .ok
+        )
+    }
+
+    func test_policy_detectedEqualToRequired_returnsOk() {
+        XCTAssertEqual(
+            KeystoneFirmwarePolicy.evaluate(
+                detected: KeystoneFirmwareVersion(major: 12, minor: 4, build: 0),
+                required: KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+            ),
+            .ok
+        )
+    }
+
+    func test_policy_detectedBelowRequired_returnsUpdateRequired() {
+        XCTAssertEqual(
+            KeystoneFirmwarePolicy.evaluate(
+                detected: KeystoneFirmwareVersion(major: 12, minor: 4, build: 0),
+                required: KeystoneFirmwareVersion(major: 13, minor: 0, build: 0)
+            ),
+            .updateRequired
+        )
+    }
+
+    func test_policy_noDetectedVersion_returnsLegacy() {
+        XCTAssertEqual(
+            KeystoneFirmwarePolicy.evaluate(
+                detected: nil,
+                required: KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+            ),
+            .legacy
+        )
+    }
+
+    // MARK: - TCA reducer: `.foundPCZT` branching
+
+    /// A PCZT whose firmware stamp meets the wallet's requirement must
+    /// proceed straight into `createTransactionFromPCZT` as before.
+    @MainActor
+    func test_reducer_foundPCZT_okFirmware_schedulesCreateTransaction() async {
+        var initialState = SendConfirmation.State.initial
+        initialState.requiredKeystoneFirmware = KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+
+        let store = TestStore(initialState: initialState) {
+            SendConfirmation()
+        }
+        store.dependencies.mainQueue = .immediate
+
+        let pczt = stampedBlob(major: 12, minor: 4, build: 0)
+        await store.send(.foundPCZT(pczt)) { state in
+            state.isKeystoneCodeFound = true
+            state.pcztWithSigs = pczt
+            state.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+        }
+        await store.receive(.createTransactionFromPCZT)
+        // Downstream effects from createTransactionFromPCZT are outside the
+        // scope of this test; cancel the store to prevent dangling work.
+        await store.finish(timeout: .seconds(1))
+    }
+
+    /// A PCZT whose firmware stamp is *below* the requirement must emit
+    /// `.keystoneFirmwareUpdateRequired(detected:)` and NOT proceed to
+    /// broadcast.
+    @MainActor
+    func test_reducer_foundPCZT_tooOldFirmware_emitsUpdateRequired() async {
+        var initialState = SendConfirmation.State.initial
+        initialState.requiredKeystoneFirmware = KeystoneFirmwareVersion(major: 13, minor: 0, build: 0)
+
+        let store = TestStore(initialState: initialState) {
+            SendConfirmation()
+        }
+        store.dependencies.mainQueue = .immediate
+
+        let pczt = stampedBlob(major: 12, minor: 4, build: 0)
+        await store.send(.foundPCZT(pczt)) { state in
+            state.isKeystoneCodeFound = true
+            state.pcztWithSigs = pczt
+            state.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+        }
+        await store.receive(.keystoneFirmwareUpdateRequired(
+            detected: KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+        ))
+    }
+
+    /// When minimumKeystoneFirmware is (0, 0, 0), the version check is
+    /// skipped entirely — legacy and stamped firmware both proceed.
+    @MainActor
+    func test_reducer_foundPCZT_zeroMinVersion_skipsCheck() async {
+        var initialState = SendConfirmation.State.initial
+        initialState.requiredKeystoneFirmware = KeystoneFirmwareVersion(major: 0, minor: 0, build: 0)
+
+        let store = TestStore(initialState: initialState) {
+            SendConfirmation()
+        }
+        store.dependencies.mainQueue = .immediate
+
+        let pczt = unstampedBlob()
+        await store.send(.foundPCZT(pczt)) { state in
+            state.isKeystoneCodeFound = true
+            state.pcztWithSigs = pczt
+        }
+        await store.receive(.createTransactionFromPCZT)
+        await store.finish(timeout: .seconds(1))
+    }
+
+    /// When minimumKeystoneFirmware is set to a real version, a PCZT
+    /// with no firmware stamp (legacy device) emits
+    /// `.keystoneFirmwareUpdateRequired`.
+    @MainActor
+    func test_reducer_foundPCZT_legacyFirmware_emitsUpdateRequired() async {
+        var initialState = SendConfirmation.State.initial
+        initialState.requiredKeystoneFirmware = KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+
+        let store = TestStore(initialState: initialState) {
+            SendConfirmation()
+        }
+        store.dependencies.mainQueue = .immediate
+
+        let pczt = unstampedBlob()
+        await store.send(.foundPCZT(pczt)) { state in
+            state.isKeystoneCodeFound = true
+            state.pcztWithSigs = pczt
+            state.detectedKeystoneFirmware = nil
+        }
+        await store.receive(.keystoneFirmwareUpdateRequired(detected: nil))
+    }
+
+    /// The dismiss action clears the scanned PCZT and the detected firmware
+    /// so the user can retry after updating.
+    @MainActor
+    func test_reducer_dismissKeystoneFirmwareUpdate_clearsScannedState() async {
+        var initialState = SendConfirmation.State.initial
+        initialState.isKeystoneCodeFound = true
+        initialState.pcztWithSigs = stampedBlob(major: 12, minor: 4, build: 0)
+        initialState.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)
+
+        let store = TestStore(initialState: initialState) {
+            SendConfirmation()
+        }
+
+        await store.send(.dismissKeystoneFirmwareUpdate) { state in
+            state.isKeystoneCodeFound = false
+            state.pcztWithSigs = nil
+            state.detectedKeystoneFirmware = nil
+        }
+    }
+}


### PR DESCRIPTION
Closes #1688

## Summary

When Zodl scans a signed PCZT back from Keystone, it now attempts to read `global.proprietary["keystone:fw_version"]` (3 bytes: major, minor, build) and compares it to a wallet-side minimum. 

Three outcomes:

- **Version greater than or equal to min version** → transaction proceeds to broadcast (no behavior change)
- **Version less than min version** → "Update your Keystone to continue" screen, broadcast blocked
- **No stamp (legacy firmware)** → same update screen, broadcast blocked

The firmware side (stamping the version into signed PCZTs) is in KeystoneHQ/keystone3-firmware#2134.

## Changes

- `KeystoneFirmwareVersion.swift` — `Version` struct, byte-scanner that reads the stamp from raw PCZT bytes, and `KeystoneFirmwarePolicy` evaluator.
- `KeystoneFirmwareUpdateView.swift` — "Update your Keystone" screen mirroring `PreSendingFailureView`.
- `SendConfirmationStore.swift` — version check in `.foundPCZT`, new actions and state fields.
- All four coord flows (SignWithKeystone, Send, SwapAndPay, Scan) — path case, coordinator routing, and view wiring for the update screen.
- `Localizable.xcstrings` — 5 new English strings.
- `KeystoneFirmwareTests.swift` — scanner, policy, and TCA reducer tests.

## Testing

This was tested against the modified Keystone firmware

Version meets minimum version requirement (this is the same flow today, but [I tested it anyway if interested in watching](https://github.com/user-attachments/assets/6cd9f4e9-4557-4ad6-a7b9-46c58ad245fe))

Version mismatch:

https://github.com/user-attachments/assets/f5ed92c8-9a4a-4c99-9680-a037b95c7527

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [x] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes?
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.