### PR TITLE
Update voting SDK alpha2 API integration

### DIFF
--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -9465,7 +9465,7 @@
 			repositoryURL = "https://github.com/zcash/zcash-swift-wallet-sdk.git";
 			requirement = {
 				kind = revision;
-				revision = b3675ba9ecadd2b777f21d8b770e88cba294d26e;
+				revision = 909c7c5743f14a211f9f69f97ed08c05b55c2cd5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -492,7 +492,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zcash/zcash-swift-wallet-sdk.git",
       "state" : {
-        "revision" : "b3675ba9ecadd2b777f21d8b770e88cba294d26e"
+        "revision" : "909c7c5743f14a211f9f69f97ed08c05b55c2cd5"
       }
     }
   ],

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
@@ -175,9 +175,9 @@ extension VotingCryptoClient: DependencyKey {
                 )
                 return try VotingRustBackend.verifyWitness(sdkWitness)
             },
-            generateHotkey: { roundId, seed in
+            generateHotkey: { _, seed in
                 let backend = try await dbActor.backend()
-                let hotkey = try backend.generateHotkey(roundId: roundId, seed: seed)
+                let hotkey = try backend.generateHotkey(seed: seed)
                 return VotingHotkey(
                     secretKey: Data(hotkey.secretKey),
                     publicKey: Data(hotkey.publicKey),
@@ -187,7 +187,7 @@ extension VotingCryptoClient: DependencyKey {
             // swiftlint:disable:next line_length
             buildVotingPczt: { roundId, bundleIndex, notes, senderSeed, hotkeySeed, networkId, accountIndex, roundName, orchardFvkOverride, keystoneSeedFingerprintOverride in
                 let backend = try await dbActor.backend()
-                _ = try backend.generateHotkey(roundId: roundId, seed: hotkeySeed)
+                _ = try backend.generateHotkey(seed: hotkeySeed)
                 let inputs: VotingDelegationInputs
                 let actualFvkBytes: [UInt8]
                 if let orchardFvkOverride {


### PR DESCRIPTION
## Why

The voting flow was pinned to an older `zcash-swift-wallet-sdk` revision. Moving to `909c7c5` picks up the libzcashlc 2.6.0-alpha.2 artifact, which changes the hotkey API: `generateHotkey` no longer takes a `roundId`. Hotkeys are now derived from the seed alone, independent of the voting round, so the call sites have to be adapted to compile against the new SDK.

## What changed

- Bump the `ZcashLightClientKit` pin to `zcash/zcash-swift-wallet-sdk@909c7c5743f14a211f9f69f97ed08c05b55c2cd5` (`secant.xcodeproj/project.pbxproj` and `Package.resolved`).
- Adapt the two `generateHotkey` call sites in `VotingCryptoClientLiveKey.swift` to the new `generateHotkey(seed:)` signature — in the `generateHotkey` dependency closure and in `buildVotingPczt`. The closure's now-unused `roundId` argument is dropped to `_`.

## Scope

Dependency pin + call-site adaptation only. No bundle ID, entitlements, signing/development team, iCloud container, staging config, archive output, or local package wiring changes.

## Verification

```
xcodebuild -resolvePackageDependencies \
  -project secant.xcodeproj \
  -scheme zashi-internal \
  -skipPackagePluginValidation \
  -skipMacroValidation
```
