### PR TITLE
Make AddressBookClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/AddressBookClient/AddressBookInterface.swift
+++ b/secant/Sources/Dependencies/AddressBookClient/AddressBookInterface.swift
@@ -5,6 +5,7 @@
 //  Created by Lukáš Korba on 05-27-2024.
 //
 
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
@@ -17,9 +18,9 @@ extension DependencyValues {
 
 @DependencyClient
 struct AddressBookClient {
-    let resetAccount: (Account) throws -> Void
-    let allLocalContacts: (Account) throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult)
-    let syncContacts: (Account, AddressBookContacts?) async throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult)
-    let storeContact: (Account, Contact) throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult)
-    let deleteContact: (Account, Contact) throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult)
+    var resetAccount: @Sendable (Account) throws -> Void
+    var allLocalContacts: @Sendable (Account) throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult)
+    var syncContacts: @Sendable (Account, AddressBookContacts?) throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult)
+    var storeContact: @Sendable (Account, Contact) throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult)
+    var deleteContact: @Sendable (Account, Contact) throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult)
 }

--- a/secant/Sources/Dependencies/AddressBookClient/AddressBookLiveKey.swift
+++ b/secant/Sources/Dependencies/AddressBookClient/AddressBookLiveKey.swift
@@ -12,13 +12,14 @@ import ComposableArchitecture
 @preconcurrency import Combine
 
 import CryptoKit
