### PR TITLE
[#1665] Fix deeplink navigation + add Send deeplink + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Added
+- Deep link support for the Receive screen via `zcash:///home/receive`.
+
 ## 3.2.0 build 5 (2026-03-09)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Added
-- Deep link support for the Receive screen via `zcash:///home/receive`.
+- Deep link support for the Receive screen via `zcash:///home/receive`. Fetches Keystone custom unified address before navigating, matching the in-app receive flow.
+
+### Fixed
+- Deep links for `zcash:///home`, `zcash:///home/send`, and `zcash:///home/receive` were silently ignored after the ZIP-321 check — the existing `process()` pipeline was never connected to the `.deeplink(url)` handler.
 
 ## 3.2.0 build 5 (2026-03-09)
 

--- a/modules/Sources/Dependencies/Deeplink/Deeplink.swift
+++ b/modules/Sources/Dependencies/Deeplink/Deeplink.swift
@@ -13,6 +13,7 @@ import ZcashLightClientKit
 public struct Deeplink {
     public enum Destination: Equatable {
         case home
+        case receive
         case send(amount: Int, address: String, memo: String)
     }
     
@@ -39,6 +40,11 @@ public struct Deeplink {
                 Path { "home" }
             }
 
+            // GET /home/receive
+            Route(.case(Destination.receive)) {
+                Path { "home"; "receive" }
+            }
+
             // GET /home/send?amount=:amount&address=:address&memo=:memo
             Route(.case(Destination.send(amount:address:memo:))) {
                 Path { "home"; "send" }
@@ -53,6 +59,9 @@ public struct Deeplink {
         switch try appRouter.match(url: url) {
         case .home:
             return .home
+
+        case .receive:
+            return .receive
 
         case let .send(amount, address, memo):
             return .send(amount: amount, address: address, memo: memo)

--- a/modules/Sources/Features/Root/RootCoordinator.swift
+++ b/modules/Sources/Features/Root/RootCoordinator.swift
@@ -118,6 +118,22 @@ extension Root {
                 exchangeRate.refreshExchangeRateUSD()
                 return .none
 
+            case .destination(.deeplinkSend(let amount, let address, let memo)):
+                state.sendCoordFlowState = .initial
+                state.path = .sendCoordFlow
+                exchangeRate.refreshExchangeRateUSD()
+                if !memo.isEmpty {
+                    state.sendCoordFlowState.sendFormState.memoState.text = memo
+                }
+                var effects: [Effect<Root.Action>] = []
+                if amount.amount > 0 {
+                    effects.append(.send(.sendCoordFlow(.sendForm(.zecAmountUpdated(amount.decimalString().redacted)))))
+                }
+                if !address.isEmpty {
+                    effects.append(.send(.sendCoordFlow(.sendForm(.addressUpdated(address.redacted)))))
+                }
+                return effects.isEmpty ? .none : .merge(effects)
+
             case .home(.scanTapped):
                 state.scanCoordFlowState = .initial
                 state.path = .scanCoordFlow

--- a/modules/Sources/Features/Root/RootCoordinator.swift
+++ b/modules/Sources/Features/Root/RootCoordinator.swift
@@ -106,7 +106,8 @@ extension Root {
                 state.path = .settings
                 return .none
                 
-            case .home(.receiveTapped):
+            case .home(.receiveTapped),
+                .destination(.deeplinkReceive):
                 state.receiveState = .initial
                 state.path = .receive
                 return .none

--- a/modules/Sources/Features/Root/RootCoordinator.swift
+++ b/modules/Sources/Features/Root/RootCoordinator.swift
@@ -106,10 +106,24 @@ extension Root {
                 state.path = .settings
                 return .none
                 
-            case .home(.receiveTapped),
-                .destination(.deeplinkReceive):
+            case .home(.receiveTapped):
                 state.receiveState = .initial
                 state.path = .receive
+                return .none
+
+            case .destination(.deeplinkReceive):
+                guard state.destinationState.destination != .deeplinkWarning else {
+                    return .none
+                }
+                state.receiveState = .initial
+                state.path = .receive
+                let isKeystone = state.selectedWalletAccount?.vendor == .keystone
+                if let uuid = state.selectedWalletAccount?.id {
+                    return .run { send in
+                        let privateUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, isKeystone ? [.orchard] : [.sapling, .orchard])
+                        await send(.home(.updatePrivateUA(privateUA)))
+                    }
+                }
                 return .none
 
             case .home(.sendTapped):

--- a/modules/Sources/Features/Root/RootDestination.swift
+++ b/modules/Sources/Features/Root/RootDestination.swift
@@ -44,6 +44,7 @@ extension Root {
     public enum DestinationAction {
         case deeplink(URL)
         case deeplinkHome
+        case deeplinkReceive
         case deeplinkSend(Zatoshi, String, String)
         case deeplinkFailed(URL, ZcashError)
         case updateDestination(Root.DestinationState.Destination)
@@ -71,6 +72,9 @@ extension Root {
 
             case .destination(.deeplinkHome):
                 return .none
+
+            case .destination(.deeplinkReceive):
+                return .send(.destination(.updateDestination(.home)))
 
             case .destination(.deeplinkSend):
                 return .none
@@ -156,6 +160,8 @@ private extension Root {
         switch deeplink {
         case .home:
             return .destination(.deeplinkHome)
+        case .receive:
+            return .destination(.deeplinkReceive)
         case let .send(amount, address, memo):
             return .destination(.deeplinkSend(Zatoshi(Int64(amount)), address, memo))
         }

--- a/modules/Sources/Features/Root/RootDestination.swift
+++ b/modules/Sources/Features/Root/RootDestination.swift
@@ -68,7 +68,14 @@ extension Root {
                     // The deeplink is some zip321, we ignore it and let users know in a warning screen
                     return .send(.destination(.updateDestination(.deeplinkWarning)))
                 }
-                return .none
+                return .run { send in
+                    do {
+                        let action = try await process(url: url, deeplink: deeplink, derivationTool: derivationTool)
+                        await send(action)
+                    } catch {
+                        await send(.destination(.deeplinkFailed(url, error as! ZcashError)))
+                    }
+                }
 
             case .destination(.deeplinkHome):
                 return .none

--- a/modules/Sources/Features/WalletBirthday/WalletBirthdayView.swift
+++ b/modules/Sources/Features/WalletBirthday/WalletBirthdayView.swift
@@ -94,7 +94,7 @@ public struct WalletBirthdayView: View {
                         Button {
                             isBirthdayFocused = false
                         } label: {
-                            Text(L10n.General.done.uppercased())
+                            Text(String(localizable: .generalDone).uppercased())
                                 .zFont(.regular, size: 14, style: Design.Text.primary)
                         }
                         .padding(.bottom, 4)

--- a/secant/secant-mainnet-Info.plist
+++ b/secant/secant-mainnet-Info.plist
@@ -45,6 +45,21 @@
 		<string>fetch</string>
 		<string>processing</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLName</key>
+			<string>co.electriccoin.secant-mainnet</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>zcash</string>
+			</array>
+		</dict>
+	</array>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UILaunchStoryboardName</key>
@@ -57,7 +72,5 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>UIDesignRequiresCompatibility</key>
-	<true/>
 </dict>
 </plist>

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -138,6 +138,43 @@ class DeeplinkTests: XCTestCase {
         await store.finish()
     }
 
+    func testReceiveURLParsing_ExtraPathComponent_DoesNotMatch() throws {
+        guard let url = URL(string: "zcash:///home/receive/extra") else {
+            return XCTFail("Deeplink: 'testReceiveURLParsing_ExtraPathComponent_DoesNotMatch' URL is expected to be valid.")
+        }
+
+        XCTAssertThrowsError(
+            try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false }),
+            "zcash:///home/receive/extra should not match any route"
+        )
+    }
+
+    func testSendURLParsing_ExtraPathComponent_DoesNotMatch() throws {
+        guard let url = URL(string: "zcash:///home/send/extra") else {
+            return XCTFail("Deeplink: 'testSendURLParsing_ExtraPathComponent_DoesNotMatch' URL is expected to be valid.")
+        }
+
+        XCTAssertThrowsError(
+            try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false }),
+            "zcash:///home/send/extra should not match any route"
+        )
+    }
+
+    func testActionDeeplinkReceive_GuardedByDeeplinkWarning() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .deeplinkWarning
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        await store.send(.destination(.deeplinkReceive))
+
+        await store.finish()
+    }
+
     func testHomeURLParsing() throws {
         guard let url = URL(string: "zcash:///home") else {
             return XCTFail("Deeplink: 'testDeeplinkRequest_homeURL' URL is expected to be valid.")

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -66,10 +66,8 @@ class DeeplinkTests: XCTestCase {
         
         await store.send(.destination(.deeplinkSend(amount, address, memo))) { state in
             state.destinationState.destination = .home
-//            state.tabsState.selectedTab = .send
-//            state.tabsState.sendState.amount = amount
-//            state.tabsState.sendState.address = address.redacted
-//            state.tabsState.sendState.memoState.text = memo
+            state.path = .sendCoordFlow
+            state.sendCoordFlowState.sendFormState.memoState.text = memo
         }
         
         await store.finish()
@@ -230,10 +228,8 @@ class DeeplinkTests: XCTestCase {
 
         await store.receive(.destination(.deeplinkSend(amount, address, memo))) { state in
             state.destinationState.destination = .home
-//            state.tabsState.selectedTab = .send
-//            state.tabsState.sendState.amount = amount
-//            state.tabsState.sendState.address = address.redacted
-//            state.tabsState.sendState.memoState.text = memo
+            state.path = .sendCoordFlow
+            state.sendCoordFlowState.sendFormState.memoState.text = memo
         }
         
         await store.finish()

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -75,6 +75,71 @@ class DeeplinkTests: XCTestCase {
         await store.finish()
     }
 
+    func testReceiveURLParsing() throws {
+        guard let url = URL(string: "zcash:///home/receive") else {
+            return XCTFail("Deeplink: 'testReceiveURLParsing' URL is expected to be valid.")
+        }
+
+        let result = try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false })
+
+        XCTAssertEqual(result, Deeplink.Destination.receive)
+    }
+
+    func testActionDeeplinkReceive() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .welcome
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        await store.send(.destination(.deeplinkReceive)) { state in
+            state.destinationState.destination = .home
+            state.path = .receive
+        }
+
+        await store.finish()
+    }
+
+    func testDeeplinkRequest_Received_Receive() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .welcome
+        appState.appInitializationState = .initialized
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        store.dependencies.deeplink = DeeplinkClient(
+            resolveDeeplinkURL: { _, _, _ in Deeplink.Destination.receive }
+        )
+        store.dependencies.sdkSynchronizer = SDKSynchronizerClient.mocked(
+            latestState: {
+                var state = SynchronizerState.zero
+                state.syncStatus = .upToDate
+                return state
+            }
+        )
+        store.dependencies.walletConfigProvider = .noOp
+
+        guard let url = URL(string: "zcash:///home/receive") else {
+            return XCTFail("Deeplink: 'testDeeplinkRequest_Received_Receive' URL is expected to be valid.")
+        }
+
+        await store.send(.destination(.deeplink(url)))
+
+        await store.receive(.destination(.deeplinkReceive)) { state in
+            state.destinationState.destination = .home
+            state.path = .receive
+        }
+
+        await store.finish()
+    }
+
     func testHomeURLParsing() throws {
         guard let url = URL(string: "zcash:///home") else {
             return XCTFail("Deeplink: 'testDeeplinkRequest_homeURL' URL is expected to be valid.")


### PR DESCRIPTION
Builds on top of #1666 — fixes the two root causes that made deeplinks non-functional, wires up the Send screen, and adds tests.

## What was still broken

1. **`process()` was never called** — the URL parsing function existed in `RootDestination.swift` but was never invoked from the `.deeplink(url)` handler. All `zcash:///` deep links were silently going to home only.
2. **`zcash` URL scheme not registered** — `secant-mainnet-Info.plist` had no `CFBundleURLTypes` entry, so iOS never routed `zcash://` URLs to the app at all.

## Changes

- `RootDestination.swift` — wire `process()` into the `.deeplink(url)` handler
- `RootCoordinator.swift` — handle `.deeplinkReceive` (Keystone custom UA fetch + `deeplinkWarning` guard) and `.deeplinkSend` (pre-populates address, amount, memo)
- `secant-mainnet-Info.plist` — register `zcash` URL scheme via `CFBundleURLTypes`
- `DeeplinkTests.swift` — update send tests; add negative tests for extra path components; add `deeplinkWarning` guard test
- `CHANGELOG.md` — document changes

## Testing

Verified on simulator:

```bash
# Opens Receive screen ✅
xcrun simctl openurl booted "zcash:///home/receive"

# Opens Send screen with address, amount, and memo pre-filled ✅
xcrun simctl openurl booted "zcash:///home/send?address=zs1...&amount=100000&memo=hello"
```

https://github.com/user-attachments/assets/c6fb52e6-eb7a-4587-a665-3520688ff5bc
