### PR TITLE
Add DependencyKey conformance to ZcashSDKEnvironment

### DIFF
--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
@@ -8,8 +8,8 @@
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
-extension ZcashSDKEnvironment {
-    
+extension ZcashSDKEnvironment: DependencyKey {
+
     static let liveValue: ZcashSDKEnvironment = Self.live(network: TargetConstants.zcashNetwork)
 
     static func live(network: ZcashNetwork) -> Self {


### PR DESCRIPTION
## Summary

Without `DependencyKey` conformance, TCA cannot find the live implementation of `ZcashSDKEnvironment` and silently falls back to `testValue`, which uses **testnet**. This causes the wallet to derive testnet keys while scanning mainnet blocks — trial decryption never matches any notes and the wallet shows zero balance after a full sync.

The fix is a single-word change: `extension ZcashSDKEnvironment` → `extension ZcashSDKEnvironment: DependencyKey`.

## How it was found

- Wallet restored from seed, synced fully, showed 0 balance
- Same seed on App Store Zashi found funds immediately
- Added debug logging to Rust FFI `create_account` — UFVK started with `uviewtest1` (testnet prefix) despite `SECANT_MAINNET` build flag
- Traced to `@Dependency(\.zcashSDKEnvironment) has no live implementation` warning present in logs since first launch — TCA falling back to testnet `testValue`

## Test plan

- [ ] Build and restore wallet from known seed with mainnet funds
- [ ] Verify UFVK starts with `uview1` (mainnet), not `uviewtest1`
- [ ] Verify balance appears after sync
- [ ] Verify `@Dependency has no live implementation` warning no longer appears in logs