### PR TITLE
Make ZcashSDKEnvironment Swift 6 compliant 

### DIFF
--- a/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "85f89f5d0ce5a18945f65371d40ca997da85a41a",
-        "version" : "1.6.3"
+        "revision" : "565a7be4c1c9a5e0bf77e5dc21f30f054ced9d06",
+        "version" : "1.6.4"
       }
     },
     {

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
@@ -142,7 +142,7 @@ import ComposableArchitecture
 
         if isStale
             && result.state != .fetching
-            && Date().timeIntervalSince1970 - result.date.timeIntervalSince1970 > zcashSDKEnvironment.exchangeRateStaleLimit {
+            && Date().timeIntervalSince1970 - result.date.timeIntervalSince1970 > zcashSDKEnvironment.exchangeRateStaleLimit() {
             eventStream.send(.stale(latestRate))
         } else {
             eventStream.send(.value(latestRate))
@@ -162,7 +162,7 @@ import ComposableArchitecture
             isStale = false
 
             let diff = Date().timeIntervalSince1970 - latestRate.date.timeIntervalSince1970
-            let timeToSchedule = zcashSDKEnvironment.exchangeRateIPRateLimit - diff
+            let timeToSchedule = zcashSDKEnvironment.exchangeRateIPRateLimit() - diff
 
             if timeToSchedule < 0 {
                 eventStream.send(.refreshEnable(latestRate))
@@ -178,7 +178,7 @@ import ComposableArchitecture
                 }
 
                 staleTimer?.invalidate()
-                staleTimer = Timer.scheduledTimer(withTimeInterval: zcashSDKEnvironment.exchangeRateStaleLimit, repeats: false) { [weak self] _ in
+                staleTimer = Timer.scheduledTimer(withTimeInterval: zcashSDKEnvironment.exchangeRateStaleLimit(), repeats: false) { [weak self] _ in
                     Task { @MainActor [weak self] in
                         self?.staleTimer?.invalidate()
                         self?.staleTimer = nil

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -27,7 +27,7 @@ extension SDKSynchronizerClient: DependencyKey {
 
         $swapAPIAccess.withLock { $0 = isTorEnabled ? .protected : .direct }
         
-        let network = zcashSDKEnvironment.network
+        let network = zcashSDKEnvironment.network()
         
         #if DEBUG
         let loggingPolicy = Initializer.LoggingPolicy.default(.debug)

--- a/secant/Sources/Dependencies/ShieldingProcessor/ShieldingProcessorLiveKey.swift
+++ b/secant/Sources/Dependencies/ShieldingProcessor/ShieldingProcessorLiveKey.swift
@@ -49,7 +49,7 @@ private final class ShieldingProcessorImpl: Sendable {
         if account.vendor == .keystone {
             Task { [subject, sdkSynchronizer, zcashSDKEnvironment] in
                 do {
-                    let proposal = try await sdkSynchronizer.proposeShielding(account.id, zcashSDKEnvironment.shieldingThreshold, .empty, nil)
+                    let proposal = try await sdkSynchronizer.proposeShielding(account.id, zcashSDKEnvironment.shieldingThreshold(), .empty, nil)
 
                     guard let proposal else { throw "shieldFunds with Keystone: nil proposal" }
                     subject.send(.proposal(proposal))
@@ -62,9 +62,9 @@ private final class ShieldingProcessorImpl: Sendable {
                 do {
                     let storedWallet = try walletStorage.exportWallet()
                     let seedBytes = try mnemonic.toSeed(storedWallet.seedPhrase.value())
-                    let spendingKey = try derivationTool.deriveSpendingKey(seedBytes, zip32AccountIndex, zcashSDKEnvironment.network.networkType)
+                    let spendingKey = try derivationTool.deriveSpendingKey(seedBytes, zip32AccountIndex, zcashSDKEnvironment.network().networkType)
 
-                    let proposal = try await sdkSynchronizer.proposeShielding(account.id, zcashSDKEnvironment.shieldingThreshold, .empty, nil)
+                    let proposal = try await sdkSynchronizer.proposeShielding(account.id, zcashSDKEnvironment.shieldingThreshold(), .empty, nil)
 
                     guard let proposal else { throw "shieldFunds nil proposal" }
 

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
@@ -111,18 +111,20 @@ extension ZcashSDKEnvironment {
 @DependencyClient
 struct ZcashSDKEnvironment {
     var latestCheckpoint: BlockHeight
-    let endpoint: () -> LightWalletEndpoint
-    let exchangeRateIPRateLimit: TimeInterval
-    let exchangeRateStaleLimit: TimeInterval
-    let memoCharLimit: Int
-    let mnemonicWordsMaxCount: Int
-    let network: ZcashNetwork
-    let requiredTransactionConfirmations: Int
-    let sdkVersion: String
-    let serverConfig: () -> UserPreferencesStorage.ServerConfig
-    let servers: [Server]
-    let shieldingThreshold: Zatoshi
-    let tokenName: String
+    var endpoint: @Sendable () -> LightWalletEndpoint = {
+        LightWalletEndpoint(address: "", port: 0, secure: false, singleCallTimeoutInMillis: 0, streamingCallTimeoutInMillis: 0)
+    }
+    var exchangeRateIPRateLimit: TimeInterval
+    var exchangeRateStaleLimit: TimeInterval
+    var memoCharLimit: Int
+    var mnemonicWordsMaxCount: Int
+    var network: ZcashNetwork
+    var requiredTransactionConfirmations: Int
+    var sdkVersion: String
+    var serverConfig: () -> UserPreferencesStorage.ServerConfig = { UserPreferencesStorage.ServerConfig(host: "", port: 0, isCustom: false) }
+    var servers: [Server]
+    var shieldingThreshold: Zatoshi
+    var tokenName: String
 }
 
 extension LightWalletEndpoint {

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
@@ -110,21 +110,21 @@ extension ZcashSDKEnvironment {
 
 @DependencyClient
 struct ZcashSDKEnvironment {
-    var latestCheckpoint: BlockHeight
+    var latestCheckpoint: @Sendable () -> BlockHeight = { 0 }
     var endpoint: @Sendable () -> LightWalletEndpoint = {
         LightWalletEndpoint(address: "", port: 0, secure: false, singleCallTimeoutInMillis: 0, streamingCallTimeoutInMillis: 0)
     }
-    var exchangeRateIPRateLimit: TimeInterval
-    var exchangeRateStaleLimit: TimeInterval
-    var memoCharLimit: Int
-    var mnemonicWordsMaxCount: Int
-    var network: ZcashNetwork
-    var requiredTransactionConfirmations: Int
-    var sdkVersion: String
-    var serverConfig: () -> UserPreferencesStorage.ServerConfig = { UserPreferencesStorage.ServerConfig(host: "", port: 0, isCustom: false) }
-    var servers: [Server]
-    var shieldingThreshold: Zatoshi
-    var tokenName: String
+    var exchangeRateIPRateLimit: @Sendable () -> TimeInterval = { 0 }
+    var exchangeRateStaleLimit: @Sendable () -> TimeInterval = { 0 }
+    var memoCharLimit: @Sendable () -> Int = { 0 }
+    var mnemonicWordsMaxCount: @Sendable () -> Int = { 0 }
+    var network: @Sendable () -> ZcashNetwork = { ZcashNetworkBuilder.network(for: .testnet) }
+    var requiredTransactionConfirmations: @Sendable () -> Int = { 0 }
+    var sdkVersion: @Sendable () -> String = { "" }
+    var serverConfig: @Sendable () -> UserPreferencesStorage.ServerConfig = { UserPreferencesStorage.ServerConfig(host: "", port: 0, isCustom: false) }
+    var servers: @Sendable () -> [Server] = { [] }
+    var shieldingThreshold: @Sendable () -> Zatoshi = { Zatoshi(0) }
+    var tokenName: @Sendable () -> String = { "" }
 }
 
 extension LightWalletEndpoint {

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
@@ -14,23 +14,23 @@ extension ZcashSDKEnvironment: DependencyKey {
 
     static func live(network: ZcashNetwork) -> Self {
         Self(
-            latestCheckpoint: BlockHeight.ofLatestCheckpoint(network: network),
+            latestCheckpoint: { BlockHeight.ofLatestCheckpoint(network: network) },
             endpoint: {
                 ZcashSDKEnvironment.serverConfig(
                     for: network.networkType
                 ).endpoint(streamingCallTimeoutInMillis: ZcashSDKConstants.streamingCallTimeoutInMillis)
             },
-            exchangeRateIPRateLimit: 120,
-            exchangeRateStaleLimit: 15 * 60,
-            memoCharLimit: MemoBytes.capacity,
-            mnemonicWordsMaxCount: ZcashSDKConstants.mnemonicWordsMaxCount,
-            network: network,
-            requiredTransactionConfirmations: ZcashSDKConstants.requiredTransactionConfirmations,
-            sdkVersion: "0.18.1-beta",
+            exchangeRateIPRateLimit: { 120 },
+            exchangeRateStaleLimit: { 15 * 60 },
+            memoCharLimit: { MemoBytes.capacity },
+            mnemonicWordsMaxCount: { ZcashSDKConstants.mnemonicWordsMaxCount },
+            network: { network },
+            requiredTransactionConfirmations: { ZcashSDKConstants.requiredTransactionConfirmations },
+            sdkVersion: { "0.18.1-beta" },
             serverConfig: { ZcashSDKEnvironment.serverConfig(for: network.networkType) },
-            servers: ZcashSDKEnvironment.servers(for: network.networkType),
-            shieldingThreshold: Zatoshi(100_000),
-            tokenName: network.networkType == .testnet ? "TAZ" : "ZEC"
+            servers: { ZcashSDKEnvironment.servers(for: network.networkType) },
+            shieldingThreshold: { Zatoshi(100_000) },
+            tokenName: { network.networkType == .testnet ? "TAZ" : "ZEC" }
         )
     }
 }

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
@@ -11,24 +11,23 @@ import XCTestDynamicOverlay
 
 extension ZcashSDKEnvironment: TestDependencyKey {
     static let testnet = ZcashSDKEnvironment.live(network: ZcashNetworkBuilder.network(for: .testnet))
-
     static let testValue = Self.test()
 
     static func test() -> Self {
         Self(
-            latestCheckpoint: 0,
+            latestCheckpoint: { 0 },
             endpoint: { defaultEndpoint(for: .testnet) },
-            exchangeRateIPRateLimit: 120,
-            exchangeRateStaleLimit: 15 * 60,
-            memoCharLimit: MemoBytes.capacity,
-            mnemonicWordsMaxCount: ZcashSDKConstants.mnemonicWordsMaxCount,
-            network: ZcashNetworkBuilder.network(for: .testnet),
-            requiredTransactionConfirmations: ZcashSDKConstants.requiredTransactionConfirmations,
-            sdkVersion: "0.18.1-beta",
+            exchangeRateIPRateLimit: { 120 },
+            exchangeRateStaleLimit: { 15 * 60 },
+            memoCharLimit: { MemoBytes.capacity },
+            mnemonicWordsMaxCount: { ZcashSDKConstants.mnemonicWordsMaxCount },
+            network: { ZcashNetworkBuilder.network(for: .testnet) },
+            requiredTransactionConfirmations: { ZcashSDKConstants.requiredTransactionConfirmations },
+            sdkVersion: { "0.18.1-beta" },
             serverConfig: { defaultEndpoint(for: .testnet).serverConfig() },
-            servers: [],
-            shieldingThreshold: Zatoshi(100_000),
-            tokenName: "TAZ"
+            servers: { [] },
+            shieldingThreshold: { Zatoshi(100_000) },
+            tokenName: { "TAZ" }
         )
     }
 }

--- a/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
+++ b/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
@@ -32,7 +32,7 @@ struct AddKeystoneHWWallet {
 
             if let zcashAccount = zcashAccounts?.accounts.first {
                 do {
-                    return try derivationTool.deriveUnifiedAddressFrom(zcashAccount.ufvk, zcashSDKEnvironment.network.networkType).stringEncoded
+                    return try derivationTool.deriveUnifiedAddressFrom(zcashAccount.ufvk, zcashSDKEnvironment.network().networkType).stringEncoded
                 } catch {
                     return ""
                 }

--- a/secant/Sources/Features/AddressBook/AddressBookStore.swift
+++ b/secant/Sources/Features/AddressBook/AddressBookStore.swift
@@ -224,7 +224,7 @@ struct AddressBook {
                 return .send(.updateAssetsAccordingToSearchTerm)
 
             case .binding:
-                state.isValidZcashAddress = derivationTool.isZcashAddress(state.address, zcashSDKEnvironment.network.networkType)
+                state.isValidZcashAddress = derivationTool.isZcashAddress(state.address, zcashSDKEnvironment.network().networkType)
                 state.isValidForm = !state.name.isEmpty && (state.isValidZcashAddress || state.context == .swap || state.isEditingContactWithChain)
                 if state.isValidZcashAddress {
                     state.selectedChain = nil
@@ -284,7 +284,7 @@ struct AddressBook {
                 state.originalChainId = record.chainId ?? "zcash"
                 state.isValidForm = true
                 state.isNameFocused = true
-                state.isValidZcashAddress = derivationTool.isZcashAddress(state.address, zcashSDKEnvironment.network.networkType)
+                state.isValidZcashAddress = derivationTool.isZcashAddress(state.address, zcashSDKEnvironment.network().networkType)
                 state.isEditingContactWithChain = record.chainId != nil
                 state.selectedChain = state.chains.first { $0.chain == record.chainId }
                 return .none

--- a/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
+++ b/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
@@ -108,7 +108,7 @@ struct Balances {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                state.autoShieldingThreshold = zcashSDKEnvironment.shieldingThreshold
+                state.autoShieldingThreshold = zcashSDKEnvironment.shieldingThreshold()
                 return .merge(
                     .publisher {
                         sdkSynchronizer.stateStream()
@@ -182,7 +182,7 @@ struct Balances {
                 state.totalBalance = state.shieldedWithPendingBalance + state.transparentBalance + (accountBalance?.awaitingResolution ?? .zero)
 
                 let everythingCondition = state.shieldedBalance.amount > 0 && ((state.shieldedBalance == state.totalBalance)
-                || (state.transparentBalance < zcashSDKEnvironment.shieldingThreshold && state.shieldedBalance == state.totalBalance - state.transparentBalance))
+                || (state.transparentBalance < zcashSDKEnvironment.shieldingThreshold() && state.shieldedBalance == state.totalBalance - state.transparentBalance))
                 || state.totalBalance == .zero
                 
                 // spendability

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
@@ -26,7 +26,7 @@ extension RestoreWalletCoordFlow {
                 do {
                     // get the random english mnemonic
                     let newRandomPhrase = try mnemonic.randomMnemonic()
-                    let birthday = zcashSDKEnvironment.latestCheckpoint
+                    let birthday = zcashSDKEnvironment.latestCheckpoint()
                     
                     // store the wallet to the keychain
                     try walletStorage.importWallet(newRandomPhrase, birthday, .english, false)

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -246,7 +246,7 @@ extension ScanCoordFlow {
                             textMemo = memo.toString() ?? ""
                         }
                         let numberLocale = numberFormatter.convertUSToLocale(payment.amount?.toString() ?? "0") ?? ""
-                        state.recipient = try Recipient(payment.recipientAddress.value, network: zcashSDKEnvironment.network.networkType)
+                        state.recipient = try Recipient(payment.recipientAddress.value, network: zcashSDKEnvironment.network().networkType)
                         state.memo = textMemo.isEmpty ? nil : try Memo(string: textMemo)
                         
                         if let number = numberFormatter.number(numberLocale) {

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
@@ -311,7 +311,7 @@ extension SwapAndPayCoordFlow {
                     do {
                         let storedWallet = try walletStorage.exportWallet()
                         let seedBytes = try mnemonic.toSeed(storedWallet.seedPhrase.value())
-                        let network = zcashSDKEnvironment.network.networkType
+                        let network = zcashSDKEnvironment.network().networkType
                         let spendingKey = try derivationTool.deriveSpendingKey(seedBytes, zip32AccountIndex, network)
 
                         let result = try await sdkSynchronizer.createProposedTransactions(proposal, spendingKey)

--- a/secant/Sources/Features/PrivateDataConsent/PrivateDataConsentStore.swift
+++ b/secant/Sources/Features/PrivateDataConsent/PrivateDataConsentStore.swift
@@ -76,7 +76,7 @@ struct PrivateDataConsent {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                state.dataDbURL = [databaseFiles.dataDbURLFor(zcashSDKEnvironment.network)]
+                state.dataDbURL = [databaseFiles.dataDbURLFor(zcashSDKEnvironment.network())]
                 return .none
 
             case .exportLogs(.finished):

--- a/secant/Sources/Features/RequestZec/RequestZecStore.swift
+++ b/secant/Sources/Features/RequestZec/RequestZecStore.swift
@@ -62,7 +62,7 @@ struct RequestZec {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                state.memoState.charLimit = zcashSDKEnvironment.memoCharLimit
+                state.memoState.charLimit = zcashSDKEnvironment.memoCharLimit()
                 state.encryptedOutput = nil
                 return .send(.generateEnlargedQRCode)
 
@@ -98,7 +98,7 @@ struct RequestZec {
                 return .none
 
             case .generateQRCode:
-                if let recipient = RecipientAddress(value: state.address.data, context: ParserContext.from(networkType: zcashSDKEnvironment.network.networkType)) {
+                if let recipient = RecipientAddress(value: state.address.data, context: ParserContext.from(networkType: zcashSDKEnvironment.network().networkType)) {
                     do {
                         // TODO: handle this error. there's a problem either with the recipient address or the amount requested
                         let payment = try Payment(
@@ -129,7 +129,7 @@ struct RequestZec {
                 return .none
                 
             case .generateEnlargedQRCode:
-                if let recipient = RecipientAddress(value: state.address.data, context: ParserContext.from(networkType: zcashSDKEnvironment.network.networkType)) {
+                if let recipient = RecipientAddress(value: state.address.data, context: ParserContext.from(networkType: zcashSDKEnvironment.network().networkType)) {
                     do {
                         let payment = try Payment(
                             recipientAddress: recipient,

--- a/secant/Sources/Features/Root/RootDestination.swift
+++ b/secant/Sources/Features/Root/RootDestination.swift
@@ -60,7 +60,7 @@ extension Root {
                 return .none
 
             case .destination(.deeplink(let url)):
-                if let _ = uriParser.checkRP(url.absoluteString, zcashSDKEnvironment.network.networkType) {
+                if let _ = uriParser.checkRP(url.absoluteString, zcashSDKEnvironment.network().networkType) {
                     // The deeplink is some zip321, we ignore it and let users know in a warning screen
                     return .send(.destination(.updateDestination(.deeplinkWarning)))
                 }
@@ -106,15 +106,15 @@ extension Root {
                         }
 
                         // get a proposal
-                        let recipient = try Recipient(transaction.address, network: zcashSDKEnvironment.network.networkType)
+                        let recipient = try Recipient(transaction.address, network: zcashSDKEnvironment.network().networkType)
                         let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, transaction.amount, nil)
 
                         // make the actual send
                         let storedWallet = try walletStorage.exportWallet()
                         let seedBytes = try mnemonic.toSeed(storedWallet.seedPhrase.value())
-                        let network = zcashSDKEnvironment.network.networkType
+                        let network = zcashSDKEnvironment.network().networkType
                         let spendingKey = try derivationTool.deriveSpendingKey(seedBytes, zip32AccountIndex, network)
-                        
+
                         let result = try await sdkSynchronizer.createProposedTransactions(proposal, spendingKey)
                         
                         switch result {
@@ -148,7 +148,7 @@ private extension Root {
         derivationTool: DerivationToolClient
     ) async throws -> Root.Action {
         @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
-        let deeplink = try deeplink.resolveDeeplinkURL(url, zcashSDKEnvironment.network.networkType, derivationTool)
+        let deeplink = try deeplink.resolveDeeplinkURL(url, zcashSDKEnvironment.network().networkType, derivationTool)
         
         switch deeplink {
         case .home:

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -259,7 +259,7 @@ extension Root {
                 let walletState = Root.walletInitializationState(
                     databaseFiles: databaseFiles,
                     walletStorage: walletStorage,
-                    zcashNetwork: zcashSDKEnvironment.network
+                    zcashNetwork: zcashSDKEnvironment.network()
                 )
                 return .send(.initialization(.respondToWalletInitializationState(walletState)))
 
@@ -324,7 +324,7 @@ extension Root {
                     } catch {
                         return .send(.destination(.updateDestination(.osStatusError)))
                     }
-                    let birthday = storedWallet.birthday?.value() ?? zcashSDKEnvironment.latestCheckpoint
+                    let birthday = storedWallet.birthday?.value() ?? zcashSDKEnvironment.latestCheckpoint()
                     try mnemonic.isValid(storedWallet.seedPhrase.value())
                     let seedBytes = try mnemonic.toSeed(storedWallet.seedPhrase.value())
                     
@@ -369,7 +369,7 @@ extension Root {
                                         try keys.cacheFor(
                                             seed: seedBytes,
                                             account: account.account,
-                                            network: zcashSDKEnvironment.network.networkType
+                                            network: zcashSDKEnvironment.network().networkType
                                         )
                                         try walletStorage.importAddressBookEncryptionKeys(keys)
                                     } catch {
@@ -442,7 +442,7 @@ extension Root {
                                         try keys.cacheFor(
                                             seed: seedBytes,
                                             account: account.account,
-                                            network: zcashSDKEnvironment.network.networkType
+                                            network: zcashSDKEnvironment.network().networkType
                                         )
                                         try walletStorage.importUserMetadataEncryptionKeys(keys, account.account)
                                         await send(.loadUserMetadata)

--- a/secant/Sources/Features/Scan/ScanChecker.swift
+++ b/secant/Sources/Features/Scan/ScanChecker.swift
@@ -23,7 +23,7 @@ struct ZcashAddressScanChecker: ScanChecker, Equatable {
         @Dependency(\.uriParser) var uriParser
         @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
         
-        if uriParser.isValidURI(qrCode, zcashSDKEnvironment.network.networkType) {
+        if uriParser.isValidURI(qrCode, zcashSDKEnvironment.network().networkType) {
             return .foundAddress(qrCode.redacted)
         } else {
             return nil
@@ -38,7 +38,7 @@ struct RequestZecScanChecker: ScanChecker, Equatable {
         @Dependency(\.uriParser) var uriParser
         @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
         
-        if let parserResult = uriParser.checkRP(qrCode, zcashSDKEnvironment.network.networkType) {
+        if let parserResult = uriParser.checkRP(qrCode, zcashSDKEnvironment.network().networkType) {
             return .foundRequestZec(parserResult)
         } else {
             return nil

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -205,7 +205,7 @@ struct SendConfirmation {
                 state.randomSuccessIconIndex = Int.random(in: 1...2)
                 state.randomFailureIconIndex = Int.random(in: 1...3)
                 state.randomResubmissionIconIndex = Int.random(in: 1...2)
-                state.isTransparentAddress = derivationTool.isTransparentAddress(state.address, zcashSDKEnvironment.network.networkType)
+                state.isTransparentAddress = derivationTool.isTransparentAddress(state.address, zcashSDKEnvironment.network().networkType)
                 state.canSendMail = MFMailComposeViewController.canSendMail()
                 state.alias = nil
                 for contact in state.addressBookContacts.contacts {
@@ -285,7 +285,7 @@ struct SendConfirmation {
                     do {
                         let storedWallet = try walletStorage.exportWallet()
                         let seedBytes = try mnemonic.toSeed(storedWallet.seedPhrase.value())
-                        let network = zcashSDKEnvironment.network.networkType
+                        let network = zcashSDKEnvironment.network().networkType
                         let spendingKey = try derivationTool.deriveSpendingKey(seedBytes, zip32AccountIndex, network)
 
                         let result = try await sdkSynchronizer.createProposedTransactions(proposal, spendingKey)

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -245,7 +245,7 @@ struct SendForm {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                state.memoState.charLimit = zcashSDKEnvironment.memoCharLimit
+                state.memoState.charLimit = zcashSDKEnvironment.memoCharLimit()
                 return .send(.exchangeRateSetupChanged)
 
             case .onDisapear:
@@ -314,7 +314,7 @@ struct SendForm {
                 state.amount = state.isLatestInputFiat ? state.amount.roundToAvoidDustSpend() : state.amount
                 return .run { [state, confirmationType] send in
                     do {
-                        let recipient = try Recipient(state.address.data, network: zcashSDKEnvironment.network.networkType)
+                        let recipient = try Recipient(state.address.data, network: zcashSDKEnvironment.network().networkType)
                         
                         let memo: Memo?
                         if state.isValidTransparentAddress || state.isValidTexAddress {
@@ -442,7 +442,7 @@ struct SendForm {
                 return .none
                 
             case .addressUpdated(let newValue):
-                let network = zcashSDKEnvironment.network.networkType
+                let network = zcashSDKEnvironment.network().networkType
                 state.address = newValue
                 state.isValidAddress = derivationTool.isZcashAddress(state.address.data, network)
                 state.isValidTransparentAddress = derivationTool.isTransparentAddress(state.address.data, network)
@@ -488,7 +488,7 @@ struct SendForm {
                 return .send(.syncAmounts(false))
                 
             case .validateAddress:
-                let network = zcashSDKEnvironment.network.networkType
+                let network = zcashSDKEnvironment.network().networkType
                 state.isValidAddress = derivationTool.isZcashAddress(state.address.data, network)
                 state.isValidTransparentAddress = derivationTool.isTransparentAddress(state.address.data, network)
                 state.isValidTexAddress = derivationTool.isTexAddress(state.address.data, network)

--- a/secant/Sources/Features/ServerSetup/ServerSetupStore.swift
+++ b/secant/Sources/Features/ServerSetup/ServerSetupStore.swift
@@ -86,7 +86,7 @@ struct ServerSetup {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                state.network = zcashSDKEnvironment.network.networkType
+                state.network = zcashSDKEnvironment.network().networkType
                 
                 if !state.topKServers.isEmpty {
                     let allServers = ZcashSDKEnvironment.servers(for: state.network)

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -165,7 +165,7 @@ struct SmartBanner {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                state.tokenName = zcashSDKEnvironment.tokenName
+                state.tokenName = zcashSDKEnvironment.tokenName()
                 state.isWalletBackupAcknowledgedAtKeychain = walletStorage.exportWalletBackupAcknowledged()
                 state.isWalletBackupAcknowledged = state.isWalletBackupAcknowledgedAtKeychain
                 state.isShieldingAcknowledgedAtKeychain = walletStorage.exportShieldingAcknowledged()
@@ -378,7 +378,7 @@ struct SmartBanner {
                     
                     if let account = state.selectedWalletAccount, let accountBalance = latestState.data.accountsBalances[account.id] {
                         if state.priorityContent == .priority7 {
-                            if accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold {
+                            if accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold() {
                                 return .send(.transparentBalanceUpdated(accountBalance.unshielded))
                             } else {
                                 return .merge(
@@ -386,7 +386,7 @@ struct SmartBanner {
                                     .send(.closeSheetTapped)
                                 )
                             }
-                        } else if state.transparentBalance < zcashSDKEnvironment.shieldingThreshold && accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold {
+                        } else if state.transparentBalance < zcashSDKEnvironment.shieldingThreshold() && accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold() {
                             return .merge(
                                 .send(.transparentBalanceUpdated(accountBalance.unshielded)),
                                 .send(.triggerPriority(.priority7))
@@ -477,7 +477,7 @@ struct SmartBanner {
                 }
                 return .run { [remindMeShieldedPhaseCounter = state.remindMeShieldedPhaseCounter] send in
                     if let accountBalance = try? await sdkSynchronizer.getAccountsBalances()[account.id],
-                       accountBalance.unshielded >= zcashSDKEnvironment.shieldingThreshold {
+                       accountBalance.unshielded >= zcashSDKEnvironment.shieldingThreshold() {
                         await send(.transparentBalanceUpdated(accountBalance.unshielded))
                         
                         if let shieldedReminder = walletStorage.exportShieldingReminder(account.vendor.name()) {

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -741,7 +741,7 @@ struct SwapAndPay {
                 let zecAmount = Zatoshi(NSDecimalNumber(decimal: quote.amountIn).int64Value)
                 return .run { send in
                     do {
-                        let recipient = try Recipient(quote.depositAddress, network: zcashSDKEnvironment.network.networkType)
+                        let recipient = try Recipient(quote.depositAddress, network: zcashSDKEnvironment.network().networkType)
 
                         let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, zecAmount, nil)
                         

--- a/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
+++ b/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
@@ -154,7 +154,7 @@ struct TransactionDetails {
             @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
             
             let address = swapDetails.addressToCheckShield
-            let network = zcashSDKEnvironment.network.networkType
+            let network = zcashSDKEnvironment.network().networkType
             
             return !derivationTool.isTransparentAddress(address, network)
         }

--- a/secant/Sources/Features/Voting/VotingStore+Delegation.swift
+++ b/secant/Sources/Features/Voting/VotingStore+Delegation.swift
@@ -43,7 +43,7 @@ extension Voting {
             let roundId = activeSession.voteRoundId.hexString
             let snapshotHeight = activeSession.snapshotHeight
             let notes = state.walletNotes
-            let network = zcashSDKEnvironment.network
+            let network = zcashSDKEnvironment.network()
             let walletDbPath = databaseFiles.dataDbURLFor(network).path
             return .run { [sdkSynchronizer, votingCrypto, votingAPI] send in
                 // Check if this round already exists and ALL bundles have proofs
@@ -377,7 +377,7 @@ extension Voting {
             let expectedSnapshotHeight = activeSession.snapshotHeight
             let cachedNotes = state.walletNotes
             let bundleCount = state.bundleCount
-            let network = zcashSDKEnvironment.network
+            let network = zcashSDKEnvironment.network()
             let networkId: UInt32 = network.networkType.votingRustNetworkId
             let accountIndex = votingAccountIndex(for: state.selectedWalletAccount)
             let roundName = state.votingRound.title
@@ -502,7 +502,7 @@ extension Voting {
                 state.delegationProofStatus = .generating(progress: 0)
             }
             let cachedNotes = state.walletNotes
-            let network = zcashSDKEnvironment.network
+            let network = zcashSDKEnvironment.network()
             let networkId: UInt32 = network.networkType.votingRustNetworkId
             let isKeystoneUser = state.isKeystoneUser
             let accountIndex: UInt32 = isKeystoneUser
@@ -735,7 +735,7 @@ extension Voting {
             let roundId = activeSession.voteRoundId.hexString
             let expectedSnapshotHeight = activeSession.snapshotHeight
             let cachedNotes = state.walletNotes
-            let network = zcashSDKEnvironment.network
+            let network = zcashSDKEnvironment.network()
             let networkId: UInt32 = network.networkType.votingRustNetworkId
             let accountIndex: UInt32 = state.selectedWalletAccount.flatMap(\.zip32AccountIndex).map { UInt32($0.index) } ?? 0
             guard

--- a/secant/Sources/Features/Voting/VotingStore+Session.swift
+++ b/secant/Sources/Features/Voting/VotingStore+Session.swift
@@ -189,7 +189,7 @@ extension Voting {
 
         case .startActiveRoundPipeline:
             guard let session = state.activeSession, session.status == .active else { return .none }
-            let network = zcashSDKEnvironment.network
+            let network = zcashSDKEnvironment.network()
             let walletDbPath = databaseFiles.dataDbURLFor(network).path
             let networkId: UInt32 = network.networkType.votingRustNetworkId
             let snapshotHeight = session.snapshotHeight

--- a/secant/Sources/Features/Voting/VotingStore+Submission.swift
+++ b/secant/Sources/Features/Voting/VotingStore+Submission.swift
@@ -73,7 +73,7 @@ extension Voting {
             state.batchVoteErrors = [:]
 
             let roundId = state.roundId
-            let network = zcashSDKEnvironment.network
+            let network = zcashSDKEnvironment.network()
             let networkId: UInt32 = network.networkType.votingRustNetworkId
             let accountIndex = votingAccountIndex(for: state.selectedWalletAccount)
             let seedFingerprint = votingSeedFingerprint(for: state.selectedWalletAccount)

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -98,7 +98,7 @@ struct WalletBalances {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                 state.autoShieldingThreshold = zcashSDKEnvironment.shieldingThreshold
+                 state.autoShieldingThreshold = zcashSDKEnvironment.shieldingThreshold()
                 if let exchangeRate = userStoredPreferences.exchangeRate(), exchangeRate.automatic {
                     state.isExchangeRateFeatureOn = true
                 } else {
@@ -190,7 +190,7 @@ struct WalletBalances {
                 state.totalBalance = state.shieldedWithPendingBalance + state.transparentBalance + (accountBalance?.awaitingResolution ?? .zero)
                
                 let everythingCondition = state.shieldedBalance.amount > 0 && ((state.shieldedBalance == state.totalBalance)
-                || (state.transparentBalance < zcashSDKEnvironment.shieldingThreshold && state.shieldedBalance == state.totalBalance - state.transparentBalance))
+                || (state.transparentBalance < zcashSDKEnvironment.shieldingThreshold() && state.shieldedBalance == state.totalBalance - state.transparentBalance))
                 || state.totalBalance == .zero
 
                 // spendability

--- a/secant/Sources/Features/WalletBirthday/WalletBirthdayStore.swift
+++ b/secant/Sources/Features/WalletBirthday/WalletBirthdayStore.swift
@@ -77,13 +77,14 @@ struct WalletBirthday {
                 // __LD TESTED
                 let currentYear = Calendar.current.component(.year, from: Date())
                 state.years = Array(Constants.startYear...currentYear)
-                if state.estimatedHeight < zcashSDKEnvironment.network.constants.saplingActivationHeight {
-                    state.estimatedHeight = zcashSDKEnvironment.network.constants.saplingActivationHeight
+
+                if state.estimatedHeight < zcashSDKEnvironment.network().constants.saplingActivationHeight {
+                    state.estimatedHeight = zcashSDKEnvironment.network().constants.saplingActivationHeight
                 }
                 return .send(.updateMonths)
-            
+
             case .binding(\.birthday):
-                let saplingActivation = zcashSDKEnvironment.network.constants.saplingActivationHeight
+                let saplingActivation = zcashSDKEnvironment.network().constants.saplingActivationHeight
 
                 if let birthdayHeight = BlockHeight(state.birthday), birthdayHeight >= saplingActivation {
                     state.estimatedHeight = birthdayHeight


### PR DESCRIPTION
Another PR in a series aimed at converting the project to Swift 6. This PR makes `ZcashSDKEnvironment` Swift 6 compliant.

There no is logical change in this PR. Biggest change is that all the let properties in `ZcashSDKEnvironment` and now var closures. Reason for this is that @DepedencyClient macro can't handle combination of let properties, var properties and var closures at one dependency. 

To make `ZcashSDKEnvironment` Swift 6 compliant I had to change:
`let endpoint: () -> LightWalletEndpoint`
to:
```
    var endpoint: @Sendable () -> LightWalletEndpoint = {
        LightWalletEndpoint(address: "", port: 0, secure: false, singleCallTimeoutInMillis: 0, streamingCallTimeoutInMillis: 0)
    }
```

and this cause use of var closures and let properties and one dependency. And this state ten required to switch from let properties to var closures.

