### PR TITLE
Make SupportDataGeneratorClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGenerator.swift
+++ b/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGenerator.swift
@@ -116,7 +116,8 @@ private struct SystemVersionItem: SupportDataGeneratorItem {
     }
 
     func generate() -> [(String, String)] {
-        return [(Constants.systemVersionKey, UIDevice.current.systemVersion)]
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return [(Constants.systemVersionKey, "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)")]
     }
 }
 

--- a/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGeneratorInterface.swift
+++ b/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGeneratorInterface.swift
@@ -16,5 +16,5 @@ extension DependencyValues {
 
 @DependencyClient
 struct SupportDataGeneratorClient {
-    let generate: () -> SupportData
+    var generate: @Sendable () -> SupportData = { SupportData(toAddress: "", subject: "", message: "") }
 }

--- a/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGeneratorTestKey.swift
+++ b/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGeneratorTestKey.swift
@@ -8,12 +8,6 @@
 import ComposableArchitecture
 import XCTestDynamicOverlay
 
-extension SupportDataGeneratorClient: TestDependencyKey {
-    static let testValue = Self(
-        generate: unimplemented("\(Self.self).generate", placeholder: SupportData(toAddress: "", subject: "", message: ""))
-    )
-}
-
 extension SupportDataGeneratorClient {
     static let noOp = Self(
         generate: { SupportData(toAddress: "", subject: "", message: "") }


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `SupportDataGeneratorClient ` Swift 6 compliant. Previously `SupportDataGeneratorClient` used `UIDevice` to get system version. But UIDevice must be used from main thread and that means isolation to @MainActor and that means that API of `SupportDataGeneratorClient` would have to change to async. So instead of `UIDevice` I used `ProcessInfo` to get system version. It gives same results as UIDevice.