### PR TITLE
Make Root.Action Sendable

### DIFF
--- a/secant/Sources/Features/About/AboutView.swift
+++ b/secant/Sources/Features/About/AboutView.swift
@@ -91,7 +91,7 @@ extension About.State {
 }
 
 extension About {
-    static let initial = StoreOf<About>(
+    @MainActor static let initial = StoreOf<About>(
         initialState: .initial
     ) {
         About()

--- a/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletView.swift
+++ b/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletView.swift
@@ -204,7 +204,7 @@ extension AddKeystoneHWWallet.State {
 }
 
 extension AddKeystoneHWWallet {
-    static let initial = StoreOf<AddKeystoneHWWallet>(
+    @MainActor static let initial = StoreOf<AddKeystoneHWWallet>(
         initialState: .initial
     ) {
         AddKeystoneHWWallet()

--- a/secant/Sources/Features/DisconnectHWWallet/DisconnectHWWalletView.swift
+++ b/secant/Sources/Features/DisconnectHWWallet/DisconnectHWWalletView.swift
@@ -271,7 +271,7 @@ extension DisconnectHWWallet.State {
 }
 
 extension StoreOf<DisconnectHWWallet> {
-    static let initial = StoreOf<DisconnectHWWallet>(
+    @MainActor static let initial = StoreOf<DisconnectHWWallet>(
         initialState: .initial
     ) {
         DisconnectHWWallet()

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -140,7 +140,7 @@ extension Root {
                             .receive(on: mainQueue)
                     }
                     .cancellable(id: state.CancelResyncStateId, cancelInFlight: true),
-                    .send(.batteryStateChanged(nil))
+                    .send(.batteryStateChanged)
                 )
                 
             case .rewindDone(let zcashError):

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -303,7 +303,7 @@ extension Root {
                 return .concatenate(
                     .send(.initialization(.initializeSDK(.restoreWallet))),
                     .send(.initialization(.checkBackupPhraseValidation)),
-                    .send(.batteryStateChanged(nil))
+                    .send(.batteryStateChanged)
                 )
 
                 // MARK: - Scan Coord Flow

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -394,10 +394,10 @@ extension Root {
                     .send(.initialization(.registerForSynchronizersUpdate)),
                     .publisher {
                         autolockHandler.batteryStatePublisher()
-                            .map(Root.Action.batteryStateChanged)
+                            .map { _ in Root.Action.batteryStateChanged }
                     }
                     .cancellable(id: state.CancelBatteryStateId, cancelInFlight: true),
-                    .send(.batteryStateChanged(nil)),
+                    .send(.batteryStateChanged),
                     .send(.observeTransactions),
                     .send(.observeShieldingProcessor),
                     .send(.observeTorInit)

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -143,7 +143,7 @@ struct Root {
         }
 
         case alert(PresentationAction<Action>)
-        case batteryStateChanged(Notification?)
+        case batteryStateChanged
         case binding(BindingAction<Root.State>)
         case cancelAllRunningEffects
         case confirmationDialog(PresentationAction<ConfirmationDialog>)


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `Root.Action`  Swift 6 compliant.

It basically changes `case batteryStateChanged(Notification?)` to `case batteryStateChanged`. Problem was that `Notification` is not Sendable. And I checked the code and notification from batteryStateChanged have never been used in the code.