### PR TITLE
Make ExchangeRateClient Swift 6 compliant

### DIFF
--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -8761,8 +8761,6 @@
 				kind = upToNextMinorVersion;
 				minimumVersion = 1.25.5;
 			};
-			traits = (
-			);
 		};
 		34AA771D2F857DFF00D244E2 /* XCRemoteSwiftPackageReference "xctest-dynamic-overlay" */ = {
 			isa = XCRemoteSwiftPackageReference;

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
@@ -30,6 +30,6 @@ struct ExchangeRateClient {
         case sdk
     }
 
-    let exchangeRateEventStream: () -> AnyPublisher<EchangeRateEvent, Never>
-    var refreshExchangeRateUSD: () -> Void
+    var exchangeRateEventStream: @Sendable () -> AnyPublisher<EchangeRateEvent, Never> = { Empty().eraseToAnyPublisher() }
+    var refreshExchangeRateUSD: @Sendable () -> Void = { }
 }

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
@@ -11,31 +11,39 @@ import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
-class ExchangeRateProvider {
+@MainActor final class ExchangeRateProvider {
     enum Constants {
         static let cmcRateURL = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=ZEC&convert=USD"
         static let zecKey = "ZEC"
     }
-    
-    var cancellable: AnyCancellable? = nil
-    let eventStream = CurrentValueSubject<ExchangeRateClient.EchangeRateEvent, Never>(.value(nil))
-    var latestRate: FiatCurrencyResult? = nil
-    var refreshTimer: Timer? = nil
-    var staleTimer: Timer? = nil
-    var isStale = false
-    var nilValuesCounter = 0
 
-    init() {
+    private var cancellable: AnyCancellable? = nil
+    nonisolated let eventStream = CurrentValueSubject<ExchangeRateClient.EchangeRateEvent, Never>(.value(nil))
+    private var latestRate: FiatCurrencyResult? = nil
+    private var refreshTimer: Timer? = nil
+    private var staleTimer: Timer? = nil
+    private var isStale = false
+    private var nilValuesCounter = 0
+    private var isSetUp = false
+
+    // nonisolated init() — empty, so live() can create it without main actor context
+    nonisolated init() {}
+
+    func setup() {
+        guard !isSetUp else { return }
+        isSetUp = true
         if !_XCTIsTesting {
             @Dependency(\.sdkSynchronizer) var sdkSynchronizer
-            
+
             cancellable = sdkSynchronizer.exchangeRateUSDStream().sink { [weak self] result in
-                self?.resolveResult(result)
+                Task { @MainActor [weak self] in
+                    self?.resolveResult(result)
+                }
             }
         }
     }
-    
-    func getCMCRate() async throws -> Double {
+
+    nonisolated func getCMCRate() async throws -> Double {
         guard let cmcKey = PartnerKeys.cmcKey else {
             throw "CMC API Key missing"
         }
@@ -46,7 +54,7 @@ class ExchangeRateProvider {
         guard let url = URL(string: Constants.cmcRateURL) else {
             throw URLError(.badURL)
         }
-        
+
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -55,23 +63,24 @@ class ExchangeRateProvider {
         let (data, response) = swapAPIAccess == .direct
         ? try await URLSession.shared.data(for: request)
         : try await sdkSynchronizer.httpRequestOverTor(request)
-        
+
         guard let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode) else {
             let code = (response as? HTTPURLResponse)?.statusCode ?? -1
             throw "httpStatus \(code)"
         }
-        
+
         if let result = try? JSONDecoder().decode(CMCPrice.self, from: data) {
             if let zec = result.data[Constants.zecKey] {
                 return zec.quote.USD.price
             }
         }
-        
+
         throw "Decode CMCPrice.self failed"
     }
 
     func refreshExchangeRateUSD(_ rateSource: ExchangeRateClient.RateSource = .coinMarketCap) {
+        setup()
         if !_XCTIsTesting {
             // guard the feature is opted-in by a user
             @Dependency(\.userStoredPreferences) var userStoredPreferences
@@ -85,47 +94,48 @@ class ExchangeRateProvider {
             }
 
             if rateSource == .coinMarketCap {
-                Task(priority: .low) {
+                Task(priority: .low) { [weak self] in
+                    guard let self else { return }
                     do {
                         let price = try await getCMCRate()
-                        
+
                         let fiat = FiatCurrencyResult(
                             date: Date(),
                             rate: NSDecimalNumber(value: price),
                             state: .success
                         )
-                        
+
                         eventStream.send(.value(fiat))
                     } catch {
-                        await coinMarketCapRateFailed()
+                        coinMarketCapRateFailed()
                     }
                 }
             } else if rateSource == .sdk {
                 @Dependency(\.sdkSynchronizer) var sdkSynchronizer
-                
+
                 sdkSynchronizer.refreshExchangeRateUSD()
             }
         }
     }
-    
-    func coinMarketCapRateFailed() async {
+
+    func coinMarketCapRateFailed() {
         refreshExchangeRateUSD(.sdk)
     }
-    
+
     func resolveResult(_ result: FiatCurrencyResult?) {
         // retry logic for nil value
         guard let result else {
             nilValuesCounter += 1
-            
+
             if nilValuesCounter == 2 {
                 refreshExchangeRateUSD(.coinMarketCap)
             } else if nilValuesCounter > 2 {
                 eventStream.send(.stale(latestRate))
             }
-            
+
             return
         }
-        
+
         latestRate = result
 
         @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
@@ -140,12 +150,12 @@ class ExchangeRateProvider {
 
         rescheduleTimer()
     }
-    
+
     func rescheduleTimer() {
         guard let latestRate else {
             return
         }
-        
+
         if latestRate.state == .success {
             @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
 
@@ -153,24 +163,26 @@ class ExchangeRateProvider {
 
             let diff = Date().timeIntervalSince1970 - latestRate.date.timeIntervalSince1970
             let timeToSchedule = zcashSDKEnvironment.exchangeRateIPRateLimit - diff
-            
+
             if timeToSchedule < 0 {
                 eventStream.send(.refreshEnable(latestRate))
             } else {
-                DispatchQueue.main.async { [weak self] in
-                    self?.refreshTimer?.invalidate()
-                    self?.refreshTimer = Timer.scheduledTimer(withTimeInterval: timeToSchedule, repeats: false) { [weak self] _ in
+                refreshTimer?.invalidate()
+                refreshTimer = Timer.scheduledTimer(withTimeInterval: timeToSchedule, repeats: false) { [weak self] _ in
+                    Task { @MainActor [weak self] in
                         self?.refreshTimer?.invalidate()
                         self?.refreshTimer = nil
-                        
+
                         self?.eventStream.send(.refreshEnable(self?.latestRate))
                     }
+                }
 
-                    self?.staleTimer?.invalidate()
-                    self?.staleTimer = Timer.scheduledTimer(withTimeInterval: zcashSDKEnvironment.exchangeRateStaleLimit, repeats: false) { [weak self] _ in
+                staleTimer?.invalidate()
+                staleTimer = Timer.scheduledTimer(withTimeInterval: zcashSDKEnvironment.exchangeRateStaleLimit, repeats: false) { [weak self] _ in
+                    Task { @MainActor [weak self] in
                         self?.staleTimer?.invalidate()
                         self?.staleTimer = nil
-                        
+
                         self?.isStale = true
                         self?.refreshExchangeRateUSD()
                     }
@@ -182,14 +194,20 @@ class ExchangeRateProvider {
 
 extension ExchangeRateClient: DependencyKey {
     static let liveValue: ExchangeRateClient = Self.live()
-    
+
     static func live() -> Self {
         let exchangeRateProvider = ExchangeRateProvider()
-        
+
+        Task { @MainActor in
+            exchangeRateProvider.setup()
+        }
+
         return ExchangeRateClient(
             exchangeRateEventStream: { exchangeRateProvider.eventStream.eraseToAnyPublisher() },
             refreshExchangeRateUSD: {
-                exchangeRateProvider.refreshExchangeRateUSD()
+                Task { @MainActor in
+                    exchangeRateProvider.refreshExchangeRateUSD()
+                }
             }
         )
     }


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `ExchangeRateClient` Swift 6 compliant.

Internals of `ExchangeRateClient` are refactored to be Swift 6 compliant. Logic is same as before.