### PR TITLE
Preserve Keystone import birthday

### DIFF
--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -79,7 +79,8 @@ extension SDKSynchronizerClient: DependencyKey {
                     zip32AccountIndex: zip32AccountIndex,
                     purpose: purpose,
                     name: name,
-                    keySource: keySource
+                    keySource: keySource,
+                    birthday: birthday
                 )
             },
             deleteAccount: { accountUUID in


### PR DESCRIPTION
Restores forwarding the selected wallet birthday into the SDK when importing a Keystone account. This keeps reconnect/import flows syncing from the user-selected height instead of falling back to the SDK default.

Validation: `xcodebuild build -scheme zashi-internal -project secant.xcodeproj -destination "platform=iOS Simulator,name=iPhone 17 Pro" IPHONEOS_DEPLOYMENT_TARGET=16.0 -skipPackagePluginValidation -skipMacroValidation` succeeded.