### PR TITLE
[#MOB-1196] Forward-port 3.4.1 release fixes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Changed
+- We updated the copy on the shielding Wallet Status Widget from "Transparent Balance Detected" to "Unshielded Balance" so it's easier to understand at a glance.
+
 ## 3.4.0 build 1 (2026-05-11)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Changed
 - We updated the copy on the shielding Wallet Status Widget from "Transparent Balance Detected" to "Unshielded Balance" so it's easier to understand at a glance.
 
+### Fixed
+- We fixed a broken Restore Wallet flow when switching Tor ON in the Tor sheet — the Restore button now takes you to the next screen in both Tor ON and Tor OFF cases.
+
 ## 3.4.0 build 1 (2026-05-11)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+## 3.4.1 build 1 (2026-05-18)
+
 ### Changed
 - We updated the copy on the shielding Wallet Status Widget from "Transparent Balance Detected" to "Unshielded Balance" so it's easier to understand at a glance.
 
 ### Fixed
+- We fixed a bug that prevented shielding when many small transparent inputs were involved.
 - We fixed a broken Restore Wallet flow when switching Tor ON in the Tor sheet — the Restore button now takes you to the next screen in both Tor ON and Tor OFF cases.
 
 ## 3.4.0 build 1 (2026-05-11)

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -11231,13 +11231,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Transparent Balance Detected"
+            "value" : "Unshielded Balance"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Saldo Transparente Detectado"
+            "value" : "Saldo No Protegido"
           }
         }
       }

--- a/secant/Resources/WhatsNew/whatsNew.json
+++ b/secant/Resources/WhatsNew/whatsNew.json
@@ -1,6 +1,26 @@
 {
     "releases": [
         {
+            "version": "3.4.1",
+            "date": "18-05-2026",
+            "timestamp": 1778606653,
+            "sections": [
+                {
+                    "title": "Changed:",
+                    "bulletpoints": [
+                        "We updated the copy on the shielding status widget."
+                    ]
+                },
+                {
+                    "title": "Fixed:",
+                    "bulletpoints": [
+                        "We fixed a bug that prevented shielding when many small transparent inputs were involved.",
+                        "We fixed a navigation issue in the Restore flow."
+                    ]
+                }
+            ]
+        },
+        {
             "version": "3.4.0",
             "date": "07-05-2026",
             "timestamp": 1778001853,

--- a/secant/Resources/WhatsNew/whatsNew_es.json
+++ b/secant/Resources/WhatsNew/whatsNew_es.json
@@ -1,6 +1,26 @@
 {
     "releases": [
         {
+            "version": "3.4.1",
+            "date": "18-05-2026",
+            "timestamp": 1778606653,
+            "sections": [
+                {
+                    "title": "Cambiado:",
+                    "bulletpoints": [
+                        "Actualizamos el texto del widget de estado de protección."
+                    ]
+                },
+                {
+                    "title": "Corregido:",
+                    "bulletpoints": [
+                        "Corregimos un error que impedía proteger cuando había muchas entradas transparentes pequeñas.",
+                        "Corregimos un problema de navegación en el flujo de Restauración."
+                    ]
+                }
+            ]
+        },
+        {
             "version": "3.4.0",
             "date": "07-05-2026",
             "timestamp": 1778001853,

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
@@ -73,10 +73,10 @@ extension RestoreWalletCoordFlow {
                 state.isTorSheetPresented = false
                 let isTorOn = state.isTorOn
                 try? walletStorage.importTorSetupFlag(isTorOn)
-                return .run { send in
-                    try? await sdkSynchronizer.torEnabled(isTorOn)
-                    await send(.resolveRestore)
-                }
+                return .merge(
+                    .send(.resolveRestore),
+                    .run { _ in try? await sdkSynchronizer.torEnabled(isTorOn) }
+                )
 
                 // MARK: Recovery Seed Phrase Entry
                 


### PR DESCRIPTION
Resolves MOB-1198, MOB-1119, MOB-1196

## Summary

Forward-port of the four user-facing commits from the `3.4.1` hotfix release (branched from tag `3.4.0`) onto `main`, so the fixes flow alongside the voting work.

Cherry-picked commits:
- **[#MOB-1119]** Update shielding widget copy "Transparent Balance Detected" → "Unshielded Balance" (EN + ES).
- **[#MOB-1198]** Fix broken Restore flow when toggling Tor ON — restore CTA now navigates immediately in both Tor ON/OFF cases.
- **[#MOB-1196]** Add 3.4.1 release entry to What's New (EN + ES).
- **[#MOB-1196]** Promote CHANGELOG [Unreleased] block under "3.4.1 build 1 (2026-05-18)".

## Explicitly skipped from the release branch

- **`ae3f416c` — Bump ZcashLightClientKit 2.5.0 → 2.5.1.** `main` currently pins the SDK to a specific revision (`909c7c57…` — the voting alpha pre-release SDK). Forcibly downgrading to published 2.5.1 would break the voting alpha API integration. Whoever owns the voting SDK rebase needs to ensure the next voting-alpha SDK revision carries the 2.5.1 shielding fix (many-small-transparent-inputs).
- **`08b4519f` — SwiftGen regenerate (btc(omni)).** `main` already has the asset registered; cherry-pick was empty.
- **`b570cab1` — Release 3.4.1 project version bump.** Release-branch only; `main`'s version is managed independently.

## Test plan
- [ ] CI green.
- [ ] Verify shielding widget copy reads "Unshielded Balance" / "Saldo No Protegido".
- [ ] Verify Restore → Tor sheet → toggle ON → Restore CTA → Keep Zodl open screen pushes immediately.
- [ ] Spot-check Settings → About → What's New shows the 3.4.1 entry in both EN and ES.
- [ ] Confirm voting alpha SDK still resolves (no Package.resolved drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)