### PR TITLE
Use @preconcurrency on import of packages which aren't migrated to swift concurrency yet

### DIFF
--- a/secant/Sources/AppDelegate.swift
+++ b/secant/Sources/AppDelegate.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import Network
 
 import BackgroundTasks

--- a/secant/Sources/Dependencies/AddressBookClient/AddressBookEncryption.swift
+++ b/secant/Sources/Dependencies/AddressBookClient/AddressBookEncryption.swift
@@ -9,7 +9,7 @@ import ComposableArchitecture
 
 import Foundation
 import CryptoKit
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension AddressBookClient {
     static func serializeContacts(_ abContacts: AddressBookContacts) -> Data {

--- a/secant/Sources/Dependencies/AddressBookClient/AddressBookInterface.swift
+++ b/secant/Sources/Dependencies/AddressBookClient/AddressBookInterface.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var addressBook: AddressBookClient {

--- a/secant/Sources/Dependencies/AddressBookClient/AddressBookLiveKey.swift
+++ b/secant/Sources/Dependencies/AddressBookClient/AddressBookLiveKey.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
-import Combine
+@preconcurrency import Combine
 
 import CryptoKit
 

--- a/secant/Sources/Dependencies/AudioServices/AudioServicesInterface.swift
+++ b/secant/Sources/Dependencies/AudioServices/AudioServicesInterface.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import AVFoundation
+@preconcurrency import AVFoundation
 
 extension DependencyValues {
     var audioServices: AudioServicesClient {

--- a/secant/Sources/Dependencies/AudioServices/AudioServicesLiveKey.swift
+++ b/secant/Sources/Dependencies/AudioServices/AudioServicesLiveKey.swift
@@ -5,7 +5,7 @@
 //  Created by Lukáš Korba on 11.11.2022.
 //
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import ComposableArchitecture
 
 extension AudioServicesClient: DependencyKey {

--- a/secant/Sources/Dependencies/BalanceFormatter/BalanceFormatterInterface.swift
+++ b/secant/Sources/Dependencies/BalanceFormatter/BalanceFormatterInterface.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var balanceFormatter: BalanceFormatterClient {

--- a/secant/Sources/Dependencies/BalanceFormatter/ZatoshiStringRepresentation.swift
+++ b/secant/Sources/Dependencies/BalanceFormatter/ZatoshiStringRepresentation.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ComposableArchitecture
 
 struct ZatoshiStringRepresentation: Equatable {

--- a/secant/Sources/Dependencies/CaptureDevice/CaptureDeviceLiveKey.swift
+++ b/secant/Sources/Dependencies/CaptureDevice/CaptureDeviceLiveKey.swift
@@ -5,7 +5,7 @@
 //  Created by Lukáš Korba on 11.11.2022.
 //
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import ComposableArchitecture
 
 extension CaptureDeviceClient: DependencyKey {

--- a/secant/Sources/Dependencies/DatabaseFiles/DatabaseFiles.swift
+++ b/secant/Sources/Dependencies/DatabaseFiles/DatabaseFiles.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct DatabaseFiles {
     enum DatabaseFilesError: Error {

--- a/secant/Sources/Dependencies/DatabaseFiles/DatabaseFilesInterface.swift
+++ b/secant/Sources/Dependencies/DatabaseFiles/DatabaseFilesInterface.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var databaseFiles: DatabaseFilesClient {

--- a/secant/Sources/Dependencies/DatabaseFiles/DatabaseFilesLiveKey.swift
+++ b/secant/Sources/Dependencies/DatabaseFiles/DatabaseFilesLiveKey.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DatabaseFilesClient: DependencyKey {
     static let liveValue = DatabaseFilesClient.live()

--- a/secant/Sources/Dependencies/Deeplink/Deeplink.swift
+++ b/secant/Sources/Dependencies/Deeplink/Deeplink.swift
@@ -8,7 +8,7 @@
 import Foundation
 import URLRouting
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct Deeplink {
     enum Destination: Equatable {

--- a/secant/Sources/Dependencies/Deeplink/DeeplinkInterface.swift
+++ b/secant/Sources/Dependencies/Deeplink/DeeplinkInterface.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var deeplink: DeeplinkClient {

--- a/secant/Sources/Dependencies/DerivationTool/DerivationToolInterface.swift
+++ b/secant/Sources/Dependencies/DerivationTool/DerivationToolInterface.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var derivationTool: DerivationToolClient {

--- a/secant/Sources/Dependencies/DerivationTool/DerivationToolLiveKey.swift
+++ b/secant/Sources/Dependencies/DerivationTool/DerivationToolLiveKey.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DerivationToolClient: DependencyKey {
     static let liveValue = DerivationToolClient.live()

--- a/secant/Sources/Dependencies/DerivationTool/DerivationToolTestKey.swift
+++ b/secant/Sources/Dependencies/DerivationTool/DerivationToolTestKey.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 import XCTestDynamicOverlay
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DerivationToolClient: TestDependencyKey {
     static let testValue = Self(

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
@@ -6,9 +6,9 @@
 //
 
 import ComposableArchitecture
-import Combine
+@preconcurrency import Combine
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var exchangeRate: ExchangeRateClient {

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
@@ -6,10 +6,10 @@
 //
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 class ExchangeRateProvider {
     enum Constants {

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateTestKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateTestKey.swift
@@ -5,7 +5,7 @@
 //  Created by Lukáš Korba on 08-02-2024.
 //
 
-import Combine
+@preconcurrency import Combine
 
 extension ExchangeRateClient {
     static let noOp = Self(

--- a/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerInterface.swift
+++ b/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerInterface.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 import ComposableArchitecture
-import Combine
+@preconcurrency import Combine
 import Flexa
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var flexaHandler: FlexaHandlerClient {

--- a/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerLiveKey.swift
+++ b/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerLiveKey.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 import ComposableArchitecture
-import Combine
+@preconcurrency import Combine
 import Flexa
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import CryptoKit
 import UIKit
 

--- a/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerTestKey.swift
+++ b/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerTestKey.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 import XCTestDynamicOverlay
-import Combine
+@preconcurrency import Combine
 
 extension FlexaHandlerClient: TestDependencyKey {
     static let testValue = Self(

--- a/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerInterface.swift
+++ b/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerInterface.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import KeystoneSDK
+@preconcurrency import KeystoneSDK
 
 extension DependencyValues {
     var keystoneHandler: KeystoneHandlerClient {

--- a/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerLiveKey.swift
+++ b/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerLiveKey.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import KeystoneSDK
+@preconcurrency import KeystoneSDK
 
 class KeystoneSDKWrapper {
     let keystoneSDK = KeystoneSDK()

--- a/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerTestKey.swift
+++ b/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerTestKey.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 import XCTestDynamicOverlay
-import KeystoneSDK
+@preconcurrency import KeystoneSDK
 
 extension KeystoneHandlerClient: TestDependencyKey {
     static let testValue = Self(

--- a/secant/Sources/Dependencies/MnemonicClient/MnemonicLiveKey.swift
+++ b/secant/Sources/Dependencies/MnemonicClient/MnemonicLiveKey.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import MnemonicSwift
+@preconcurrency import MnemonicSwift
 
 extension MnemonicClient: DependencyKey {
     static let liveValue = Self(

--- a/secant/Sources/Dependencies/NetworkMonitor/NetworkMonitorInterface.swift
+++ b/secant/Sources/Dependencies/NetworkMonitor/NetworkMonitorInterface.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import Combine
+@preconcurrency import Combine
 
 extension DependencyValues {
     var networkMonitor: NetworkMonitorClient {

--- a/secant/Sources/Dependencies/NetworkMonitor/NetworkMonitorLiveKey.swift
+++ b/secant/Sources/Dependencies/NetworkMonitor/NetworkMonitorLiveKey.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Network
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 
 extension NetworkMonitorClient: DependencyKey {

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import URKit
 
 extension DependencyValues {

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -6,10 +6,10 @@
 //
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
-import ZcashLightClientKit
-import KeystoneSDK
+@preconcurrency import ZcashLightClientKit
+@preconcurrency import KeystoneSDK
 
 extension SDKSynchronizerClient: DependencyKey {
     static let liveValue: SDKSynchronizerClient = Self.live()

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 15.11.2022.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import URKit
 
 extension HTTPURLResponse {

--- a/secant/Sources/Dependencies/ShieldingProcessor/ShieldingProcessorInterface.swift
+++ b/secant/Sources/Dependencies/ShieldingProcessor/ShieldingProcessorInterface.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
-import Combine
+@preconcurrency import ZcashLightClientKit
+@preconcurrency import Combine
 
 extension DependencyValues {
     var shieldingProcessor: ShieldingProcessorClient {

--- a/secant/Sources/Dependencies/ShieldingProcessor/ShieldingProcessorLiveKey.swift
+++ b/secant/Sources/Dependencies/ShieldingProcessor/ShieldingProcessorLiveKey.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ComposableArchitecture
 import UIKit
-import Combine
+@preconcurrency import Combine
 
 extension ShieldingProcessorClient: DependencyKey {
     static let liveValue: ShieldingProcessorClient = Self.live()

--- a/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGenerator.swift
+++ b/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGenerator.swift
@@ -5,7 +5,7 @@
 //  Created by Michal Fousek on 28.02.2023.
 //
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import Foundation
 import LocalAuthentication
 import UIKit

--- a/secant/Sources/Dependencies/SwapAndPay/SwapAndPayLiveKey.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/SwapAndPayLiveKey.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Network
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 
 extension SwapAndPayClient: DependencyKey {

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuote.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuote.swift
@@ -5,7 +5,7 @@
 //  Created by Lukáš Korba on 2025-06-18.
 //
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import Foundation
 
 struct SwapQuote: Codable, Equatable, Hashable {

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct Near1Click {
     enum Constants {

--- a/secant/Sources/Dependencies/URIParser/RequestPaymentParser.swift
+++ b/secant/Sources/Dependencies/URIParser/RequestPaymentParser.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ZcashPaymentURI
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct RequestPaymentParser {
     let network: NetworkType 

--- a/secant/Sources/Dependencies/URIParser/URIParser.swift
+++ b/secant/Sources/Dependencies/URIParser/URIParser.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct URIParser {
     enum URIParserError: Error { }

--- a/secant/Sources/Dependencies/URIParser/URIParserInterface.swift
+++ b/secant/Sources/Dependencies/URIParser/URIParserInterface.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ZcashPaymentURI
 
 extension DependencyValues {

--- a/secant/Sources/Dependencies/UserMetadataProvider/UMSerialization.swift
+++ b/secant/Sources/Dependencies/UserMetadataProvider/UMSerialization.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import CryptoKit
 
 extension UserMetadata {

--- a/secant/Sources/Dependencies/UserMetadataProvider/UserMetadataProviderInterface.swift
+++ b/secant/Sources/Dependencies/UserMetadataProvider/UserMetadataProviderInterface.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var userMetadataProvider: UserMetadataProviderClient {

--- a/secant/Sources/Dependencies/UserMetadataProvider/UserMetadataStorage.swift
+++ b/secant/Sources/Dependencies/UserMetadataProvider/UserMetadataStorage.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ComposableArchitecture
 
 class UserMetadataStorage {

--- a/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift
+++ b/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 /// Live implementation of the `UserPreferences` using User Defaults
 /// according to https://developer.apple.com/documentation/foundation/userdefaults

--- a/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProvider.swift
+++ b/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProvider.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 
 struct WalletConfigProvider {
     /// Objects that fetches flags configuration from some source. It can be fetched from user defaults or some backend API for example. It depends

--- a/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderInterface.swift
+++ b/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderInterface.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 import Foundation
-import Combine
+@preconcurrency import Combine
 
 extension DependencyValues {
     var walletConfigProvider: WalletConfigProviderClient {

--- a/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderTestKey.swift
+++ b/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderTestKey.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 import XCTestDynamicOverlay
-import Combine
+@preconcurrency import Combine
 
 extension WalletConfigProviderClient: TestDependencyKey {
     static let testValue = Self(

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import MnemonicSwift
-import ZcashLightClientKit
+@preconcurrency import MnemonicSwift
+@preconcurrency import ZcashLightClientKit
 
 /// Zcash implementation of the keychain that is not universal but designed to deliver functionality needed by the wallet itself.
 /// All the APIs should be thread safe according to official doc:

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
@@ -6,8 +6,8 @@
 //
 
 import ComposableArchitecture
-import MnemonicSwift
-import ZcashLightClientKit
+@preconcurrency import MnemonicSwift
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var walletStorage: WalletStorageClient {

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageLiveKey.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageLiveKey.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import MnemonicSwift
-import ZcashLightClientKit
+@preconcurrency import MnemonicSwift
+@preconcurrency import ZcashLightClientKit
 import ComposableArchitecture
 
 extension WalletStorageClient: DependencyKey {

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension DependencyValues {
     var zcashSDKEnvironment: ZcashSDKEnvironment {

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
@@ -6,9 +6,12 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension ZcashSDKEnvironment {
+    
+    static let liveValue: ZcashSDKEnvironment = Self.live(network: TargetConstants.zcashNetwork)
+
     static func live(network: ZcashNetwork) -> Self {
         Self(
             latestCheckpoint: BlockHeight.ofLatestCheckpoint(network: network),

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import XCTestDynamicOverlay
 
 extension ZcashSDKEnvironment: TestDependencyKey {

--- a/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
+++ b/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 import ComposableArchitecture
-import KeystoneSDK
-import ZcashLightClientKit
+@preconcurrency import KeystoneSDK
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct AddKeystoneHWWallet {

--- a/secant/Sources/Features/AddressBook/AddressBookStore.swift
+++ b/secant/Sources/Features/AddressBook/AddressBookStore.swift
@@ -8,7 +8,7 @@
 import ComposableArchitecture
 import SwiftUI
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct AddressBook {

--- a/secant/Sources/Features/AddressDetails/AddressDetailsStore.swift
+++ b/secant/Sources/Features/AddressDetails/AddressDetailsStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct AddressDetails {

--- a/secant/Sources/Features/AddressDetails/AddressDetailsView.swift
+++ b/secant/Sources/Features/AddressDetails/AddressDetailsView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct AddressDetailsView: View {
     @Environment(\.colorScheme) var colorScheme

--- a/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
+++ b/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct Balances {

--- a/secant/Sources/Features/BalanceBreakdown/BalancesView.swift
+++ b/secant/Sources/Features/BalanceBreakdown/BalancesView.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
-import Combine
+@preconcurrency import ZcashLightClientKit
+@preconcurrency import Combine
 
 struct BalancesView: View {
     @Environment(\.colorScheme) private var colorScheme

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct AddKeystoneHWWalletCoordFlow {

--- a/secant/Sources/Features/CoordFlows/RequestZecCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/RequestZecCoordFlowStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct RequestZecCoordFlow {

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowStore.swift
@@ -7,9 +7,9 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
-import MnemonicSwift
+@preconcurrency import MnemonicSwift
 
 @Reducer
 struct RestoreWalletCoordFlow {

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ZcashPaymentURI
 
 extension ScanCoordFlow {

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ZcashPaymentURI
 
 @Reducer

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension SendCoordFlow {
     func coordinatorReduce() -> Reduce<SendCoordFlow.State, SendCoordFlow.Action> {

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct SendCoordFlow {

--- a/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct SignWithKeystoneCoordFlow {

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct SwapAndPayCoordFlow {

--- a/secant/Sources/Features/CoordFlows/TransactionsCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/TransactionsCoordFlowStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct TransactionsCoordFlow {

--- a/secant/Sources/Features/CoordFlows/WalletBackupCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/WalletBackupCoordFlowStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct WalletBackupCoordFlow {

--- a/secant/Sources/Features/DeleteWallet/DeleteWalletStore.swift
+++ b/secant/Sources/Features/DeleteWallet/DeleteWalletStore.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct DeleteWallet {

--- a/secant/Sources/Features/ExportLogs/ExportLogs.swift
+++ b/secant/Sources/Features/ExportLogs/ExportLogs.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 // MARK: Alerts
 

--- a/secant/Sources/Features/ExportLogs/ExportLogsStore.swift
+++ b/secant/Sources/Features/ExportLogs/ExportLogsStore.swift
@@ -5,10 +5,10 @@
 //  Created by Michal Fousek on 06.03.2023.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct ExportLogs {

--- a/secant/Sources/Features/ExportTransactionHistory/ExportTransactionHistoryStore.swift
+++ b/secant/Sources/Features/ExportTransactionHistory/ExportTransactionHistoryStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import SwiftUI
 
 @Reducer

--- a/secant/Sources/Features/Home/HomeStore.swift
+++ b/secant/Sources/Features/Home/HomeStore.swift
@@ -1,8 +1,8 @@
 import UIKit
 import SwiftUI
-import AVFoundation
+@preconcurrency import AVFoundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct Home {

--- a/secant/Sources/Features/PrivateDataConsent/PrivateDataConsentStore.swift
+++ b/secant/Sources/Features/PrivateDataConsent/PrivateDataConsentStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import SwiftUI
 
 @Reducer

--- a/secant/Sources/Features/Receive/ReceiveStore.swift
+++ b/secant/Sources/Features/Receive/ReceiveStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct Receive {

--- a/secant/Sources/Features/Receive/ReceiveView.swift
+++ b/secant/Sources/Features/Receive/ReceiveView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct ReceiveView: View {
     @Environment(\.colorScheme) var colorScheme

--- a/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayStore.swift
+++ b/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct RecoveryPhraseDisplay {

--- a/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
+++ b/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import MnemonicSwift
+@preconcurrency import MnemonicSwift
 
 struct RecoveryPhraseDisplayView: View {
     @Environment(\.colorScheme) private var colorScheme

--- a/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseSecurityView.swift
+++ b/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseSecurityView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import MnemonicSwift
+@preconcurrency import MnemonicSwift
 
 struct RecoveryPhraseSecurityView: View {
     @Environment(\.colorScheme) private var colorScheme

--- a/secant/Sources/Features/RequestZec/RequestZecStore.swift
+++ b/secant/Sources/Features/RequestZec/RequestZecStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ZcashPaymentURI
 
 @Reducer

--- a/secant/Sources/Features/RequestZec/RequestZecSummaryView.swift
+++ b/secant/Sources/Features/RequestZec/RequestZecSummaryView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct RequestZecSummaryView: View {
     @Environment(\.colorScheme) var colorScheme

--- a/secant/Sources/Features/RequestZec/RequestZecView.swift
+++ b/secant/Sources/Features/RequestZec/RequestZecView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct RequestZecView: View {
     @Environment(\.colorScheme) private var colorScheme

--- a/secant/Sources/Features/Root/RootAddressBook.swift
+++ b/secant/Sources/Features/Root/RootAddressBook.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 31.01.2025.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Root {
     func addressBookReduce() -> Reduce<Root.State, Root.Action> {

--- a/secant/Sources/Features/Root/RootCheckFunds.swift
+++ b/secant/Sources/Features/Root/RootCheckFunds.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 03.11.2025.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Root {
     func checkFundsReduce() -> Reduce<Root.State, Root.Action> {

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Root {
     func coordinatorReduce() -> Reduce<Root.State, Root.Action> {

--- a/secant/Sources/Features/Root/RootDebug.swift
+++ b/secant/Sources/Features/Root/RootDebug.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 02.03.2023.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 /// In this file is a collection of helpers that control all state and action related operations
 /// for the `Root` with a connection to the UI navigation.

--- a/secant/Sources/Features/Root/RootDestination.swift
+++ b/secant/Sources/Features/Root/RootDestination.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 import SwiftUI
 

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 /// In this file is a collection of helpers that control all state and action related operations
 /// for the `Root` with a connection to the app/wallet initialization and erasure of the wallet.

--- a/secant/Sources/Features/Root/RootShieldingProcessor.swift
+++ b/secant/Sources/Features/Root/RootShieldingProcessor.swift
@@ -5,12 +5,12 @@
 //  Created by Lukáš Korba on 29.01.2025.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
 import MessageUI
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Root {
     func shieldingProcessorReduce() -> Reduce<Root.State, Root.Action> {

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -1,5 +1,5 @@
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import Foundation
 import BackgroundTasks
 import Flexa

--- a/secant/Sources/Features/Root/RootSwaps.swift
+++ b/secant/Sources/Features/Root/RootSwaps.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 14.10.2025.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Root {
     func swapsReduce() -> Reduce<Root.State, Root.Action> {

--- a/secant/Sources/Features/Root/RootTorInitCheck.swift
+++ b/secant/Sources/Features/Root/RootTorInitCheck.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 18.07.2025.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Root {
     func torInitCheckReduce() -> Reduce<Root.State, Root.Action> {

--- a/secant/Sources/Features/Root/RootTransactions.swift
+++ b/secant/Sources/Features/Root/RootTransactions.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 29.01.2025.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Root {
     func transactionsReduce() -> Reduce<Root.State, Root.Action> {

--- a/secant/Sources/Features/Root/RootUserMetadata.swift
+++ b/secant/Sources/Features/Root/RootUserMetadata.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 2025-02-05.
 //
 
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Root {
     func userMetadataReduce() -> Reduce<Root.State, Root.Action> {

--- a/secant/Sources/Features/Root/RootView.swift
+++ b/secant/Sources/Features/Root/RootView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import StoreKit
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct RootView: View {
     @Environment(\.scenePhase) var scenePhase

--- a/secant/Sources/Features/Scan/ScanChecker.swift
+++ b/secant/Sources/Features/Scan/ScanChecker.swift
@@ -8,7 +8,7 @@
 import ComposableArchitecture
 import ZcashPaymentURI
 
-import KeystoneSDK
+@preconcurrency import KeystoneSDK
 
 protocol ScanChecker: Equatable {
     var id: Int { get }

--- a/secant/Sources/Features/Scan/ScanStore.swift
+++ b/secant/Sources/Features/Scan/ScanStore.swift
@@ -10,9 +10,9 @@ import CoreImage
 import ComposableArchitecture
 import Foundation
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ZcashPaymentURI
-import KeystoneSDK
+@preconcurrency import KeystoneSDK
 
 @Reducer
 struct Scan {

--- a/secant/Sources/Features/Scan/UIKitBridge/ScanUIView.swift
+++ b/secant/Sources/Features/Scan/UIKitBridge/ScanUIView.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import UIKit
-import AVFoundation
+@preconcurrency import AVFoundation
 
 class ScanUIView: UIView {
     var captureSession: AVCaptureSession?

--- a/secant/Sources/Features/SendConfirmation/FailedView.swift
+++ b/secant/Sources/Features/SendConfirmation/FailedView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct FailureView: View {
     @Perception.Bindable var store: StoreOf<SendConfirmation>

--- a/secant/Sources/Features/SendConfirmation/PendingView.swift
+++ b/secant/Sources/Features/SendConfirmation/PendingView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import Lottie
 
 struct PendingView: View {

--- a/secant/Sources/Features/SendConfirmation/PreSendingFailureView.swift
+++ b/secant/Sources/Features/SendConfirmation/PreSendingFailureView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct PreSendingFailureView: View {
     @Perception.Bindable var store: StoreOf<SendConfirmation>

--- a/secant/Sources/Features/SendConfirmation/RequestPaymentConfirmationView.swift
+++ b/secant/Sources/Features/SendConfirmation/RequestPaymentConfirmationView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct RequestPaymentConfirmationView: View {
     @Environment(\.colorScheme) private var colorScheme

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import MessageUI
 
 @Reducer

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationView.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct SendConfirmationView: View {
     @Environment(\.colorScheme) private var colorScheme

--- a/secant/Sources/Features/SendConfirmation/SendingView.swift
+++ b/secant/Sources/Features/SendConfirmation/SendingView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 import Lottie
 

--- a/secant/Sources/Features/SendConfirmation/SignWithKeystoneView.swift
+++ b/secant/Sources/Features/SendConfirmation/SignWithKeystoneView.swift
@@ -7,9 +7,9 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
-import KeystoneSDK
+@preconcurrency import KeystoneSDK
 import URKit
 
 struct SignWithKeystoneView: View {

--- a/secant/Sources/Features/SendConfirmation/SuccessView.swift
+++ b/secant/Sources/Features/SendConfirmation/SuccessView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct SuccessView: View {
     @Perception.Bindable var store: StoreOf<SendConfirmation>

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ZcashPaymentURI
 
 @Reducer

--- a/secant/Sources/Features/ServerSetup/ServerSetupStore.swift
+++ b/secant/Sources/Features/ServerSetup/ServerSetupStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension LightWalletEndpoint: @retroactive Equatable {
     public static func == (lhs: LightWalletEndpoint, rhs: LightWalletEndpoint) -> Bool {

--- a/secant/Sources/Features/ServerSetup/ServerSetupView.swift
+++ b/secant/Sources/Features/ServerSetup/ServerSetupView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct ServerSetupView: View {
     @Environment(\.colorScheme) var colorScheme

--- a/secant/Sources/Features/Settings/SettingsStore.swift
+++ b/secant/Sources/Features/Settings/SettingsStore.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct Settings {

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 import MessageUI
 

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import SwiftUI
 
 import BigDecimal

--- a/secant/Sources/Features/TorSetup/TorSetupStore.swift
+++ b/secant/Sources/Features/TorSetup/TorSetupStore.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct TorSetup {

--- a/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
+++ b/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 import SwiftUI
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import MessageUI
 
 @Reducer

--- a/secant/Sources/Features/TransactionDetails/TransactionDetailsView.swift
+++ b/secant/Sources/Features/TransactionDetails/TransactionDetailsView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct TransactionDetailsView: View {
     enum RowAppereance {

--- a/secant/Sources/Features/TransactionList/TransactionListView.swift
+++ b/secant/Sources/Features/TransactionList/TransactionListView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct TransactionListView: View {
     let store: StoreOf<TransactionList>

--- a/secant/Sources/Features/TransactionsManager/TransactionsManagerStore.swift
+++ b/secant/Sources/Features/TransactionsManager/TransactionsManagerStore.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 import SwiftUI
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct TransactionsManager {

--- a/secant/Sources/Features/TransactionsManager/TransactionsManagerView.swift
+++ b/secant/Sources/Features/TransactionsManager/TransactionsManagerView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct TransactionsManagerView: View {
     @Environment(\.colorScheme) private var colorScheme

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct WalletBalances {

--- a/secant/Sources/Features/WalletBirthday/WalletBirthdayStore.swift
+++ b/secant/Sources/Features/WalletBirthday/WalletBirthdayStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct WalletBirthday {

--- a/secant/Sources/Features/ZecKeyboard/ZecKeyboardStore.swift
+++ b/secant/Sources/Features/ZecKeyboard/ZecKeyboardStore.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 import UIKit
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 @Reducer
 struct ZecKeyboard {

--- a/secant/Sources/Features/ZecKeyboard/ZecKeyboardView.swift
+++ b/secant/Sources/Features/ZecKeyboard/ZecKeyboardView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct ZecKeyboardView: View {
     @Environment(\.colorScheme) private var colorScheme

--- a/secant/Sources/Models/AddressBookEncryptionKeys.swift
+++ b/secant/Sources/Models/AddressBookEncryptionKeys.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import CryptoKit
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 /// Representation of the address book encryption keys
 struct AddressBookEncryptionKeys: Codable, Equatable {

--- a/secant/Sources/Models/Currency.swift
+++ b/secant/Sources/Models/Currency.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 // Both will be defined in the SDK
 enum CurrencyISO4217: String, CaseIterable, Equatable {

--- a/secant/Sources/Models/RecoveryPhrase.swift
+++ b/secant/Sources/Models/RecoveryPhrase.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 enum RecoveryPhraseError: Error {
     /// This error is thrown then the Recovery Phrase can't be generated

--- a/secant/Sources/Models/StoredWallet.swift
+++ b/secant/Sources/Models/StoredWallet.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import ZcashLightClientKit
-import MnemonicSwift
+@preconcurrency import ZcashLightClientKit
+@preconcurrency import MnemonicSwift
 
 /// Representation of the wallet stored in the persistent storage (typically keychain, handled by `WalletStorage`).
 struct StoredWallet: Codable, Equatable {

--- a/secant/Sources/Models/SyncStatusSnapshot.swift
+++ b/secant/Sources/Models/SyncStatusSnapshot.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct SyncStatusSnapshot: Equatable {
     let message: String

--- a/secant/Sources/Models/TransactionState.swift
+++ b/secant/Sources/Models/TransactionState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import SwiftUI
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 /// Representation of the transaction on the SDK side, used as a bridge to the TCA wallet side. 
 struct TransactionState: Equatable, Identifiable {

--- a/secant/Sources/Models/UserMetadataEncryptionKeys.swift
+++ b/secant/Sources/Models/UserMetadataEncryptionKeys.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import CryptoKit
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 /// Representation of the user metadata encryption keys
 struct UserMetadataEncryptionKeys: Codable, Equatable {

--- a/secant/Sources/Models/WalletAccount.swift
+++ b/secant/Sources/Models/WalletAccount.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct WalletAccount: Equatable, Hashable, Codable, Identifiable {
     enum Vendor: Int, Equatable, Codable, Hashable {

--- a/secant/Sources/SecantApp.swift
+++ b/secant/Sources/SecantApp.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import Flexa
 
 @main
@@ -73,10 +73,6 @@ enum TargetConstants {
     fatalError("SECANT_MAINNET or SECANT_TESTNET flags not defined on Swift Compiler custom flags of your build target.")
 #endif
     }
-}
-
-extension ZcashSDKEnvironment: @retroactive DependencyKey {
-    static let liveValue: ZcashSDKEnvironment = Self.live(network: TargetConstants.zcashNetwork)
 }
 
 extension SecantApp {

--- a/secant/Sources/UIComponents/Balance/AvailableBalanceView.swift
+++ b/secant/Sources/UIComponents/Balance/AvailableBalanceView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import ComposableArchitecture
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct AvailableBalanceView: View {
     @Environment(\.colorScheme) var colorScheme

--- a/secant/Sources/UIComponents/Balance/BalanceWithIconView.swift
+++ b/secant/Sources/UIComponents/Balance/BalanceWithIconView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 struct BalanceWithIconView: View {
     let balance: Zatoshi

--- a/secant/Sources/UIComponents/Balance/ZatoshiRepresentationView.swift
+++ b/secant/Sources/UIComponents/Balance/ZatoshiRepresentationView.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftUI
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import ComposableArchitecture
 import XCTestDynamicOverlay
-import Combine
+@preconcurrency import Combine
 
 struct ZatoshiText: View {
     let balance: Zatoshi

--- a/secant/Sources/UIComponents/HiddenIfSet/HiddenIfSet.swift
+++ b/secant/Sources/UIComponents/HiddenIfSet/HiddenIfSet.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import Combine
+@preconcurrency import Combine
 
 struct HiddenIfSetModifier: ViewModifier {
     @Shared(.appStorage(.sensitiveContent)) var isSensitiveContentHidden = false

--- a/secant/Sources/Utils/BalanceFormatter.swift
+++ b/secant/Sources/Utils/BalanceFormatter.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Zatoshi {
     func decimalZashiFormatted() -> String {

--- a/secant/Sources/Utils/Logging/TCALoggerReducer.swift
+++ b/secant/Sources/Utils/Logging/TCALoggerReducer.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension Reducer {
     func logging(

--- a/secant/Sources/Utils/Logging/TCALogging.swift
+++ b/secant/Sources/Utils/Logging/TCALogging.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import os
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension OSLogger {
     static let live = OSLogger(logLevel: .debug, category: LoggerConstants.tcaLogs)

--- a/secant/Sources/Utils/QRCodeGenerator.swift
+++ b/secant/Sources/Utils/QRCodeGenerator.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 import CoreImage.CIFilterBuiltins
 import SwiftUI
 

--- a/secant/Sources/Utils/SensitiveData.swift
+++ b/secant/Sources/Utils/SensitiveData.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 // MARK: - Redactable Protocol
 

--- a/secant/Sources/Utils/WalletLogger.swift
+++ b/secant/Sources/Utils/WalletLogger.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import os
 
 enum LoggerConstants {

--- a/secant/Sources/Utils/ZcashError+DetailedMessage.swift
+++ b/secant/Sources/Utils/ZcashError+DetailedMessage.swift
@@ -5,7 +5,7 @@
 //  Created by Lukáš Korba on 24.03.2024.
 //
 
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 extension ZcashError {
     var detailedMessage: String {

--- a/secant/Sources/Vendors/Keystone/AnimatedQRCode.swift
+++ b/secant/Sources/Vendors/Keystone/AnimatedQRCode.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import KeystoneSDK
+@preconcurrency import KeystoneSDK
 import URKit
 import UIKit
 

--- a/secantTests/BalanceBreakdownTests/BalanceBreakdownTests.swift
+++ b/secantTests/BalanceBreakdownTests/BalanceBreakdownTests.swift
@@ -7,8 +7,8 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
-import Combine
+@preconcurrency import ZcashLightClientKit
+@preconcurrency import Combine
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -5,10 +5,10 @@
 //  Created by Lukáš Korba on 16.06.2022.
 //
 
-import Combine
+@preconcurrency import Combine
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/HomeTests/HomeTests.swift
+++ b/secantTests/HomeTests/HomeTests.swift
@@ -5,11 +5,11 @@
 //  Created by Lukáš Korba on 02.06.2022.
 //
 
-import Combine
+@preconcurrency import Combine
 import XCTest
 import ComposableArchitecture
 @testable import secant_testnet
-@testable import ZcashLightClientKit
+@testable @preconcurrency import ZcashLightClientKit
 
 class HomeTests: XCTestCase {
     /// The .onAppear action is important to register for the synchronizer state updates.

--- a/secantTests/ReceiveTests/ReceiveTests.swift
+++ b/secantTests/ReceiveTests/ReceiveTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/ReviewRequestTests/ReviewRequestTests.swift
+++ b/secantTests/ReviewRequestTests/ReviewRequestTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/RootTests/AppInitializationTests.swift
+++ b/secantTests/RootTests/AppInitializationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class AppInitializationTests: XCTestCase {

--- a/secantTests/RootTests/DebugTests.swift
+++ b/secantTests/RootTests/DebugTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/RootTests/RestoreWalletTests.swift
+++ b/secantTests/RootTests/RestoreWalletTests.swift
@@ -6,9 +6,9 @@
 //
 
 import XCTest
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/RootTests/RootTests.swift
+++ b/secantTests/RootTests/RootTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/RootTests/WalletNukeTests.swift
+++ b/secantTests/RootTests/WalletNukeTests.swift
@@ -6,9 +6,9 @@
 //
 
 import XCTest
-import Combine
+@preconcurrency import Combine
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/ScanTests/ScanTests.swift
+++ b/secantTests/ScanTests/ScanTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/SendTests/SendTests.swift
+++ b/secantTests/SendTests/SendTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 // swiftlint:disable type_body_length

--- a/secantTests/SensitiveDataTests/SensitiveDataTests.swift
+++ b/secantTests/SensitiveDataTests/SensitiveDataTests.swift
@@ -6,8 +6,8 @@
 //
 
 import XCTest
-import MnemonicSwift
-import ZcashLightClientKit
+@preconcurrency import MnemonicSwift
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class SensitiveDataTests: XCTestCase {

--- a/secantTests/SnapshotTests/BalanceBreakdownSnapshotTests/BalanceBreakdownSnapshotTests.swift
+++ b/secantTests/SnapshotTests/BalanceBreakdownSnapshotTests/BalanceBreakdownSnapshotTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import SwiftUI
 @testable import secant_testnet
 

--- a/secantTests/SnapshotTests/HomeSnapshotTests/HomeSnapshotTests.swift
+++ b/secantTests/SnapshotTests/HomeSnapshotTests/HomeSnapshotTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class HomeSnapshotTests: XCTestCase {

--- a/secantTests/SnapshotTests/ReceiveSnapshotTests/ReceiveSnapshotTests.swift
+++ b/secantTests/SnapshotTests/ReceiveSnapshotTests/ReceiveSnapshotTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 import SwiftUI
 @testable import secant_testnet
 

--- a/secantTests/SnapshotTests/SecurityWarningSnapshotTests/SecurityWarningSnapshotTests.swift
+++ b/secantTests/SnapshotTests/SecurityWarningSnapshotTests/SecurityWarningSnapshotTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class SecurityWarningSnapshotTests: XCTestCase {

--- a/secantTests/SnapshotTests/SendSnapshotTests/TransactionSendingSnapshotTests.swift
+++ b/secantTests/SnapshotTests/SendSnapshotTests/TransactionSendingSnapshotTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import ComposableArchitecture
 import SwiftUI
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class SendSnapshotTests: XCTestCase {

--- a/secantTests/SnapshotTests/TransactionListSnapshotTests/TransactionListSnapshotTests.swift
+++ b/secantTests/SnapshotTests/TransactionListSnapshotTests/TransactionListSnapshotTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class TransactionListSnapshotTests: XCTestCase {

--- a/secantTests/SyncProgressTests/SyncProgressTests.swift
+++ b/secantTests/SyncProgressTests/SyncProgressTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/TabsTests/TabsTests.swift
+++ b/secantTests/TabsTests/TabsTests.swift
@@ -5,11 +5,11 @@
 //  Created by Lukáš Korba on 10.10.2023.
 //
 
-import Combine
+@preconcurrency import Combine
 import XCTest
 import ComposableArchitecture
 @testable import secant_testnet
-@testable import ZcashLightClientKit
+@testable @preconcurrency import ZcashLightClientKit
 
 @MainActor
 class TabsTests: XCTestCase {

--- a/secantTests/TransactionListTests/TransactionListTests.swift
+++ b/secantTests/TransactionListTests/TransactionListTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 @MainActor

--- a/secantTests/TransactionListTests/TransactionStateTests.swift
+++ b/secantTests/TransactionListTests/TransactionStateTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 final class TransactionStateTests: XCTestCase {
     // MARK: - Title tests (String & Color)

--- a/secantTests/UtilTests/DatabaseFilesTests.swift
+++ b/secantTests/UtilTests/DatabaseFilesTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class DatabaseFilesTests: XCTestCase {

--- a/secantTests/UtilTests/LoggerTests.swift
+++ b/secantTests/UtilTests/LoggerTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import OSLog
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class LoggerTests: XCTestCase {

--- a/secantTests/UtilTests/WalletStorageTests.swift
+++ b/secantTests/UtilTests/WalletStorageTests.swift
@@ -6,8 +6,8 @@
 //
 
 import XCTest
-import MnemonicSwift
-import ZcashLightClientKit
+@preconcurrency import MnemonicSwift
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 extension WalletStorage.WalletStorageError {

--- a/secantTests/UtilTests/ZatoshiTests.swift
+++ b/secantTests/UtilTests/ZatoshiTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 @testable import secant_testnet
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 
 class ZatoshiTests: XCTestCase {
     let usNumberFormatter = NumberFormatter()

--- a/secantTests/WalletConfigProviderTests/WalletConfigProviderTests.swift
+++ b/secantTests/WalletConfigProviderTests/WalletConfigProviderTests.swift
@@ -5,10 +5,10 @@
 //  Created by Michal Fousek on 23.02.2023.
 //
 
-import Combine
+@preconcurrency import Combine
 import XCTest
 import ComposableArchitecture
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 class WalletConfigProviderTests: XCTestCase {

--- a/secantTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationCommaTests.swift
+++ b/secantTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationCommaTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 final class ZatoshiStringRepresentationCommaTests: XCTestCase {

--- a/secantTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationTests.swift
+++ b/secantTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import ZcashLightClientKit
+@preconcurrency import ZcashLightClientKit
 @testable import secant_testnet
 
 final class ZatoshiStringRepresentationTests: XCTestCase {


### PR DESCRIPTION
This is first PR from list of PRs that convert Zodl project to Swift 6. In this PR packages which are not converted to Swift 6 are imported with `@preconcurrency`. It shouldn't affect how Zodl works in any way. It is purely technical change and it is prerequisite for futures Swift 6 related changes.