### PR TITLE
[MOB-1105] Replace os.Logger with LoggerProxy in voting/background paths

### DIFF
--- a/secant/Sources/Dependencies/BackgroundTaskClient/BackgroundTaskClientLiveKey.swift
+++ b/secant/Sources/Dependencies/BackgroundTaskClient/BackgroundTaskClientLiveKey.swift
@@ -8,8 +8,6 @@ import ComposableArchitecture
 import UIKit
 import os
 
-private let logger = Logger(subsystem: "co.zodl", category: "BackgroundTaskClient")
-
 /// Tracks the active continued processing task (iOS 26+) so endContinuedProcessing can find it.
 @available(iOS 26.0, *)
 private final class ContinuedProcessingState: Sendable {
@@ -42,7 +40,7 @@ extension BackgroundTaskClient: DependencyKey {
                     UIApplication.shared.isIdleTimerDisabled = true
                     var taskId: UIBackgroundTaskIdentifier = .invalid
                     taskId = UIApplication.shared.beginBackgroundTask(withName: name) {
-                        logger.warning("Background task '\(name)' expired by iOS — ending task")
+                        LoggerProxy.warn("Background task '\(name)' expired by iOS — ending task")
                         UIApplication.shared.isIdleTimerDisabled = false
                         UIApplication.shared.endBackgroundTask(taskId)
                         taskId = .invalid
@@ -70,7 +68,7 @@ extension BackgroundTaskClient: DependencyKey {
 
                 do {
                     try BGTaskScheduler.shared.submit(request)
-                    logger.info("Continued processing task submitted: \(identifier)")
+                    LoggerProxy.info("Continued processing task submitted: \(identifier)")
 
                     // The task is delivered via the handler registered for this identifier.
                     // Register a one-shot handler to capture the task object.
@@ -84,7 +82,7 @@ extension BackgroundTaskClient: DependencyKey {
                     }
                     return true
                 } catch {
-                    logger.warning("Continued processing submission failed: \(error)")
+                    LoggerProxy.warn("Continued processing submission failed: \(error)")
                     return false
                 }
             },
@@ -94,7 +92,7 @@ extension BackgroundTaskClient: DependencyKey {
                 }
                 if let task = state.take() {
                     task.setTaskCompleted(success: true)
-                    logger.info("Continued processing task completed")
+                    LoggerProxy.info("Continued processing task completed")
                 }
             }
         )

--- a/secant/Sources/Dependencies/VotingAPIClient/ServerHealthTracker.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/ServerHealthTracker.swift
@@ -1,7 +1,4 @@
 import Foundation
-import os
-
-private let healthLogger = Logger(subsystem: "co.zodl.voting", category: "ServerHealthTracker")
 
 // MARK: - Server Health Tracker
 
@@ -93,7 +90,7 @@ actor ServerHealthTracker {
 
         // Graceful degradation: never return empty
         if healthy.isEmpty {
-            healthLogger.info("All servers unhealthy; falling back to full list")
+            LoggerProxy.info("All servers unhealthy; falling back to full list")
             return Array(servers.keys)
         }
         return healthy
@@ -107,7 +104,7 @@ actor ServerHealthTracker {
         servers[url]!.circuit = .closed
         servers[url]!.consecutiveFailures = 0
         if previous != .closed {
-            healthLogger.info("\(url, privacy: .public) recovered; circuit closed")
+            LoggerProxy.info("\(url) recovered; circuit closed")
         }
     }
 
@@ -118,11 +115,11 @@ actor ServerHealthTracker {
 
         if failures >= failureThreshold && servers[url]!.circuit == .closed {
             servers[url]!.circuit = .open(since: Date())
-            healthLogger.warning("\(url, privacy: .public) circuit opened after \(failures) failures")
+            LoggerProxy.warn("\(url) circuit opened after \(failures) failures")
         } else if servers[url]!.circuit == .halfOpen {
             // halfOpen probe failed — re-open
             servers[url]!.circuit = .open(since: Date())
-            healthLogger.warning("\(url, privacy: .public) half-open probe failed; circuit reopened")
+            LoggerProxy.warn("\(url) half-open probe failed; circuit reopened")
         }
     }
 

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
@@ -1,8 +1,5 @@
 import ComposableArchitecture
 import Foundation
-import os
-
-private let logger = Logger(subsystem: "co.zodl.voting", category: "VotingAPIClient")
 
 // MARK: - API Configuration
 
@@ -129,7 +126,7 @@ enum SvAPIResponseParser {
             let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
             if let nestedData = trimmed.data(using: .utf8),
                let nested = try? JSONSerialization.jsonObject(with: nestedData) as? [String: Any] {
-                logger.error("[VotingAPI] \(context) returned double-encoded JSON")
+                LoggerProxy.error("[VotingAPI] \(context) returned double-encoded JSON")
                 return nested
             }
         }
@@ -218,7 +215,7 @@ private func getJSON(_ path: String) async throws -> [String: Any] {
             guard shouldTryNextVoteServer(after: error) else {
                 throw error
             }
-            logger.warning("GET \(path, privacy: .public) failed on \(base, privacy: .public); trying next vote server")
+            LoggerProxy.warn("GET \(path) failed on \(base); trying next vote server")
         }
     }
 
@@ -254,7 +251,7 @@ private func postJSON(_ path: String, body: [String: Any]) async throws -> [Stri
             guard shouldTryNextVoteServer(after: error) else {
                 throw error
             }
-            logger.warning("POST \(path, privacy: .public) failed on \(base, privacy: .public); trying next vote server")
+            LoggerProxy.warn("POST \(path) failed on \(base); trying next vote server")
         }
     }
 
@@ -392,7 +389,7 @@ func delegateSharePayloads(
                     if ok {
                         acceptedServers.append(server)
                     } else {
-                        logger.warning("Share \(shareOffset) failed on \(server, privacy: .public)")
+                        LoggerProxy.warn("Share \(shareOffset) failed on \(server)")
                         failedServers.insert(server)
                     }
                 }
@@ -404,7 +401,7 @@ func delegateSharePayloads(
         }
 
         if acceptedServers.isEmpty {
-            logger.warning("Share \(shareOffset) failed on all configured vote servers")
+            LoggerProxy.warn("Share \(shareOffset) failed on all configured vote servers")
             lastError = ShareDelegationError.noReachableVoteServers
             break
         }
