### PR TITLE
Fix dependencies creation to make code Swift 6 compliant

### DIFF
--- a/secant/Sources/Dependencies/AppVersion/AppVersionLiveKey.swift
+++ b/secant/Sources/Dependencies/AppVersion/AppVersionLiveKey.swift
@@ -9,8 +9,12 @@ import Foundation
 import ComposableArchitecture
 
 extension AppVersionClient: DependencyKey {
-    static let liveValue = Self(
-        appVersion: { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "" },
-        appBuild: { Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "" }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            appVersion: { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "" },
+            appBuild: { Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "" }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/Date/DateLiveKey.swift
+++ b/secant/Sources/Dependencies/Date/DateLiveKey.swift
@@ -9,7 +9,11 @@ import Foundation
 import ComposableArchitecture
 
 extension DateClient: DependencyKey {
-    static let liveValue = Self(
-        now: { Date.now }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            now: { Date.now }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/Deeplink/DeeplinkLiveKey.swift
+++ b/secant/Sources/Dependencies/Deeplink/DeeplinkLiveKey.swift
@@ -8,7 +8,11 @@
 import ComposableArchitecture
 
 extension DeeplinkClient: DependencyKey {
-    static let liveValue = Self(
-        resolveDeeplinkURL: { try Deeplink.resolveDeeplinkURL($0, networkType: $1, isValidZcashAddress: $2.isZcashAddress) }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            resolveDeeplinkURL: { try Deeplink.resolveDeeplinkURL($0, networkType: $1, isValidZcashAddress: $2.isZcashAddress) }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/DiskSpaceChecker/DiskSpaceCheckerLiveKey.swift
+++ b/secant/Sources/Dependencies/DiskSpaceChecker/DiskSpaceCheckerLiveKey.swift
@@ -8,11 +8,13 @@
 import ComposableArchitecture
 
 extension DiskSpaceCheckerClient: DependencyKey {
-    static let liveValue: Self = {
-        return Self(
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
             freeSpaceRequiredForSync: { DiskSpaceChecker.freeSpaceRequiredForSync() },
             hasEnoughFreeSpaceForSync: { DiskSpaceChecker.hasEnoughFreeSpaceForSync() },
             freeSpace: { DiskSpaceChecker.freeSpace() }
         )
-    }()
+    }
 }

--- a/secant/Sources/Dependencies/FeedbackGenerator/FeedbackGeneratorLiveKey.swift
+++ b/secant/Sources/Dependencies/FeedbackGenerator/FeedbackGeneratorLiveKey.swift
@@ -9,9 +9,13 @@ import UIKit
 import ComposableArchitecture
 
 extension FeedbackGeneratorClient: DependencyKey {
-    static let liveValue = Self(
-        generateSuccessFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.success) },
-        generateWarningFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.warning) },
-        generateErrorFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.error) }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            generateSuccessFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.success) },
+            generateWarningFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.warning) },
+            generateErrorFeedback: { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.error) }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerLiveKey.swift
+++ b/secant/Sources/Dependencies/FlexaHandler/FlexaHandlerLiveKey.swift
@@ -43,7 +43,9 @@ struct FlexaTransaction: Equatable {
 }
 
 extension FlexaHandlerClient: DependencyKey {
-    static var liveValue: Self {
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
         let onTransactionRequest = CurrentValueSubject<Result<FXTransaction, any Error>?, Never>(nil)
         let latestSpendableBalance = CurrentValueSubject<Decimal, Never>(0)
         let latestSpendableAvailableBalance = CurrentValueSubject<Decimal?, Never>(nil)

--- a/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerLiveKey.swift
+++ b/secant/Sources/Dependencies/KeystoneHandler/KeystoneHandlerLiveKey.swift
@@ -30,7 +30,9 @@ final class KeystoneSDKWrapper: Sendable {
 }
 
 extension KeystoneHandlerClient: DependencyKey {
-    static var liveValue: Self {
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
         let wrapper = KeystoneSDKWrapper()
 
         return .init(

--- a/secant/Sources/Dependencies/LocalAuthenticationHandler/LocalAuthenticationLiveKey.swift
+++ b/secant/Sources/Dependencies/LocalAuthenticationHandler/LocalAuthenticationLiveKey.swift
@@ -9,55 +9,59 @@ import ComposableArchitecture
 import LocalAuthentication
 
 extension LocalAuthenticationClient: DependencyKey {
-    static let liveValue = Self(
-        authenticate: {
-#if targetEnvironment(simulator)
-            return true
-#endif
-            let context = LAContext()
-            var error: NSError?
-            let reason = String(localizable: .localAuthenticationReason)
-            
-            do {
-                /// Biometrics validation
-                if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
-                    return try await context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason)
-                } else {
-                    /// Biometrics not supported by the device, fallback to passcode
-                    if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-                        return try await context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason)
-                    } else {
-                        /// No local authentication available, user's device is not protected, fallback to allow access to sensitive content
-                        return true
-                    }
-                }
-            } catch {
-                /// Some interruption occurred during the authentication, access to the sensitive content is therefore forbidden
-                return false
-            }
-        },
-        method: {
-            let context = LAContext()
-            var error: NSError?
+    static let liveValue = Self.live()
 
-            if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
-                switch context.biometryType {
-                case .faceID:
-                    return .faceID
-                case .touchID:
-                    return .touchID
-                case .none, .opticID:
-                    return .none
-                @unknown default:
-                    return .none
-                }
-            } else {
-                if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-                    return .passcode
+    static func live() -> Self {
+        Self(
+            authenticate: {
+#if targetEnvironment(simulator)
+                return true
+#endif
+                let context = LAContext()
+                var error: NSError?
+                let reason = String(localizable: .localAuthenticationReason)
+
+                do {
+                    /// Biometrics validation
+                    if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
+                        return try await context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason)
                     } else {
+                        /// Biometrics not supported by the device, fallback to passcode
+                        if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+                            return try await context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason)
+                        } else {
+                            /// No local authentication available, user's device is not protected, fallback to allow access to sensitive content
+                            return true
+                        }
+                    }
+                } catch {
+                    /// Some interruption occurred during the authentication, access to the sensitive content is therefore forbidden
+                    return false
+                }
+            },
+            method: {
+                let context = LAContext()
+                var error: NSError?
+
+                if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
+                    switch context.biometryType {
+                    case .faceID:
+                        return .faceID
+                    case .touchID:
+                        return .touchID
+                    case .none, .opticID:
+                        return .none
+                    @unknown default:
                         return .none
                     }
+                } else {
+                    if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+                        return .passcode
+                        } else {
+                            return .none
+                        }
+                }
             }
