### PR TITLE
Make BalanceFormatterClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/BalanceFormatter/BalanceFormatterInterface.swift
+++ b/secant/Sources/Dependencies/BalanceFormatter/BalanceFormatterInterface.swift
@@ -18,7 +18,7 @@ extension DependencyValues {
 
 @DependencyClient
 struct BalanceFormatterClient {
-    var convert: (
+    var convert: @Sendable (
         Zatoshi,
         ZatoshiStringRepresentation.PrefixSymbol,
         ZatoshiStringRepresentation.Format

--- a/secant/Sources/Dependencies/BalanceFormatter/BalanceFormatterLiveKey.swift
+++ b/secant/Sources/Dependencies/BalanceFormatter/BalanceFormatterLiveKey.swift
@@ -9,7 +9,11 @@ import Foundation
 import ComposableArchitecture
 
 extension BalanceFormatterClient: DependencyKey {
-    static let liveValue = Self(
-        convert: { ZatoshiStringRepresentation($0, prefixSymbol: $1, format: $2) }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        return Self(
+            convert: { ZatoshiStringRepresentation($0, prefixSymbol: $1, format: $2) }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/BalanceFormatter/BalanceFormatterTestKey.swift
+++ b/secant/Sources/Dependencies/BalanceFormatter/BalanceFormatterTestKey.swift
@@ -8,12 +8,6 @@
 import ComposableArchitecture
 import XCTestDynamicOverlay
 
-extension BalanceFormatterClient: TestDependencyKey {
-    static let testValue = Self(
-        convert: unimplemented("\(Self.self).convert", placeholder: .placeholer)
-    )
-}
-
 extension BalanceFormatterClient {
     static let noOp = Self(
         convert: { _, _, _ in .placeholer }


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `BalanceFormatterClient ` Swift 6 compliant. This is very small dependency so not much is happening here. 