@@ -444,8 +441,8 @@ func resubmitSharePayload(
             try await postShare(server, body)
             return [server]
         } catch {
-            logger.warning(
-                "Share resubmission failed on \(server, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            LoggerProxy.warn(
+                "Share resubmission failed on \(server): \(error.localizedDescription)"
             )
         }
     }
@@ -487,10 +484,10 @@ private func retryWithBackoff<T>(
         } catch {
             let isLast = attempt == maxAttempts
             if isLast || !isRetryable(error) { throw error }
-            logger.warning(
+            LoggerProxy.warn(
                 """
                 Broadcast attempt \(attempt)/\(maxAttempts) failed \
-                (\(error.localizedDescription, privacy: .public)); retrying in \(delay)s
+                (\(error.localizedDescription)); retrying in \(delay)s
                 """
             )
             try await Task.sleep(for: .seconds(delay))
@@ -638,7 +635,7 @@ func parseVotingSession(from round: [String: Any]) throws -> VotingSession {
 /// that the chain response is bound to the same `ea_pk`.
 private func authenticateVotingSession(_ session: VotingSession) async throws -> VotingSession {
     guard let configuration = await SvAPIConfigStore.shared.getConfiguration() else {
-        logger.error("Round auth failed: trust material unavailable")
+        LoggerProxy.error("Round auth failed: trust material unavailable")
         throw SvAPIError.noActiveVotingSession
     }
 
@@ -650,8 +647,8 @@ private func authenticateVotingSession(_ session: VotingSession) async throws ->
         trustedKeys: configuration.staticConfig.trustedKeys
     )
     guard status == .authenticated else {
-        logger.error(
-            "Round auth failed: status=\(String(describing: status), privacy: .public) round=\(roundIdHex, privacy: .public)"
+        LoggerProxy.error(
+            "Round auth failed: status=\(String(describing: status)) round=\(roundIdHex)"
         )
         // Per current UX, unauthenticated rounds are hidden behind the same
         // surface as "no active round" rather than shown as a separate warning.
@@ -667,7 +664,7 @@ private func authenticatedVotingSessions(from rounds: [[String: Any]]) async thr
         do {
             authenticated.append(try await authenticateVotingSession(session))
         } catch SvAPIError.noActiveVotingSession {
-            logger.error("Skipping unauthenticated round \(hexString(from: session.voteRoundId), privacy: .public)")
+            LoggerProxy.error("Skipping unauthenticated round \(hexString(from: session.voteRoundId))")
         }
     }
     return authenticated
@@ -750,7 +747,7 @@ extension VotingAPIClient: DependencyKey {
                     staticConfig: staticConfig,
                     serviceConfig: authenticatedConfig
                 )
-                logger.info(
+                LoggerProxy.info(
                     """
                     Loaded config from CDN: \(authenticatedConfig.voteServers.count) vote servers, \
                     \(authenticatedConfig.rounds.count) authenticated rounds, \(droppedRounds) dropped rounds
@@ -765,10 +762,10 @@ extension VotingAPIClient: DependencyKey {
                 )
                 let base = config.voteServers.first?.url
                 let pir = config.pirEndpoints.first?.url
-                logger.info(
+                LoggerProxy.info(
                     """
-                    URLs configured: base=\(base ?? "<none>", privacy: .public), \
-                    voteServers=\(config.voteServers.count), pir=\(pir ?? "<none>", privacy: .public), \
+                    URLs configured: base=\(base ?? "<none>"), \
+                    voteServers=\(config.voteServers.count), pir=\(pir ?? "<none>"), \
                     pirEndpoints=\(config.pirEndpoints.count)
                     """
                 )
@@ -965,14 +962,14 @@ extension VotingAPIClient: DependencyKey {
                 do {
                     serverURLs = try await SvAPIConfigStore.shared.configuredVoteServerURLs()
                 } catch {
-                    logger.error("fetchTxConfirmation: vote server URLs unavailable: \(error.localizedDescription, privacy: .public)")
+                    LoggerProxy.error("fetchTxConfirmation: vote server URLs unavailable: \(error.localizedDescription)")
                     return nil
                 }
 
                 for base in serverURLs {
                     let urlString = "\(base)/shielded-vote/v1/tx/\(txHash)"
                     guard let url = URL(string: urlString) else {
-                        logger.error("fetchTxConfirmation: invalid URL: \(urlString)")
+                        LoggerProxy.error("fetchTxConfirmation: invalid URL: \(urlString)")
                         continue
                     }
 
@@ -981,21 +978,21 @@ extension VotingAPIClient: DependencyKey {
                     do {
                         (data, response) = try await httpSession.data(from: url)
                     } catch {
-                        logger.debug(
-                            "fetchTxConfirmation: network error on \(base, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                        LoggerProxy.debug(
+                            "fetchTxConfirmation: network error on \(base): \(error.localizedDescription)"
                         )
                         continue
                     }
 
                     guard let http = response as? HTTPURLResponse else {
-                        logger.error("fetchTxConfirmation: not an HTTP response from \(base, privacy: .public)")
+                        LoggerProxy.error("fetchTxConfirmation: not an HTTP response from \(base)")
                         continue
                     }
 
                     // 404 = TX not yet in a block (normal during polling).
                     // Try the remaining configured servers before reporting pending.
                     if http.statusCode == 404 {
-                        logger.debug("fetchTxConfirmation: 404 (not yet in block) on \(base, privacy: .public) for \(txHash)")
+                        LoggerProxy.debug("fetchTxConfirmation: 404 (not yet in block) on \(base) for \(txHash)")
                         continue
                     }
 
@@ -1003,15 +1000,15 @@ extension VotingAPIClient: DependencyKey {
                     // Parse the response to extract the error code/log.
                     guard http.statusCode == 200 || http.statusCode == 422 else {
                         let body = String(data: data.prefix(512), encoding: .utf8) ?? "<non-utf8>"
-                        logger.debug(
-                            "fetchTxConfirmation: HTTP \(http.statusCode) on \(base, privacy: .public) for \(txHash) — \(body, privacy: .public)"
+                        LoggerProxy.debug(
+                            "fetchTxConfirmation: HTTP \(http.statusCode) on \(base) for \(txHash) — \(body)"
                         )
                         continue
                     }
 
                     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                         let snippet = String(data: data.prefix(512), encoding: .utf8) ?? "<non-utf8>"
-                        logger.error("fetchTxConfirmation: JSON parse failed on \(base, privacy: .public) — \(snippet, privacy: .public)")
+                        LoggerProxy.error("fetchTxConfirmation: JSON parse failed on \(base) — \(snippet)")
                         continue
                     }
 
@@ -1039,7 +1036,7 @@ extension VotingAPIClient: DependencyKey {
                         let keys = ev.attributes.map(\.key).joined(separator: ",")
                         return "\(ev.type)[\(keys)]"
                     }.joined(separator: "; ")
-                    logger.debug("fetchTxConfirmation: height=\(height) code=\(code) events=\(eventSummary)")
+                    LoggerProxy.debug("fetchTxConfirmation: height=\(height) code=\(code) events=\(eventSummary)")
 
                     return TxConfirmation(height: height, code: code, log: log, events: parsedEvents)
                 }

--- a/secant/Sources/Features/Voting/VotingStore+Delegation.swift
+++ b/secant/Sources/Features/Voting/VotingStore+Delegation.swift
@@ -120,7 +120,7 @@ extension Voting {
                 // Setup bundles (value-aware split into groups of up to 5)
                 let setupResult = try await votingCrypto.setupBundles(roundId, notes)
                 let bundleCount = setupResult.bundleCount
-                votingLogger.info("Setup \(bundleCount) bundle(s) for \(notes.count) notes (eligible weight: \(setupResult.eligibleWeight))")
+                LoggerProxy.info("Setup \(bundleCount) bundle(s) for \(notes.count) notes (eligible weight: \(setupResult.eligibleWeight))")
 
                 // Phase 1: Fetch tree state from lightwalletd
                 let fetchStart = ContinuousClock.now
@@ -129,7 +129,7 @@ extension Voting {
                 let fetchEnd = ContinuousClock.now
                 let fetchMs = UInt64(fetchStart.duration(to: fetchEnd).components.seconds * 1000)
                     + UInt64(fetchStart.duration(to: fetchEnd).components.attoseconds / 1_000_000_000_000_000)
-                votingLogger.debug("Tree state fetch: \(fetchMs)ms")
+                LoggerProxy.debug("Tree state fetch: \(fetchMs)ms")
 
                 // Phase 2: Generate witnesses per-bundle (includes Rust-side verification)
                 let noteChunks = notes.smartBundles().bundles
@@ -144,7 +144,7 @@ extension Voting {
                 let genEnd = ContinuousClock.now
                 let genMs = UInt64(fetchEnd.duration(to: genEnd).components.seconds * 1000)
                     + UInt64(fetchEnd.duration(to: genEnd).components.attoseconds / 1_000_000_000_000_000)
-                votingLogger.debug("Witness generation: \(genMs)ms (\(allWitnesses.count) notes)")
+                LoggerProxy.debug("Witness generation: \(genMs)ms (\(allWitnesses.count) notes)")
 
                 // Phase 3: Verify each witness on Swift side for UI display
                 let sortedNotes = noteChunks.flatMap { $0 }
@@ -153,13 +153,13 @@ extension Voting {
                     let verified = (try? await votingCrypto.verifyWitness(witness)) ?? false
                     let note = sortedNotes[idx]
                     results.append(.init(position: note.position, value: note.value, verified: verified))
-                    votingLogger.debug("Note pos=\(note.position) value=\(note.value) verified=\(verified)")
+                    LoggerProxy.debug("Note pos=\(note.position) value=\(note.value) verified=\(verified)")
                 }
                 let verifyEnd = ContinuousClock.now
                 let verifyMs = UInt64(genEnd.duration(to: verifyEnd).components.seconds * 1000)
                     + UInt64(genEnd.duration(to: verifyEnd).components.attoseconds / 1_000_000_000_000_000)
-                votingLogger.debug("Swift verification: \(verifyMs)ms")
-                votingLogger.info("Total witness pipeline: \(fetchMs + genMs + verifyMs)ms")
+                LoggerProxy.debug("Swift verification: \(verifyMs)ms")
+                LoggerProxy.info("Total witness pipeline: \(fetchMs + genMs + verifyMs)ms")
 
                 let timing = Voting.State.WitnessTiming(
                     treeStateFetchMs: fetchMs,
@@ -168,7 +168,7 @@ extension Voting {
                 )
                 await send(.witnessVerificationCompleted(results, allWitnesses, timing, bundleCount))
             } catch: { error, send in
-                votingLogger.error("Witness verification failed: \(error)")
+                LoggerProxy.error("Witness verification failed: \(error)")
                 await send(.witnessVerificationFailed(error.localizedDescription))
             }
 
@@ -236,7 +236,7 @@ extension Voting {
                         let count = try await votingCrypto.getBundleCount(roundId)
                         await send(.bundleCountRestored(count))
                     } catch: { error, send in
-                        votingLogger.error("Failed to restore bundle count: \(error)")
+                        LoggerProxy.error("Failed to restore bundle count: \(error)")
                         await send(.witnessVerificationFailed(
                             String(localizable: .coinVoteDelegationRestoreVotingStateFailed(error.localizedDescription))
                         ))
@@ -277,7 +277,7 @@ extension Voting {
                 let unsubmitted = votes.filter { !$0.submitted }
                 for vote in unsubmitted {
                     if case .present? = try? await votingCrypto.getVoteTxHash(roundId, vote.bundleIndex, vote.proposalId) {
-                        votingLogger.info("Vote resume: found in-flight vote for proposal \(vote.proposalId), auto-resuming via batch path")
+                        LoggerProxy.info("Vote resume: found in-flight vote for proposal \(vote.proposalId), auto-resuming via batch path")
                         await send(.setDraftVote(proposalId: vote.proposalId, choice: vote.choice))
                         await send(.submitAllDrafts)
                         return
@@ -297,7 +297,7 @@ extension Voting {
                     }
                     for (proposalId, info) in byProposal {
                         if info.submitted > 0, info.total < Int(bundleCount) {
-                            votingLogger.info("Vote resume: proposal \(proposalId) has \(info.total)/\(bundleCount) bundle records, resuming via batch path")
+                            LoggerProxy.info("Vote resume: proposal \(proposalId) has \(info.total)/\(bundleCount) bundle records, resuming via batch path")
                             await send(.setDraftVote(proposalId: proposalId, choice: info.choice))
                             await send(.submitAllDrafts)
                             return
@@ -366,7 +366,7 @@ extension Voting {
                 return .none
             }
             guard let seedFingerprint = votingSeedFingerprint(for: state.selectedWalletAccount) else {
-                votingLogger.debug("Skipping delegation PIR precompute: missing selected-account seed fingerprint")
+                LoggerProxy.debug("Skipping delegation PIR precompute: missing selected-account seed fingerprint")
                 return .none
             }
 
@@ -425,12 +425,12 @@ extension Voting {
                     )
                     totalCached += result.cachedCount
                     totalFetched += result.fetchedCount
-                    votingLogger.info(
+                    LoggerProxy.info(
                         "Delegation PIR precompute bundle \(bundleIndex + 1)/\(bundleCount): cached=\(result.cachedCount) fetched=\(result.fetchedCount)"
                     )
                 }
 
-                votingLogger.info("Delegation PIR precompute complete: cached=\(totalCached) fetched=\(totalFetched)")
+                LoggerProxy.info("Delegation PIR precompute complete: cached=\(totalCached) fetched=\(totalFetched)")
                 await send(.delegationPrecomputeCompleted(roundId: roundId))
             } catch: { error, send in
                 await send(.delegationPrecomputeFailed(roundId: roundId, error: error.localizedDescription))
@@ -521,7 +521,7 @@ extension Voting {
                 !pirEndpoints.isEmpty,
                 let expectedSnapshotHeight = state.activeSession?.snapshotHeight
             else {
-                votingLogger.error("serviceConfig/activeSession unexpectedly nil in startActiveRoundPipeline; aborting")
+                LoggerProxy.error("serviceConfig/activeSession unexpectedly nil in startActiveRoundPipeline; aborting")
                 return .none
             }
             let keystoneBundleIndex = state.currentKeystoneBundleIndex
@@ -561,7 +561,7 @@ extension Voting {
                             let orchardFvk = try votingCrypto.extractOrchardFvkFromUfvk(
                                 bundleNotes[0].ufvkStr, networkId
                             )
-                            votingLogger.info("Keystone: preparing PCZT for bundle \(keystoneBundleIndex + 1)/\(bundleCount)")
+                            LoggerProxy.info("Keystone: preparing PCZT for bundle \(keystoneBundleIndex + 1)/\(bundleCount)")
                             let govPczt = try await votingCrypto.buildVotingPczt(
                                 roundId,
                                 keystoneBundleIndex,
@@ -742,7 +742,7 @@ extension Voting {
                 let pirEndpoints = state.serviceConfig?.pirEndpoints.map(\.url),
                 !pirEndpoints.isEmpty
             else {
-                votingLogger.error("serviceConfig unexpectedly nil during delegation proof; aborting")
+                LoggerProxy.error("serviceConfig unexpectedly nil during delegation proof; aborting")
                 return .none
             }
             let storedSignatures = state.keystoneBundleSignatures
@@ -764,7 +764,7 @@ extension Voting {
                             votingCrypto: votingCrypto,
                             votingAPI: votingAPI
                         ) {
-                            votingLogger.debug("Recovered Keystone delegation bundle \(idx) VAN position: \(vanPosition)")
+                            LoggerProxy.debug("Recovered Keystone delegation bundle \(idx) VAN position: \(vanPosition)")
                             completedBundles.insert(idx)
                         }
                     }
@@ -772,13 +772,13 @@ extension Voting {
                     for (bundleIndex, sig) in storedSignatures.enumerated() {
                         let bundleIdx = UInt32(bundleIndex)
                         if completedBundles.contains(bundleIdx) {
-                            votingLogger.debug("Keystone delegation bundle \(bundleIdx) already submitted, skipping")
+                            LoggerProxy.debug("Keystone delegation bundle \(bundleIdx) already submitted, skipping")
                             let overallProgress = Double(bundleIndex + 1) / Double(signedCount)
                             await send(.delegationProofProgress(roundId: roundId, progress: overallProgress))
                             continue
                         }
                         let bundleNotes = noteChunks[bundleIndex]
-                        votingLogger.info("Keystone batch: proving bundle \(bundleIndex + 1)/\(signedCount)")
+                        LoggerProxy.info("Keystone batch: proving bundle \(bundleIndex + 1)/\(signedCount)")
 
                         for try await event in votingCrypto.buildAndProveDelegation(
                             roundId,
@@ -794,10 +794,10 @@ extension Voting {
                             switch event {
                             case .progress(let progress):
                                 let overallProgress = (Double(bundleIndex) + progress) / Double(signedCount)
-                                votingLogger.debug("ZKP #1 bundle \(bundleIdx) progress: \(Int(progress * 100))%")
+                                LoggerProxy.debug("ZKP #1 bundle \(bundleIdx) progress: \(Int(progress * 100))%")
                                 await send(.delegationProofProgress(roundId: roundId, progress: overallProgress))
                             case .completed(let proof):
-                                votingLogger.info("ZKP #1 bundle \(bundleIdx) COMPLETE — proof size: \(proof.count) bytes")
+                                LoggerProxy.info("ZKP #1 bundle \(bundleIdx) COMPLETE — proof size: \(proof.count) bytes")
                             }
                         }
 
@@ -810,7 +810,7 @@ extension Voting {
                             registration.sighash != sig.sighash {
                             throw VotingFlowError.invalidDelegationSignature
                         }
-                        votingLogger.debug(
+                        LoggerProxy.debug(
                             """
                             Keystone delegation tuple \
                             rk=\(Data(registration.rk.prefix(8)).hexString) \
@@ -819,7 +819,7 @@ extension Voting {
                             """
                         )
                         let delegTxResult = try await votingAPI.submitDelegation(registration)
-                        votingLogger.info("Delegation TX \(bundleIdx) submitted: \(delegTxResult.txHash)")
+                        LoggerProxy.info("Delegation TX \(bundleIdx) submitted: \(delegTxResult.txHash)")
 
                         // Persist TX hash for crash recovery
                         try await votingCrypto.storeDelegationTxHash(roundId, bundleIdx, delegTxResult.txHash)
@@ -829,7 +829,7 @@ extension Voting {
                             votingAPI: votingAPI
                         )
                         try await votingCrypto.storeVanPosition(roundId, bundleIdx, vanPosition)
-                        votingLogger.debug("VAN position stored for bundle \(bundleIdx): \(vanPosition)")
+                        LoggerProxy.debug("VAN position stored for bundle \(bundleIdx): \(vanPosition)")
                     }
 
                     await send(.delegationProofCompleted(roundId: roundId))
@@ -964,7 +964,7 @@ extension Voting {
 
         case .delegationProofFailed(let roundId, let error):
             guard state.roundId == roundId else { return .none }
-            votingLogger.error("Delegation proof failed (raw): \(error)")
+            LoggerProxy.error("Delegation proof failed (raw): \(error)")
             state.currentKeystoneBundleIndex = 0
             state.keystoneBundleSignatures = []
             let userMessage: String
@@ -1031,28 +1031,28 @@ extension Voting {
                 confirmationTimeout: delegationConfirmationTimeout,
                 retryDelay: delegationConfirmationRetryDelay
             ) {
-                votingLogger.debug("Recovered delegation bundle \(idx) VAN position: \(vanPosition)")
+                LoggerProxy.debug("Recovered delegation bundle \(idx) VAN position: \(vanPosition)")
                 completedBundles.insert(idx)
             }
         }
 
         for bundleIndex: UInt32 in 0..<bundleCount {
             if completedBundles.contains(bundleIndex) {
-                votingLogger.debug("Delegation bundle \(bundleIndex + 1)/\(bundleCount) already submitted, skipping")
+                LoggerProxy.debug("Delegation bundle \(bundleIndex + 1)/\(bundleCount) already submitted, skipping")
                 continue
             }
             let bundleNotes = noteChunks[Int(bundleIndex)]
-            votingLogger.info("Delegation bundle \(bundleIndex + 1)/\(bundleCount) (\(bundleNotes.count) notes)")
+            LoggerProxy.info("Delegation bundle \(bundleIndex + 1)/\(bundleCount) (\(bundleNotes.count) notes)")
 
             let registration: DelegationRegistration
             if let cachedRegistration = try? await votingCrypto.getDelegationSubmission(
                 roundId, bundleIndex, senderSeed, networkId, accountIndex
             ) {
-                votingLogger.debug("Delegation bundle \(bundleIndex + 1)/\(bundleCount) using cached submission")
+                LoggerProxy.debug("Delegation bundle \(bundleIndex + 1)/\(bundleCount) using cached submission")
                 registration = cachedRegistration
             } else {
                 if delegationPrepared {
-                    votingLogger.debug("Delegation bundle \(bundleIndex + 1)/\(bundleCount) using precomputed PIR data")
+                    LoggerProxy.debug("Delegation bundle \(bundleIndex + 1)/\(bundleCount) using precomputed PIR data")
                 } else {
                     let orchardFvk = try seedFingerprint.map { _ in
                         try votingCrypto.extractOrchardFvkFromUfvk(bundleNotes[0].ufvkStr, networkId)
@@ -1072,10 +1072,10 @@ extension Voting {
                     switch event {
                     case .progress(let progress):
                         let overallProgress = (Double(bundleIndex) + progress) / Double(bundleCount)
-                        votingLogger.debug("ZKP #1 bundle \(bundleIndex) progress: \(Int(progress * 100))%")
+                        LoggerProxy.debug("ZKP #1 bundle \(bundleIndex) progress: \(Int(progress * 100))%")
                         await send(.delegationProofProgress(roundId: roundId, progress: overallProgress))
                     case .completed(let proof):
-                        votingLogger.info("ZKP #1 bundle \(bundleIndex) COMPLETE — proof size: \(proof.count) bytes")
+                        LoggerProxy.info("ZKP #1 bundle \(bundleIndex) COMPLETE — proof size: \(proof.count) bytes")
                     }
                 }
 
@@ -1084,7 +1084,7 @@ extension Voting {
                 )
             }
             let delegTxResult = try await votingAPI.submitDelegation(registration)
-            votingLogger.info("Delegation TX \(bundleIndex) submitted: \(delegTxResult.txHash)")
+            LoggerProxy.info("Delegation TX \(bundleIndex) submitted: \(delegTxResult.txHash)")
 
             try await votingCrypto.storeDelegationTxHash(roundId, bundleIndex, delegTxResult.txHash)
 
@@ -1095,7 +1095,7 @@ extension Voting {
                 retryDelay: delegationConfirmationRetryDelay
             )
             try await votingCrypto.storeVanPosition(roundId, bundleIndex, vanPosition)
-            votingLogger.debug("VAN position stored for bundle \(bundleIndex): \(vanPosition)")
+            LoggerProxy.debug("VAN position stored for bundle \(bundleIndex): \(vanPosition)")
         }
 
         await send(.delegationProofCompleted(roundId: roundId))
@@ -1144,13 +1144,13 @@ extension Voting {
             return vanPosition
 
         case let .failed(code, log):
-            votingLogger.warning(
+            LoggerProxy.warn(
                 "Cached delegation TX \(txHash) for bundle \(bundleIndex) is not reusable: code=\(code) log=\(log)"
             )
             return nil
 
         case .notFound:
-            votingLogger.debug("Cached delegation TX \(txHash) for bundle \(bundleIndex) is not confirmed yet")
+            LoggerProxy.debug("Cached delegation TX \(txHash) for bundle \(bundleIndex) is not confirmed yet")
             return nil
         }
     }
@@ -1227,12 +1227,12 @@ extension Voting {
                 return try await votingAPI.delegateShares(payloads, roundId, serverURLs)
             } catch let error as ShareDelegationError where error == .noReachableVoteServers {
                 lastExhaustionError = error
-                votingLogger.warning("delegateShares attempt \(attempt)/3 exhausted vote servers")
+                LoggerProxy.warn("delegateShares attempt \(attempt)/3 exhausted vote servers")
                 if attempt < 3 {
                     try await Task.sleep(for: retryDelay)
                 }
             } catch {
-                votingLogger.warning("delegateShares failed with non-exhaustion error: \(error)")
+                LoggerProxy.warn("delegateShares failed with non-exhaustion error: \(error)")
                 throw error
             }
         }

--- a/secant/Sources/Features/Voting/VotingStore+Navigation.swift
+++ b/secant/Sources/Features/Voting/VotingStore+Navigation.swift
@@ -76,7 +76,7 @@ func pollShareStatusesForRecovery(
                     break
                 }
             } catch {
-                votingLogger.warning("Share status check failed for helper \(helperURL), share \(share.shareIndex): \(error)")
+                LoggerProxy.warn("Share status check failed for helper \(helperURL), share \(share.shareIndex): \(error)")
             }
         }
 
@@ -215,7 +215,7 @@ extension Voting {
                     let allRounds = try await votingAPI.fetchAllRounds()
                     await send(.allRoundsLoaded(allRounds))
                 } catch: { error, _ in
-                    votingLogger.error("Failed to refresh rounds list: \(error)")
+                    LoggerProxy.error("Failed to refresh rounds list: \(error)")
                 }
             )
 
@@ -243,7 +243,7 @@ extension Voting {
                 await send(.shareDelegationsLoaded(delegations))
             } catch: { error, _ in
                 // Share tracking is non-critical — silently degrade
-                votingLogger.error("Failed to load share delegations: \(error)")
+                LoggerProxy.error("Failed to load share delegations: \(error)")
             }
 
         case .shareDelegationsLoaded(let delegations):
@@ -293,7 +293,7 @@ extension Voting {
                 let unconfirmed = freshDelegations.filter { !$0.confirmed }
                 let now = UInt64(Date().timeIntervalSince1970)
 
-                votingLogger.debug("[SharePoll] total=\(freshDelegations.count) confirmed=\(confirmed) unconfirmed=\(unconfirmed.count)")
+                LoggerProxy.debug("[SharePoll] total=\(freshDelegations.count) confirmed=\(confirmed) unconfirmed=\(unconfirmed.count)")
 
                 // Track shares that need resubmission (still pending after overdue threshold)
                 struct ResubmitCandidate {
@@ -311,7 +311,7 @@ extension Voting {
                 }
                 let futureCount = unconfirmed.count - readyShares.count
 
-                votingLogger.debug("[SharePoll] ready=\(readyShares.count) future=\(futureCount)")
+                LoggerProxy.debug("[SharePoll] ready=\(readyShares.count) future=\(futureCount)")
 
                 let pollResult = await pollShareStatusesForRecovery(
                     readyShares: readyShares,
@@ -329,7 +329,7 @@ extension Voting {
                         )
                         newlyConfirmed += 1
                     } catch {
-                        votingLogger.warning("Failed to mark share confirmed for proposal \(key.proposalId), share \(key.shareIndex): \(error)")
+                        LoggerProxy.warn("Failed to mark share confirmed for proposal \(key.proposalId), share \(key.shareIndex): \(error)")
                     }
                 }
 
@@ -342,7 +342,7 @@ extension Voting {
                 }
 
                 if !readyShares.isEmpty {
-                    votingLogger.debug("[SharePoll] queried=\(pollResult.queriedCount) newlyConfirmed=\(newlyConfirmed)")
+                    LoggerProxy.debug("[SharePoll] queried=\(pollResult.queriedCount) newlyConfirmed=\(newlyConfirmed)")
                 }
 
                 // Phase 2: Resubmit overdue pending shares
@@ -392,11 +392,11 @@ extension Voting {
                                     roundId, bundleIndex, proposalId,
                                     candidate.share.shareIndex, newServers
                                 )
-                                votingLogger.info("Resubmitted share p\(proposalId)s\(candidate.share.shareIndex) to \(newServers.count) new server(s)")
+                                LoggerProxy.info("Resubmitted share p\(proposalId)s\(candidate.share.shareIndex) to \(newServers.count) new server(s)")
                             }
                         }
                     } catch {
-                        votingLogger.warning("Share resubmission failed for bundle \(bundleIndex), proposal \(proposalId): \(error)")
+                        LoggerProxy.warn("Share resubmission failed for bundle \(bundleIndex), proposal \(proposalId): \(error)")
                     }
                 }
 
@@ -416,7 +416,7 @@ extension Voting {
 
                 let sleepSeconds: UInt64
                 if stillUnconfirmed.isEmpty {
-                    votingLogger.debug("[SharePoll] all confirmed, stopping poll")
+                    LoggerProxy.debug("[SharePoll] all confirmed, stopping poll")
                     return
                 } else if let soonest = futureCheckTimes.min() {
                     sleepSeconds = min(soonest - refreshedNow, 30)
@@ -425,7 +425,7 @@ extension Voting {
                 }
 
                 let actualSleep = max(sleepSeconds, 3)
-                votingLogger.debug("[SharePoll] sleeping \(actualSleep)s (stillUnconfirmed=\(stillUnconfirmed.count) futureShares=\(futureCheckTimes.count))")
+                LoggerProxy.debug("[SharePoll] sleeping \(actualSleep)s (stillUnconfirmed=\(stillUnconfirmed.count) futureShares=\(futureCheckTimes.count))")
                 try await Task.sleep(for: .seconds(actualSleep))
                 await send(.pollShareStatus)
             } catch: { _, _ in }
@@ -482,7 +482,7 @@ extension Voting {
             // vote, continue submitting.
             if state.canSubmitBatch {
                 let remainingCount = state.draftVotes.count
-                votingLogger.info("Auto-resuming batch submission with \(remainingCount) remaining drafts")
+                LoggerProxy.info("Auto-resuming batch submission with \(remainingCount) remaining drafts")
                 return .send(.submitAllDrafts)
             }
             // Vote finished — start share tracking now that delegation rows are written.

--- a/secant/Sources/Features/Voting/VotingStore+Session.swift
+++ b/secant/Sources/Features/Voting/VotingStore+Session.swift
@@ -28,7 +28,7 @@ extension Voting {
                 let allRounds = try await votingAPI.fetchAllRounds()
                 await send(.allRoundsLoaded(allRounds))
             } catch: { error, send in
-                votingLogger.error("Retry rounds fetch failed: \(error)")
+                LoggerProxy.error("Retry rounds fetch failed: \(error)")
                 await send(.roundsLoadFailed)
             }
 
@@ -108,9 +108,9 @@ extension Voting {
             state.hasStartedProvingCacheWarmup = true
             return .run { [votingCrypto] _ in
                 try await votingCrypto.warmProvingCaches()
-                votingLogger.info("Voting proving caches warmed")
+                LoggerProxy.info("Voting proving caches warmed")
             } catch: { error, _ in
-                votingLogger.error("Voting proving cache warm-up failed: \(error)")
+                LoggerProxy.error("Voting proving cache warm-up failed: \(error)")
             }
 
         case .initialize:
@@ -140,7 +140,7 @@ extension Voting {
                 let config = try await votingAPI.fetchServiceConfig(override)
                 await send(.serviceConfigLoaded(config))
             } catch: { error, send in
-                votingLogger.error("Service config unavailable: \(error)")
+                LoggerProxy.error("Service config unavailable: \(error)")
                 let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
                 await send(.configUnsupported(message))
             }
@@ -171,19 +171,19 @@ extension Voting {
                 //    error screen (which belongs to DB/wallet/config failures).
                 do {
                     let allRounds = try await votingAPI.fetchAllRounds()
-                    votingLogger.info("Fetched \(allRounds.count) rounds")
+                    LoggerProxy.info("Fetched \(allRounds.count) rounds")
                     for round in allRounds {
-                        votingLogger.debug(
+                        LoggerProxy.debug(
                             "round=\(round.voteRoundId.hexString.prefix(16))... status=\(round.status.rawValue) snapshot=\(round.snapshotHeight)"
                         )
                     }
                     await send(.allRoundsLoaded(allRounds))
                 } catch {
-                    votingLogger.error("Failed to fetch rounds: \(error)")
+                    LoggerProxy.error("Failed to fetch rounds: \(error)")
                     await send(.roundsLoadFailed)
                 }
             } catch: { error, send in
-                votingLogger.error("Initialization failed: \(error)")
+                LoggerProxy.error("Initialization failed: \(error)")
                 await send(.initializeFailed(error.localizedDescription))
             }
 
@@ -212,7 +212,7 @@ extension Voting {
                     }
                 }
                 if walletScannedHeight < snapshotHeight {
-                    votingLogger.info("Wallet scanned to \(walletScannedHeight), snapshot at \(snapshotHeight) — not synced yet")
+                    LoggerProxy.info("Wallet scanned to \(walletScannedHeight), snapshot at \(snapshotHeight) — not synced yet")
                     await send(.walletNotSynced(scannedHeight: walletScannedHeight, snapshotHeight: snapshotHeight))
                     return
                 }
@@ -224,7 +224,7 @@ extension Voting {
                     accountUUID
                 )
                 let totalWeight = notes.reduce(UInt64(0)) { $0 + $1.value }
-                votingLogger.info("Loaded \(notes.count) notes at height \(snapshotHeight), total weight: \(totalWeight)")
+                LoggerProxy.info("Loaded \(notes.count) notes at height \(snapshotHeight), total weight: \(totalWeight)")
                 await send(.votingWeightLoaded(totalWeight, notes))
 
                 // Load or generate voting hotkey mnemonic, derive address for UI
@@ -238,13 +238,13 @@ extension Voting {
                     }
                     let seed = try mnemonic.toSeed(phrase)
                     let hotkey = try await votingCrypto.generateHotkey(roundId, seed)
-                    votingLogger.debug("Hotkey address: \(hotkey.address)")
+                    LoggerProxy.debug("Hotkey address: \(hotkey.address)")
                     await send(.hotkeyLoaded(hotkey.address))
                 } catch {
-                    votingLogger.error("Failed to generate hotkey: \(error)")
+                    LoggerProxy.error("Failed to generate hotkey: \(error)")
                 }
             } catch: { error, send in
-                votingLogger.error("Active round pipeline failed: \(error)")
+                LoggerProxy.error("Active round pipeline failed: \(error)")
                 await send(.initializeFailed(error.localizedDescription))
             }
             .cancellable(id: cancelPipelineId, cancelInFlight: true)
@@ -255,7 +255,7 @@ extension Voting {
             state.votingRound = sessionBackedRound(from: session, title: state.votingRound.title, fallback: state.votingRound)
             reconcileProposalState(&state)
             let roundPrefix = session.voteRoundId.hexString.prefix(16)
-            votingLogger.info("activeSessionLoaded: status=\(session.status.rawValue) round=\(roundPrefix)... proposals=\(session.proposals.count)")
+            LoggerProxy.info("activeSessionLoaded: status=\(session.status.rawValue) round=\(roundPrefix)... proposals=\(session.proposals.count)")
             return .none
 
         case .noActiveRound:
@@ -277,7 +277,7 @@ extension Voting {
             state.votingWeight = eligibleWeight
             if bundleResult.droppedCount > 0 {
                 let dropped = bundleResult.droppedCount
-                votingLogger.info("Smart bundling: dropped \(dropped) notes in sub-threshold bundles (eligible: \(eligibleWeight) of \(weight) total)")
+                LoggerProxy.info("Smart bundling: dropped \(dropped) notes in sub-threshold bundles (eligible: \(eligibleWeight) of \(weight) total)")
             }
             if eligibleWeight < ballotDivisor {
                 state.ineligibilityReason = .balanceTooLow
@@ -295,7 +295,7 @@ extension Voting {
             state.draftVotes = restored.filter { state.votes[$0.key] == nil }
             if !state.draftVotes.isEmpty {
                 let draftCount = state.draftVotes.count
-                votingLogger.info("Restored \(draftCount) persisted draft votes")
+                LoggerProxy.info("Restored \(draftCount) persisted draft votes")
             }
 
             state.screenStack = [.pollsList, .proposalList]
@@ -310,7 +310,7 @@ extension Voting {
             )
 
         case .initializeFailed(let error):
-            votingLogger.error("Initialization error: \(error)")
+            LoggerProxy.error("Initialization error: \(error)")
             state.screenStack = [.error(VotingErrorMapper.userFriendlyMessage(from: error))]
             return .none
 
@@ -351,7 +351,7 @@ extension Voting {
                     await send(.roundStatusUpdated(roundId: updated.voteRoundId, updated.status))
                 }
             } catch: { error, _ in
-                votingLogger.error("Status polling error: \(error)")
+                LoggerProxy.error("Status polling error: \(error)")
             }
             .cancellable(id: cancelStatusPollingId, cancelInFlight: true)
 
@@ -365,12 +365,12 @@ extension Voting {
             guard polledRoundId == session.voteRoundId else {
                 let polledPrefix = polledRoundId.hexString.prefix(16)
                 let activePrefix = session.voteRoundId.hexString.prefix(16)
-                votingLogger.debug("roundStatusUpdated: ignoring stale poll for \(polledPrefix)..., active round is \(activePrefix)...")
+                LoggerProxy.debug("roundStatusUpdated: ignoring stale poll for \(polledPrefix)..., active round is \(activePrefix)...")
                 return .none
             }
 
             // Only react to actual transitions
-            votingLogger.info("roundStatusUpdated: old=\(session.status.rawValue) new=\(newStatus.rawValue)")
+            LoggerProxy.info("roundStatusUpdated: old=\(session.status.rawValue) new=\(newStatus.rawValue)")
             guard newStatus != session.status else { return .none }
 
             // Update session status
@@ -492,7 +492,7 @@ extension Voting {
                 let results = try await votingAPI.fetchTallyResults(roundIdHex)
                 await send(.tallyResultsLoaded(results))
             } catch: { error, send in
-                votingLogger.error("Failed to fetch tally results: \(error)")
+                LoggerProxy.error("Failed to fetch tally results: \(error)")
                 await send(.tallyResultsLoadFailed)
             }
 
@@ -518,7 +518,7 @@ extension Voting {
                 let ids = try await votingAPI.fetchZodlEndorsedRoundIds()
                 await send(.zodlEndorsementsLoaded(ids))
             } catch: { error, send in
-                votingLogger.error("Failed to fetch zodl endorsements: \(error)")
+                LoggerProxy.error("Failed to fetch zodl endorsements: \(error)")
                 // Non-fatal decoration: no icon is shown when endorsements are unavailable.
                 await send(.zodlEndorsementsLoaded([]))
             }
@@ -546,7 +546,7 @@ extension Voting {
             if let addr = dbState.roundState.hotkeyAddress {
                 state.hotkeyAddress = addr
             }
-            votingLogger.debug("DB state: phase=\(String(describing: dbState.roundState.phase)), \(dbState.votes.count) votes")
+            LoggerProxy.debug("DB state: phase=\(String(describing: dbState.roundState.phase)), \(dbState.votes.count) votes")
 
             // If votes arrived and share tracking hasn't started yet, kick it off.
             // This handles cold start where governanceTabAppeared fires before votes are loaded.

--- a/secant/Sources/Features/Voting/VotingStore+Submission.swift
+++ b/secant/Sources/Features/Voting/VotingStore+Submission.swift
@@ -85,7 +85,7 @@ extension Voting {
                 !pirEndpoints.isEmpty,
                 let expectedSnapshotHeight = state.activeSession?.snapshotHeight
             else {
-                votingLogger.error("serviceConfig/activeSession unexpectedly nil during vote submission; aborting")
+                LoggerProxy.error("serviceConfig/activeSession unexpectedly nil during vote submission; aborting")
                 return .none
             }
             let bundleCount = state.bundleCount
@@ -147,7 +147,7 @@ extension Voting {
                             send: send
                         )
                     } catch {
-                        votingLogger.error("Delegation pipeline failed (raw): \(error.localizedDescription)")
+                        LoggerProxy.error("Delegation pipeline failed (raw): \(error.localizedDescription)")
                         await send(.batchAuthorizationFailed(
                             error: VotingErrorMapper.userFriendlyMessage(from: error.localizedDescription)
                         ))
@@ -192,7 +192,7 @@ extension Voting {
 
                         for bundleIndex: UInt32 in 0..<bundleCount {
                             if submittedBundles.contains(bundleIndex) {
-                                votingLogger.debug("Batch: bundle \(bundleIndex + 1)/\(bundleCount) already submitted for proposal \(proposalId)")
+                                LoggerProxy.debug("Batch: bundle \(bundleIndex + 1)/\(bundleCount) already submitted for proposal \(proposalId)")
                                 continue
                             }
 
@@ -250,7 +250,7 @@ extension Voting {
                                                         [UInt8](votingDataFromHex(nfHex)), payload.submitAt
                                                     )
                                                 } catch {
-                                                    votingLogger.warning("Batch recovery: failed to record share delegation for share \(info.shareIndex): \(error)")
+                                                    LoggerProxy.warn("Batch recovery: failed to record share delegation for share \(info.shareIndex): \(error)")
                                                 }
                                             }
                                         }
@@ -351,7 +351,7 @@ extension Voting {
                                         [UInt8](votingDataFromHex(nullifierHex)), payload.submitAt
                                     )
                                 } catch {
-                                    votingLogger.warning("Batch: failed to record share delegation for share \(info.shareIndex): \(error)")
+                                    LoggerProxy.warn("Batch: failed to record share delegation for share \(info.shareIndex): \(error)")
                                 }
                             }
                             try await votingCrypto.markVoteSubmitted(roundId, bundleIndex, proposalId)
@@ -361,7 +361,7 @@ extension Voting {
                         await send(.batchVoteSubmitted(proposalId: proposalId, choice: choice))
                     } catch {
                         failCount += 1
-                        votingLogger.error("Batch vote failed for proposal \(proposalId): \(error)")
+                        LoggerProxy.error("Batch vote failed for proposal \(proposalId): \(error)")
                         let shouldStopBatch = error as? ShareDelegationError == .noReachableVoteServers
                         if shouldStopBatch {
                             shareServerURLs = []
@@ -378,7 +378,7 @@ extension Voting {
 
                 await send(.batchSubmissionCompleted(successCount: successCount, failCount: failCount))
             } catch: { error, send in
-                votingLogger.error("Batch submission failed at top level: \(error)")
+                LoggerProxy.error("Batch submission failed at top level: \(error)")
                 await send(.batchSubmissionFailed(
                     error: VotingErrorMapper.userFriendlyMessage(from: error.localizedDescription),
                     submittedCount: 0,

--- a/secant/Sources/Features/Voting/VotingStore.swift
+++ b/secant/Sources/Features/Voting/VotingStore.swift
@@ -2,9 +2,6 @@ import Combine
 import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
-import os
-
-let votingLogger = Logger(subsystem: "co.zodl.voting", category: "VotingStore")
 
 enum VotingFlowError: LocalizedError {
     case missingActiveSession


### PR DESCRIPTION
## Summary
Mechanical swap of direct `os.Logger` usage in voting and background-task code paths over to the project's `LoggerProxy`, so logs are gated by DEBUG (consistent with the rest of the codebase) and don't leak voting subsystem details in release builds.

This is **PR 1 of 4** in the decomposition of the original [#1764](https://github.com/zodl-inc/zodl-ios/pull/1764) per reviewer request. Target base: `MOB-1105-integration`.

## Files touched
- `BackgroundTaskClient/BackgroundTaskClientLiveKey.swift`
- `VotingAPIClient/ServerHealthTracker.swift`
- `VotingAPIClient/VotingAPIClientLiveKey.swift`
- `Voting/VotingStore.swift` + `VotingStore+{Delegation,Navigation,Session,Submission}.swift`

Net: -126/+115 lines, all mechanical (declarations removed, call sites renamed, `, privacy: .public` modifiers stripped since `LoggerProxy` doesn't need them).

## Test plan
- [ ] Build passes (verified locally)
- [ ] No behavioral change expected — pure logging refactor