### PR TITLE
Update bundled production static voting config pin

### DIFF
--- a/secant/Sources/Dependencies/VotingModels/StaticVotingConfig.swift
+++ b/secant/Sources/Dependencies/VotingModels/StaticVotingConfig.swift
@@ -9,8 +9,8 @@ struct StaticVotingConfig: Codable, Equatable, Sendable {
     static let supportedVersion = 1
     static let algEd25519 = "ed25519"
     static let bundledPinnedSource =
-        "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/d19edb058081d72aba8a955a57607eabf815e5df/static-voting-config.json" +
-        "?checksum=sha256:f56224c6552178e64f9cc75e8ee2a663130c46172b2470fc02efdf94c522f2ac"
+        "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/5ed8d623e4150d383a4dac05dd6bfbdd126a5408/prod/static-voting-config.json" +
+        "?checksum=sha256:5a6bc0dce85a8ee8d6585d2a180e62f145abcfee7768c15b88de47c9a01a5738"
 
     let staticConfigVersion: Int
     let dynamicConfigURL: URL


### PR DESCRIPTION
Duplicate of https://github.com/zodl-inc/zodl-ios/pull/1759 from a separate branch.

## Summary
- Update **`secant/Sources/Dependencies/VotingModels/StaticVotingConfig.swift`**: pin `bundledPinnedSource` to [`token-holder-voting-config@5ed8d623`](https://github.com/valargroup/token-holder-voting-config/commit/5ed8d623e4150d383a4dac05dd6bfbdd126a5408) (`prod/static-voting-config.json`).
- SHA-256 checksum: `5a6bc0dce85a8ee8d6585d2a180e62f145abcfee7768c15b88de47c9a01a5738`.

## Files changed
- `secant/Sources/Dependencies/VotingModels/StaticVotingConfig.swift`

## Test plan
- [x] Fetched commit-pinned URL returns HTTP 200
- [x] Response body SHA-256 matches embedded checksum