### PR TITLE
[#1665] Fix deeplink navigation + add Receive/Send deeplinks + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Added
+- Deep link support for the Receive screen via `zcash:///home/receive`.
+
 ## 3.3.0 build 2 (2026-04-07)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Added
-- Deep link support for the Receive screen via `zcash:///home/receive`.
+- Deep link support for the Receive screen via `zcash:///home/receive`. Fetches Keystone custom unified address before navigating, matching the in-app receive flow.
+
+### Fixed
+- Deep links for `zcash:///home`, `zcash:///home/send`, and `zcash:///home/receive` were silently ignored after the ZIP-321 check — the existing `process()` pipeline was never connected to the `.deeplink(url)` handler.
 
 ## 3.3.0 build 2 (2026-04-07)
 

--- a/modules/Sources/Dependencies/Deeplink/Deeplink.swift
+++ b/modules/Sources/Dependencies/Deeplink/Deeplink.swift
@@ -13,6 +13,7 @@ import ZcashLightClientKit
 public struct Deeplink {
     public enum Destination: Equatable {
         case home
+        case receive
         case send(amount: Int, address: String, memo: String)
     }
     
@@ -39,6 +40,11 @@ public struct Deeplink {
                 Path { "home" }
             }
 
+            // GET /home/receive
+            Route(.case(Destination.receive)) {
+                Path { "home"; "receive" }
+            }
+
             // GET /home/send?amount=:amount&address=:address&memo=:memo
             Route(.case(Destination.send(amount:address:memo:))) {
                 Path { "home"; "send" }
@@ -53,6 +59,9 @@ public struct Deeplink {
         switch try appRouter.match(url: url) {
         case .home:
             return .home
+
+        case .receive:
+            return .receive
 
         case let .send(amount, address, memo):
             return .send(amount: amount, address: address, memo: memo)

--- a/modules/Sources/Features/Root/RootCoordinator.swift
+++ b/modules/Sources/Features/Root/RootCoordinator.swift
@@ -118,6 +118,22 @@ extension Root {
                 exchangeRate.refreshExchangeRateUSD()
                 return .none
 
+            case .destination(.deeplinkSend(let amount, let address, let memo)):
+                state.sendCoordFlowState = .initial
+                state.path = .sendCoordFlow
+                exchangeRate.refreshExchangeRateUSD()
+                if !memo.isEmpty {
+                    state.sendCoordFlowState.sendFormState.memoState.text = memo
+                }
+                var effects: [Effect<Root.Action>] = []
+                if amount.amount > 0 {
+                    effects.append(.send(.sendCoordFlow(.sendForm(.zecAmountUpdated(amount.decimalString().redacted)))))
+                }
+                if !address.isEmpty {
+                    effects.append(.send(.sendCoordFlow(.sendForm(.addressUpdated(address.redacted)))))
+                }
+                return effects.isEmpty ? .none : .merge(effects)
+
             case .home(.scanTapped):
                 state.scanCoordFlowState = .initial
                 state.path = .scanCoordFlow

--- a/modules/Sources/Features/Root/RootCoordinator.swift
+++ b/modules/Sources/Features/Root/RootCoordinator.swift
@@ -106,7 +106,8 @@ extension Root {
                 state.path = .settings
                 return .none
                 
-            case .home(.receiveTapped):
+            case .home(.receiveTapped),
+                .destination(.deeplinkReceive):
                 state.receiveState = .initial
                 state.path = .receive
                 return .none

--- a/modules/Sources/Features/Root/RootCoordinator.swift
+++ b/modules/Sources/Features/Root/RootCoordinator.swift
@@ -106,10 +106,24 @@ extension Root {
                 state.path = .settings
                 return .none
                 
-            case .home(.receiveTapped),
-                .destination(.deeplinkReceive):
+            case .home(.receiveTapped):
                 state.receiveState = .initial
                 state.path = .receive
+                return .none
+
+            case .destination(.deeplinkReceive):
+                guard state.destinationState.destination != .deeplinkWarning else {
+                    return .none
+                }
+                state.receiveState = .initial
+                state.path = .receive
+                let isKeystone = state.selectedWalletAccount?.vendor == .keystone
+                if let uuid = state.selectedWalletAccount?.id {
+                    return .run { send in
+                        let privateUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, isKeystone ? [.orchard] : [.sapling, .orchard])
+                        await send(.home(.updatePrivateUA(privateUA)))
+                    }
+                }
                 return .none
 
             case .home(.sendTapped):

--- a/modules/Sources/Features/Root/RootDestination.swift
+++ b/modules/Sources/Features/Root/RootDestination.swift
@@ -73,7 +73,7 @@ extension Root {
                         let action = try await process(url: url, deeplink: deeplink, derivationTool: derivationTool)
                         await send(action)
                     } catch {
-                        await send(.destination(.deeplinkFailed(url, error as! ZcashError)))
+                        await send(.destination(.deeplinkFailed(url, error.toZcashError())))
                     }
                 }
 

--- a/modules/Sources/Features/Root/RootDestination.swift
+++ b/modules/Sources/Features/Root/RootDestination.swift
@@ -44,6 +44,7 @@ extension Root {
     public enum DestinationAction {
         case deeplink(URL)
         case deeplinkHome
+        case deeplinkReceive
         case deeplinkSend(Zatoshi, String, String)
         case deeplinkFailed(URL, ZcashError)
         case updateDestination(Root.DestinationState.Destination)
@@ -71,6 +72,9 @@ extension Root {
 
             case .destination(.deeplinkHome):
                 return .none
+
+            case .destination(.deeplinkReceive):
+                return .send(.destination(.updateDestination(.home)))
 
             case .destination(.deeplinkSend):
                 return .none
@@ -156,6 +160,8 @@ private extension Root {
         switch deeplink {
         case .home:
             return .destination(.deeplinkHome)
+        case .receive:
+            return .destination(.deeplinkReceive)
         case let .send(amount, address, memo):
             return .destination(.deeplinkSend(Zatoshi(Int64(amount)), address, memo))
         }

--- a/modules/Sources/Features/Root/RootDestination.swift
+++ b/modules/Sources/Features/Root/RootDestination.swift
@@ -68,7 +68,14 @@ extension Root {
                     // The deeplink is some zip321, we ignore it and let users know in a warning screen
                     return .send(.destination(.updateDestination(.deeplinkWarning)))
                 }
-                return .none
+                return .run { send in
+                    do {
+                        let action = try await process(url: url, deeplink: deeplink, derivationTool: derivationTool)
+                        await send(action)
+                    } catch {
+                        await send(.destination(.deeplinkFailed(url, error as! ZcashError)))
+                    }
+                }
 
             case .destination(.deeplinkHome):
                 return .none

--- a/secant/secant-mainnet-Info.plist
+++ b/secant/secant-mainnet-Info.plist
@@ -50,6 +50,21 @@
 		<string>fetch</string>
 		<string>processing</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLName</key>
+			<string>co.electriccoin.secant-mainnet</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>zcash</string>
+			</array>
+		</dict>
+	</array>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UILaunchStoryboardName</key>
@@ -62,7 +77,5 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>UIDesignRequiresCompatibility</key>
-	<true/>
 </dict>
 </plist>

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -138,6 +138,43 @@ class DeeplinkTests: XCTestCase {
         await store.finish()
     }
 
+    func testReceiveURLParsing_ExtraPathComponent_DoesNotMatch() throws {
+        guard let url = URL(string: "zcash:///home/receive/extra") else {
+            return XCTFail("Deeplink: 'testReceiveURLParsing_ExtraPathComponent_DoesNotMatch' URL is expected to be valid.")
+        }
+
+        XCTAssertThrowsError(
+            try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false }),
+            "zcash:///home/receive/extra should not match any route"
+        )
+    }
+
+    func testSendURLParsing_ExtraPathComponent_DoesNotMatch() throws {
+        guard let url = URL(string: "zcash:///home/send/extra") else {
+            return XCTFail("Deeplink: 'testSendURLParsing_ExtraPathComponent_DoesNotMatch' URL is expected to be valid.")
+        }
+
+        XCTAssertThrowsError(
+            try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false }),
+            "zcash:///home/send/extra should not match any route"
+        )
+    }
+
+    func testActionDeeplinkReceive_GuardedByDeeplinkWarning() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .deeplinkWarning
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        await store.send(.destination(.deeplinkReceive))
+
+        await store.finish()
+    }
+
     func testHomeURLParsing() throws {
         guard let url = URL(string: "zcash:///home") else {
             return XCTFail("Deeplink: 'testDeeplinkRequest_homeURL' URL is expected to be valid.")

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -66,10 +66,8 @@ class DeeplinkTests: XCTestCase {
         
         await store.send(.destination(.deeplinkSend(amount, address, memo))) { state in
             state.destinationState.destination = .home
-//            state.tabsState.selectedTab = .send
-//            state.tabsState.sendState.amount = amount
-//            state.tabsState.sendState.address = address.redacted
-//            state.tabsState.sendState.memoState.text = memo
+            state.path = .sendCoordFlow
+            state.sendCoordFlowState.sendFormState.memoState.text = memo
         }
         
         await store.finish()
@@ -230,10 +228,8 @@ class DeeplinkTests: XCTestCase {
 
         await store.receive(.destination(.deeplinkSend(amount, address, memo))) { state in
             state.destinationState.destination = .home
-//            state.tabsState.selectedTab = .send
-//            state.tabsState.sendState.amount = amount
-//            state.tabsState.sendState.address = address.redacted
-//            state.tabsState.sendState.memoState.text = memo
+            state.path = .sendCoordFlow
+            state.sendCoordFlowState.sendFormState.memoState.text = memo
         }
         
         await store.finish()

--- a/secantTests/DeeplinkTests/DeeplinkTests.swift
+++ b/secantTests/DeeplinkTests/DeeplinkTests.swift
@@ -75,6 +75,71 @@ class DeeplinkTests: XCTestCase {
         await store.finish()
     }
 
+    func testReceiveURLParsing() throws {
+        guard let url = URL(string: "zcash:///home/receive") else {
+            return XCTFail("Deeplink: 'testReceiveURLParsing' URL is expected to be valid.")
+        }
+
+        let result = try Deeplink().resolveDeeplinkURL(url, networkType: .testnet, isValidZcashAddress: { _, _ in false })
+
+        XCTAssertEqual(result, Deeplink.Destination.receive)
+    }
+
+    func testActionDeeplinkReceive() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .welcome
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        await store.send(.destination(.deeplinkReceive)) { state in
+            state.destinationState.destination = .home
+            state.path = .receive
+        }
+
+        await store.finish()
+    }
+
+    func testDeeplinkRequest_Received_Receive() async throws {
+        var appState = Root.State.initial
+        appState.destinationState.destination = .welcome
+        appState.appInitializationState = .initialized
+
+        let store = TestStore(
+            initialState: appState
+        ) {
+            Root()
+        }
+
+        store.dependencies.deeplink = DeeplinkClient(
+            resolveDeeplinkURL: { _, _, _ in Deeplink.Destination.receive }
+        )
+        store.dependencies.sdkSynchronizer = SDKSynchronizerClient.mocked(
+            latestState: {
+                var state = SynchronizerState.zero
+                state.syncStatus = .upToDate
+                return state
+            }
+        )
+        store.dependencies.walletConfigProvider = .noOp
+
+        guard let url = URL(string: "zcash:///home/receive") else {
+            return XCTFail("Deeplink: 'testDeeplinkRequest_Received_Receive' URL is expected to be valid.")
+        }
+
+        await store.send(.destination(.deeplink(url)))
+
+        await store.receive(.destination(.deeplinkReceive)) { state in
+            state.destinationState.destination = .home
+            state.path = .receive
+        }
+
+        await store.finish()
+    }
+
     func testHomeURLParsing() throws {
         guard let url = URL(string: "zcash:///home") else {
             return XCTFail("Deeplink: 'testDeeplinkRequest_homeURL' URL is expected to be valid.")


### PR DESCRIPTION
Closes #1665.

Built on top of #1666 which added the receive deeplink routing. This PR covers the remaining pieces needed to make deeplinks actually work end-to-end.

## What this adds

**1. Register `zcash` URL scheme in `secant-mainnet-Info.plist`**
Without this, iOS never routes `zcash://` URLs to the app at all — no deeplink code runs regardless of what's in the reducers.

**2. Handle `.deeplinkSend` in the coordinator**
`zcash:///home/send?address=...&amount=...&memo=...` was previously a stub (`return .none`). Now opens the send flow and pre-fills address, amount, and memo.

## Additional tests

- `testReceiveURLParsing` — URL parsing produces `.receive`
- `testDeeplinkRequest_Received_Receive` — end-to-end receive deeplink flow
- `testReceiveURLParsing_ExtraPathComponent_DoesNotMatch` — `zcash:///home/receive/extra` throws
- `testSendURLParsing_ExtraPathComponent_DoesNotMatch` — `zcash:///home/send/extra` throws

## Testing

Verified on simulator:

```bash
# Opens Receive screen ✅
xcrun simctl openurl booted "zcash:///home/receive"

# Opens Send screen with address, amount, and memo pre-filled ✅
xcrun simctl openurl booted "zcash:///home/send?address=zs1...&amount=100000&memo=hello"
```

https://github.com/user-attachments/assets/43286503-d455-4835-ad0c-b9081b4ca2e5

