### PR TITLE
Make LogsHandlerClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/LogsHandler/LogsHandlerInterface.swift
+++ b/secant/Sources/Dependencies/LogsHandler/LogsHandlerInterface.swift
@@ -17,9 +17,5 @@ extension DependencyValues {
 
 @DependencyClient
 struct LogsHandlerClient {
-    let exportAndStoreLogs: (String, String, String) async throws -> URL?
-    
-    init(exportAndStoreLogs: @escaping (String, String, String) async throws -> URL?) {
-        self.exportAndStoreLogs = exportAndStoreLogs
-    }
+    var exportAndStoreLogs: @Sendable (String, String, String) async throws -> URL?
 }

--- a/secant/Sources/Dependencies/LogsHandler/LogsHandlerTest.swift
+++ b/secant/Sources/Dependencies/LogsHandler/LogsHandlerTest.swift
@@ -8,12 +8,6 @@
 import ComposableArchitecture
 import XCTestDynamicOverlay
 
-extension LogsHandlerClient: TestDependencyKey {
-    static let testValue = Self(
-        exportAndStoreLogs: unimplemented("\(Self.self).exportAndStoreLogs", placeholder: nil)
-    )
-}
-
 extension LogsHandlerClient {
     static let noOp = Self(
         exportAndStoreLogs: { _, _, _ in nil }


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `LogsHandlerClient ` Swift 6 compliant. This is very small dependency so not much is happening here.