### PR TITLE
Restore VotingCoordFlow feature parity after Phase 5D

### DIFF
--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/RoundSession.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/RoundSession.swift
@@ -139,6 +139,12 @@ struct RoundSession: Equatable {
     /// proposal count) into the encrypted voting metadata file. The Results
     /// screen uses this to render "Voted MMM d - Voting Power X.XXX ZEC".
     var voteRecord: Voting.VoteRecord?
+
+    /// DB-backed helper-server share confirmation tracking. The UI
+    /// workstream owns presentation; the coordinator keeps this state
+    /// current so My Votes/review surfaces can read it.
+    var shareTrackingStatus: ShareTrackingStatus = .idle
+    var shareDelegations: [VotingShareDelegation] = []
 }
 
 // MARK: - Submission state machine types
@@ -227,4 +233,11 @@ struct KeystoneBundleSignature: Equatable {
     let sig: Data
     let sighash: Data
     let rk: Data // swiftlint:disable:this identifier_name
+}
+
+enum ShareTrackingStatus: Equatable {
+    case idle
+    case loading
+    case tracking
+    case fullyConfirmed
 }

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/RoundSession.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/RoundSession.swift
@@ -26,6 +26,12 @@ struct RoundSession: Equatable {
     /// (wallet, round) pair until a new snapshot or wallet rescan.
     var votingWeight: UInt64 = 0
 
+    /// Original eligible power before any Keystone bundle skipping. For
+    /// Zashi and full Keystone submissions this matches `votingWeight`; when
+    /// Keystone users skip unsigned bundles, `votingWeight` is reduced and
+    /// this remains the pre-skip value for persisted transparency metadata.
+    var eligibleVotingWeight: UInt64 = 0
+
     /// Eligible notes at the round's snapshot height. Cached because the
     /// SDK query is non-trivial and the snapshot is immutable.
     var walletNotes: [NoteInfo] = []
@@ -38,6 +44,10 @@ struct RoundSession: Equatable {
     /// bundling step in the active-round pipeline. Drives both the
     /// delegation proof loop and the per-bundle vote submission loop.
     var bundleCount: UInt32 = 0
+
+    /// Original eligible bundle count before any Keystone skip. Kept so a
+    /// completed vote record can explain reduced power later.
+    var eligibleBundleCount: UInt32 = 0
 
     /// Per-round hotkey address derived deterministically from the per-
     /// account hotkey mnemonic (in the Keychain) and the round id. Same

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -51,6 +51,7 @@ extension VotingCoordFlow {
                 state.pollClosedRoundId = nil
                 return .merge(
                     .cancel(id: cancelPipelineId),
+                    .cancel(id: cancelDelegationPrecomputeId),
                     .cancel(id: cancelStatusPollingId),
                     .cancel(id: cancelNewRoundPollingId),
                     .send(.initialize)
@@ -264,6 +265,7 @@ extension VotingCoordFlow {
                     .cancel(id: cancelPipelineId),
                     .cancel(id: cancelSubmissionId),
                     .cancel(id: cancelDelegationProofId),
+                    .cancel(id: cancelDelegationPrecomputeId),
                     .cancel(id: cancelStatusPollingId),
                     .cancel(id: cancelNewRoundPollingId)
                 )
@@ -405,17 +407,36 @@ extension VotingCoordFlow {
             case let .delegationProofFailed(roundId, error):
                 return reduceDelegationProofFailed(&state, roundId: roundId, error: error)
 
-            case .maybeStartDelegationPrecompute:
-                // Zashi optimization (PIR precompute) — Stage 5B+ refinement,
-                // not required for the happy path. Left as a no-op so the
-                // pipeline still runs correctly; precompute just doesn't kick
-                // in early.
+            case let .maybeStartDelegationPrecompute(roundId):
+                return reduceMaybeStartDelegationPrecompute(&state, roundId: roundId)
+
+            case let .delegationPrecomputeCompleted(roundId):
+                mutateSession(&state, roundId: roundId) { roundSession in
+                    roundSession.delegationPrecomputeStatus = .ready
+                    roundSession.isDelegationPrecomputeInFlight = false
+                }
+                if state.pendingBatchSubmission && !state.isKeystoneUser {
+                    state.pendingBatchSubmission = false
+                    mutateSession(&state, roundId: roundId) {
+                        $0.batchSubmissionStatus = .idle
+                    }
+                    return .send(.authenticationSucceeded(roundId: roundId))
+                }
                 return .none
 
-            case .delegationPrecomputeCompleted:
-                return .none
-
-            case .delegationPrecomputeFailed:
+            case let .delegationPrecomputeFailed(roundId, error):
+                let message = VotingErrorMapper.userFriendlyMessage(from: error)
+                mutateSession(&state, roundId: roundId) { roundSession in
+                    roundSession.delegationPrecomputeStatus = .failed(message)
+                    roundSession.isDelegationPrecomputeInFlight = false
+                }
+                if state.pendingBatchSubmission && !state.isKeystoneUser {
+                    state.pendingBatchSubmission = false
+                    mutateSession(&state, roundId: roundId) {
+                        $0.batchSubmissionStatus = .idle
+                    }
+                    return .send(.authenticationSucceeded(roundId: roundId))
+                }
                 return .none
 
             case let .batchSubmissionProgress(roundId, currentIndex, totalCount, proposalId):
@@ -926,6 +947,9 @@ extension VotingCoordFlow {
                     state.roundCache[roundId, default: RoundSession(roundId: roundId)].delegationPrecomputeStatus = .notStarted
                     state.roundCache[roundId, default: RoundSession(roundId: roundId)].isDelegationPrecomputeInFlight = false
                 }
+                if state.roundCache[roundId]?.hotkeyAddress != nil {
+                    return .send(.maybeStartDelegationPrecompute(roundId: roundId))
+                }
                 return .none
 
             case let .hotkeyLoaded(roundId, address):
@@ -933,7 +957,7 @@ extension VotingCoordFlow {
                 if state.pendingPipelineRoundId == roundId {
                     state.pendingPipelineRoundId = nil
                 }
-                return .none
+                return .send(.maybeStartDelegationPrecompute(roundId: roundId))
 
             case let .pipelineFailed(roundId, message):
                 // Pop the proposal list back to the polls list and surface
@@ -1610,6 +1634,107 @@ extension VotingCoordFlow {
             ))
         }
         .cancellable(id: cancelSubmissionId, cancelInFlight: true)
+    }
+
+    // MARK: - Delegation precompute
+
+    func reduceMaybeStartDelegationPrecompute(_ state: inout State, roundId: String) -> Effect<Action> {
+        guard !state.isKeystoneUser else { return .none }
+        guard let session = state.roundCache[roundId] else { return .none }
+        guard !isDelegationReady(session) else { return .none }
+        guard !session.isDelegationProofInFlight,
+              !session.isDelegationPrecomputeInFlight
+        else { return .none }
+        guard session.delegationPrecomputeStatus == .notStarted else { return .none }
+        guard session.hotkeyAddress != nil else { return .none }
+        guard session.bundleCount > 0, !session.walletNotes.isEmpty else { return .none }
+        guard let activeSession = activeSession(in: state, roundId: roundId),
+              activeSession.status == .active
+        else { return .none }
+        guard
+            let pirEndpoints = state.serviceConfig?.pirEndpoints.map(\.url).nonEmpty,
+            let seedFingerprint = votingSeedFingerprint(for: state.selectedWalletAccount),
+            let accountId = state.selectedWalletAccount?.id
+        else {
+            return .none
+        }
+
+        mutateSession(&state, roundId: roundId) { roundSession in
+            roundSession.delegationPrecomputeStatus = .inProgress
+            roundSession.isDelegationPrecomputeInFlight = true
+        }
+
+        let expectedSnapshotHeight = activeSession.snapshotHeight
+        let cachedNotes = session.walletNotes
+        let bundleCount = session.bundleCount
+        let network = zcashSDKEnvironment.network
+        let networkId: UInt32 = network.networkType.votingRustNetworkId
+        let accountIndex = votingAccountIndex(for: state.selectedWalletAccount)
+        let roundName = activeSession.title
+
+        return .run { [votingCrypto, mnemonic, walletStorage] send in
+            let hotkeyPhrase = try walletStorage.exportVotingHotkey(accountId).seedPhrase.value()
+            let hotkeySeed = try mnemonic.toSeed(hotkeyPhrase)
+            let noteChunks = cachedNotes.smartBundles().bundles
+            guard Int(bundleCount) <= noteChunks.count else {
+                throw VotingFlowError.inconsistentBundleSetup(
+                    bundleCount: bundleCount,
+                    noteChunkCount: noteChunks.count
+                )
+            }
+
+            var totalCached: UInt32 = 0
+            var totalFetched: UInt32 = 0
+            for bundleIndex: UInt32 in 0..<bundleCount {
+                try Task.checkCancellation()
+                if case .present? = try? await votingCrypto.getDelegationTxHash(roundId, bundleIndex) {
+                    continue
+                }
+
+                let bundleNotes = noteChunks[Int(bundleIndex)]
+                guard let firstNote = bundleNotes.first else { continue }
+                let orchardFvk = try votingCrypto.extractOrchardFvkFromUfvk(
+                    firstNote.ufvkStr,
+                    networkId
+                )
+
+                _ = try await votingCrypto.buildVotingPczt(
+                    roundId,
+                    bundleIndex,
+                    bundleNotes,
+                    emptySenderSeed,
+                    hotkeySeed,
+                    networkId,
+                    accountIndex,
+                    roundName,
+                    orchardFvk,
+                    seedFingerprint
+                )
+
+                let result = try await votingCrypto.precomputeDelegationPir(
+                    roundId,
+                    bundleIndex,
+                    bundleNotes,
+                    pirEndpoints,
+                    expectedSnapshotHeight,
+                    networkId
+                )
+                totalCached += result.cachedCount
+                totalFetched += result.fetchedCount
+                LoggerProxy.info(
+                    "Delegation PIR precompute bundle \(bundleIndex + 1)/\(bundleCount): " +
+                        "cached=\(result.cachedCount) fetched=\(result.fetchedCount)"
+                )
+            }
+
+            LoggerProxy.info(
+                "Delegation PIR precompute complete: cached=\(totalCached) fetched=\(totalFetched)"
+            )
+            await send(.delegationPrecomputeCompleted(roundId: roundId))
+        } catch: { error, send in
+            await send(.delegationPrecomputeFailed(roundId: roundId, error: error.localizedDescription))
+        }
+        .cancellable(id: cancelDelegationPrecomputeId, cancelInFlight: true)
     }
 
     // MARK: - Per-action state updates

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -950,10 +950,15 @@ extension VotingCoordFlow {
                 return .none
 
             case let .votingWeightLoaded(roundId, weight, notes, witnesses, bundleCount, delegationReady):
+                let eligibleTotals = Self.eligibleTotals(for: notes)
                 state.roundCache[roundId, default: RoundSession(roundId: roundId)].votingWeight = weight
+                state.roundCache[roundId, default: RoundSession(roundId: roundId)].eligibleVotingWeight =
+                    eligibleTotals.weight > 0 ? eligibleTotals.weight : weight
                 state.roundCache[roundId, default: RoundSession(roundId: roundId)].walletNotes = notes
                 state.roundCache[roundId, default: RoundSession(roundId: roundId)].cachedWitnesses = witnesses
                 state.roundCache[roundId, default: RoundSession(roundId: roundId)].bundleCount = bundleCount
+                state.roundCache[roundId, default: RoundSession(roundId: roundId)].eligibleBundleCount =
+                    eligibleTotals.bundleCount > 0 ? eligibleTotals.bundleCount : bundleCount
                 if delegationReady {
                     state.roundCache[roundId, default: RoundSession(roundId: roundId)].delegationProofStatus = .complete
                 } else {
@@ -2223,7 +2228,14 @@ extension VotingCoordFlow {
             let record = Voting.VoteRecord(
                 votedAt: Date(),
                 votingWeight: session.votingWeight,
-                proposalCount: proposalCount
+                proposalCount: proposalCount,
+                eligibleVotingWeight: state.isKeystoneUser
+                    ? completedEligibleVotingWeight(session)
+                    : nil,
+                submittedBundleCount: state.isKeystoneUser ? session.bundleCount : nil,
+                totalBundleCount: state.isKeystoneUser
+                    ? completedEligibleBundleCount(session)
+                    : nil
             )
             do {
                 try Voting.persistCompletedRound(record, roundId: roundId, account: account)
@@ -2650,6 +2662,12 @@ extension VotingCoordFlow {
         }
 
         mutateSession(&state, roundId: roundId) { roundSession in
+            if roundSession.eligibleBundleCount == 0 {
+                roundSession.eligibleBundleCount = session.bundleCount
+            }
+            if roundSession.eligibleVotingWeight == 0 {
+                roundSession.eligibleVotingWeight = session.votingWeight
+            }
             roundSession.bundleCount = signedCount
             roundSession.votingWeight = signedWeight
             roundSession.pendingVotingPczt = nil
@@ -2892,6 +2910,11 @@ extension VotingCoordFlow {
         }
     }
 
+    private static func eligibleTotals(for notes: [NoteInfo]) -> (weight: UInt64, bundleCount: UInt32) {
+        let bundleResult = notes.smartBundles()
+        return (bundleResult.eligibleWeight, UInt32(bundleResult.bundles.count))
+    }
+
     private static func votingWeight(for notes: [NoteInfo], bundleCount: UInt32) -> UInt64 {
         let allBundles = notes.smartBundles().bundles
         guard bundleCount > 0, Int(bundleCount) < allBundles.count else {
@@ -2997,6 +3020,18 @@ extension VotingCoordFlow {
         return proposals.allSatisfy { proposal in
             session.votes[proposal.id] != nil
         }
+    }
+
+    private func completedEligibleVotingWeight(_ session: RoundSession) -> UInt64 {
+        session.eligibleVotingWeight > 0
+            ? session.eligibleVotingWeight
+            : session.votingWeight
+    }
+
+    private func completedEligibleBundleCount(_ session: RoundSession) -> UInt32 {
+        session.eligibleBundleCount > 0
+            ? session.eligibleBundleCount
+            : session.bundleCount
     }
 
     private func votingMetadataPersistenceMessage(_ error: Error) -> String {

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -54,6 +54,7 @@ extension VotingCoordFlow {
                     .cancel(id: cancelDelegationPrecomputeId),
                     .cancel(id: cancelStatusPollingId),
                     .cancel(id: cancelNewRoundPollingId),
+                    .cancel(id: cancelShareTrackingId),
                     .send(.initialize)
                 )
 
@@ -267,7 +268,8 @@ extension VotingCoordFlow {
                     .cancel(id: cancelDelegationProofId),
                     .cancel(id: cancelDelegationPrecomputeId),
                     .cancel(id: cancelStatusPollingId),
-                    .cancel(id: cancelNewRoundPollingId)
+                    .cancel(id: cancelNewRoundPollingId),
+                    .cancel(id: cancelShareTrackingId)
                 )
 
             case .howToVoteContinueTapped:
@@ -294,6 +296,7 @@ extension VotingCoordFlow {
                 guard let item = state.allRounds.first(where: { $0.id == roundId }) else {
                     return .none
                 }
+                let cancelShareTracking = cancelShareTrackingIfSwitchingRound(state, to: roundId)
                 switch item.session.status {
                 case .active:
                     hydratePersistedRoundChoices(&state, roundId: roundId)
@@ -303,6 +306,7 @@ extension VotingCoordFlow {
                         // pipeline needed.
                         state.path.append(.reviewVotes(ReviewVotes.State(roundId: roundId)))
                         return .merge(
+                            cancelShareTracking,
                             .cancel(id: cancelNewRoundPollingId),
                             .send(.startRoundStatusPolling(roundId: roundId)),
                             loadSubmittedVotesFromDb(roundId: roundId)
@@ -316,12 +320,14 @@ extension VotingCoordFlow {
                        cached.hotkeyAddress != nil,
                        cached.bundleCount > 0 {
                         return .merge(
+                            cancelShareTracking,
                             .cancel(id: cancelNewRoundPollingId),
                             .send(.startRoundStatusPolling(roundId: roundId)),
                             loadSubmittedVotesFromDb(roundId: roundId)
                         )
                     }
                     return .merge(
+                        cancelShareTracking,
                         .cancel(id: cancelNewRoundPollingId),
                         .send(.startRoundStatusPolling(roundId: roundId)),
                         .send(.startActiveRoundPipeline(roundId: roundId)),
@@ -329,10 +335,11 @@ extension VotingCoordFlow {
                     )
                 case .tallying:
                     state.path.append(.tallying(Tallying.State(roundId: roundId)))
-                    return .none
+                    return cancelShareTracking
                 case .finalized:
                     state.path.append(.results(Results.State(roundId: roundId)))
                     return .merge(
+                        cancelShareTracking,
                         .cancel(id: cancelStatusPollingId),
                         .send(.fetchTallyResults(roundId: roundId)),
                         .send(.startNewRoundPolling)
@@ -345,6 +352,7 @@ extension VotingCoordFlow {
                 // Explicit user intent to view submitted votes in read-only
                 // form. Always routes to reviewVotes regardless of round
                 // status (active or finalized — both have a vote record).
+                let cancelShareTracking = cancelShareTrackingIfSwitchingRound(state, to: roundId)
                 hydratePersistedRoundChoices(&state, roundId: roundId)
                 state.path.append(.reviewVotes(ReviewVotes.State(roundId: roundId)))
                 let statusPolling: Effect<Action>
@@ -353,7 +361,11 @@ extension VotingCoordFlow {
                 } else {
                     statusPolling = .none
                 }
-                return .merge(statusPolling, loadSubmittedVotesFromDb(roundId: roundId))
+                return .merge(
+                    cancelShareTracking,
+                    statusPolling,
+                    loadSubmittedVotesFromDb(roundId: roundId)
+                )
 
             case let .proposalTapped(roundId, proposalId, mode):
                 state.path.append(
@@ -980,6 +992,12 @@ extension VotingCoordFlow {
                 let filteredDrafts = session.draftVotes
                     .filter { mergedVotes[$0.key] == nil }
                 session.draftVotes = filteredDrafts
+                let shouldStartShareTracking = !mergedVotes.isEmpty
+                    && session.shareTrackingStatus == .idle
+                    && !session.isSubmittingVote
+                if shouldStartShareTracking {
+                    session.shareTrackingStatus = .loading
+                }
                 do {
                     try Voting.persistRoundChoices(
                         drafts: filteredDrafts,
@@ -992,6 +1010,9 @@ extension VotingCoordFlow {
                     LoggerProxy.error("Failed to persist submitted voting choices: \(error)")
                     state.submissionAlert = .votingMetadataPersistenceFailed(error)
                     state.roundCache[roundId] = session
+                }
+                if shouldStartShareTracking {
+                    return .send(.loadShareDelegations(roundId: roundId))
                 }
                 return .none
 
@@ -1051,26 +1072,36 @@ extension VotingCoordFlow {
 
                 switch status {
                 case .tallying:
+                    let isCurrentRound = topPathRoundId(state) == roundId
                     if activeVotingFlowRoundId(state) == roundId {
                         state.pollClosedAlert = .pollClosed(status: status)
                         state.pollClosedRoundId = roundId
-                    } else if topPathRoundId(state) == roundId {
+                    } else if isCurrentRound {
                         replacePathWithStatusScreen(&state, roundId: roundId, status: status)
                     }
-                    return .cancel(id: cancelStatusPollingId)
+                    return isCurrentRound
+                        ? .merge(
+                            .cancel(id: cancelStatusPollingId),
+                            .cancel(id: cancelShareTrackingId)
+                        )
+                        : .none
 
                 case .finalized:
+                    let isCurrentRound = topPathRoundId(state) == roundId
                     if activeVotingFlowRoundId(state) == roundId {
                         state.pollClosedAlert = .pollClosed(status: status)
                         state.pollClosedRoundId = roundId
-                    } else if topPathRoundId(state) == roundId {
+                    } else if isCurrentRound {
                         replacePathWithStatusScreen(&state, roundId: roundId, status: status)
                     }
-                    return .merge(
-                        .cancel(id: cancelStatusPollingId),
-                        .send(.fetchTallyResults(roundId: roundId)),
-                        .send(.startNewRoundPolling)
-                    )
+                    return isCurrentRound
+                        ? .merge(
+                            .cancel(id: cancelStatusPollingId),
+                            .cancel(id: cancelShareTrackingId),
+                            .send(.fetchTallyResults(roundId: roundId)),
+                            .send(.startNewRoundPolling)
+                        )
+                        : .none
 
                 case .active, .unspecified:
                     return .none
@@ -1129,6 +1160,38 @@ extension VotingCoordFlow {
                     LoggerProxy.warn("Voting new-round polling failed: \(error)")
                 }
                 .cancellable(id: cancelNewRoundPollingId, cancelInFlight: true)
+
+            case let .loadShareDelegations(roundId):
+                mutateSession(&state, roundId: roundId) {
+                    $0.shareTrackingStatus = .loading
+                }
+                return .run { [votingCrypto] send in
+                    let delegations = try await votingCrypto.getShareDelegations(roundId)
+                    await send(.shareDelegationsLoaded(
+                        roundId: roundId,
+                        delegations: delegations
+                    ))
+                } catch: { error, _ in
+                    LoggerProxy.warn("Failed to load share delegations: \(error)")
+                }
+
+            case let .shareDelegationsLoaded(roundId, delegations):
+                updateShareTrackingState(&state, roundId: roundId, delegations: delegations)
+                guard state.roundCache[roundId]?.shareTrackingStatus == .tracking else {
+                    return .none
+                }
+                return .run { send in
+                    try await Task.sleep(for: .seconds(1))
+                    await send(.pollShareStatus(roundId: roundId))
+                }
+                .cancellable(id: cancelShareTrackingId, cancelInFlight: true)
+
+            case let .shareDelegationsRefreshed(roundId, delegations):
+                updateShareTrackingState(&state, roundId: roundId, delegations: delegations)
+                return .none
+
+            case let .pollShareStatus(roundId):
+                return reducePollShareStatus(&state, roundId: roundId)
 
             case .refreshActiveRoundsList:
                 // Lightweight re-fetch used by the tallying-status poll.
@@ -1199,6 +1262,15 @@ extension VotingCoordFlow {
         case .configSettings:
             return nil
         }
+    }
+
+    private func cancelShareTrackingIfSwitchingRound(
+        _ state: State,
+        to roundId: String
+    ) -> Effect<Action> {
+        topPathRoundId(state).map { $0 != roundId } == true
+            ? .cancel(id: cancelShareTrackingId)
+            : .none
     }
 
     private func activeVotingFlowRoundId(_ state: State) -> String? {
@@ -1737,6 +1809,230 @@ extension VotingCoordFlow {
         .cancellable(id: cancelDelegationPrecomputeId, cancelInFlight: true)
     }
 
+    // MARK: - Share tracking
+
+    func reducePollShareStatus(_ state: inout State, roundId: String) -> Effect<Action> {
+        guard let session = state.roundCache[roundId],
+              session.shareTrackingStatus == .tracking,
+              let activeSession = activeSession(in: state, roundId: roundId)
+        else {
+            return .none
+        }
+
+        let votes = session.votes
+        let proposals = activeSession.proposals
+        let singleShare = activeSession.isLastMoment
+        let voteEndTime = UInt64(activeSession.voteEndTime.timeIntervalSince1970)
+
+        return .run { [votingAPI, votingCrypto] send in
+            let freshDelegations = (try? await votingCrypto.getShareDelegations(roundId)) ?? []
+            let unconfirmed = freshDelegations.filter { !$0.confirmed }
+            let now = UInt64(Date().timeIntervalSince1970)
+
+            let readyShares = unconfirmed.filter {
+                Self.isShareReadyForStatusCheck($0, now: now)
+            }
+            let pollResult = await Self.pollShareStatusesForRecovery(
+                readyShares: readyShares,
+                roundId: roundId,
+                now: now,
+                voteEndTime: voteEndTime,
+                fetchShareStatus: votingAPI.fetchShareStatus
+            )
+
+            for key in pollResult.confirmedShares {
+                do {
+                    try await votingCrypto.markShareConfirmed(
+                        roundId,
+                        key.bundleIndex,
+                        key.proposalId,
+                        key.shareIndex
+                    )
+                } catch {
+                    LoggerProxy.warn("Failed to mark share confirmed: \(error)")
+                }
+            }
+
+            let grouped = Dictionary(grouping: pollResult.resubmissionShares) {
+                "\($0.bundleIndex):\($0.proposalId)"
+            }
+            for (_, shares) in grouped {
+                guard let first = shares.first else { continue }
+                let bundleIndex = first.bundleIndex
+                let proposalId = first.proposalId
+                guard
+                    let result = try? await votingCrypto.getVoteCommitmentBundleWithPosition(
+                        roundId,
+                        bundleIndex,
+                        proposalId
+                    ),
+                    let choice = votes[proposalId]
+                else {
+                    continue
+                }
+
+                let numOptions = UInt32(proposals.first { $0.id == proposalId }?.options.count ?? 3)
+                do {
+                    var payloads = try await votingCrypto.buildSharePayloads(
+                        result.bundle.encShares,
+                        result.bundle,
+                        choice,
+                        numOptions,
+                        result.vcTreePosition,
+                        singleShare
+                    )
+                    for index in payloads.indices {
+                        payloads[index].submitAt = 0
+                    }
+
+                    for share in shares {
+                        guard let payload = payloads.first(where: {
+                            $0.encShare.shareIndex == share.shareIndex
+                        }) else {
+                            continue
+                        }
+                        let acceptedServers = try await votingAPI.resubmitShare(
+                            payload,
+                            roundId,
+                            share.sentToURLs
+                        )
+                        let newServers = acceptedServers.filter {
+                            !share.sentToURLs.contains($0)
+                        }
+                        if !newServers.isEmpty {
+                            try await votingCrypto.addSentServers(
+                                roundId,
+                                bundleIndex,
+                                proposalId,
+                                share.shareIndex,
+                                newServers
+                            )
+                        }
+                    }
+                } catch {
+                    LoggerProxy.warn("Share resubmission failed: \(error)")
+                }
+            }
+
+            let updatedDelegations = (try? await votingCrypto.getShareDelegations(roundId))
+                ?? freshDelegations
+            await send(.shareDelegationsRefreshed(
+                roundId: roundId,
+                delegations: updatedDelegations
+            ))
+
+            let refreshedNow = UInt64(Date().timeIntervalSince1970)
+            let stillUnconfirmed = updatedDelegations.filter { !$0.confirmed }
+            guard !stillUnconfirmed.isEmpty else { return }
+
+            let futureCheckTimes = stillUnconfirmed.compactMap { share -> UInt64? in
+                let readyAt = Self.shareRecoveryBaseTime(share) + Self.shareCheckGrace
+                return readyAt > refreshedNow ? readyAt : nil
+            }
+            let sleepSeconds: UInt64
+            if let soonest = futureCheckTimes.min() {
+                sleepSeconds = min(soonest - refreshedNow, 30)
+            } else {
+                sleepSeconds = 15
+            }
+            try await Task.sleep(for: .seconds(max(sleepSeconds, 3)))
+            await send(.pollShareStatus(roundId: roundId))
+        } catch: { error, _ in
+            LoggerProxy.warn("Share tracking poll failed: \(error)")
+        }
+        .cancellable(id: cancelShareTrackingId, cancelInFlight: true)
+    }
+
+    private func updateShareTrackingState(
+        _ state: inout State,
+        roundId: String,
+        delegations: [VotingShareDelegation]
+    ) {
+        mutateSession(&state, roundId: roundId) { roundSession in
+            roundSession.shareDelegations = delegations
+            let allConfirmed = !delegations.isEmpty && delegations.allSatisfy(\.confirmed)
+            if delegations.isEmpty {
+                roundSession.shareTrackingStatus = .idle
+            } else if allConfirmed {
+                roundSession.shareTrackingStatus = .fullyConfirmed
+            } else {
+                roundSession.shareTrackingStatus = .tracking
+            }
+        }
+    }
+
+    private static let shareCheckGrace: UInt64 = 10
+
+    private static func shareRecoveryBaseTime(_ share: VotingShareDelegation) -> UInt64 {
+        share.submitAt > 0 ? share.submitAt : share.createdAt
+    }
+
+    private static func isShareReadyForStatusCheck(
+        _ share: VotingShareDelegation,
+        now: UInt64
+    ) -> Bool {
+        now >= shareRecoveryBaseTime(share) + shareCheckGrace
+    }
+
+    private static func shouldResubmitShare(
+        _ share: VotingShareDelegation,
+        now: UInt64,
+        voteEndTime: UInt64
+    ) -> Bool {
+        let baseTime = shareRecoveryBaseTime(share)
+        let remainingWindow = voteEndTime > baseTime ? voteEndTime - baseTime : 0
+        let overdueThreshold: UInt64 = max(30, min(3_600, remainingWindow / 4))
+
+        return now >= baseTime + overdueThreshold && voteEndTime > now + 10
+    }
+
+    private static func pollShareStatusesForRecovery(
+        readyShares: [VotingShareDelegation],
+        roundId: String,
+        now: UInt64,
+        voteEndTime: UInt64,
+        fetchShareStatus: @escaping @Sendable (
+            _ helperBaseURL: String,
+            _ roundIdHex: String,
+            _ nullifierHex: String
+        ) async throws -> ShareConfirmationResult
+    ) async -> ShareRecoveryPollResult {
+        var confirmedShares: [ShareDelegationKey] = []
+        var resubmissionShares: [VotingShareDelegation] = []
+        var queriedCount = 0
+
+        for share in readyShares {
+            var confirmed = false
+            for helperURL in share.sentToURLs {
+                queriedCount += 1
+                do {
+                    let result = try await fetchShareStatus(helperURL, roundId, share.nullifier)
+                    if result == .confirmed {
+                        confirmedShares.append(ShareDelegationKey(
+                            bundleIndex: share.bundleIndex,
+                            proposalId: share.proposalId,
+                            shareIndex: share.shareIndex
+                        ))
+                        confirmed = true
+                        break
+                    }
+                } catch {
+                    LoggerProxy.warn("Share status check failed: \(error)")
+                }
+            }
+
+            if !confirmed && shouldResubmitShare(share, now: now, voteEndTime: voteEndTime) {
+                resubmissionShares.append(share)
+            }
+        }
+
+        return ShareRecoveryPollResult(
+            confirmedShares: confirmedShares,
+            resubmissionShares: resubmissionShares,
+            queriedCount: queriedCount
+        )
+    }
+
     // MARK: - Per-action state updates
 
     func reduceBatchSubmissionProgress(
@@ -1886,6 +2182,12 @@ extension VotingCoordFlow {
 
         if let record = session.voteRecord {
             state.voteRecords[roundId] = record
+        }
+        if session.shareTrackingStatus == .idle {
+            mutateSession(&state, roundId: roundId) {
+                $0.shareTrackingStatus = .loading
+            }
+            return .send(.loadShareDelegations(roundId: roundId))
         }
         return .none
     }
@@ -2960,6 +3262,20 @@ extension VotingCoordFlow {
             try await Task.sleep(for: retryDelay)
         } while true
     }
+}
+
+// MARK: - Share delegation recovery
+
+private struct ShareDelegationKey: Equatable, Sendable {
+    let bundleIndex: UInt32
+    let proposalId: UInt32
+    let shareIndex: UInt32
+}
+
+private struct ShareRecoveryPollResult: Equatable, Sendable {
+    let confirmedShares: [ShareDelegationKey]
+    let resubmissionShares: [VotingShareDelegation]
+    let queriedCount: Int
 }
 
 // MARK: - Alerts

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -47,8 +47,12 @@ extension VotingCoordFlow {
                 state.serviceConfig = nil
                 state.pollsLoadError = false
                 state.rootScreen = .loading
+                state.pollClosedAlert = nil
+                state.pollClosedRoundId = nil
                 return .merge(
                     .cancel(id: cancelPipelineId),
+                    .cancel(id: cancelStatusPollingId),
+                    .cancel(id: cancelNewRoundPollingId),
                     .send(.initialize)
                 )
 
@@ -80,6 +84,19 @@ extension VotingCoordFlow {
                 }
                 state.rootScreen = .loading
                 return .send(.initialize)
+
+            case .warmProvingCaches:
+                guard !state.hasRequestedProvingCacheWarmup else {
+                    return .none
+                }
+                state.hasRequestedProvingCacheWarmup = true
+                return .run { [votingCrypto] _ in
+                    do {
+                        try await votingCrypto.warmProvingCaches()
+                    } catch {
+                        LoggerProxy.warn("Voting proving cache warm-up failed: \(error)")
+                    }
+                }
 
             case .initialize:
                 // Sweep legacy plaintext keys from a prior internal-build
@@ -180,7 +197,8 @@ extension VotingCoordFlow {
                 // TallyingView lands them on the right screen without a
                 // manual back tap. Same for proposal list → results when a
                 // previously-active round finalized out from under them.
-                if let topRoundId = finalizedTopOfPath(state) {
+                let finalizedRoundFromPath = finalizedTopOfPath(state)
+                if let topRoundId = finalizedRoundFromPath {
                     _ = state.path.popLast()
                     state.path.append(.results(Results.State(roundId: topRoundId)))
                 }
@@ -189,7 +207,7 @@ extension VotingCoordFlow {
                 // list lands. PollsListView filters bundled rounds by this
                 // set when `isOnDefaultConfig` is true, so without the
                 // fetch the list would be empty on the default source.
-                return .run { [votingAPI] send in
+                let endorsements: Effect<Action> = .run { [votingAPI] send in
                     do {
                         let ids = try await votingAPI.fetchZodlEndorsedRoundIds()
                         await send(.zodlEndorsementsLoaded(ids))
@@ -198,6 +216,14 @@ extension VotingCoordFlow {
                         await send(.zodlEndorsementsFailed)
                     }
                 }
+                guard let finalizedRoundFromPath else {
+                    return endorsements
+                }
+                return .merge(
+                    endorsements,
+                    .send(.fetchTallyResults(roundId: finalizedRoundFromPath)),
+                    .send(.startNewRoundPolling)
+                )
 
             case let .zodlEndorsementsLoaded(ids):
                 state.zodlEndorsedRoundIds = ids
@@ -232,10 +258,14 @@ extension VotingCoordFlow {
                 state.roundCache.removeAll()
                 state.path.removeAll()
                 state.pendingBatchSubmission = false
+                state.pollClosedAlert = nil
+                state.pollClosedRoundId = nil
                 return .merge(
                     .cancel(id: cancelPipelineId),
                     .cancel(id: cancelSubmissionId),
-                    .cancel(id: cancelDelegationProofId)
+                    .cancel(id: cancelDelegationProofId),
+                    .cancel(id: cancelStatusPollingId),
+                    .cancel(id: cancelNewRoundPollingId)
                 )
 
             case .howToVoteContinueTapped:
@@ -270,7 +300,11 @@ extension VotingCoordFlow {
                         // Already submitted — review-mode read-only, no
                         // pipeline needed.
                         state.path.append(.reviewVotes(ReviewVotes.State(roundId: roundId)))
-                        return loadSubmittedVotesFromDb(roundId: roundId)
+                        return .merge(
+                            .cancel(id: cancelNewRoundPollingId),
+                            .send(.startRoundStatusPolling(roundId: roundId)),
+                            loadSubmittedVotesFromDb(roundId: roundId)
+                        )
                     }
                     state.path.append(.proposalList(ProposalList.State(roundId: roundId)))
                     // Cache check: skip pipeline if hotkey is already
@@ -279,9 +313,15 @@ extension VotingCoordFlow {
                     if let cached = state.roundCache[roundId],
                        cached.hotkeyAddress != nil,
                        cached.bundleCount > 0 {
-                        return loadSubmittedVotesFromDb(roundId: roundId)
+                        return .merge(
+                            .cancel(id: cancelNewRoundPollingId),
+                            .send(.startRoundStatusPolling(roundId: roundId)),
+                            loadSubmittedVotesFromDb(roundId: roundId)
+                        )
                     }
                     return .merge(
+                        .cancel(id: cancelNewRoundPollingId),
+                        .send(.startRoundStatusPolling(roundId: roundId)),
                         .send(.startActiveRoundPipeline(roundId: roundId)),
                         loadSubmittedVotesFromDb(roundId: roundId)
                     )
@@ -290,7 +330,11 @@ extension VotingCoordFlow {
                     return .none
                 case .finalized:
                     state.path.append(.results(Results.State(roundId: roundId)))
-                    return .none
+                    return .merge(
+                        .cancel(id: cancelStatusPollingId),
+                        .send(.fetchTallyResults(roundId: roundId)),
+                        .send(.startNewRoundPolling)
+                    )
                 case .unspecified:
                     return .none
                 }
@@ -301,7 +345,13 @@ extension VotingCoordFlow {
                 // status (active or finalized — both have a vote record).
                 hydratePersistedRoundChoices(&state, roundId: roundId)
                 state.path.append(.reviewVotes(ReviewVotes.State(roundId: roundId)))
-                return loadSubmittedVotesFromDb(roundId: roundId)
+                let statusPolling: Effect<Action>
+                if state.allRounds.first(where: { $0.id == roundId })?.session.status == .active {
+                    statusPolling = .send(.startRoundStatusPolling(roundId: roundId))
+                } else {
+                    statusPolling = .none
+                }
+                return .merge(statusPolling, loadSubmittedVotesFromDb(roundId: roundId))
 
             case let .proposalTapped(roundId, proposalId, mode):
                 state.path.append(
@@ -865,6 +915,128 @@ extension VotingCoordFlow {
                 state.path.append(.ineligible(Ineligible.State(roundId: roundId)))
                 return .cancel(id: cancelPipelineId)
 
+            case let .startRoundStatusPolling(roundId):
+                guard let item = state.allRounds.first(where: { $0.id == roundId }),
+                      item.session.status == .active
+                else {
+                    return .none
+                }
+                return .run { [votingAPI] send in
+                    while !Task.isCancelled {
+                        do {
+                            try await Task.sleep(for: .seconds(5))
+                            let updated = try await votingAPI.fetchRoundById(roundId)
+                            await send(
+                                .roundStatusUpdated(
+                                    roundId: roundId,
+                                    status: updated.status
+                                )
+                            )
+                        } catch is CancellationError {
+                            return
+                        } catch {
+                            LoggerProxy.warn("Voting round status polling fetch failed: \(error)")
+                        }
+                    }
+                } catch: { error, _ in
+                    LoggerProxy.warn("Voting round status polling failed: \(error)")
+                }
+                .cancellable(id: cancelStatusPollingId, cancelInFlight: true)
+
+            case let .roundStatusUpdated(roundId, status):
+                guard let index = state.allRounds.firstIndex(where: { $0.id == roundId }) else {
+                    return .none
+                }
+                let current = state.allRounds[index].session.status
+                guard current != status else { return .none }
+
+                let item = state.allRounds[index]
+                state.allRounds[index] = RoundListItem(
+                    roundNumber: item.roundNumber,
+                    session: session(item.session, withStatus: status)
+                )
+
+                switch status {
+                case .tallying:
+                    if activeVotingFlowRoundId(state) == roundId {
+                        state.pollClosedAlert = .pollClosed(status: status)
+                        state.pollClosedRoundId = roundId
+                    } else if topPathRoundId(state) == roundId {
+                        replacePathWithStatusScreen(&state, roundId: roundId, status: status)
+                    }
+                    return .cancel(id: cancelStatusPollingId)
+
+                case .finalized:
+                    if activeVotingFlowRoundId(state) == roundId {
+                        state.pollClosedAlert = .pollClosed(status: status)
+                        state.pollClosedRoundId = roundId
+                    } else if topPathRoundId(state) == roundId {
+                        replacePathWithStatusScreen(&state, roundId: roundId, status: status)
+                    }
+                    return .merge(
+                        .cancel(id: cancelStatusPollingId),
+                        .send(.fetchTallyResults(roundId: roundId)),
+                        .send(.startNewRoundPolling)
+                    )
+
+                case .active, .unspecified:
+                    return .none
+                }
+
+            case .dismissPollClosedAlert:
+                state.pollClosedAlert = nil
+                state.pollClosedRoundId = nil
+                state.path.removeAll()
+                return .none
+
+            case .viewPollClosedResults:
+                let roundId = state.pollClosedRoundId ?? activeVotingFlowRoundId(state)
+                state.pollClosedAlert = nil
+                state.pollClosedRoundId = nil
+                guard let roundId,
+                      let status = state.allRounds.first(where: { $0.id == roundId })?.session.status
+                else {
+                    state.path.removeAll()
+                    return .none
+                }
+                replacePathWithStatusScreen(&state, roundId: roundId, status: status)
+                if status == .finalized {
+                    return .merge(
+                        .send(.fetchTallyResults(roundId: roundId)),
+                        .send(.startNewRoundPolling)
+                    )
+                }
+                return .none
+
+            case .pollClosedAlert(.presented(.dismissPollClosedAlert)):
+                return .send(.dismissPollClosedAlert)
+
+            case .pollClosedAlert(.presented(.viewPollClosedResults)):
+                return .send(.viewPollClosedResults)
+
+            case .pollClosedAlert(.dismiss):
+                return .send(.dismissPollClosedAlert)
+
+            case .pollClosedAlert:
+                return .none
+
+            case .startNewRoundPolling:
+                return .run { [votingAPI] send in
+                    while !Task.isCancelled {
+                        try await Task.sleep(for: .seconds(30))
+                        let sessions = try await votingAPI.fetchAllRounds()
+                        let hasOpenRound = sessions.contains {
+                            $0.status == .active || $0.status == .tallying
+                        }
+                        if hasOpenRound {
+                            await send(.allRoundsLoaded(sessions))
+                        }
+                    }
+                } catch: { error, _ in
+                    LoggerProxy.warn("Voting new-round polling failed: \(error)")
+                }
+                .cancellable(id: cancelNewRoundPollingId, cancelInFlight: true)
+
             case .refreshActiveRoundsList:
                 // Lightweight re-fetch used by the tallying-status poll.
                 // Reuses the same allRoundsLoaded path so we pick up any
@@ -911,6 +1083,89 @@ extension VotingCoordFlow {
         else { return nil }
         return roundId
     }
+
+    private func topPathRoundId(_ state: State) -> String? {
+        guard let top = state.path.last else { return nil }
+        switch top {
+        case let .proposalList(scoped):
+            return scoped.roundId
+        case let .proposalDetail(scoped):
+            return scoped.roundId
+        case let .reviewVotes(scoped):
+            return scoped.roundId
+        case let .confirmSubmission(scoped):
+            return scoped.roundId
+        case let .delegationSigning(scoped):
+            return scoped.roundId
+        case let .tallying(scoped):
+            return scoped.roundId
+        case let .results(scoped):
+            return scoped.roundId
+        case let .ineligible(scoped):
+            return scoped.roundId
+        case .configSettings:
+            return nil
+        }
+    }
+
+    private func activeVotingFlowRoundId(_ state: State) -> String? {
+        guard let top = state.path.last else { return nil }
+        switch top {
+        case let .proposalList(scoped):
+            return scoped.roundId
+        case let .proposalDetail(scoped):
+            return scoped.roundId
+        case let .reviewVotes(scoped):
+            return scoped.roundId
+        case let .confirmSubmission(scoped):
+            return scoped.roundId
+        case let .delegationSigning(scoped):
+            return scoped.roundId
+        case .tallying, .results, .ineligible, .configSettings:
+            return nil
+        }
+    }
+
+    private func replacePathWithStatusScreen(
+        _ state: inout State,
+        roundId: String,
+        status: SessionStatus
+    ) {
+        state.path.removeAll()
+        switch status {
+        case .tallying:
+            state.path.append(.tallying(Tallying.State(roundId: roundId)))
+        case .finalized:
+            state.path.append(.results(Results.State(roundId: roundId)))
+        case .active, .unspecified:
+            break
+        }
+    }
+
+    private func session(_ session: VotingSession, withStatus status: SessionStatus) -> VotingSession {
+        VotingSession(
+            voteRoundId: session.voteRoundId,
+            snapshotHeight: session.snapshotHeight,
+            snapshotBlockhash: session.snapshotBlockhash,
+            proposalsHash: session.proposalsHash,
+            voteEndTime: session.voteEndTime,
+            ceremonyStart: session.ceremonyStart,
+            eaPK: session.eaPK,
+            vkZkp1: session.vkZkp1,
+            vkZkp2: session.vkZkp2,
+            vkZkp3: session.vkZkp3,
+            ncRoot: session.ncRoot,
+            nullifierIMTRoot: session.nullifierIMTRoot,
+            creator: session.creator,
+            description: session.description,
+            discussionURL: session.discussionURL,
+            proposals: session.proposals,
+            status: status,
+            createdAtHeight: session.createdAtHeight,
+            title: session.title
+        )
+    }
+
     // MARK: - Entry point
 
     /// `.submitAllDraftsTapped` handler. Gates the request, prompts for
@@ -2524,6 +2779,28 @@ extension AlertState where Action == VotingCoordFlow.Action {
             }
         } message: {
             TextState(String(localizable: .coinVoteDelegationSigningSkipAlertMessage(lockedIn, givingUp)))
+        }
+    }
+
+    static func pollClosed(status: SessionStatus) -> AlertState {
+        AlertState {
+            TextState("Voting closed")
+        } actions: {
+            ButtonState(action: .viewPollClosedResults) {
+                TextState(status == .finalized ? "View results" : "View status")
+            }
+            ButtonState(role: .cancel, action: .dismissPollClosedAlert) {
+                TextState("Back to polls")
+            }
+        } message: {
+            switch status {
+            case .finalized:
+                TextState("This round has finalized. You can view the results now.")
+            case .tallying:
+                TextState("This round is tallying. Results will appear once tallying finishes.")
+            case .active, .unspecified:
+                TextState("This round is no longer available for voting.")
+            }
         }
     }
 }

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -100,6 +100,9 @@ extension VotingCoordFlow {
                     }
                 }
 
+            case let .walletAccountChanged(account):
+                return reduceWalletAccountChanged(&state, account: account)
+
             case .initialize:
                 // Sweep legacy plaintext keys from a prior internal-build
                 // persistence shape. Idempotent and cheap; safe to keep.
@@ -1216,6 +1219,69 @@ extension VotingCoordFlow {
                 return .send(.fetchTallyResults(roundId: roundId))
             }
         }
+    }
+
+    func reduceWalletAccountChanged(
+        _ state: inout State,
+        account: WalletAccount?
+    ) -> Effect<Action> {
+        let nextWalletId = walletId(for: account)
+        let nextIsKeystoneUser = account?.vendor.isHWWallet() ?? false
+        guard state.walletId != nextWalletId
+            || state.isKeystoneUser != nextIsKeystoneUser
+        else {
+            return .none
+        }
+
+        state.walletId = nextWalletId
+        state.isKeystoneUser = nextIsKeystoneUser
+        resetAccountScopedVotingState(&state)
+        votingMetadata.reset()
+
+        let cancellation: Effect<Action> = .merge(
+            .cancel(id: cancelPipelineId),
+            .cancel(id: cancelSubmissionId),
+            .cancel(id: cancelDelegationProofId),
+            .cancel(id: cancelDelegationPrecomputeId),
+            .cancel(id: cancelStatusPollingId),
+            .cancel(id: cancelNewRoundPollingId),
+            .cancel(id: cancelShareTrackingId)
+        )
+
+        guard account != nil else {
+            state.rootScreen = .loading
+            return cancellation
+        }
+        guard state.hasSeenHowToVoteForCurrentWallet else {
+            state.rootScreen = .howToVote
+            return cancellation
+        }
+
+        state.rootScreen = .loading
+        return .merge(cancellation, .send(.initialize))
+    }
+
+    private func resetAccountScopedVotingState(_ state: inout State) {
+        state.path.removeAll()
+        state.roundCache.removeAll()
+        state.voteRecords.removeAll()
+        state.allRounds.removeAll()
+        state.zodlEndorsedRoundIds.removeAll()
+        state.pendingPipelineRoundId = nil
+        state.pendingBatchSubmission = false
+        state.submissionAlertRoundId = nil
+        state.submissionAlert = nil
+        state.keystoneScan = nil
+        state.skipBundlesAlert = nil
+        state.pollClosedAlert = nil
+        state.pollClosedRoundId = nil
+        state.pollsLoadError = false
+        state.serviceConfig = nil
+        state.walletScannedHeight = 0
+    }
+
+    private func walletId(for account: WalletAccount?) -> String {
+        account?.id.id.map { String(format: "%02x", $0) }.joined() ?? ""
     }
 
     /// Returns the topmost path element's round id when it's a

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -526,13 +526,40 @@ extension VotingCoordFlow {
                 return reduceKeystoneAllBundlesSigned(&state, roundId: roundId)
 
             case let .keystoneSignaturesRestored(roundId, signatures):
+                guard let session = state.roundCache[roundId],
+                      let validSignatures = Self.validKeystoneSignatures(
+                        signatures,
+                        bundleCount: session.bundleCount
+                      ),
+                      !validSignatures.isEmpty
+                else {
+                    return .none
+                }
                 mutateSession(&state, roundId: roundId) { roundSession in
-                    roundSession.keystoneBundleSignatures = signatures.map {
+                    roundSession.keystoneBundleSignatures = validSignatures.map {
                         KeystoneBundleSignature(sig: $0.sig, sighash: $0.sighash, rk: $0.rk)
                     }
-                    roundSession.currentKeystoneBundleIndex = UInt32(signatures.count)
+                    roundSession.currentKeystoneBundleIndex = UInt32(validSignatures.count)
+                    roundSession.pendingVotingPczt = nil
+                    roundSession.pendingUnsignedDelegationPczt = nil
+                    roundSession.keystoneSigningStatus = .idle
                 }
-                return .none
+                if UInt32(validSignatures.count) >= session.bundleCount {
+                    mutateSession(&state, roundId: roundId) { roundSession in
+                        roundSession.delegationProofStatus = .generating(progress: 0)
+                        roundSession.isDelegationProofInFlight = true
+                        roundSession.batchSubmissionStatus = .authorizing
+                        roundSession.voteSubmissionStep = .authorizingVote
+                    }
+                    if case .delegationSigning = state.path.last {
+                        _ = state.path.popLast()
+                    }
+                    return .send(.keystoneAllBundlesSigned(roundId: roundId))
+                }
+                if !hasKeystoneSigningRound(state: state, roundId: roundId) {
+                    state.path.append(.delegationSigning(DelegationSigning.State(roundId: roundId)))
+                }
+                return .send(.startDelegationProof(roundId: roundId))
 
             case let .keystoneShowSigningScreen(roundId):
                 if !hasKeystoneSigningRound(state: state) {
@@ -655,6 +682,7 @@ extension VotingCoordFlow {
                 let networkId: UInt32 = network.networkType.votingRustNetworkId
                 let accountId = state.selectedWalletAccount?.id
                 let accountUUID: [UInt8] = accountId?.id ?? []
+                let isKeystoneUser = state.isKeystoneUser
 
                 // Seed the cache entry so subsequent re-entries see an
                 // in-progress session and don't trigger duplicate pipelines.
@@ -709,8 +737,14 @@ extension VotingCoordFlow {
 
                     let existingState = try? await votingCrypto.getRoundState(roundId)
                     let existingBundleCount = (try? await votingCrypto.getBundleCount(roundId)) ?? 0
+                    var preClearKeystoneSignatures: [KeystoneBundleSignatureInfo] = []
+                    var resolvedBundleCount: UInt32 = 0
+                    var shouldRestoreKeystoneSignatures = isKeystoneUser
+                    var didPrepareFreshRound = false
                     if existingState?.proofGenerated == true {
                         let bundleCount = existingBundleCount
+                        resolvedBundleCount = bundleCount
+                        shouldRestoreKeystoneSignatures = false
                         let eligibleWeight = Self.votingWeight(for: notes, bundleCount: bundleCount)
                         guard bundleCount > 0, eligibleWeight > 0 else {
                             await send(.ineligibleForRound(roundId: roundId))
@@ -725,6 +759,7 @@ extension VotingCoordFlow {
                             delegationReady: true
                         ))
                     } else if existingBundleCount > 0 {
+                        resolvedBundleCount = existingBundleCount
                         var recoveredBundleCount: UInt32 = 0
                         for bundleIndex: UInt32 in 0..<existingBundleCount {
                             if let vanPosition = try? await Self.recoverDelegationVanPosition(
@@ -761,6 +796,9 @@ extension VotingCoordFlow {
                                 delegationReady: recoveredBundleCount >= existingBundleCount
                             ))
                         } else {
+                            if isKeystoneUser {
+                                preClearKeystoneSignatures = try await votingCrypto.loadKeystoneBundleSignatures(roundId)
+                            }
                             guard try await Self.prepareFreshRound(
                                 roundId: roundId,
                                 session: session,
@@ -771,8 +809,13 @@ extension VotingCoordFlow {
                                 sdkSynchronizer: sdkSynchronizer,
                                 send: send
                             ) else { return }
+                            didPrepareFreshRound = true
+                            resolvedBundleCount = (try? await votingCrypto.getBundleCount(roundId)) ?? 0
                         }
                     } else {
+                        if isKeystoneUser {
+                            preClearKeystoneSignatures = try await votingCrypto.loadKeystoneBundleSignatures(roundId)
+                        }
                         guard try await Self.prepareFreshRound(
                             roundId: roundId,
                             session: session,
@@ -783,6 +826,8 @@ extension VotingCoordFlow {
                             sdkSynchronizer: sdkSynchronizer,
                             send: send
                         ) else { return }
+                        didPrepareFreshRound = true
+                        resolvedBundleCount = (try? await votingCrypto.getBundleCount(roundId)) ?? 0
                     }
 
                     // 3. Hotkey: load or generate the per-account hotkey
@@ -801,6 +846,30 @@ extension VotingCoordFlow {
                     let seed = try mnemonic.toSeed(phrase)
                     let hotkey = try await votingCrypto.generateHotkey(roundId, seed)
                     await send(.hotkeyLoaded(roundId: roundId, address: hotkey.address))
+
+                    if shouldRestoreKeystoneSignatures {
+                        let savedSignatures = didPrepareFreshRound
+                            ? preClearKeystoneSignatures
+                            : try await votingCrypto.loadKeystoneBundleSignatures(roundId)
+                        guard let validSignatures = Self.validKeystoneSignatures(
+                            savedSignatures,
+                            bundleCount: resolvedBundleCount
+                        ) else {
+                            LoggerProxy.warn("Ignoring inconsistent Keystone signing recovery state")
+                            return
+                        }
+                        if !validSignatures.isEmpty {
+                            if didPrepareFreshRound {
+                                for signature in validSignatures {
+                                    try await votingCrypto.storeKeystoneBundleSignature(roundId, signature)
+                                }
+                            }
+                            await send(.keystoneSignaturesRestored(
+                                roundId: roundId,
+                                signatures: validSignatures
+                            ))
+                        }
+                    }
                 } catch: { error, send in
                     LoggerProxy.error("Active round pipeline failed: \(error)")
                     await send(.pipelineFailed(roundId: roundId, message: error.localizedDescription))
@@ -2123,6 +2192,20 @@ extension VotingCoordFlow {
             return nil
         }
         return (signingState.roundId, govPczt)
+    }
+
+    private static func validKeystoneSignatures(
+        _ signatures: [KeystoneBundleSignatureInfo],
+        bundleCount: UInt32
+    ) -> [KeystoneBundleSignatureInfo]? {
+        guard bundleCount > 0 else { return [] }
+        let sorted = signatures.sorted { $0.bundleIndex < $1.bundleIndex }
+        guard sorted.count <= Int(bundleCount) else { return nil }
+        for (index, signature) in sorted.enumerated()
+            where signature.bundleIndex != UInt32(index) {
+            return nil
+        }
+        return sorted
     }
 
     /// Crash-recovery lookup for a Keystone delegation TX hash.

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
@@ -301,6 +301,9 @@ struct VotingCoordFlow {
     /// Cancellation id for the delegation proof (ZKP #1) `.run` effect.
     let cancelDelegationProofId = UUID()
 
+    /// Cancellation id for Zashi's background delegation PIR precompute.
+    let cancelDelegationPrecomputeId = UUID()
+
     /// Cancellation id for the opened-round status polling loop.
     let cancelStatusPollingId = UUID()
 

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
@@ -162,6 +162,7 @@ struct VotingCoordFlow {
         case path(StackActionOf<Path>)
         case onAppear
         case warmProvingCaches
+        case walletAccountChanged(WalletAccount?)
         case dismissFlow
         case howToVoteContinueTapped
         case retryLoadRounds

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
@@ -80,6 +80,11 @@ struct VotingCoordFlow {
         /// and any non-endorsed entry surfaces an unverified-poll warning.
         var zodlEndorsedRoundIds: Set<String> = []
 
+        /// Process-lifetime proving caches should be warmed once when the
+        /// flow opens. Failure is non-fatal; this only avoids cold proof
+        /// latency for the first vote/delegation operation.
+        var hasRequestedProvingCacheWarmup = false
+
         /// Whether the user is on the default (Zodl-bundled) voting service
         /// vs a custom override pinned via VotingConfigSettings. Drives the
         /// trust-indicator UI on the polls list cards.
@@ -123,6 +128,14 @@ struct VotingCoordFlow {
         /// giving-up amounts so the decision is informed.
         @Presents var skipBundlesAlert: AlertState<Action>?
 
+        /// Alert shown when an opened active round transitions to tallying
+        /// or finalized while the user is still in voting/review/submission.
+        @Presents var pollClosedAlert: AlertState<Action>?
+
+        /// Round id associated with `pollClosedAlert`; retained so the alert
+        /// actions still know which status screen to route to.
+        var pollClosedRoundId: String?
+
         @Shared(.inMemory(.selectedWalletAccount))
         var selectedWalletAccount: WalletAccount?
 
@@ -148,6 +161,7 @@ struct VotingCoordFlow {
     enum Action {
         case path(StackActionOf<Path>)
         case onAppear
+        case warmProvingCaches
         case dismissFlow
         case howToVoteContinueTapped
         case retryLoadRounds
@@ -163,6 +177,11 @@ struct VotingCoordFlow {
         case roundTapped(String)
         case ineligibleForRound(roundId: String)
         case refreshActiveRoundsList
+        case startRoundStatusPolling(roundId: String)
+        case roundStatusUpdated(roundId: String, status: SessionStatus)
+        case dismissPollClosedAlert
+        case viewPollClosedResults
+        case startNewRoundPolling
         case retryFetchTallyResults(roundId: String)
         case viewMyVotesTapped(roundId: String)
         case proposalTapped(roundId: String, proposalId: UInt32, mode: ProposalDetail.Mode = .voting)
@@ -186,6 +205,7 @@ struct VotingCoordFlow {
         case tallyResultsLoaded(roundId: String, results: [UInt32: TallyResult])
         case tallyResultsFailed(roundId: String, message: String)
         case submissionAlert(PresentationAction<Never>)
+        case pollClosedAlert(PresentationAction<Action>)
 
         // MARK: - Stage 5: submission pipeline
 
@@ -281,6 +301,12 @@ struct VotingCoordFlow {
     /// Cancellation id for the delegation proof (ZKP #1) `.run` effect.
     let cancelDelegationProofId = UUID()
 
+    /// Cancellation id for the opened-round status polling loop.
+    let cancelStatusPollingId = UUID()
+
+    /// Cancellation id for the post-finalization rounds-list polling loop.
+    let cancelNewRoundPollingId = UUID()
+
     var body: some Reducer<State, Action> {
         coordinatorReduce()
             .forEach(\.path, action: \.path)
@@ -289,5 +315,6 @@ struct VotingCoordFlow {
                 Scan()
             }
             .ifLet(\.$skipBundlesAlert, action: \.skipBundlesAlert)
+            .ifLet(\.$pollClosedAlert, action: \.pollClosedAlert)
     }
 }

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
@@ -182,6 +182,10 @@ struct VotingCoordFlow {
         case dismissPollClosedAlert
         case viewPollClosedResults
         case startNewRoundPolling
+        case loadShareDelegations(roundId: String)
+        case shareDelegationsLoaded(roundId: String, delegations: [VotingShareDelegation])
+        case shareDelegationsRefreshed(roundId: String, delegations: [VotingShareDelegation])
+        case pollShareStatus(roundId: String)
         case retryFetchTallyResults(roundId: String)
         case viewMyVotesTapped(roundId: String)
         case proposalTapped(roundId: String, proposalId: UInt32, mode: ProposalDetail.Mode = .voting)
@@ -309,6 +313,9 @@ struct VotingCoordFlow {
 
     /// Cancellation id for the post-finalization rounds-list polling loop.
     let cancelNewRoundPollingId = UUID()
+
+    /// Cancellation id for DB-backed helper share confirmation polling.
+    let cancelShareTrackingId = UUID()
 
     var body: some Reducer<State, Action> {
         coordinatorReduce()

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowView.swift
@@ -65,6 +65,9 @@ struct VotingCoordFlowView: View {
             .alert($store.scope(state: \.submissionAlert, action: \.submissionAlert))
             .alert($store.scope(state: \.skipBundlesAlert, action: \.skipBundlesAlert))
             .alert($store.scope(state: \.pollClosedAlert, action: \.pollClosedAlert))
+            .onChange(of: store.selectedWalletAccount?.id) { _ in
+                store.send(.walletAccountChanged(store.selectedWalletAccount))
+            }
         }
     }
 

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowView.swift
@@ -17,7 +17,10 @@ struct VotingCoordFlowView: View {
         WithPerceptionTracking {
             NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
                 rootContent
-                    .onAppear { store.send(.onAppear) }
+                    .onAppear {
+                        store.send(.onAppear)
+                        store.send(.warmProvingCaches)
+                    }
             } destination: { destinationStore in
                 // NavigationStack's destination closure is escaping; it needs
                 // its own WithPerceptionTracking so reads from
@@ -61,6 +64,7 @@ struct VotingCoordFlowView: View {
             }
             .alert($store.scope(state: \.submissionAlert, action: \.submissionAlert))
             .alert($store.scope(state: \.skipBundlesAlert, action: \.skipBundlesAlert))
+            .alert($store.scope(state: \.pollClosedAlert, action: \.pollClosedAlert))
         }
     }
 

--- a/secant/Sources/Features/Voting/VotingHelpers.swift
+++ b/secant/Sources/Features/Voting/VotingHelpers.swift
@@ -41,25 +41,58 @@ enum Voting {
         let votedAt: Date
         let votingWeight: UInt64
         let proposalCount: Int
+        let eligibleVotingWeight: UInt64?
+        let submittedBundleCount: UInt32?
+        let totalBundleCount: UInt32?
 
-        init(votedAt: Date, votingWeight: UInt64, proposalCount: Int) {
+        init(
+            votedAt: Date,
+            votingWeight: UInt64,
+            proposalCount: Int,
+            eligibleVotingWeight: UInt64? = nil,
+            submittedBundleCount: UInt32? = nil,
+            totalBundleCount: UInt32? = nil
+        ) {
             self.votedAt = votedAt
             self.votingWeight = votingWeight
             self.proposalCount = proposalCount
+            self.eligibleVotingWeight = eligibleVotingWeight
+            self.submittedBundleCount = submittedBundleCount
+            self.totalBundleCount = totalBundleCount
         }
 
         init(_ persisted: PersistedVotingRecord) {
             self.votedAt = Date(timeIntervalSince1970: persisted.votedAt)
             self.votingWeight = persisted.votingWeight
             self.proposalCount = persisted.proposalCount
+            self.eligibleVotingWeight = persisted.eligibleVotingWeight
+            self.submittedBundleCount = persisted.submittedBundleCount
+            self.totalBundleCount = persisted.totalBundleCount
         }
 
         var persisted: PersistedVotingRecord {
             PersistedVotingRecord(
                 votedAt: votedAt.timeIntervalSince1970,
                 votingWeight: votingWeight,
-                proposalCount: proposalCount
+                proposalCount: proposalCount,
+                eligibleVotingWeight: eligibleVotingWeight,
+                submittedBundleCount: submittedBundleCount,
+                totalBundleCount: totalBundleCount
             )
+        }
+
+        var skippedKeystoneBundleCount: UInt32? {
+            guard let submittedBundleCount,
+                  let totalBundleCount,
+                  totalBundleCount > submittedBundleCount
+            else {
+                return nil
+            }
+            return totalBundleCount - submittedBundleCount
+        }
+
+        var hasSkippedKeystoneBundles: Bool {
+            skippedKeystoneBundleCount != nil
         }
     }
 

--- a/secant/Sources/Models/VotingMetadata.swift
+++ b/secant/Sources/Models/VotingMetadata.swift
@@ -85,4 +85,7 @@ struct PersistedVotingRecord: Codable, Equatable, Sendable {
     let votedAt: Double
     let votingWeight: UInt64
     let proposalCount: Int
+    let eligibleVotingWeight: UInt64?
+    let submittedBundleCount: UInt32?
+    let totalBundleCount: UInt32?
 }


### PR DESCRIPTION
## Why

Phase 5D deleted the legacy `Voting` reducer and swapped the production entry to `VotingCoordFlow`. The coordinator-backed flow shipped without several behaviors the legacy reducer carried — most were no-ops or one-shot loads instead of lifecycle-scoped loops. This PR restores those gaps so the new flow is at feature parity before the broader MOB-1105 integration lands.

## Changes

Each commit is one discrete restoration:

- **Restore voting flow polling lifecycle** — proving-cache warm-up, opened-round status poll, poll-closed alert handling, post-finalization new-round poll. Cancel IDs wired into config changes and flow dismissal so loops do not outlive the flow.
- **Restore Keystone signing recovery on round entry** — loads persisted partial Keystone bundle signatures after the active-round pipeline rebuilds bundle state, validates indices, resumes the next signing request or the all-signed delegation proof path. Recovers from crash/restart mid-signing.
- **Restore Zashi delegation precompute** — starts background PIR precompute once hotkey and voting weight are ready, caches delegation inputs per bundle, resumes pending submission through the existing auth path. Avoids paying the PIR setup cost inline at submission time.
- **Restore share confirmation recovery** — per-round share tracking state, DB load, confirmation polling, and overdue resubmit through the existing helper APIs. Started after submitted votes load or a batch completes, cancelled with the flow lifecycle.
- **Reset voting state when wallets change** — votes/hotkeys/witnesses/recovery are wallet-scoped but the flow cached round data by round id only. Now listens for selected-wallet changes from the view, clears account-scoped state, cancels in-flight work, and reinitializes for the new wallet id when the intro has already been seen.
- **Persist Keystone skipped bundle metadata** — completed vote records now carry the original eligible Keystone weight and bundle count alongside submitted weight, so review surfaces can show submitted-vs-total. Legacy/Zashi records decode through optional fields.

## Scope

Concentrated in `VotingCoordFlowCoordinator.swift` (+944), with small touches to `RoundSession.swift`, `VotingCoordFlowStore.swift`, `VotingCoordFlowView.swift`, `VotingHelpers.swift`, and `VotingMetadata.swift`. No public API changes outside the voting flow.

## Test plan

- [ ] Enter an active round → confirm proving cache warms and opened-round poll runs; close round externally → poll-closed alert fires.
- [ ] Keystone: sign part of a bundle set, force-kill app, re-enter round → signing resumes from the right bundle; skip a bundle → completed record reflects submitted-vs-total weight.
- [ ] Zashi: submit a vote → precompute is already cached (no inline PIR setup wait).
- [ ] Submit shares → confirm DB row persists; force overdue → resubmit fires.
- [ ] Switch selected wallet mid-flow → state clears and reinitializes for the new account.