-        }
-    )
+        )
+    }
 }

--- a/secant/Sources/Dependencies/LogsHandler/LogsHandlerLive.swift
+++ b/secant/Sources/Dependencies/LogsHandler/LogsHandlerLive.swift
@@ -10,64 +10,68 @@ import ComposableArchitecture
 import OSLog
 
 extension LogsHandlerClient: DependencyKey {
-    static let liveValue = LogsHandlerClient(
-        exportAndStoreLogs: { sdkLogs, tcaLogs, walletLogs in
-            // create a directory
-            let logsURL = FileManager.default.temporaryDirectory.appendingPathComponent("zashiPrivateData")
-            try FileManager.default.createDirectory(atPath: logsURL.path, withIntermediateDirectories: true)
-            
-            // export the logs
-            async let sdkLogsVerbose = LogsHandlerClient.exportAndStoreLogsFor(
-                key: sdkLogs,
-                atURL: logsURL.appendingPathComponent("sdkLogs_verbose.txt")
-            )
-            async let sdkLogsSync = LogsHandlerClient.exportAndStoreLogsFor(
-                key: sdkLogs,
-                atURL: logsURL.appendingPathComponent("sdkLogs_sync.txt"),
-                level: .info // The info level represents the sync log in the SDK
-            )
-            async let tcaLogs = LogsHandlerClient.exportAndStoreLogsFor(
-                key: tcaLogs,
-                atURL: logsURL.appendingPathComponent("tcaLogs.txt")
-            )
-            async let walletLogs = LogsHandlerClient.exportAndStoreLogsFor(
-                key: walletLogs,
-                atURL: logsURL.appendingPathComponent("walletLogs.txt")
-            )
+    static let liveValue = Self.live()
 
-            let logs = try await [sdkLogsVerbose, sdkLogsSync, tcaLogs, walletLogs]
-            
-            // store the log files into the logs folder
-            try logs.forEach { logsHandler in
-                try logsHandler.result.write(to: logsHandler.dir, atomically: true, encoding: String.Encoding.utf8)
-            }
-            
-            // zip the logs folder
-            let coordinator = NSFileCoordinator()
-            var zipError: NSError?
-            var archiveURL: URL?
-            
-            archiveURL = await withCheckedContinuation { continuation in
-                coordinator.coordinate(readingItemAt: logsURL, options: [.forUploading], error: &zipError) { zipURL in
-                    do {
-                        let tmpURL = try FileManager.default.url(
-                            for: .itemReplacementDirectory,
-                            in: .userDomainMask,
-                            appropriateFor: zipURL,
-                            create: true
-                        )
-                        .appendingPathComponent("zashiPrivateData.zip")
-                        try FileManager.default.moveItem(at: zipURL, to: tmpURL)
-                        continuation.resume(returning: tmpURL)
-                    } catch {
-                        continuation.resume(returning: nil)
+    static func live() -> Self {
+        Self(
+            exportAndStoreLogs: { sdkLogs, tcaLogs, walletLogs in
+                // create a directory
+                let logsURL = FileManager.default.temporaryDirectory.appendingPathComponent("zashiPrivateData")
+                try FileManager.default.createDirectory(atPath: logsURL.path, withIntermediateDirectories: true)
+
+                // export the logs
+                async let sdkLogsVerbose = LogsHandlerClient.exportAndStoreLogsFor(
+                    key: sdkLogs,
+                    atURL: logsURL.appendingPathComponent("sdkLogs_verbose.txt")
+                )
+                async let sdkLogsSync = LogsHandlerClient.exportAndStoreLogsFor(
+                    key: sdkLogs,
+                    atURL: logsURL.appendingPathComponent("sdkLogs_sync.txt"),
+                    level: .info // The info level represents the sync log in the SDK
+                )
+                async let tcaLogs = LogsHandlerClient.exportAndStoreLogsFor(
+                    key: tcaLogs,
+                    atURL: logsURL.appendingPathComponent("tcaLogs.txt")
+                )
+                async let walletLogs = LogsHandlerClient.exportAndStoreLogsFor(
+                    key: walletLogs,
+                    atURL: logsURL.appendingPathComponent("walletLogs.txt")
+                )
+
+                let logs = try await [sdkLogsVerbose, sdkLogsSync, tcaLogs, walletLogs]
+
+                // store the log files into the logs folder
+                try logs.forEach { logsHandler in
+                    try logsHandler.result.write(to: logsHandler.dir, atomically: true, encoding: String.Encoding.utf8)
+                }
+
+                // zip the logs folder
+                let coordinator = NSFileCoordinator()
+                var zipError: NSError?
+                var archiveURL: URL?
+
+                archiveURL = await withCheckedContinuation { continuation in
+                    coordinator.coordinate(readingItemAt: logsURL, options: [.forUploading], error: &zipError) { zipURL in
+                        do {
+                            let tmpURL = try FileManager.default.url(
+                                for: .itemReplacementDirectory,
+                                in: .userDomainMask,
+                                appropriateFor: zipURL,
+                                create: true
+                            )
+                            .appendingPathComponent("zashiPrivateData.zip")
+                            try FileManager.default.moveItem(at: zipURL, to: tmpURL)
+                            continuation.resume(returning: tmpURL)
+                        } catch {
+                            continuation.resume(returning: nil)
+                        }
                     }
                 }
+
+                return archiveURL
             }
-            
-            return archiveURL
-        }
-    )
+        )
+    }
 }
 
 private extension LogsHandlerClient {

--- a/secant/Sources/Dependencies/MnemonicClient/MnemonicLiveKey.swift
+++ b/secant/Sources/Dependencies/MnemonicClient/MnemonicLiveKey.swift
@@ -9,26 +9,30 @@ import ComposableArchitecture
 @preconcurrency import MnemonicSwift
 
 extension MnemonicClient: DependencyKey {
-    static let liveValue = Self(
-        randomMnemonic: {
-            try Mnemonic.generateMnemonic(strength: 256)
-        },
-        randomMnemonicWords: {
-            try Mnemonic.generateMnemonic(strength: 256).components(separatedBy: " ")
-        },
-        toSeed: { mnemonic in
-            let data = try Mnemonic.deterministicSeedBytes(from: mnemonic)
+    static let liveValue = Self.live()
 
-            return [UInt8](data)
-        },
-        asWords: { mnemonic in
-            mnemonic.components(separatedBy: " ")
-        },
-        isValid: { mnemonic in
-            try Mnemonic.validate(mnemonic: mnemonic)
-        },
-        suggestWords: { prefix in
-            MnemonicLanguageType.english.words().filter { $0.hasPrefix(prefix) }
-        }
-    )
+    static func live() -> Self {
+        Self(
+            randomMnemonic: {
+                try Mnemonic.generateMnemonic(strength: 256)
+            },
+            randomMnemonicWords: {
+                try Mnemonic.generateMnemonic(strength: 256).components(separatedBy: " ")
+            },
+            toSeed: { mnemonic in
+                let data = try Mnemonic.deterministicSeedBytes(from: mnemonic)
+
+                return [UInt8](data)
+            },
+            asWords: { mnemonic in
+                mnemonic.components(separatedBy: " ")
+            },
+            isValid: { mnemonic in
+                try Mnemonic.validate(mnemonic: mnemonic)
+            },
+            suggestWords: { prefix in
+                MnemonicLanguageType.english.words().filter { $0.hasPrefix(prefix) }
+            }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/Pasteboard/PasteboardLiveKey.swift
+++ b/secant/Sources/Dependencies/Pasteboard/PasteboardLiveKey.swift
@@ -9,8 +9,12 @@ import ComposableArchitecture
 import UIKit
 
 extension PasteboardClient: DependencyKey {
-    static let liveValue = Self(
-        setString: { UIPasteboard.general.string = $0.data },
-        getString: { UIPasteboard.general.string?.redacted }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            setString: { UIPasteboard.general.string = $0.data },
+            getString: { UIPasteboard.general.string?.redacted }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/QRImageDetector/QRImageDetectorLiveKey.swift
+++ b/secant/Sources/Dependencies/QRImageDetector/QRImageDetectorLiveKey.swift
@@ -9,19 +9,23 @@ import ComposableArchitecture
 import CoreImage
 
 extension QRImageDetectorClient: DependencyKey {
-    static let liveValue = Self(
-        check: { image in
-            guard let image else { return nil }
-            guard let ciImage = CIImage(image: image) else { return nil }
-            
-            let detectorOptions = [CIDetectorAccuracy: CIDetectorAccuracyHigh]
-            let qrDetector = CIDetector(ofType: CIDetectorTypeQRCode, context: CIContext(), options: detectorOptions)
-            let decoderOptions = [CIDetectorImageOrientation: ciImage.properties[(kCGImagePropertyOrientation as String)] ?? 1]
-            let features = qrDetector?.features(in: ciImage, options: decoderOptions)
-            
-            return features?.compactMap {
-                ($0 as? CIQRCodeFeature)?.messageString
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            check: { image in
+                guard let image else { return nil }
+                guard let ciImage = CIImage(image: image) else { return nil }
+
+                let detectorOptions = [CIDetectorAccuracy: CIDetectorAccuracyHigh]
+                let qrDetector = CIDetector(ofType: CIDetectorTypeQRCode, context: CIContext(), options: detectorOptions)
+                let decoderOptions = [CIDetectorImageOrientation: ciImage.properties[(kCGImagePropertyOrientation as String)] ?? 1]
+                let features = qrDetector?.features(in: ciImage, options: decoderOptions)
+
+                return features?.compactMap {
+                    ($0 as? CIQRCodeFeature)?.messageString
+                }
             }
-        }
-    )
+        )
+    }
 }

--- a/secant/Sources/Dependencies/ReadTransactionsStorage/ReadTransactionsStorageLiveKey.swift
+++ b/secant/Sources/Dependencies/ReadTransactionsStorage/ReadTransactionsStorageLiveKey.swift
@@ -9,124 +9,128 @@ import ComposableArchitecture
 import CoreData
 
 extension ReadTransactionsStorageClient: DependencyKey {
-    static let liveValue = Self(
-        markIdAsRead: {
-            let context = persistentContainer.viewContext
-            
-            if let entity = NSEntityDescription.entity(
-                forEntityName: ReadTransactionsStorageClient.Constants.entityName,
-                in: context
-            ) {
-                let newRead = NSManagedObject(entity: entity, insertInto: context)
-                
-                newRead.setValue($0.data, forKey: "id")
-                
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            markIdAsRead: {
+                let context = persistentContainer.viewContext
+
+                if let entity = NSEntityDescription.entity(
+                    forEntityName: ReadTransactionsStorageClient.Constants.entityName,
+                    in: context
+                ) {
+                    let newRead = NSManagedObject(entity: entity, insertInto: context)
+
+                    newRead.setValue($0.data, forKey: "id")
+
+                    do {
+                        try context.save()
+                    } catch {
+                        throw error
+                    }
+                } else {
+                    throw ReadTransactionsStorageError.createEntity
+                }
+            },
+            readIds: {
+                let context = persistentContainer.viewContext
+
+                let request = NSFetchRequest<NSFetchRequestResult>(entityName: ReadTransactionsStorageClient.Constants.entityName)
+                request.returnsObjectsAsFaults = false
+
                 do {
+                    let result = try context.fetch(request)
+
+                    if let managedObjects = result as? [NSManagedObject] {
+                        let ids = managedObjects.compactMap { element in
+                            (element.value(forKey: "id") as? String)?.redacted
+                        }
+
+                        var idsDict: [RedactableString: Bool] = [:]
+
+                        ids.forEach { id in
+                            idsDict[id] = true
+                        }
+
+                        return idsDict
+                    }
+
+                    return [:]
+                } catch {
+                    throw error
+                }
+            },
+            availabilityTimestamp: {
+                let context = persistentContainer.viewContext
+
+                // check presence of the timestamp
+                let request = NSFetchRequest<NSFetchRequestResult>(entityName: ReadTransactionsStorageClient.Constants.availabilityEntityName)
+                request.returnsObjectsAsFaults = false
+
+                do {
+                    let result = try context.fetch(request)
+
+                    if let managedObjects = result as? [NSManagedObject] {
+                        // no timestamp stored, create one
+                        if managedObjects.isEmpty {
+                            if let entity = NSEntityDescription.entity(
+                                forEntityName: ReadTransactionsStorageClient.Constants.availabilityEntityName,
+                                in: context
+                            ) {
+                                let newAvailability = NSManagedObject(entity: entity, insertInto: context)
+                                let now = Date.now.timeIntervalSince1970
+
+                                newAvailability.setValue(now, forKey: "timestamp")
+
+                                do {
+                                    try context.save()
+                                } catch {
+                                    throw error
+                                }
+
+                                return now
+                            } else {
+                                throw ReadTransactionsStorageError.createEntity
+                            }
+                        } else {
+                            if let timestamp = managedObjects.first?.value(forKey: "timestamp") as? TimeInterval {
+                                return timestamp
+                            }
+
+                            throw ReadTransactionsStorageError.availability
+                        }
+                    } else {
+                        throw ReadTransactionsStorageError.availability
+                    }
+                } catch {
+                    throw error
+                }
+            },
+            resetZashi: {
+                let context = persistentContainer.viewContext
+
+                let deleteRequestIds = NSBatchDeleteRequest(
+                    fetchRequest: NSFetchRequest<NSFetchRequestResult>(
+                        entityName: ReadTransactionsStorageClient.Constants.entityName
+                    )
+                )
+                let deleteRequestTimestamp = NSBatchDeleteRequest(
+                    fetchRequest: NSFetchRequest<NSFetchRequestResult>(
+                        entityName: ReadTransactionsStorageClient.Constants.availabilityEntityName
+                    )
+                )
+
+                do {
+                    try context.execute(deleteRequestIds)
+                    try context.execute(deleteRequestTimestamp)
                     try context.save()
                 } catch {
                     throw error
                 }
-            } else {
-                throw ReadTransactionsStorageError.createEntity
             }
-        },
-        readIds: {
-            let context = persistentContainer.viewContext
-
-            let request = NSFetchRequest<NSFetchRequestResult>(entityName: ReadTransactionsStorageClient.Constants.entityName)
-            request.returnsObjectsAsFaults = false
-            
-            do {
-                let result = try context.fetch(request)
-
-                if let managedObjects = result as? [NSManagedObject] {
-                    let ids = managedObjects.compactMap { element in
-                        (element.value(forKey: "id") as? String)?.redacted
-                    }
-                    
-                    var idsDict: [RedactableString: Bool] = [:]
-                    
-                    ids.forEach { id in
-                        idsDict[id] = true
-                    }
-                    
-                    return idsDict
-                }
-                
-                return [:]
-            } catch {
-                throw error
-            }
-        },
-        availabilityTimestamp: {
-            let context = persistentContainer.viewContext
-
-            // check presence of the timestamp
-            let request = NSFetchRequest<NSFetchRequestResult>(entityName: ReadTransactionsStorageClient.Constants.availabilityEntityName)
-            request.returnsObjectsAsFaults = false
-            
-            do {
-                let result = try context.fetch(request)
-                
-                if let managedObjects = result as? [NSManagedObject] {
-                    // no timestamp stored, create one
-                    if managedObjects.isEmpty {
-                        if let entity = NSEntityDescription.entity(
-                            forEntityName: ReadTransactionsStorageClient.Constants.availabilityEntityName,
-                            in: context
-                        ) {
-                            let newAvailability = NSManagedObject(entity: entity, insertInto: context)
-                            let now = Date.now.timeIntervalSince1970
-                            
-                            newAvailability.setValue(now, forKey: "timestamp")
-                            
-                            do {
-                                try context.save()
-                            } catch {
-                                throw error
-                            }
-                            
-                            return now
-                        } else {
-                            throw ReadTransactionsStorageError.createEntity
-                        }
-                    } else {
-                        if let timestamp = managedObjects.first?.value(forKey: "timestamp") as? TimeInterval {
-                            return timestamp
-                        }
-                        
-                        throw ReadTransactionsStorageError.availability
-                    }
-                } else {
-                    throw ReadTransactionsStorageError.availability
-                }
-            } catch {
-                throw error
-            }
-        },
-        resetZashi: {
-            let context = persistentContainer.viewContext
-
-            let deleteRequestIds = NSBatchDeleteRequest(
-                fetchRequest: NSFetchRequest<NSFetchRequestResult>(
-                    entityName: ReadTransactionsStorageClient.Constants.entityName
-                )
-            )
-            let deleteRequestTimestamp = NSBatchDeleteRequest(
-                fetchRequest: NSFetchRequest<NSFetchRequestResult>(
-                    entityName: ReadTransactionsStorageClient.Constants.availabilityEntityName
-                )
-            )
-
-            do {
-                try context.execute(deleteRequestIds)
-                try context.execute(deleteRequestTimestamp)
-                try context.save()
-            } catch {
-                throw error
-            }
-        }
-    )
+        )
+    }
 }
 
 private extension ReadTransactionsStorageClient {

--- a/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGeneratorLiveKey.swift
+++ b/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGeneratorLiveKey.swift
@@ -8,7 +8,11 @@
 import ComposableArchitecture
 
 extension SupportDataGeneratorClient: DependencyKey {
-    static let liveValue = Self(
-        generate: { SupportDataGenerator.generate() }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            generate: { SupportDataGenerator.generate() }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/SwapAndPay/SwapAndPayLiveKey.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/SwapAndPayLiveKey.swift
@@ -11,31 +11,35 @@ import Network
 import ComposableArchitecture
 
 extension SwapAndPayClient: DependencyKey {
-    static let liveValue = Self(
-        submitDepositTxId: { txId, depositAddress in
-            try await Near1Click.liveValue.submitDepositTxId(
-                txId,
-                depositAddress
-            )
-        },
-        swapAssets: {
-            try await Near1Click.liveValue.swapAssets()
-        },
-        quote: { dry, isSwapToZec, exactInput, slippageTolerance, zecAsset, toAsset, refundTo, destination, amount in
-            try await Near1Click.liveValue.quote(
-                dry,
-                isSwapToZec,
-                exactInput,
-                slippageTolerance,
-                zecAsset,
-                toAsset,
-                refundTo,
-                destination,
-                amount
-            )
-        },
-        status: { depositAddress, isSwapToZec in
-            try await Near1Click.liveValue.status(depositAddress, isSwapToZec)
-        }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            submitDepositTxId: { txId, depositAddress in
+                try await Near1Click.liveValue.submitDepositTxId(
+                    txId,
+                    depositAddress
+                )
+            },
+            swapAssets: {
+                try await Near1Click.liveValue.swapAssets()
+            },
+            quote: { dry, isSwapToZec, exactInput, slippageTolerance, zecAsset, toAsset, refundTo, destination, amount in
+                try await Near1Click.liveValue.quote(
+                    dry,
+                    isSwapToZec,
+                    exactInput,
+                    slippageTolerance,
+                    zecAsset,
+                    toAsset,
+                    refundTo,
+                    destination,
+                    amount
+                )
+            },
+            status: { depositAddress, isSwapToZec in
+                try await Near1Click.liveValue.status(depositAddress, isSwapToZec)
+            }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -169,8 +169,11 @@ struct Near1Click {
 }
 
 extension Near1Click {
-    static let liveValue = Self(
-        submitDepositTxId: { txId, depositAddress in
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            submitDepositTxId: { txId, depositAddress in
             let requestData = SwapSubmitHash(
                 txHash: txId,
                 depositAddress: depositAddress
@@ -496,5 +499,6 @@ extension Near1Click {
                 depositedAmountFormatted: depositedAmountFormattedDecimal
             )
         }
-    )
+        )
+    }
 }

--- a/secant/Sources/Dependencies/TaxExporter/TaxExporterLiveKey.swift
+++ b/secant/Sources/Dependencies/TaxExporter/TaxExporterLiveKey.swift
@@ -10,92 +10,96 @@ import ComposableArchitecture
 import UIKit
 
 extension TaxExporterClient: DependencyKey {
-    static let liveValue = Self(
-        cointrackerCSVfor: {
-            let calendar = Calendar(identifier: .gregorian)
-            
-            let thisYear = calendar.component(.year, from: Date())
-            let prevYear = thisYear - 1
+    static let liveValue = Self.live()
 
-            // export previous year
-            let transactionsToExport = $0.compactMap { transaction -> TransactionState? in
-                guard let timestamp = transaction.timestamp else {
-                    return nil
+    static func live() -> Self {
+        Self(
+            cointrackerCSVfor: {
+                let calendar = Calendar(identifier: .gregorian)
+
+                let thisYear = calendar.component(.year, from: Date())
+                let prevYear = thisYear - 1
+
+                // export previous year
+                let transactionsToExport = $0.compactMap { transaction -> TransactionState? in
+                    guard let timestamp = transaction.timestamp else {
+                        return nil
+                    }
+
+                    let date = Date(timeIntervalSince1970: timestamp)
+
+                    let year = calendar.component(.year, from: date)
+                    return year == prevYear ? transaction : nil
+                }.sorted { lhs, rhs in
+                    guard let lhsTimeStamp = lhs.timestamp, let rhsTimeStamp = rhs.timestamp else {
+                        return false
+                    }
+
+                    return lhsTimeStamp < rhsTimeStamp
                 }
 
-                let date = Date(timeIntervalSince1970: timestamp)
-                
-                let year = calendar.component(.year, from: date)
-                return year == prevYear ? transaction : nil
-            }.sorted { lhs, rhs in
-                guard let lhsTimeStamp = lhs.timestamp, let rhsTimeStamp = rhs.timestamp else {
-                    return false
+                var csvString = "Date,Received Quantity,Received Currency,Sent Quantity,Sent Currency,Fee Amount,Fee Currency,Tag\n"
+
+                let formatter = DateFormatter()
+                formatter.dateFormat = "MM/dd/yyyy HH:mm:ss"
+                formatter.timeZone = TimeZone(abbreviation: "UTC") // Ensure UTC time
+
+                transactionsToExport.forEach { transaction in
+                    guard !transaction.isShieldingTransaction else {
+                        return
+                    }
+
+                    guard let timestamp = transaction.timestamp else {
+                        return
+                    }
+
+                    var row = ""
+
+                    // Date
+                    let date = Date(timeIntervalSince1970: timestamp)
+                    row = "\(formatter.string(from: date)),"
+
+                    // Received Quantity
+                    row = "\(row)\(transaction.isSentTransaction ? "" : transaction.zecAmount.decimalZashiUSFormatted()),"
+
+                    // Received Currency
+                    row = "\(row)\(transaction.isSentTransaction ? "" : "ZEC"),"
+
+                    // Sent Quantity
+                    row = "\(row)\(transaction.isSentTransaction ? transaction.zecAmount.decimalZashiTaxUSFormatted() : ""),"
+
+                    // Sent Currency
+                    row = "\(row)\(transaction.isSentTransaction ? "ZEC" : ""),"
+
+                    // Fee Amount
+                    if let fee = transaction.fee {
+                        row = "\(row)\(fee.decimalZashiTaxUSFormatted()),"
+                    } else {
+                        row = "\(row),"
+                    }
+
+                    // Fee Currency
+                    row = "\(row)\(transaction.fee == nil ? "" : "ZEC"),"
+
+                    // Tag
+                    row = "\(row)\n"
+
+                    csvString += row
                 }
 
-                return lhsTimeStamp < rhsTimeStamp
+                let csvData = csvString.data(using: .utf8) ?? Data()
+
+                // Create a temporary file URL
+                let component = String(localizable: .taxExportFileName($1, String(prevYear)))
+                let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(component)
+
+                do {
+                    try csvData.write(to: tempURL)
+                    return tempURL
+                } catch {
+                    throw error
+                }
             }
-            
-            var csvString = "Date,Received Quantity,Received Currency,Sent Quantity,Sent Currency,Fee Amount,Fee Currency,Tag\n"
-
-            let formatter = DateFormatter()
-            formatter.dateFormat = "MM/dd/yyyy HH:mm:ss"
-            formatter.timeZone = TimeZone(abbreviation: "UTC") // Ensure UTC time
-
-            transactionsToExport.forEach { transaction in
-                guard !transaction.isShieldingTransaction else {
-                    return
-                }
-                
-                guard let timestamp = transaction.timestamp else {
-                    return
-                }
-
-                var row = ""
-
-                // Date
-                let date = Date(timeIntervalSince1970: timestamp)
-                row = "\(formatter.string(from: date)),"
-
-                // Received Quantity
-                row = "\(row)\(transaction.isSentTransaction ? "" : transaction.zecAmount.decimalZashiUSFormatted()),"
-                
-                // Received Currency
-                row = "\(row)\(transaction.isSentTransaction ? "" : "ZEC"),"
-
-                // Sent Quantity
-                row = "\(row)\(transaction.isSentTransaction ? transaction.zecAmount.decimalZashiTaxUSFormatted() : ""),"
-
-                // Sent Currency
-                row = "\(row)\(transaction.isSentTransaction ? "ZEC" : ""),"
-
-                // Fee Amount
-                if let fee = transaction.fee {
-                    row = "\(row)\(fee.decimalZashiTaxUSFormatted()),"
-                } else {
-                    row = "\(row),"
-                }
-
-                // Fee Currency
-                row = "\(row)\(transaction.fee == nil ? "" : "ZEC"),"
-
-                // Tag
-                row = "\(row)\n"
-
-                csvString += row
-            }
-
-            let csvData = csvString.data(using: .utf8) ?? Data()
-            
-            // Create a temporary file URL
-            let component = String(localizable: .taxExportFileName($1, String(prevYear)))
-            let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(component)
-
-            do {
-                try csvData.write(to: tempURL)
-                return tempURL
-            } catch {
-                throw error
-            }
-        }
-    )
+        )
+    }
 }

--- a/secant/Sources/Dependencies/URIParser/URIParserLive.swift
+++ b/secant/Sources/Dependencies/URIParser/URIParserLive.swift
@@ -8,12 +8,16 @@
 import ComposableArchitecture
 
 extension URIParserClient: DependencyKey {
-    static let liveValue = Self(
-        isValidURI: { uri, network in
-            URIParser().isValidURI(uri, network: network)
-        },
-        checkRP: { data, network in
-            RequestPaymentParser(network: network).checkRP(data)
-        }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            isValidURI: { uri, network in
+                URIParser().isValidURI(uri, network: network)
+            },
+            checkRP: { data, network in
+                RequestPaymentParser(network: network).checkRP(data)
+            }
+        )
+    }
 }

--- a/secant/Sources/Dependencies/UserMetadataProvider/UserMetadataProviderLiveKey.swift
+++ b/secant/Sources/Dependencies/UserMetadataProvider/UserMetadataProviderLiveKey.swift
@@ -8,7 +8,9 @@
 import ComposableArchitecture
 
 extension UserMetadataProviderClient: DependencyKey {
-    static var liveValue: UserMetadataProviderClient = {
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
         let ums = UserMetadataStorage.live
 
         return UserMetadataProviderClient(
@@ -43,7 +45,7 @@ extension UserMetadataProviderClient: DependencyKey {
             lastUsedAssetHistory: { ums.lastUsedAssetHistory },
             addLastUsedSwapAsset: { ums.addLastUsedSwap(asset: $0) }
         )
-    }()
+    }
 }
 
 extension UserMetadataStorage {

--- a/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageLive.swift
+++ b/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageLive.swift
@@ -9,7 +9,9 @@ import Foundation
 import ComposableArchitecture
 
 extension UserPreferencesStorageClient: DependencyKey {
-    static var liveValue: UserPreferencesStorageClient = {
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
         let live = UserPreferencesStorage.live
 
         return UserPreferencesStorageClient(
@@ -19,7 +21,7 @@ extension UserPreferencesStorageClient: DependencyKey {
             setExchangeRate: { try live.setExchangeRate($0) },
             removeAll: { live.removeAll() }
         )
-    }()
+    }
 }
 
 extension UserPreferencesStorage {

--- a/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageMocks.swift
+++ b/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageMocks.swift
@@ -9,7 +9,9 @@ import Foundation
 import ComposableArchitecture
 
 extension UserPreferencesStorageClient: TestDependencyKey {
-    static var testValue = {
+    static let testValue = Self.test()
+
+    static func test() -> Self {
         let mock = UserPreferencesStorage.mock
 
         return UserPreferencesStorageClient(
@@ -19,7 +21,7 @@ extension UserPreferencesStorageClient: TestDependencyKey {
             setExchangeRate: mock.setExchangeRate(_:),
             removeAll: mock.removeAll
         )
-    }()
+    }
 }
 
 extension UserPreferencesStorage {

--- a/secant/Sources/Dependencies/WhatsNewProvider/WhatsNewProviderLiveKey.swift
+++ b/secant/Sources/Dependencies/WhatsNewProvider/WhatsNewProviderLiveKey.swift
@@ -10,14 +10,18 @@ import ComposableArchitecture
 import SwiftUI
 
 extension WhatsNewProviderClient: DependencyKey {
-    static let liveValue = Self(
-        latest: {
-            WhatsNewProviderClient.releases().releases.first ?? .zero
-        },
-        all: {
-            WhatsNewProviderClient.releases()
-        }
-    )
+    static let liveValue = Self.live()
+
+    static func live() -> Self {
+        Self(
+            latest: {
+                WhatsNewProviderClient.releases().releases.first ?? .zero
+            },
+            all: {
+                WhatsNewProviderClient.releases()
+            }
+        )
+    }
 
     private static func checkCountryCodeEligibility(_ code: String) -> Bool {
         switch code {

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
@@ -12,19 +12,23 @@ import XCTestDynamicOverlay
 extension ZcashSDKEnvironment: TestDependencyKey {
     static let testnet = ZcashSDKEnvironment.live(network: ZcashNetworkBuilder.network(for: .testnet))
 
-    static let testValue = Self(
-        latestCheckpoint: 0,
-        endpoint: { defaultEndpoint(for: .testnet) },
-        exchangeRateIPRateLimit: 120,
-        exchangeRateStaleLimit: 15 * 60,
-        memoCharLimit: MemoBytes.capacity,
-        mnemonicWordsMaxCount: ZcashSDKConstants.mnemonicWordsMaxCount,
-        network: ZcashNetworkBuilder.network(for: .testnet),
-        requiredTransactionConfirmations: ZcashSDKConstants.requiredTransactionConfirmations,
-        sdkVersion: "0.18.1-beta",
-        serverConfig: { defaultEndpoint(for: .testnet).serverConfig() },
-        servers: [],
-        shieldingThreshold: Zatoshi(100_000),
-        tokenName: "TAZ"
-    )
+    static let testValue = Self.test()
+
+    static func test() -> Self {
+        Self(
+            latestCheckpoint: 0,
+            endpoint: { defaultEndpoint(for: .testnet) },
+            exchangeRateIPRateLimit: 120,
+            exchangeRateStaleLimit: 15 * 60,
+            memoCharLimit: MemoBytes.capacity,
+            mnemonicWordsMaxCount: ZcashSDKConstants.mnemonicWordsMaxCount,
+            network: ZcashNetworkBuilder.network(for: .testnet),
+            requiredTransactionConfirmations: ZcashSDKConstants.requiredTransactionConfirmations,
+            sdkVersion: "0.18.1-beta",
+            serverConfig: { defaultEndpoint(for: .testnet).serverConfig() },
+            servers: [],
+            shieldingThreshold: Zatoshi(100_000),
+            tokenName: "TAZ"
+        )
+    }
 }


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes initialization of dependencies Swift 6 compliant.

This PR is just pure refactor how dependencies are created and assigned to `liveKey` variable.

In general code like this was used previously: `static let liveValue = Self(...)`
And this PR changes it to this:
```
static let liveValue = Self.live()

static func live() -> Self {
        Self(....)
}
```