+import os
 
 extension AddressBookClient: DependencyKey {
     enum Constants {
         static let unencryptedFilename = "AddressBookData"
         static let int64Size = MemoryLayout<Int64>.size
     }
-    
+
     enum RemoteStoreResult: Equatable {
         case failure
         case notAttempted
@@ -38,185 +39,204 @@ extension AddressBookClient: DependencyKey {
     static let liveValue: AddressBookClient = Self.live()
 
     static func live() -> Self {
-        var latestKnownContacts: AddressBookContacts?
-
-        @Dependency(\.remoteStorage) var remoteStorage
+        let impl = AddressBookImpl()
 
         return Self(
-            resetAccount: { account in
-                guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-                    throw AddressBookClientError.documentsFolder
-                }
-
-                let filenameForEncryptedFile = try filenameForEncryptedFile(account: account)
-                let fileURL = documentsDirectory.appendingPathComponent(filenameForEncryptedFile)
-
-                try FileManager.default.removeItem(at: fileURL)
-
-                @Dependency(\.remoteStorage) var remoteStorage
-
-                // try to remove the remote as well
-                try? remoteStorage.removeFile(filenameForEncryptedFile)
-                
-                latestKnownContacts = nil
-            },
-            allLocalContacts: { account in
-                // return latest known contacts or load ones for the first time
-                guard latestKnownContacts == nil else {
-                    return (latestKnownContacts ?? .empty, .notAttempted)
-                }
-
-                // contacts haven't been loaded from the local storage yet, do it
-                do {
-                    guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-                        throw AddressBookClientError.documentsFolder
-                    }
-
-                    // Try to find and get the data from the encrypted file with the latest encryption version
-                    let encryptedFileURL = documentsDirectory.appendingPathComponent(try AddressBookClient.filenameForEncryptedFile(account: account))
-
-                    if let contactsData = try? Data(contentsOf: encryptedFileURL) {
-                        let result = try AddressBookClient.contactsFrom(encryptedData: contactsData, account: account)
-                        let contacts = result.0
-
-                        // file exists and was successfully decrypted and parsed;
-                        // try to find the unencrypted file and delete it
-                        let unencryptedFileURL = documentsDirectory.appendingPathComponent(Constants.unencryptedFilename)
-                        if FileManager.default.fileExists(atPath: unencryptedFileURL.path) {
-                            try? FileManager.default.removeItem(at: unencryptedFileURL)
-                        }
-
-                        latestKnownContacts = contacts
-                        return (contacts, .notAttempted)
-                    } else {
-                        // Fallback to the unencrypted file check and resolution
-                        let unencryptedFileURL = documentsDirectory.appendingPathComponent(Constants.unencryptedFilename)
-                        
-                        if let contactsData = try? Data(contentsOf: unencryptedFileURL) {
-                            // Unencrypted file exists; ensure data are parsed, re-saved as encrypted, and the original file deleted.
-
-                            let result = try AddressBookClient.contactsFrom(plainData: contactsData)
-                            var contacts = result.0
-
-                            // try to encrypt and store the data
-                            var remoteStoreResult: RemoteStoreResult
-                            do {
-                                remoteStoreResult = try AddressBookClient.storeContacts(
-                                    account: account,
-                                    contacts: contacts,
-                                    remoteStorage: remoteStorage,
-                                    remoteStore: false
-                                )
-
-                                let result = try syncContacts(
-                                    account: account,
-                                    contacts: contacts,
-                                    remoteStorage: remoteStorage,
-                                    storeAfterSync: true
-                                )
-                                
-                                remoteStoreResult = result.remoteStoreResult
-                                contacts = result.contacts
-                            } catch {
-                                // the store of the new file failed locally, skip the file remove
-                                latestKnownContacts = contacts
-                                throw error
-                            }
-                            
-                            try? FileManager.default.removeItem(at: unencryptedFileURL)
-                            
-                            latestKnownContacts = contacts
-                            return (contacts, remoteStoreResult)
-                        } else {
-                            return (.empty, .notAttempted)
-                        }
-                    }
-                } catch {
-                    throw error
-                }
-            },
-            syncContacts: { account, contacts in
-                let abContacts = contacts ?? latestKnownContacts ?? AddressBookContacts.empty
-
-                let result = try syncContacts(
-                    account: account,
-                    contacts: abContacts,
-                    remoteStorage: remoteStorage
-                )
-
-                latestKnownContacts = result.contacts
-
-                return result
-            },
-            storeContact: { account, contact in
-                let abContacts = latestKnownContacts ?? AddressBookContacts.empty
-
-                let result = try syncContacts(
-                    account: account,
-                    contacts: abContacts,
-                    remoteStorage: remoteStorage,
-                    storeAfterSync: false
-                )
-                
-                var syncedContacts = result.contacts
-
-                // if already exists, remove it
-                if syncedContacts.contacts.contains(contact) {
-                    syncedContacts.contacts.remove(contact)
-                }
-                
-                syncedContacts.contacts.append(contact)
-                
-                let remoteStoreResult = try storeContacts(
-                    account: account,
-                    contacts: syncedContacts,
-                    remoteStorage: remoteStorage
-                )
-                
-                // update the latest known contacts
-                latestKnownContacts = syncedContacts
-                
-                return (syncedContacts, remoteStoreResult)
-            },
-            deleteContact: { account, contact in
-                let abContacts = latestKnownContacts ?? AddressBookContacts.empty
-                
-                let result = try syncContacts(
-                    account: account,
-                    contacts: abContacts,
-                    remoteStorage: remoteStorage,
-                    storeAfterSync: false
-                )
-                
-                var syncedContacts = result.contacts
-
-                // if it doesn't exist, do nothing
-                guard syncedContacts.contacts.contains(contact) else {
-                    return (syncedContacts, .notAttempted)
-                }
-                
-                syncedContacts.contacts.remove(contact)
-                
-                let remoteStoreResult = try storeContacts(
-                    account: account,
-                    contacts: syncedContacts,
-                    remoteStorage: remoteStorage
-                )
-                
-                // update the latest known contacts
-                latestKnownContacts = syncedContacts
-                
-                return (syncedContacts, remoteStoreResult)
-            }
+            resetAccount: { try impl.resetAccount($0) },
+            allLocalContacts: { try impl.allLocalContacts($0) },
+            syncContacts: { try impl.syncContacts($0, $1) },
+            storeContact: { try impl.storeContact($0, $1) },
+            deleteContact: { try impl.deleteContact($0, $1) }
         )
     }
-    
-    private static func syncContacts(
+
+    static func filenameForEncryptedFile(account: Account) throws -> String {
+        @Dependency(\.walletStorage) var walletStorage
+
+        guard let encryptionKeys = try? walletStorage.exportAddressBookEncryptionKeys(), let addressBookKey = encryptionKeys.getCached(account: account) else {
+            throw AddressBookClientError.missingEncryptionKey
+        }
+
+        guard let filename = addressBookKey.fileIdentifier() else {
+            throw AddressBookClientError.fileIdentifier
+        }
+
+        return filename
+    }
+}
+
+private final class AddressBookImpl: Sendable {
+    @Dependency(\.remoteStorage) var remoteStorage
+    private let latestKnownContacts = OSAllocatedUnfairLock<AddressBookContacts?>(initialState: nil)
+
+    func resetAccount(_ account: Account) throws {
+        guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw AddressBookClient.AddressBookClientError.documentsFolder
+        }
+
+        let filenameForEncryptedFile = try AddressBookClient.filenameForEncryptedFile(account: account)
+        let fileURL = documentsDirectory.appendingPathComponent(filenameForEncryptedFile)
+
+        try FileManager.default.removeItem(at: fileURL)
+
+        // try to remove the remote as well
+        try? remoteStorage.removeFile(filenameForEncryptedFile)
+
+        latestKnownContacts.withLock { $0 = nil }
+    }
+
+    func allLocalContacts(_ account: Account) throws -> (contacts: AddressBookContacts, remoteStoreResult: AddressBookClient.RemoteStoreResult) {
+        // return latest known contacts or load ones for the first time
+        if let cached = latestKnownContacts.withLock({ $0 }) {
+            return (cached, .notAttempted)
+        }
+
+        // contacts haven't been loaded from the local storage yet, do it
+        do {
+            guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+                throw AddressBookClient.AddressBookClientError.documentsFolder
+            }
+
+            // Try to find and get the data from the encrypted file with the latest encryption version
+            let encryptedFileURL = documentsDirectory.appendingPathComponent(try AddressBookClient.filenameForEncryptedFile(account: account))
+
+            if let contactsData = try? Data(contentsOf: encryptedFileURL) {
+                let result = try AddressBookClient.contactsFrom(encryptedData: contactsData, account: account)
+                let contacts = result.0
+
+                // file exists and was successfully decrypted and parsed;
+                // try to find the unencrypted file and delete it
+                let unencryptedFileURL = documentsDirectory.appendingPathComponent(AddressBookClient.Constants.unencryptedFilename)
+                if FileManager.default.fileExists(atPath: unencryptedFileURL.path) {
+                    try? FileManager.default.removeItem(at: unencryptedFileURL)
+                }
+
+                latestKnownContacts.withLock { $0 = contacts }
+                return (contacts, .notAttempted)
+            } else {
+                // Fallback to the unencrypted file check and resolution
+                let unencryptedFileURL = documentsDirectory.appendingPathComponent(AddressBookClient.Constants.unencryptedFilename)
+
+                if let contactsData = try? Data(contentsOf: unencryptedFileURL) {
+                    // Unencrypted file exists; ensure data are parsed, re-saved as encrypted, and the original file deleted.
+
+                    let result = try AddressBookClient.contactsFrom(plainData: contactsData)
+                    var contacts = result.0
+
+                    // try to encrypt and store the data
+                    var remoteStoreResult: AddressBookClient.RemoteStoreResult
+                    do {
+                        remoteStoreResult = try storeContacts(
+                            account: account,
+                            contacts: contacts,
+                            remoteStore: false
+                        )
+
+                        let result = try syncContactsWithRemote(
+                            account: account,
+                            contacts: contacts,
+                            storeAfterSync: true
+                        )
+
+                        remoteStoreResult = result.remoteStoreResult
+                        contacts = result.contacts
+                    } catch {
+                        // the store of the new file failed locally, skip the file remove
+                        latestKnownContacts.withLock { [contacts] state in state = contacts }
+                        throw error
+                    }
+
+                    try? FileManager.default.removeItem(at: unencryptedFileURL)
+
+                    latestKnownContacts.withLock { [contacts] state in state = contacts }
+                    return (contacts, remoteStoreResult)
+                } else {
+                    return (.empty, .notAttempted)
+                }
+            }
+        } catch {
+            throw error
+        }
+    }
+
+    func syncContacts(_ account: Account, _ contacts: AddressBookContacts?) throws -> (contacts: AddressBookContacts, remoteStoreResult: AddressBookClient.RemoteStoreResult) {
+        let abContacts = contacts ?? latestKnownContacts.withLock({ $0 }) ?? AddressBookContacts.empty
+
+        let result = try syncContactsWithRemote(
+            account: account,
+            contacts: abContacts
+        )
+
+        latestKnownContacts.withLock { $0 = result.contacts }
+
+        return result
+    }
+
+    func storeContact(_ account: Account, _ contact: Contact) throws -> (contacts: AddressBookContacts, remoteStoreResult: AddressBookClient.RemoteStoreResult) {
+        let abContacts = latestKnownContacts.withLock({ $0 }) ?? AddressBookContacts.empty
+
+        let result = try syncContactsWithRemote(
+            account: account,
+            contacts: abContacts,
+            storeAfterSync: false
+        )
+
+        var syncedContacts = result.contacts
+
+        // if already exists, remove it
+        if syncedContacts.contacts.contains(contact) {
+            syncedContacts.contacts.remove(contact)
+        }
+
+        syncedContacts.contacts.append(contact)
+
+        let remoteStoreResult = try storeContacts(
+            account: account,
+            contacts: syncedContacts
+        )
+
+        // update the latest known contacts
+        latestKnownContacts.withLock { [syncedContacts] state in state = syncedContacts }
+
+        return (syncedContacts, remoteStoreResult)
+    }
+
+    func deleteContact(_ account: Account, _ contact: Contact) throws -> (contacts: AddressBookContacts, remoteStoreResult: AddressBookClient.RemoteStoreResult) {
+        let abContacts = latestKnownContacts.withLock({ $0 }) ?? AddressBookContacts.empty
+
+        let result = try syncContactsWithRemote(
+            account: account,
+            contacts: abContacts,
+            storeAfterSync: false
+        )
+
+        var syncedContacts = result.contacts
+
+        // if it doesn't exist, do nothing
+        guard syncedContacts.contacts.contains(contact) else {
+            return (syncedContacts, .notAttempted)
+        }
+
+        syncedContacts.contacts.remove(contact)
+
+        let remoteStoreResult = try storeContacts(
+            account: account,
+            contacts: syncedContacts
+        )
+
+        // update the latest known contacts
+        latestKnownContacts.withLock { [syncedContacts] state in state = syncedContacts }
+
+        return (syncedContacts, remoteStoreResult)
+    }
+
+    // MARK: - Private helpers
+
+    private func syncContactsWithRemote(
         account: Account,
         contacts: AddressBookContacts,
-        remoteStorage: RemoteStorageClient,
         storeAfterSync: Bool = true
-    ) throws -> (contacts: AddressBookContacts, remoteStoreResult: RemoteStoreResult) {
+    ) throws -> (contacts: AddressBookContacts, remoteStoreResult: AddressBookClient.RemoteStoreResult) {
         // Ensure remote contacts are prepared
         var remoteContacts: AddressBookContacts = .empty
         var shouldUpdateRemote = false
@@ -247,13 +267,13 @@ extension AddressBookClient: DependencyKey {
 
         remoteContacts.contacts.forEach {
             var notFound = true
-            
+
             for i in 0..<syncedContacts.contacts.count {
                 let contact = syncedContacts.contacts[i]
 
                 if $0.id == contact.id {
                     notFound = false
-                    
+
                     // If the timestamps are equal, the local entry takes priority.
                     if $0.lastUpdated >= contact.lastUpdated {
                         syncedContacts.contacts[i].name = $0.name
@@ -263,37 +283,35 @@ extension AddressBookClient: DependencyKey {
                     break
                 }
             }
-            
+
             if notFound {
                 syncedContacts.contacts.append($0)
                 shouldUpdateRemote = true
             }
         }
 
-        var remoteStoreResult = RemoteStoreResult.notAttempted
+        var remoteStoreResult = AddressBookClient.RemoteStoreResult.notAttempted
 
         if storeAfterSync {
             remoteStoreResult = try storeContacts(
                 account: account,
                 contacts: syncedContacts,
-                remoteStorage: remoteStorage,
                 remoteStore: shouldUpdateRemote && !cannotUpdateRemote
             )
-            
+
             if cannotUpdateRemote {
                 remoteStoreResult = .failure
             }
         }
-        
+
         return (syncedContacts, remoteStoreResult)
     }
-    
-    private static func storeContacts(
+
+    private func storeContacts(
         account: Account,
         contacts: AddressBookContacts,
-        remoteStorage: RemoteStorageClient,
         remoteStore: Bool = true
-    ) throws -> RemoteStoreResult {
+    ) throws -> AddressBookClient.RemoteStoreResult {
         // encrypt data
         let encryptedContacts = try AddressBookClient.encryptContacts(contacts, account: account)
 
@@ -301,7 +319,7 @@ extension AddressBookClient: DependencyKey {
 
         // store encrypted data to the local storage
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            throw AddressBookClientError.documentsFolder
+            throw AddressBookClient.AddressBookClientError.documentsFolder
         }
 
         let fileURL = documentsDirectory.appendingPathComponent(filenameForEncryptedFile)
@@ -318,19 +336,5 @@ extension AddressBookClient: DependencyKey {
         } else {
             return .notAttempted
         }
-    }
-    
-    private static func filenameForEncryptedFile(account: Account) throws -> String {
-        @Dependency(\.walletStorage) var walletStorage
-
-        guard let encryptionKeys = try? walletStorage.exportAddressBookEncryptionKeys(), let addressBookKey = encryptionKeys.getCached(account: account) else {
-            throw AddressBookClientError.missingEncryptionKey
-        }
-
-        guard let filename = addressBookKey.fileIdentifier() else {
-            throw AddressBookClientError.fileIdentifier
-        }
-        
-        return filename
     }
 }


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `AddressBookClient` (and all related code) Swift 6 compliant. 

Main changes in this PR:
- Logic from this dependency is extracted from closures to it's own class `AddressBookImpl`. This class is private so rest of the codebase still see only `AddressBookClient` interface. This is just refactoring logic is not changed it is just moved.
- `AddressBookClient.latestKnownContacts` variable is now protected by `OSAllocatedUnfairLock`. It makes this variable Sendable even when it's mutated. And thanks to this whole `AddressBookImpl` is Sendable. 