### PR TITLE
Make CaptureDeviceClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/CaptureDevice/CaptureDeviceInterface.swift
+++ b/secant/Sources/Dependencies/CaptureDevice/CaptureDeviceInterface.swift
@@ -23,7 +23,7 @@ struct CaptureDeviceClient {
         case torchUnavailable
     }
 
-    let isAuthorized: () -> Bool
-    let isTorchAvailable: () -> Bool
-    let torch: (Bool) throws -> Void
+    var isAuthorized: @Sendable () -> Bool = { false }
+    var isTorchAvailable: @Sendable () -> Bool = { false }
+    var torch: @Sendable(Bool) throws -> Void
 }

--- a/secant/Sources/Dependencies/CaptureDevice/CaptureDeviceLiveKey.swift
+++ b/secant/Sources/Dependencies/CaptureDevice/CaptureDeviceLiveKey.swift
@@ -9,45 +9,50 @@
 import ComposableArchitecture
 
 extension CaptureDeviceClient: DependencyKey {
-    static let liveValue = Self(
-        isAuthorized: {
-            AVCaptureDevice.authorizationStatus(for: .video) == .authorized
-        },
-        isTorchAvailable: {
-            guard let videoCaptureDevice = AVCaptureDevice.default(for: .video) else {
-                return false
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        return Self(
+            isAuthorized: {
+                AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+            },
+            isTorchAvailable: {
+                guard let videoCaptureDevice = AVCaptureDevice.default(for: .video) else {
+                    return false
+                }
+
+                return videoCaptureDevice.hasTorch
+            },
+            torch: { isTorchOn in
+                var device: AVCaptureDevice?
+
+                if #available(iOS 17, *) {
+                    device = AVCaptureDevice.userPreferredCamera
+                } else {
+                    let deviceDiscoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInTripleCamera, .builtInDualWideCamera, .builtInUltraWideCamera, .builtInWideAngleCamera, .builtInTrueDepthCamera], mediaType: AVMediaType.video, position: .back)
+                    device = deviceDiscoverySession.devices.first
+                }
+                guard let device else {
+                    throw CaptureDeviceClientError.captureDevice
+                }
+
+                if device.hasTorch && device.isTorchAvailable {
+                    do {
+                        try device.lockForConfiguration()
+                        if isTorchOn {
+                            try device.setTorchModeOn(level: 1.0)
+                        } else {
+                            device.torchMode = .off
+                        }
+                        device.unlockForConfiguration()
+                    } catch {
+                        throw CaptureDeviceClientError.lockForConfiguration
+                    }
+                } else {
+                    throw CaptureDeviceClientError.torchUnavailable
+                }
             }
 
-            return videoCaptureDevice.hasTorch
-        },
-        torch: { isTorchOn in
-            var device: AVCaptureDevice?
-            
-            if #available(iOS 17, *) {
-                device = AVCaptureDevice.userPreferredCamera
-            } else {
-                let deviceDiscoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInTripleCamera, .builtInDualWideCamera, .builtInUltraWideCamera, .builtInWideAngleCamera, .builtInTrueDepthCamera], mediaType: AVMediaType.video, position: .back)
-                device = deviceDiscoverySession.devices.first
-            }
-            guard let device else {
-                throw CaptureDeviceClientError.captureDevice
-            }
-            
-            if device.hasTorch && device.isTorchAvailable {
-                do {
-                    try device.lockForConfiguration()
-                    if isTorchOn {
-                        try device.setTorchModeOn(level: 1.0)
-                    } else {
-                        device.torchMode = .off
-                    }
-                    device.unlockForConfiguration()
-                } catch {
-                    throw CaptureDeviceClientError.lockForConfiguration
-                }
-            } else {
-                throw CaptureDeviceClientError.torchUnavailable
-            }
-        }
-    )
+        )
+    }
 }

--- a/secant/Sources/Dependencies/CaptureDevice/CaptureDeviceTestKey.swift
+++ b/secant/Sources/Dependencies/CaptureDevice/CaptureDeviceTestKey.swift
@@ -8,14 +8,6 @@
 import ComposableArchitecture
 import XCTestDynamicOverlay
 
-extension CaptureDeviceClient: TestDependencyKey {
-    static let testValue = Self(
-        isAuthorized: unimplemented("\(Self.self).isAuthorized", placeholder: false),
-        isTorchAvailable: unimplemented("\(Self.self).isTorchAvailable", placeholder: false),
-        torch: unimplemented("\(Self.self).torch", placeholder: {}())
-    )
-}
-
 extension CaptureDeviceClient {
     static let noOp = Self(
         isAuthorized: { false },


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `CaptureDeviceClient ` Swift 6 compliant. This is very small dependency so not much is happening here. 