### PR TITLE
Make WalletConfigProviderClient Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProvider.swift
+++ b/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProvider.swift
@@ -6,13 +6,9 @@
 //
 
 import Foundation
-@preconcurrency import Combine
 
 struct WalletConfigProvider {
-    /// Objects that fetches flags configuration from some source. It can be fetched from user defaults or some backend API for example. It depends
-    /// on implementation.
     private let configSourceProvider: WalletConfigSourceProvider
-    /// Object that caches provided flags configuration.
     private let cache: WalletConfigProviderCache
 
     init(configSourceProvider: WalletConfigSourceProvider, cache: WalletConfigProviderCache) {
@@ -20,26 +16,7 @@ struct WalletConfigProvider {
         self.cache = cache
     }
 
-    /// Loads flags configuration.
-    ///
-    /// First `configurationProvider` is used to fetch flags configuration. If that fails then `cache` is used to load flags configuration. And if
-    /// that fails `WalletConfig.default` is used.
-    ///
-    /// Loaded configuration is merged with with `WalletConfig.default` to be sure that all recognized flags are always returned in
-    /// configuration.
-    ///
-    /// Merged configuration is stored in cache.
-    func load() -> AnyPublisher<WalletConfig, Never> {
-        let publisher = PassthroughSubject<WalletConfig, Never>()
-        Task {
-            let config = await load()
-            publisher.send(config)
-            publisher.send(completion: .finished)
-        }
-        return publisher.eraseToAnyPublisher()
-    }
-
-    private func load() async -> WalletConfig {
+    func load() async -> WalletConfig {
         let configuration: WalletConfig
         do {
             configuration = try await configSourceProvider.load()
@@ -60,17 +37,7 @@ struct WalletConfigProvider {
     }
 
     // This is used only in debug menu to change configuration for specific flag
-    func update(featureFlag: FeatureFlag, isEnabled: Bool) -> AnyPublisher<Void, Never> {
-        let publisher = PassthroughSubject<Void, Never>()
-        Task {
-            await update(featureFlag: featureFlag, isEnabled: isEnabled)
-            publisher.send(Void())
-            publisher.send(completion: .finished)
-        }
-        return publisher.eraseToAnyPublisher()
-    }
-
-    private func update(featureFlag: FeatureFlag, isEnabled: Bool) async {
+    func update(featureFlag: FeatureFlag, isEnabled: Bool) async {
         guard let provider = configSourceProvider as? UserDefaultsWalletConfigStorage else {
             LoggerProxy.debug("This is now only support with UserDefaultsWalletConfigStorage as configurationProvider.")
             return
@@ -89,11 +56,11 @@ struct WalletConfigProvider {
     }
 }
 
-protocol WalletConfigSourceProvider {
+protocol WalletConfigSourceProvider: Sendable {
     func load() async throws -> WalletConfig
 }
 
-protocol WalletConfigProviderCache {
+protocol WalletConfigProviderCache: Sendable {
     func load() async -> WalletConfig?
     func store(_ configuration: WalletConfig) async
 }

--- a/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderInterface.swift
+++ b/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderInterface.swift
@@ -7,7 +7,6 @@
 
 import ComposableArchitecture
 import Foundation
-@preconcurrency import Combine
 
 extension DependencyValues {
     var walletConfigProvider: WalletConfigProviderClient {
@@ -18,6 +17,6 @@ extension DependencyValues {
 
 @DependencyClient
 struct WalletConfigProviderClient {
-    let load: () -> AnyPublisher<WalletConfig, Never>
-    let update: (FeatureFlag, Bool) -> AnyPublisher<Void, Never>
+    var load: @Sendable () async -> WalletConfig = { WalletConfig.initial }
+    var update: @Sendable (FeatureFlag, Bool) async -> Void
 }

--- a/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderLiveKey.swift
+++ b/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderLiveKey.swift
@@ -20,9 +20,9 @@ extension WalletConfigProviderClient: DependencyKey {
 
     static func live(walletConfigProvider: WalletConfigProvider = WalletConfigProviderClient.defaultWalletConfigProvider) -> Self {
         Self(
-            load: { walletConfigProvider.load() },
+            load: { await walletConfigProvider.load() },
             update: { flag, isEnabled in
-                return walletConfigProvider.update(featureFlag: flag, isEnabled: isEnabled)
+                await walletConfigProvider.update(featureFlag: flag, isEnabled: isEnabled)
             }
         )
     }

--- a/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderTestKey.swift
+++ b/secant/Sources/Dependencies/WalletConfigProvider/WalletConfigProviderTestKey.swift
@@ -7,18 +7,10 @@
 
 import ComposableArchitecture
 import XCTestDynamicOverlay
-@preconcurrency import Combine
-
-extension WalletConfigProviderClient: TestDependencyKey {
-    static let testValue = Self(
-        load: unimplemented("\(Self.self).load", placeholder: Just(WalletConfig.initial).eraseToAnyPublisher()),
-        update: unimplemented("\(Self.self).update", placeholder: Just({}()).eraseToAnyPublisher())
-    )
-}
 
 extension WalletConfigProviderClient {
     static let noOp = Self(
-        load: { Just(WalletConfig.initial).eraseToAnyPublisher() },
-        update: { _, _ in Just(Void()).eraseToAnyPublisher() }
+        load: { WalletConfig.initial },
+        update: { _, _ in }
     )
 }

--- a/secant/Sources/Features/Root/RootDebug.swift
+++ b/secant/Sources/Features/Root/RootDebug.swift
@@ -62,18 +62,16 @@ extension Root {
                 }
                 
             case let .debug(.updateFlag(flag, isEnabled)):
-                return .publisher {
-                    walletConfigProvider.update(flag, !isEnabled)
-                        .receive(on: mainQueue)
-                        .map { _ in return Action.debug(.flagUpdated) }
+                return .run { send in
+                    await walletConfigProvider.update(flag, !isEnabled)
+                    await send(.debug(.flagUpdated))
                 }
                 .cancellable(id: state.WalletConfigCancelId, cancelInFlight: true)
 
             case .debug(.flagUpdated):
-                return .publisher {
-                    walletConfigProvider.load()
-                        .receive(on: mainQueue)
-                        .map { Action.debug(.walletConfigLoaded($0)) }
+                return .run { send in
+                    let walletConfig = await walletConfigProvider.load()
+                    await send(.debug(.walletConfigLoaded(walletConfig)))
                 }
                 .cancellable(id: state.WalletConfigCancelId, cancelInFlight: true)
 

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -208,10 +208,9 @@ extension Root {
                 }
 
             case .initialization(.checkWalletConfig):
-                return .publisher {
-                    walletConfigProvider.load()
-                        .receive(on: mainQueue)
-                        .map(Root.Action.walletConfigLoaded)
+                return .run { send in
+                    let walletConfig = await walletConfigProvider.load()
+                    await send(.walletConfigLoaded(walletConfig))
                 }
                 .cancellable(id: state.WalletConfigCancelId, cancelInFlight: true)
 


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `WalletConfigProviderClient ` Swift 6 compliant. 

I simply removed Combine based API from `WalletConfigProviderClient` and kept only async one. Changes for the app were minimal. It was super hard to rewrite Combine API to be Swift 6 compliant. Not because of use of Combine but because how it was used in this specific case. To use async only was easier. 