### PR TITLE
Make FeedbackGeneratorClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/FeedbackGenerator/FeedbackGeneratorInterface.swift
+++ b/secant/Sources/Dependencies/FeedbackGenerator/FeedbackGeneratorInterface.swift
@@ -16,7 +16,7 @@ extension DependencyValues {
 
 @DependencyClient
 struct FeedbackGeneratorClient {
-    let generateSuccessFeedback: () -> Void
-    let generateWarningFeedback: () -> Void
-    let generateErrorFeedback: () -> Void
+    var generateSuccessFeedback: @Sendable () async -> Void = { }
+    var generateWarningFeedback: @Sendable () async -> Void = { }
+    var generateErrorFeedback: @Sendable () async -> Void = { }
 }

--- a/secant/Sources/Dependencies/FeedbackGenerator/FeedbackGeneratorLiveKey.swift
+++ b/secant/Sources/Dependencies/FeedbackGenerator/FeedbackGeneratorLiveKey.swift
@@ -10,8 +10,8 @@ import ComposableArchitecture
 
 extension FeedbackGeneratorClient: DependencyKey {
     static let liveValue = Self(
-        generateSuccessFeedback: { UINotificationFeedbackGenerator().notificationOccurred(.success) },
-        generateWarningFeedback: { UINotificationFeedbackGenerator().notificationOccurred(.warning) },
-        generateErrorFeedback: { UINotificationFeedbackGenerator().notificationOccurred(.error) }
+        generateSuccessFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.success) },
+        generateWarningFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.warning) },
+        generateErrorFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.error) }
     )
 }

--- a/secant/Sources/Dependencies/FeedbackGenerator/FeedbackGeneratorTestKey.swift
+++ b/secant/Sources/Dependencies/FeedbackGenerator/FeedbackGeneratorTestKey.swift
@@ -8,14 +8,6 @@
 import ComposableArchitecture
 import XCTestDynamicOverlay
 
-extension FeedbackGeneratorClient: TestDependencyKey {
-    static let testValue = Self(
-        generateSuccessFeedback: unimplemented("\(Self.self).generateSuccessFeedback"),
-        generateWarningFeedback: unimplemented("\(Self.self).generateWarningFeedback"),
-        generateErrorFeedback: unimplemented("\(Self.self).generateErrorFeedback")
-    )
-}
-
 extension FeedbackGeneratorClient {
     static let noOp = Self(
         generateSuccessFeedback: { },


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `FeedbackGeneratorClient ` Swift 6 compliant. This is very small dependency so not much is happening here. 