### PR TITLE
Make KeystoneHandlerClient Swift 6 compliant

### DIFF
--- a/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "02947d5f70aac7aeb110eedb248adf571005a68f181b378df8aa0e2f22916e33",
+  "originHash" : "9db742dfffbc23c7f406d71067e70d00f530649466a451949a9a283d7234e177",
   "pins" : [
     {
       "identity" : "base32",

--- a/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerLiveKey.swift
+++ b/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerLiveKey.swift
@@ -7,23 +7,24 @@
 
 import ComposableArchitecture
 @preconcurrency import KeystoneSDK
+import Atomics
 
-class KeystoneSDKWrapper {
+final class KeystoneSDKWrapper: Sendable {
     let keystoneSDK = KeystoneSDK()
-    var foundResult = false
-    
+    let foundResult = ManagedAtomic<Bool>(false)
+
     func decodeQR(_ qrCode: String) -> DecodeResult? {
-        guard !foundResult else { return nil }
-        
+        guard !foundResult.load(ordering: .acquiring) else { return nil }
+
         let result = try? keystoneSDK.decodeQR(qrCode: qrCode)
-        
-        foundResult = result?.progress == 100
-        
+
+        foundResult.store(result?.progress == 100, ordering: .releasing)
+
         return result
     }
-    
+
     func resetQRDecoder() {
-        foundResult = false
+        foundResult.store(false, ordering: .releasing)
         keystoneSDK.resetQRDecoder()
     }
 }

--- a/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerTestKey.swift
+++ b/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerTestKey.swift
@@ -9,13 +9,6 @@ import ComposableArchitecture
 import XCTestDynamicOverlay
 @preconcurrency import KeystoneSDK
 
-extension KeystoneHandlerClient: TestDependencyKey {
-    static let testValue = Self(
-        decodeQR: unimplemented("\(Self.self).decodeQR", placeholder: nil),
-        resetQRDecoder: unimplemented("\(Self.self).resetQRDecoder")
-    )
-}
-
 extension KeystoneHandlerClient {
     static let noOp = Self(
         decodeQR: { _ in nil },


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `KeystoneHandlerClient ` Swift 6 compliant. This is very small dependency so not much is happening here. Just `KeystoneSDKWrapper.foundResult` is now using atomic to protect it's mutability.