### PR TITLE
Make FlexaHandlerClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerLiveKey.swift
+++ b/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerLiveKey.swift
@@ -12,16 +12,17 @@ import Flexa
 @preconcurrency import ZcashLightClientKit
 import CryptoKit
 import UIKit
+import os
 
 /// This is a quick fix for Flexa changing the balances of the account from an expected value to 0.
-var accountHashInMemoryUUID = UUID()
+private let accountHashInMemoryUUID = OSAllocatedUnfairLock(initialState: UUID())
 
 enum Constants {
     static let zecHash = "bip122:00040fe8ec8471911baa1db1266ea15d"
     static let zecId = "\(Constants.zecHash)/slip44:133"
 
     static func assetAccountHash() -> String {
-        let uuid = accountHashInMemoryUUID
+        let uuid = accountHashInMemoryUUID.withLock { $0 }
         let uuidString = uuid.uuidString
         let data = Data(uuidString.utf8)
         let hash = SHA256.hash(data: data)
@@ -54,7 +55,7 @@ extension FlexaHandlerClient: DependencyKey {
                 isPrepared.value = true
             },
             open: {
-                accountHashInMemoryUUID = UUID()
+                accountHashInMemoryUUID.withLock { $0 = UUID() }
                 
                 if !isPrepared.value {
                     FlexaHandlerClient.prepare()

--- a/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerTestKey.swift
+++ b/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerTestKey.swift
@@ -9,19 +9,6 @@ import ComposableArchitecture
 import XCTestDynamicOverlay
 @preconcurrency import Combine
 
-extension FlexaHandlerClient: TestDependencyKey {
-    static let testValue = Self(
-        prepare: unimplemented("\(Self.self).prepare"),
-        open: unimplemented("\(Self.self).open"),
-        onTransactionRequest: unimplemented("\(Self.self).onTransactionRequest", placeholder: Empty().eraseToAnyPublisher()),
-        clearTransactionRequest: unimplemented("\(Self.self).clearTransactionRequest"),
-        transactionSent: unimplemented("\(Self.self).transactionSent"),
-        updateBalance: unimplemented("\(Self.self).updateBalance"),
-        flexaAlert: unimplemented("\(Self.self).flexaAlert"),
-        signOut: unimplemented("\(Self.self).signOut")
-    )
-}
-
 extension FlexaHandlerClient {
     static let noOp = Self(
         prepare: { },


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `FlexaHandlerClient ` Swift 6 compliant. No big changes were required. 