### PR TITLE
Make AppVersionClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/AppVersion/AppVersionInterface.swift
+++ b/secant/Sources/Dependencies/AppVersion/AppVersionInterface.swift
@@ -16,11 +16,6 @@ extension DependencyValues {
 
 @DependencyClient
 struct AppVersionClient {
-    let appVersion: () -> String
-    let appBuild: () -> String
-    
-    init(appVersion: @escaping () -> String, appBuild: @escaping () -> String) {
-        self.appVersion = appVersion
-        self.appBuild = appBuild
-    }
+    var appVersion: @Sendable () -> String = { "" }
+    var appBuild: @Sendable () -> String = { "" }
 }


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes AppVersionClient Swift 6 compliant. This is super simple dependency. Not much is happening here.