### PR TITLE
Make DatabaseFilesClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/DatabaseFiles/DatabaseFilesInterface.swift
+++ b/secant/Sources/Dependencies/DatabaseFiles/DatabaseFilesInterface.swift
@@ -18,13 +18,13 @@ extension DependencyValues {
 
 @DependencyClient
 struct DatabaseFilesClient {
-    let documentsDirectory: () -> URL
-    let fsBlockDbRootFor: (ZcashNetwork) -> URL
-    let cacheDbURLFor: (ZcashNetwork) -> URL
-    var dataDbURLFor: (ZcashNetwork) -> URL = { _ in .emptyURL }
-    let outputParamsURLFor: (ZcashNetwork) -> URL
-    let pendingDbURLFor: (ZcashNetwork) -> URL
-    let spendParamsURLFor: (ZcashNetwork) -> URL
-    var toDirURLFor: (ZcashNetwork) -> URL = { _ in .emptyURL }
-    var areDbFilesPresentFor: (ZcashNetwork) -> Bool = { _ in false }
+    var documentsDirectory: @Sendable () -> URL = { .emptyURL }
+    var fsBlockDbRootFor: @Sendable (ZcashNetwork) -> URL = { _ in .emptyURL }
+    var cacheDbURLFor: @Sendable (ZcashNetwork) -> URL = { _ in .emptyURL }
+    var dataDbURLFor: @Sendable (ZcashNetwork) -> URL = { _ in .emptyURL }
+    var outputParamsURLFor: @Sendable (ZcashNetwork) -> URL = { _ in .emptyURL }
+    var pendingDbURLFor: @Sendable (ZcashNetwork) -> URL = { _ in .emptyURL }
+    var spendParamsURLFor: @Sendable (ZcashNetwork) -> URL = { _ in .emptyURL }
+    var toDirURLFor: @Sendable (ZcashNetwork) -> URL = { _ in .emptyURL }
+    var areDbFilesPresentFor: @Sendable (ZcashNetwork) -> Bool = { _ in false }
 }

--- a/secant/Sources/Dependencies/DatabaseFiles/DatabaseFilesTestKey.swift
+++ b/secant/Sources/Dependencies/DatabaseFiles/DatabaseFilesTestKey.swift
@@ -9,20 +9,6 @@ import Foundation
 import ComposableArchitecture
 import XCTestDynamicOverlay
 
-extension DatabaseFilesClient: TestDependencyKey {
-    static let testValue = Self(
-        documentsDirectory: unimplemented("\(Self.self).documentsDirectory", placeholder: .emptyURL),
-        fsBlockDbRootFor: unimplemented("\(Self.self).fsBlockDbRootFor", placeholder: .emptyURL),
-        cacheDbURLFor: unimplemented("\(Self.self).cacheDbURLFor", placeholder: .emptyURL),
-        dataDbURLFor: unimplemented("\(Self.self).dataDbURLFor", placeholder: .emptyURL),
-        outputParamsURLFor: unimplemented("\(Self.self).outputParamsURLFor", placeholder: .emptyURL),
-        pendingDbURLFor: unimplemented("\(Self.self).pendingDbURLFor", placeholder: .emptyURL),
-        spendParamsURLFor: unimplemented("\(Self.self).spendParamsURLFor", placeholder: .emptyURL),
-        toDirURLFor: unimplemented("\(Self.self).toDirURLFor", placeholder: .emptyURL),
-        areDbFilesPresentFor: unimplemented("\(Self.self).areDbFilesPresentFor", placeholder: false)
-    )
-}
-
 extension DatabaseFilesClient {
     static let noOp = Self(
         documentsDirectory: { .emptyURL },


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `DatabaseFilesClient ` Swift 6 compliant. This is very small dependency so not much is happening here. 