### PR TITLE
Make AutolockHandlerClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/AutolockHandler/AutolockHandlerInterface.swift
+++ b/secant/Sources/Dependencies/AutolockHandler/AutolockHandlerInterface.swift
@@ -17,6 +17,8 @@ extension DependencyValues {
 
 @DependencyClient
 struct AutolockHandlerClient {
-    var value: (Bool) -> Void
-    var batteryStatePublisher: () -> NotificationCenter.Publisher = { .init(center: .default, name: .AVAssetChapterMetadataGroupsDidChange) }
+    var value: @Sendable (Bool) async -> Void = { _ in }
+    var batteryStatePublisher: @Sendable () -> NotificationCenter.Publisher = {
+        NotificationCenter.Publisher(center: .default, name: .AVAssetChapterMetadataGroupsDidChange)
+    }
 }

--- a/secant/Sources/Dependencies/AutolockHandler/AutolockHandlerLiveKey.swift
+++ b/secant/Sources/Dependencies/AutolockHandler/AutolockHandlerLiveKey.swift
@@ -9,19 +9,23 @@ import ComposableArchitecture
 import UIKit
 
 extension AutolockHandlerClient: DependencyKey {
-    static let liveValue = Self(
-        value: { isRestoring in
-            UIDevice.current.isBatteryMonitoringEnabled = true
-            AutolockHandlerClient.handleAutolock(isRestoring)
-        },
-        batteryStatePublisher: {
-            NotificationCenter.default.publisher(for: UIDevice.batteryStateDidChangeNotification)
-        }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        return Self(
+            value: { @MainActor isRestoring in
+                UIDevice.current.isBatteryMonitoringEnabled = true
+                AutolockHandlerClient.handleAutolock(isRestoring)
+            },
+            batteryStatePublisher: {
+                NotificationCenter.default.publisher(for: UIDevice.batteryStateDidChangeNotification)
+            }
+        )
+    }
 }
 
 private extension AutolockHandlerClient {
-    static func handleAutolock(_ isRestoring: Bool) -> Void {
+    @MainActor static func handleAutolock(_ isRestoring: Bool) -> Void {
         switch UIDevice.current.batteryState {
         case .charging, .full:
             UIApplication.shared.isIdleTimerDisabled = isRestoring

--- a/secant/Sources/Dependencies/AutolockHandler/AutolockHandlerTestKey.swift
+++ b/secant/Sources/Dependencies/AutolockHandler/AutolockHandlerTestKey.swift
@@ -9,16 +9,6 @@ import Foundation
 import ComposableArchitecture
 import XCTestDynamicOverlay
 
-extension AutolockHandlerClient: TestDependencyKey {
-    static let testValue = Self(
-        value: unimplemented("\(Self.self).value", placeholder: {}()),
-        batteryStatePublisher: unimplemented(
-            "\(Self.self).batteryStatePublisher",
-            placeholder: NotificationCenter.Publisher(center: .default, name: Notification.Name(rawValue: "placeholder"))
-        )
-    )
-}
-
 extension AutolockHandlerClient {
     static let noOp = Self(
         value: { _ in },

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -56,8 +56,7 @@ extension Root {
                     }
                 }
                 userDefaults.setValue(leavesScreenOpen, Constants.udLeavesScreenOpen)
-                autolockHandler.value(leavesScreenOpen)
-                return .none
+                return .run { _ in await autolockHandler.value(leavesScreenOpen) }
 
             case .addKeystoneHWWalletCoordFlow(.path(.element(id: _, action: .accountHWWalletSelection(.forgetThisDeviceTapped)))),
                 .addKeystoneHWWalletCoordFlow(.path(.element(id: _, action: .keystoneDeviceReady(.forgetThisDeviceTapped)))):

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -394,9 +394,9 @@ struct Root {
                 
             case .batteryStateChanged:
                 let leavesScreenOpen = userDefaults.objectForKey(Constants.udLeavesScreenOpen) as? Bool ?? false
-                autolockHandler.value(state.walletStatus.isNotReadyForFullySyncedOperation && leavesScreenOpen)
-                return .none
-                
+                let autolockShouldBeEnabled = state.walletStatus.isNotReadyForFullySyncedOperation && leavesScreenOpen
+                return .run { _ in await autolockHandler.value(autolockShouldBeEnabled) }
+
             case .cancelAllRunningEffects:
                 return .concatenate(
                     .cancel(id: state.CancelId),


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `AutolockHandlerClient ` Swift 6 compliant. This is very small dependency so not much is happening here. API of this dependency had to be changed to async because it used `UIDevice` and that must be isolated by @MainActor.