### PR TITLE
[#MOB-1105] Voting UI polish: agency screens + localization + cosmetic refresh

### DIFF
--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -4,15 +4,6 @@
     " %@" : {
 
     },
-    "—" : {
-
-    },
-    "·" : {
-
-    },
-    "#%@" : {
-
-    },
     "%" : {
 
     },
@@ -989,9 +980,6 @@
         }
       }
     },
-    "Catching up to round snapshot" : {
-
-    },
     "coinVote.common.abstain" : {
       "comment" : "MARK: - Coin Vote",
       "extractionState" : "manual",
@@ -1253,6 +1241,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Try again"
+          }
+        }
+      }
+    },
+    "coinVote.common.viewLess" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View less"
+          }
+        }
+      }
+    },
+    "coinVote.common.viewMore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View more"
           }
         }
       }
@@ -1598,6 +1608,17 @@
         }
       }
     },
+    "coinVote.confirmSubmission.bundleProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bundle %@ of %@"
+          }
+        }
+      }
+    },
     "coinVote.confirmSubmission.confirmWithKeystone" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1704,6 +1725,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ZEC"
+          }
+        }
+      }
+    },
+    "coinVote.confirmSubmission.headerSubmittedCountMultiple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitted %@ votes with voting power %@."
+          }
+        }
+      }
+    },
+    "coinVote.confirmSubmission.headerSubmittedCountSingle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitted %@ vote with voting power %@."
+          }
+        }
+      }
+    },
+    "coinVote.confirmSubmission.headerSubmittingCountMultiple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting %@ votes with voting power %@."
+          }
+        }
+      }
+    },
+    "coinVote.confirmSubmission.headerSubmittingCountSingle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting %@ vote with voting power %@."
           }
         }
       }
@@ -1862,6 +1927,28 @@
         }
       }
     },
+    "coinVote.confirmSubmission.submitCTA" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submit"
+          }
+        }
+      }
+    },
+    "coinVote.confirmSubmission.voteProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote %@ of %@"
+          }
+        }
+      }
+    },
     "coinVote.delegation.insufficientSnapshotBalance" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1961,6 +2048,17 @@
         }
       }
     },
+    "coinVote.delegationSigning.parsingSignatureEllipsis" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parsing signature…"
+          }
+        }
+      }
+    },
     "coinVote.delegationSigning.preparingNextBundle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1968,6 +2066,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bundle %@ signed. Preparing bundle %@ of %@..."
+          }
+        }
+      }
+    },
+    "coinVote.delegationSigning.preparingRequestEllipsis" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing signing request…"
           }
         }
       }
@@ -2034,6 +2143,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scan Signed Bundle %@"
+          }
+        }
+      }
+    },
+    "coinVote.delegationSigning.scanSignedPCZTCTA" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan signed PCZT"
+          }
+        }
+      }
+    },
+    "coinVote.delegationSigning.scanSignedPCZTInstruction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open your Keystone device and scan the signed PCZT back to continue."
           }
         }
       }
@@ -2126,6 +2257,17 @@
         }
       }
     },
+    "coinVote.delegationSigning.skipRemainingBundlesCTA" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip remaining bundles"
+          }
+        }
+      }
+    },
     "coinVote.delegationSigning.useSignedBundlesOnly" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2144,6 +2286,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continue without the remaining %@ ZEC."
+          }
+        }
+      }
+    },
+    "coinVote.error.configUnavailableTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting unavailable"
           }
         }
       }
@@ -2198,7 +2351,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vote Support, Oppose, or Abstain on each question. You can skip questions and change your vote before submitting."
+            "value" : "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
           }
         }
       }
@@ -2346,6 +2499,17 @@
         }
       }
     },
+    "coinVote.ineligible.snapshotBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
+          }
+        }
+      }
+    },
     "coinVote.ineligible.title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2353,6 +2517,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Not Eligible for This Round"
+          }
+        }
+      }
+    },
+    "coinVote.ineligible.titleNoVote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can't vote in this round"
           }
         }
       }
@@ -2436,6 +2611,28 @@
         }
       }
     },
+    "coinVote.pollsList.insufficientBalanceMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
+          }
+        }
+      }
+    },
+    "coinVote.pollsList.insufficientBalanceTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insufficient Balance"
+          }
+        }
+      }
+    },
     "coinVote.pollsList.loadErrorMessage" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2503,6 +2700,17 @@
         }
       }
     },
+    "coinVote.proposalDetail.notFound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proposal not found"
+          }
+        }
+      }
+    },
     "coinVote.proposalDetail.position" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2510,6 +2718,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ OF %@"
+          }
+        }
+      }
+    },
+    "coinVote.proposalDetail.skippedMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You haven't answered question(s) %@. Continue to the review screen without them, or go back to respond."
           }
         }
       }
@@ -2580,6 +2799,17 @@
         }
       }
     },
+    "coinVote.proposalList.ctaReviewAnswers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review Answers"
+          }
+        }
+      }
+    },
     "coinVote.proposalList.ctaStartVoting" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2587,6 +2817,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start Voting"
+          }
+        }
+      }
+    },
+    "coinVote.proposalList.headerEndsAt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ends %@"
           }
         }
       }
@@ -2613,6 +2854,28 @@
         }
       }
     },
+    "coinVote.proposalList.preparingVotingPower" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing your voting power…"
+          }
+        }
+      }
+    },
+    "coinVote.proposalList.reviewSubmitted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review your submitted votes"
+          }
+        }
+      }
+    },
     "coinVote.proposalList.reviewSubtitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2631,6 +2894,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Review and submit vote"
+          }
+        }
+      }
+    },
+    "coinVote.proposalList.submitVotesCount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submit votes (%@)"
           }
         }
       }
@@ -2712,6 +2986,28 @@
         }
       }
     },
+    "coinVote.proposalList.votingPower" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting power: %@"
+          }
+        }
+      }
+    },
+    "coinVote.proposalList.yourVote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote:"
+          }
+        }
+      }
+    },
     "coinVote.results.approvedByZodl" : {
       "comment" : "Accessibility label for the Zodl badge on the results header indicating an approved poll.",
       "extractionState" : "manual",
@@ -2768,6 +3064,17 @@
         }
       }
     },
+    "coinVote.results.noProposalsInRound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No proposals in this round"
+          }
+        }
+      }
+    },
     "coinVote.results.noVotesRecorded" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2786,6 +3093,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Option %@"
+          }
+        }
+      }
+    },
+    "coinVote.results.percentValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%%"
           }
         }
       }
@@ -3230,6 +3548,17 @@
         }
       }
     },
+    "coinVote.tallying.bodyInProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting has closed. Final results will appear here once the helpers finish tallying."
+          }
+        }
+      }
+    },
     "coinVote.tallying.detailEnded" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3292,6 +3621,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Votes Closed"
+          }
+        }
+      }
+    },
+    "coinVote.tallying.titleInProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallying in progress"
           }
         }
       }
@@ -3372,6 +3712,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unverified Poll"
+          }
+        }
+      }
+    },
+    "coinVote.walletSyncing.catchingUp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catching up to round snapshot"
           }
         }
       }
@@ -4029,10 +4380,6 @@
     },
     "Default" : {
       "comment" : "The name of the default polling configuration option.",
-      "isCommentAutoGenerated" : true
-    },
-    "Delegation signing" : {
-      "comment" : "A label for a screen that asks the user to sign a delegation transaction.",
       "isCommentAutoGenerated" : true
     },
     "Delete" : {
@@ -5889,10 +6236,6 @@
         }
       }
     },
-    "How Coinholder Polling works" : {
-      "comment" : "The title of the section that explains how Coinholder",
-      "isCommentAutoGenerated" : true
-    },
     "importWallet.birthday.title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6796,10 +7139,6 @@
         }
       }
     },
-    "Loading results…" : {
-      "comment" : "A placeholder text shown while fetching tally results.",
-      "isCommentAutoGenerated" : true
-    },
     "localAuthentication.reason" : {
       "comment" : "MARK: - Local authentication",
       "extractionState" : "manual",
@@ -6869,14 +7208,6 @@
           }
         }
       }
-    },
-    "No proposals in this round" : {
-      "comment" : "A message displayed when a round has no proposals.",
-      "isCommentAutoGenerated" : true
-    },
-    "No votes recorded" : {
-      "comment" : "A message indicating that no votes have been cast for a particular proposal.",
-      "isCommentAutoGenerated" : true
     },
     "notEnoughFreeSpace.dataAvailable" : {
       "extractionState" : "manual",
@@ -7107,7 +7438,7 @@
       "isCommentAutoGenerated" : true
     },
     "Preparing your voting power…" : {
-      "comment" : "A text shown while waiting for the user's voting power to be calculated.",
+      "comment" : "A message displayed while calculating the user's voting power.",
       "isCommentAutoGenerated" : true
     },
     "privateDataConsent.confirmation" : {
@@ -7231,7 +7562,7 @@
       }
     },
     "Proposal not found" : {
-      "comment" : "A message displayed when a proposal ID does not match any in the store.",
+      "comment" : "A message displayed when a proposal ID does not match any in the current round.",
       "isCommentAutoGenerated" : true
     },
     "proposalPartial.mailSubject" : {
@@ -8751,9 +9082,6 @@
           }
         }
       }
-    },
-    "Review and submit" : {
-
     },
     "Review your submitted votes" : {
 
@@ -12104,16 +12432,6 @@
         }
       }
     },
-    "Submitting %@ vote%@ with voting power %@." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Submitting %1$@ vote%2$@ with voting power %3$@."
-          }
-        }
-      }
-    },
     "supportData.appVersionItem.bundleIdentifier" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -14855,10 +15173,6 @@
         }
       }
     },
-    "Tallying in progress" : {
-      "comment" : "A message displayed while a tally is being computed.",
-      "isCommentAutoGenerated" : true
-    },
     "taxExport.desc" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -16043,14 +16357,6 @@
       "comment" : "A label for the custom poll source URL field.",
       "isCommentAutoGenerated" : true
     },
-    "Voting has closed. Final results will appear here once the helpers finish tallying." : {
-      "comment" : "A description of what will happen when voting in a round has closed.",
-      "isCommentAutoGenerated" : true
-    },
-    "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment." : {
-      "comment" : "A description of why a user can't vote in a round when their wallet has no shielded notes at that round's snapshot height.",
-      "isCommentAutoGenerated" : true
-    },
     "Voting power: %@" : {
 
     },
@@ -16158,14 +16464,6 @@
         }
       }
     },
-    "You can't vote in this round" : {
-      "comment" : "A description of why a user can't vote in a particular round.",
-      "isCommentAutoGenerated" : true
-    },
-    "Your voting power is derived from your shielded ZEC at the round's snapshot height. Vote choices are private; results are tallied by helper servers using zero-knowledge proofs." : {
-      "comment" : "A description of how Coinholder Polling works.",
-      "isCommentAutoGenerated" : true
-    },
     "Zcash" : {
       "localizations" : {
         "es" : {
@@ -16193,9 +16491,6 @@
           }
         }
       }
-    },
-    "Zodl" : {
-      "comment" : "The name of the organization shown next to the Zodl logo when a poll is endorsed."
     }
   },
   "version" : "1.1"

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
@@ -627,7 +627,8 @@ func parseVotingSession(from round: [String: Any]) throws -> VotingSession {
         let options = optionsJSON.map { o in
             VoteOption(
                 index: parseUInt32(o["index"]),
-                label: o["label"] as? String ?? "Option \(parseUInt32(o["index"]))"
+                label: o["label"] as? String ?? "Option \(parseUInt32(o["index"]))",
+                description: o["description"] as? String
             )
         }
         let forumURLString = p["forum_url"] as? String

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
@@ -175,7 +175,7 @@ extension VotingCryptoClient: DependencyKey {
                 )
                 return try VotingRustBackend.verifyWitness(sdkWitness)
             },
-            generateHotkey: { _, seed in
+            generateHotkey: { roundId, seed in
                 let backend = try await dbActor.backend()
                 let hotkey = try backend.generateHotkey(seed: seed)
                 return VotingHotkey(

--- a/secant/Sources/Dependencies/VotingModels/Proposal.swift
+++ b/secant/Sources/Dependencies/VotingModels/Proposal.swift
@@ -2,13 +2,19 @@ import Foundation
 
 /// A single vote option within a proposal (e.g. "Support", "Oppose").
 /// Maps to VoteOption message (zvote/v1/types.proto).
+///
+/// `description` is optional richer copy that policy-heavy polls (NU7, NSM,
+/// etc.) use to explain the consequences of choosing the option. UI renders
+/// it as a second line below `label` when present.
 struct VoteOption: Equatable, Sendable {
     let index: UInt32
     let label: String
+    let description: String?
 
-    init(index: UInt32, label: String) {
+    init(index: UInt32, label: String, description: String? = nil) {
         self.index = index
         self.label = label
+        self.description = description
     }
 }
 

--- a/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
+++ b/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
@@ -5,11 +5,16 @@
 
 import SwiftUI
 import ComposableArchitecture
+import ZcashLightClientKit
 
-/// Final review screen before vote submission. Displays each drafted vote
-/// (proposal title + chosen option label) and the voting power that will
-/// be applied. Renders progress, success, and error states once submission
-/// is in flight via `RoundSession.batchSubmissionStatus`.
+/// Final review screen before vote submission. Renders four visual states from
+/// the same body, driven by `RoundSession.batchSubmissionStatus`:
+///   • `.idle` — Poll/Memo card + Confirm CTA
+///   • `.authorizing` / `.submitting` — Poll/VotingPower card + monotonic
+///     progress bar + disabled CTA reflecting the current sub-step
+///   • `.completed` — Poll/VotingPower card + green-check icon + Done CTA
+/// `.authorizationFailed` / `.submissionFailed` keep the in-progress chrome
+/// underneath while a `votingSheet` drives retry/cancel.
 struct ConfirmSubmissionView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) private var dismiss
@@ -19,247 +24,330 @@ struct ConfirmSubmissionView: View {
 
     var body: some View {
         WithPerceptionTracking {
-            let item = store.allRounds.first { $0.id == roundId }
-            let proposals = item?.session.proposals ?? []
             let session = store.roundCache[roundId]
-            let weight = session?.votingWeight ?? 0
+            let status = session?.batchSubmissionStatus ?? .idle
+            let pollTitle = store.allRounds.first { $0.id == roundId }?.title ?? ""
+            let weightString = Self.formatZec(session?.votingWeight ?? 0)
             let drafts = session?.draftVotes ?? [:]
             let submittedVotes = session?.votes ?? [:]
-            let status = session?.batchSubmissionStatus ?? .idle
             let bundleCount = session?.bundleCount ?? 0
-            let summaryVotes = submissionSummaryVotes(
-                status: status,
-                drafts: drafts,
-                submittedVotes: submittedVotes
-            )
-            let headerCount = submissionCount(
-                status: status,
-                draftCount: drafts.count,
-                submittedCount: submittedVotes.count
-            )
+            let delegationStatus = session?.delegationProofStatus ?? .notStarted
 
-            ZStack(alignment: .bottom) {
+            VStack(spacing: 0) {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 16) {
-                        header(weight: weight, count: headerCount, status: status)
-
-                        if let step = session?.voteSubmissionStep, status.isInFlight {
-                            progressCard(
-                                step: step,
-                                bundleIndex: session?.currentVoteBundleIndex,
-                                bundleCount: session?.bundleCount ?? 0,
-                                status: status
-                            )
-                        }
-
-                        VStack(spacing: 8) {
-                            ForEach(proposals) { proposal in
-                                if let choice = summaryVotes[proposal.id],
-                                   let label = proposal.options.first(where: { $0.index == choice.index })?.label {
-                                    summaryRow(title: proposal.title, choice: label)
-                                }
-                            }
-                        }
+                    VStack(alignment: .leading, spacing: 0) {
+                        headerSection(status: status)
+                        detailsCard(
+                            status: status,
+                            pollTitle: pollTitle,
+                            weightString: weightString
+                        )
+                        .padding(.top, 24)
                     }
                     .padding(.horizontal, 24)
-                    .padding(.top, 12)
-                    .padding(.bottom, 120)
+                    .padding(.bottom, 24)
                 }
-                .padding(.vertical, 1)
 
-                submitCTA(status: status, drafts: drafts, bundleCount: bundleCount)
+                Spacer(minLength: 0)
+
+                bottomSection(
+                    status: status,
+                    delegationStatus: delegationStatus,
+                    drafts: drafts,
+                    submittedVotes: submittedVotes,
+                    bundleCount: bundleCount
+                )
+                .padding(.horizontal, 24)
+                .padding(.bottom, 16)
             }
             .applyScreenBackground()
-            .screenTitle(String(localizable: .coinVoteCommonScreenTitle))
+            .screenTitle(navTitle(status: status))
             .zashiBack {
                 guard !status.isInFlight else { return }
                 dismiss()
             }
-            .alert(
-                String(localizable: .coinVoteConfirmSubmissionAuthorizationFailedTitle),
-                isPresented: authorizationErrorBinding(status: status)
-            ) {
-                Button(String(localizable: .coinVoteCommonTryAgain), role: nil) {
+            .votingSheet(
+                isPresented: authorizationFailedBinding(status: status),
+                title: String(localizable: .coinVoteConfirmSubmissionAuthorizationFailedTitle),
+                message: String(localizable: .coinVoteConfirmSubmissionAuthorizationFailedMessage),
+                primary: .init(title: String(localizable: .coinVoteCommonTryAgain), style: .primary) {
                     store.send(.retryBatchSubmission(roundId: roundId))
-                }
-                Button(String(localizable: .coinVoteCommonCancel), role: .cancel) {
+                },
+                secondary: .init(title: String(localizable: .coinVoteCommonCancel), style: .secondary) {
                     store.send(.dismissBatchResults(roundId: roundId))
-                }
-            } message: {
-                if case let .authorizationFailed(error) = status {
-                    Text(error)
-                }
-            }
-            .alert(
-                String(localizable: .coinVoteConfirmSubmissionSubmissionFailedTitle),
-                isPresented: submissionErrorBinding(status: status)
-            ) {
-                Button(String(localizable: .coinVoteCommonTryAgain), role: nil) {
-                    store.send(.retryBatchSubmission(roundId: roundId))
-                }
-                Button(String(localizable: .coinVoteCommonCancel), role: .cancel) {
-                    store.send(.dismissBatchResults(roundId: roundId))
-                }
-            } message: {
-                if case let .submissionFailed(error, _, _) = status {
-                    Text(error)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func header(weight: UInt64, count: Int, status: BatchSubmissionStatus) -> some View {
-        let title: String = {
-            switch status {
-            case .completed:
-                return String(localizable: .coinVoteCommonSubmission)
-            case .authorizing, .submitting:
-                return String(localizable: .coinVoteCommonSubmission)
-            default:
-                return String(localizable: .coinVoteCommonConfirmation)
-            }
-        }()
-        let verb = status.isCompleted ? "Submitted" : "Submitting"
-        let subtitle = "\(verb) \(count) vote\(count == 1 ? "" : "s") with voting power \(weight)."
-
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .zFont(.semiBold, size: 24, style: Design.Text.primary)
-                .tracking(-0.384)
-
-            Text(subtitle)
-                .zFont(.medium, size: 14, style: Design.Text.tertiary)
-                .tracking(-0.224)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.bottom, 8)
-    }
-
-    private func submissionSummaryVotes(
-        status: BatchSubmissionStatus,
-        drafts: [UInt32: VoteChoice],
-        submittedVotes: [UInt32: VoteChoice]
-    ) -> [UInt32: VoteChoice] {
-        if case .completed = status {
-            return submittedVotes.isEmpty ? drafts : submittedVotes
-        }
-        return drafts
-    }
-
-    private func submissionCount(
-        status: BatchSubmissionStatus,
-        draftCount: Int,
-        submittedCount: Int
-    ) -> Int {
-        switch status {
-        case let .submitting(_, totalCount, _):
-            return totalCount
-        case let .completed(successCount):
-            return max(successCount, submittedCount)
-        case let .submissionFailed(_, submittedCount, totalCount):
-            return max(submittedCount, totalCount)
-        default:
-            return draftCount
-        }
-    }
-
-    @ViewBuilder
-    private func progressCard(
-        step: VoteSubmissionStep,
-        bundleIndex: UInt32?,
-        bundleCount: UInt32,
-        status: BatchSubmissionStatus
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 12) {
-                ProgressView()
-                    .scaleEffect(0.9)
-                Text(step.label)
-                    .zFont(.medium, size: 14, style: Design.Text.primary)
-                    .tracking(-0.224)
-            }
-
-            if bundleCount > 1, let bundleIndex {
-                Text("Bundle \(bundleIndex + 1) of \(bundleCount)")
-                    .zFont(.medium, size: 12, style: Design.Text.tertiary)
-                    .tracking(-0.144)
-            }
-
-            if case let .submitting(currentIndex, totalCount, _) = status, totalCount > 1 {
-                Text("Vote \(currentIndex + 1) of \(totalCount)")
-                    .zFont(.medium, size: 12, style: Design.Text.tertiary)
-                    .tracking(-0.144)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Design.Spacing._xl)
-        .background(Design.Surfaces.bgPrimary.color(colorScheme))
-        .clipShape(RoundedRectangle(cornerRadius: Design.Radius._2xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                .stroke(Design.Surfaces.strokeSecondary.color(colorScheme), lineWidth: 1)
-        )
-    }
-
-    @ViewBuilder
-    private func summaryRow(title: String, choice: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .zFont(.semiBold, size: 16, style: Design.Text.primary)
-                .tracking(-0.256)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Text(choice)
-                .zFont(.medium, size: 14, style: Design.Text.tertiary)
-                .tracking(-0.224)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Design.Spacing._xl)
-        .background(Design.Surfaces.bgPrimary.color(colorScheme))
-        .clipShape(RoundedRectangle(cornerRadius: Design.Radius._2xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                .stroke(Design.Surfaces.strokeSecondary.color(colorScheme), lineWidth: 1)
-        )
-    }
-
-    @ViewBuilder
-    private func submitCTA(status: BatchSubmissionStatus, drafts: [UInt32: VoteChoice], bundleCount: UInt32) -> some View {
-        VStack(spacing: 0) {
-            switch status {
-            case .idle, .authorizationFailed, .submissionFailed:
-                ZashiButton("Submit") {
-                    store.send(.submitAllDraftsTapped(roundId: roundId))
-                }
-                .disabled(drafts.isEmpty || bundleCount == 0)
-            case .authorizing, .submitting:
-                ZashiButton(String(localizable: .coinVoteCommonSubmission)) {}
-                    .disabled(true)
-            case .completed:
-                ZashiButton(String(localizable: .coinVoteCommonDone)) {
-                    store.send(.dismissFlow)
-                }
-            }
-        }
-        .padding(.horizontal, 24)
-        .padding(.bottom, 24)
-        .background(
-            LinearGradient(
-                colors: [
-                    Design.Surfaces.bgPrimary.color(colorScheme).opacity(0),
-                    Design.Surfaces.bgPrimary.color(colorScheme).opacity(0.95)
-                ],
-                startPoint: .top,
-                endPoint: .bottom
+                },
+                visualStyle: .unverifiedWarning
             )
-        )
+            .votingSheet(
+                isPresented: submissionFailedBinding(status: status),
+                title: String(localizable: .coinVoteConfirmSubmissionSubmissionFailedTitle),
+                message: String(localizable: .coinVoteConfirmSubmissionSubmissionFailedMessage),
+                primary: .init(title: String(localizable: .coinVoteCommonTryAgain), style: .primary) {
+                    store.send(.retryBatchSubmission(roundId: roundId))
+                },
+                secondary: .init(title: String(localizable: .coinVoteCommonCancel), style: .secondary) {
+                    store.send(.dismissBatchResults(roundId: roundId))
+                },
+                visualStyle: .unverifiedWarning
+            )
+        }
     }
 
-    // MARK: - Alert bindings
+    // MARK: - Header
 
-    private func authorizationErrorBinding(status: BatchSubmissionStatus) -> Binding<Bool> {
+    @ViewBuilder
+    private func headerSection(status: BatchSubmissionStatus) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            VotingHeaderIcons(
+                isKeystone: store.isKeystoneUser,
+                showCheckmark: status.isCompleted
+            )
+            .padding(.top, 12)
+            .padding(.bottom, 24)
+
+            Text(headerTitle(status: status))
+                .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(headerSubtitle(status: status))
+                .zFont(size: 14, style: Design.Text.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func navTitle(status: BatchSubmissionStatus) -> String {
+        if case .idle = status {
+            return String(localizable: .coinVoteCommonConfirmation)
+        }
+        return String(localizable: .coinVoteCommonSubmission)
+    }
+
+    private func headerTitle(status: BatchSubmissionStatus) -> String {
+        switch status {
+        case .idle:
+            return String(localizable: .coinVoteConfirmSubmissionHeaderTitleIdle)
+        case .authorizing, .submitting, .authorizationFailed, .submissionFailed:
+            return String(localizable: .coinVoteConfirmSubmissionHeaderTitleSubmitting)
+        case .completed:
+            return String(localizable: .coinVoteConfirmSubmissionHeaderTitleCompleted)
+        }
+    }
+
+    private func headerSubtitle(status: BatchSubmissionStatus) -> String {
+        switch status {
+        case .idle:
+            if store.isKeystoneUser {
+                return String(localizable: .coinVoteConfirmSubmissionHeaderSubtitleIdleKeystone)
+            }
+            return String(localizable: .coinVoteConfirmSubmissionHeaderSubtitleIdle)
+        case .authorizing, .submitting, .authorizationFailed, .submissionFailed:
+            return String(localizable: .coinVoteConfirmSubmissionHeaderSubtitleSubmitting)
+        case .completed:
+            return String(localizable: .coinVoteConfirmSubmissionHeaderSubtitleCompleted)
+        }
+    }
+
+    // MARK: - Details Card
+
+    @ViewBuilder
+    private func detailsCard(
+        status: BatchSubmissionStatus,
+        pollTitle: String,
+        weightString: String
+    ) -> some View {
+        let isIdle: Bool = {
+            if case .idle = status { return true }
+            return false
+        }()
+
+        VStack(spacing: 0) {
+            detailRow(
+                label: String(localizable: .coinVoteConfirmSubmissionDetailPoll),
+                value: pollTitle
+            )
+
+            detailsDivider()
+
+            if isIdle {
+                memoRow(pollTitle: pollTitle, weightString: weightString)
+            } else {
+                detailRow(
+                    label: String(localizable: .coinVoteConfirmSubmissionDetailVotingPower),
+                    value: String(localizable: .coinVoteConfirmSubmissionDetailVotingPowerValue(weightString))
+                )
+            }
+        }
+        .background(Design.Surfaces.bgSecondary.color(colorScheme))
+        .clipShape(RoundedRectangle(cornerRadius: Design.Radius._2xl))
+    }
+
+    @ViewBuilder
+    private func detailRow(label: String, value: String) -> some View {
+        HStack(alignment: .center, spacing: 8) {
+            Text(label)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .tracking(-0.224)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            Text(value)
+                .zFont(.medium, size: 14, style: Design.Text.primary)
+                .tracking(-0.224)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private func memoRow(pollTitle: String, weightString: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(localizable: .coinVoteConfirmSubmissionDetailMemo)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .tracking(-0.224)
+
+            Text(localizable: .coinVoteConfirmSubmissionMemoMessage(pollTitle, weightString))
+                .zFont(.medium, size: 12, style: Design.Text.primary)
+                .tracking(-0.072)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    private func detailsDivider() -> some View {
+        Design.Surfaces.bgPrimary.color(colorScheme)
+            .frame(height: 1)
+    }
+
+    // MARK: - Progress
+
+    /// Authorization gets its own label until it finishes; submission then
+    /// drives the bar from the (currentIndex, totalCount) pair. The 30%
+    /// reservation for the delegation phase keeps the bar monotonic when
+    /// the screen flips from authorizing to submitting mid-flight.
+    private func submissionProgress(
+        status: BatchSubmissionStatus,
+        delegationStatus: ProofStatus
+    ) -> (progress: Double, title: String) {
+        let delegationWeight = 0.3
+
+        switch status {
+        case .authorizing:
+            let proof: Double
+            switch delegationStatus {
+            case .generating(let value): proof = value
+            case .complete: proof = 1.0
+            default: proof = 0
+            }
+            return (
+                proof * delegationWeight,
+                String(localizable: .coinVoteStoreSubmissionAuthorizingVote)
+            )
+
+        case let .submitting(currentIndex, totalCount, _):
+            let offset = delegationStatus == .complete ? delegationWeight : 0.0
+            let fraction = Double(currentIndex + 1) / Double(max(totalCount, 1))
+            let overall = min(1.0, offset + fraction * (1.0 - offset))
+            return (
+                overall,
+                String(
+                    localizable: .coinVoteConfirmSubmissionProgressSubmittingVoteCount(
+                        String(currentIndex + 1),
+                        String(totalCount)
+                    )
+                )
+            )
+
+        case .authorizationFailed:
+            return (0, String(localizable: .coinVoteStoreSubmissionAuthorizingVote))
+
+        case let .submissionFailed(_, submittedCount, totalCount):
+            let fraction = Double(submittedCount) / Double(max(totalCount, 1))
+            let overall = min(1.0, delegationWeight + fraction * (1.0 - delegationWeight))
+            return (
+                overall,
+                String(
+                    localizable: .coinVoteConfirmSubmissionProgressSubmittingVoteCount(
+                        String(submittedCount),
+                        String(totalCount)
+                    )
+                )
+            )
+
+        default:
+            return (0, "")
+        }
+    }
+
+    // MARK: - Bottom Section
+
+    @ViewBuilder
+    private func bottomSection(
+        status: BatchSubmissionStatus,
+        delegationStatus: ProofStatus,
+        drafts: [UInt32: VoteChoice],
+        submittedVotes: [UInt32: VoteChoice],
+        bundleCount: UInt32
+    ) -> some View {
+        switch status {
+        case .idle:
+            ZashiButton(
+                store.isKeystoneUser
+                    ? String(localizable: .coinVoteConfirmSubmissionConfirmWithKeystone)
+                    : String(localizable: .coinVoteCommonConfirm)
+            ) {
+                store.send(.submitAllDraftsTapped(roundId: roundId))
+            }
+            .disabled(drafts.isEmpty || bundleCount == 0)
+
+        case .authorizing, .submitting, .authorizationFailed, .submissionFailed:
+            // Progress card stays on screen while the error sheets (driven
+            // by the `authorizationFailed` / `submissionFailed` bindings)
+            // own retry / cancel.
+            let progressInfo = submissionProgress(
+                status: status,
+                delegationStatus: delegationStatus
+            )
+            VStack(spacing: Design.Spacing._lg) {
+                VStack(alignment: .leading, spacing: Design.Spacing._lg) {
+                    Text(progressInfo.title)
+                        .zFont(.semiBold, size: 15, style: Design.Text.primary)
+
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Design.Surfaces.bgTertiary.color(colorScheme))
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Design.Text.primary.color(colorScheme))
+                                .frame(width: geo.size.width * progressInfo.progress)
+                                .animation(.easeInOut(duration: 0.3), value: progressInfo.progress)
+                        }
+                    }
+                    .frame(height: 8)
+                }
+                .padding(Design.Spacing._2xl)
+                .background(Design.Surfaces.bgSecondary.color(colorScheme))
+                .clipShape(RoundedRectangle(cornerRadius: Design.Radius._xl))
+
+                ZashiButton(progressInfo.title) {}
+                    .disabled(true)
+            }
+
+        case .completed:
+            ZashiButton(String(localizable: .coinVoteCommonDone)) {
+                store.send(.dismissFlow)
+            }
+        }
+    }
+
+    // MARK: - Sheet bindings
+
+    private func authorizationFailedBinding(status: BatchSubmissionStatus) -> Binding<Bool> {
         Binding(
             get: {
                 if case .authorizationFailed = status { return true }
@@ -273,7 +361,7 @@ struct ConfirmSubmissionView: View {
         )
     }
 
-    private func submissionErrorBinding(status: BatchSubmissionStatus) -> Binding<Bool> {
+    private func submissionFailedBinding(status: BatchSubmissionStatus) -> Binding<Bool> {
         Binding(
             get: {
                 if case .submissionFailed = status { return true }
@@ -285,6 +373,72 @@ struct ConfirmSubmissionView: View {
                 }
             }
         )
+    }
+
+    // MARK: - Helpers
+
+    /// Zatoshi → "X.XXX" ZEC string. Three fractional digits matches the
+    /// Polls list copy so the in-app voting-power values stay consistent.
+    private static func formatZec(_ zatoshi: UInt64) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 3
+        formatter.maximumFractionDigits = 3
+        formatter.usesGroupingSeparator = true
+        let value = Zatoshi(Int64(zatoshi)).decimalValue.roundedZec
+        return formatter.string(from: value) ?? "0.000"
+    }
+}
+
+// MARK: - Header Icons
+
+/// Restored from the agency build (deleted in `MOB-1105 Phase 5D`). Renders
+/// the white Zashi disc + thumbs-up bubble, swapping the thumbs-up for a
+/// green checkmark seal once submission succeeds. The Keystone variant uses
+/// the brandmark disc instead of the white Zashi mark.
+private struct VotingHeaderIcons: View {
+    @Environment(\.colorScheme) var colorScheme
+    var isKeystone: Bool = false
+    var showCheckmark: Bool = false
+
+    var body: some View {
+        HStack(spacing: -4) {
+            if isKeystone {
+                Asset.Assets.Brandmarks.brandmarkKeystone.image
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .clipShape(Circle())
+            } else {
+                ZStack {
+                    Circle()
+                        .fill(Design.Text.primary.color(colorScheme))
+                        .frame(width: 48, height: 48)
+                    Asset.Assets.zashiLogo.image
+                        .zImage(size: 22, color: Design.Surfaces.bgPrimary.color(colorScheme))
+                }
+            }
+
+            if showCheckmark {
+                ZStack {
+                    Circle()
+                        .fill(Design.Utility.SuccessGreen._500.color(colorScheme).opacity(0.15))
+                        .frame(width: 48, height: 48)
+                    Image(systemName: "checkmark.seal.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(Design.Utility.SuccessGreen._500.color(colorScheme))
+                }
+                .zIndex(1)
+            } else {
+                ZStack {
+                    Circle()
+                        .fill(Design.Surfaces.bgTertiary.color(colorScheme))
+                        .frame(width: 48, height: 48)
+                    Image(systemName: "hand.thumbsup")
+                        .font(.system(size: 22, weight: .regular))
+                        .foregroundStyle(Design.Text.primary.color(colorScheme))
+                }
+            }
+        }
     }
 }
 

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -134,7 +134,7 @@ struct DelegationSigningView: View {
     @ViewBuilder
     private func multiBundleProgressCard(current: UInt32, total: UInt32) -> some View {
         HStack {
-            Text("Bundle \(current + 1) of \(total)")
+            Text(localizable: .coinVoteDelegationSigningCurrentBundleProgress(String(current + 1), String(total)))
                 .zFont(.semiBold, size: 14, style: Design.Text.primary)
             Spacer()
         }
@@ -157,7 +157,7 @@ struct DelegationSigningView: View {
             VStack {
                 ProgressView()
                     .padding(.bottom, 8)
-                Text("Preparing signing request...")
+                Text(localizable: .coinVoteDelegationSigningPreparingRequestEllipsis)
                     .zFont(.medium, size: 13, style: Design.Text.tertiary)
                     .multilineTextAlignment(.center)
             }
@@ -193,7 +193,7 @@ struct DelegationSigningView: View {
         case .parsingSignature:
             VStack {
                 ProgressView()
-                Text("Parsing signature...")
+                Text(localizable: .coinVoteDelegationSigningParsingSignatureEllipsis)
                     .zFont(.medium, size: 13, style: Design.Text.tertiary)
                     .multilineTextAlignment(.center)
                     .padding(.top, 8)
@@ -236,7 +236,7 @@ struct DelegationSigningView: View {
     private func instructionText(status: KeystoneSigningStatus) -> some View {
         switch status {
         case .awaitingSignature:
-            Text("Open your Keystone device and scan the signed PCZT back to continue.")
+            Text(localizable: .coinVoteDelegationSigningScanSignedPCZTInstruction)
                 .zFont(.medium, size: 14, style: Design.Text.primary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -252,13 +252,13 @@ struct DelegationSigningView: View {
         switch status {
         case .awaitingSignature:
             VStack(spacing: 12) {
-                ZashiButton("Scan signed PCZT") {
+                ZashiButton(String(localizable: .coinVoteDelegationSigningScanSignedPCZTCTA)) {
                     store.send(.openKeystoneSignatureScan)
                 }
                 if (store.roundCache[roundId]?.bundleCount ?? 0) > 1
                     && !(store.roundCache[roundId]?.keystoneBundleSignatures.isEmpty ?? true) {
                     ZashiButton(
-                        "Skip remaining bundles",
+                        String(localizable: .coinVoteDelegationSigningSkipRemainingBundlesCTA),
                         type: .tertiary
                     ) {
                         store.send(.skipRemainingKeystoneBundles(roundId: roundId))

--- a/secant/Sources/Features/Voting/HowToVote/HowToVoteView.swift
+++ b/secant/Sources/Features/Voting/HowToVote/HowToVoteView.swift
@@ -7,8 +7,8 @@ import SwiftUI
 import ComposableArchitecture
 
 /// First-time intro shown to users who have not yet seen the Coinholder
-/// Polling onboarding. Continue marks the per-wallet `hasSeenHowToVote`
-/// flag and re-triggers `.onAppear` which advances into `.initialize`.
+/// Polling onboarding. Renders the same 2-step layout for Zodl and Keystone
+/// accounts; only the brand icon + title copy differ.
 struct HowToVoteView: View {
     @Environment(\.colorScheme) var colorScheme
 
@@ -16,25 +16,48 @@ struct HowToVoteView: View {
 
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 24) {
-                Spacer()
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        iconRow
+                            .padding(.top, 24)
+                            .padding(.bottom, 24)
 
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("How Coinholder Polling works")
-                        .zFont(.semiBold, size: 24, style: Design.Text.primary)
-                        .tracking(-0.384)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        Text(titleCopy)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .tracking(-0.384)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 8)
 
-                    Text("Your voting power is derived from your shielded ZEC at the round's snapshot height. Vote choices are private; results are tallied by helper servers using zero-knowledge proofs.")
-                        .zFont(.medium, size: 14, style: Design.Text.tertiary)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        Text(subtitleCopy)
+                            .zFont(.medium, size: 14, style: Design.Text.tertiary)
+                            .tracking(-0.224)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        stepRow(
+                            number: 1,
+                            title: String(localizable: .coinVoteHowToVoteStepVotingTitle),
+                            body: String(localizable: .coinVoteHowToVoteStepVotingBody)
+                        )
+                        .padding(.bottom, 16)
+
+                        stepRow(
+                            number: 2,
+                            title: String(localizable: .coinVoteHowToVoteStepAuthorizeTitle),
+                            body: String(localizable: .coinVoteHowToVoteStepAuthorizeBody)
+                        )
+                    }
+                    .padding(.horizontal, 24)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .padding(.horizontal, 24)
+                .padding(.vertical, 1)
 
-                Spacer()
+                snapshotNote
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 12)
 
-                ZashiButton(String(localizable: .coinVoteCommonGotIt)) {
+                ZashiButton(String(localizable: .coinVoteCommonContinue)) {
                     store.send(.howToVoteContinueTapped)
                 }
                 .padding(.horizontal, 24)
@@ -44,5 +67,102 @@ struct HowToVoteView: View {
             .screenTitle(String(localizable: .coinVoteCommonScreenTitle))
             .zashiBack { store.send(.dismissFlow) }
         }
+    }
+
+    // MARK: - Top icon row
+
+    @ViewBuilder
+    private var iconRow: some View {
+        HStack(spacing: -8) {
+            ZStack {
+                Circle()
+                    .fill(Design.Text.primary.color(colorScheme))
+                    .frame(width: 48, height: 48)
+
+                brandIcon
+            }
+
+            ZStack {
+                Circle()
+                    .fill(Design.Surfaces.bgSecondary.color(colorScheme))
+                    .frame(width: 48, height: 48)
+
+                Image(systemName: "hand.thumbsup.fill")
+                    .font(.system(size: 20))
+                    .foregroundStyle(Design.Text.primary.color(colorScheme))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var brandIcon: some View {
+        if store.isKeystoneUser {
+            Asset.Assets.Partners.keystoneLogo.image
+                .resizable()
+                .frame(width: 48, height: 48)
+                .clipShape(Circle())
+        } else {
+            Asset.Assets.zashiLogo.image
+                .zImage(size: 22, color: Design.Surfaces.bgPrimary.color(colorScheme))
+        }
+    }
+
+    // MARK: - Steps
+
+    @ViewBuilder
+    private func stepRow(number: Int, title: String, body: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Design.Text.primary.color(colorScheme))
+                    .frame(width: 24, height: 24)
+
+                Text("\(number)")
+                    .zFont(.semiBold, size: 12, color: Design.Surfaces.bgPrimary.color(colorScheme))
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+                    .tracking(-0.256)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(body)
+                    .zFont(.medium, size: 14, style: Design.Text.tertiary)
+                    .tracking(-0.224)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Bottom info note
+
+    @ViewBuilder
+    private var snapshotNote: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "info.circle")
+                .font(.system(size: 16, weight: .regular))
+                .foregroundStyle(Design.Text.tertiary.color(colorScheme))
+                .padding(.top, 1)
+
+            Text(localizable: .coinVoteHowToVoteInfoCard)
+                .zFont(.medium, size: 13, style: Design.Text.tertiary)
+                .tracking(-0.208)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Variant copy
+
+    private var titleCopy: String {
+        store.isKeystoneUser
+            ? String(localizable: .coinVoteHowToVoteTitleKeystone)
+            : String(localizable: .coinVoteHowToVoteTitleZodl)
+    }
+
+    private var subtitleCopy: String {
+        String(localizable: .coinVoteHowToVoteSubtitle)
     }
 }

--- a/secant/Sources/Features/Voting/Ineligible/IneligibleView.swift
+++ b/secant/Sources/Features/Voting/Ineligible/IneligibleView.swift
@@ -25,11 +25,11 @@ struct IneligibleView: View {
                         .font(.system(size: 40, weight: .regular))
                         .foregroundStyle(Design.Text.tertiary.color(colorScheme))
 
-                    Text("You can't vote in this round")
+                    Text(localizable: .coinVoteIneligibleTitleNoVote)
                         .zFont(.semiBold, size: 20, style: Design.Text.primary)
                         .multilineTextAlignment(.center)
 
-                    Text("Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment.")
+                    Text(localizable: .coinVoteIneligibleSnapshotBody)
                         .zFont(.medium, size: 14, style: Design.Text.tertiary)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)

--- a/secant/Sources/Features/Voting/NoRounds/NoRoundsView.swift
+++ b/secant/Sources/Features/Voting/NoRounds/NoRoundsView.swift
@@ -8,18 +8,20 @@ import ComposableArchitecture
 
 /// Empty-state shown when the voting service returns zero rounds. Renders the
 /// shimmering polls-list backdrop with a dimmed "No polls right now" sheet on
-/// top, matching the same pattern used while the polls list is loading.
+/// top. "Got it" hides the sheet but keeps the user inside the voting flow
+/// so they can tap the toolbar cog and try a different data source.
 struct NoRoundsView: View {
     let store: StoreOf<VotingCoordFlow>
+
+    @State private var sheetPresented = true
 
     var body: some View {
         WithPerceptionTracking {
             VotingCoordFlowBackdrop(store: store)
-                .votingBlockingSheet(
-                    isActive: { store.rootScreen == .noRounds },
-                    visualStyle: .unverifiedWarning,
-                    onExit: { store.send(.dismissFlow) }
-                ) { dismiss in
+                .zashiSheet(
+                    isPresented: $sheetPresented,
+                    horizontalPadding: VotingSheetContent.VisualStyle.unverifiedWarning.horizontalPadding
+                ) {
                     VotingSheetContent(
                         iconSystemName: "exclamationmark.circle",
                         iconStyle: Design.Utility.ErrorRed._500,
@@ -29,7 +31,10 @@ struct NoRoundsView: View {
                             title: String(localizable: .coinVoteCommonGotIt),
                             style: .primary
                         ) {
-                            dismiss()
+                            // Just hide the sheet — keep the user on the
+                            // backdrop so they can open Voting Settings via
+                            // the toolbar cog.
+                            sheetPresented = false
                         },
                         secondary: .init(
                             title: String(localizable: .coinVoteCommonRefresh),
@@ -46,8 +51,12 @@ struct NoRoundsView: View {
 
 /// Shared shimmering backdrop used by the `.loading` and `.noRounds` root
 /// screens. Renders the screen title + a single outlined skeleton card so the
-/// chrome stays consistent across loading, empty, and error states.
+/// chrome stays consistent across loading, empty, and error states. The
+/// toolbar cog is always available so the user can change the data source
+/// without first reaching the polls list.
 struct VotingCoordFlowBackdrop: View {
+    @Environment(\.colorScheme) var colorScheme
+
     let store: StoreOf<VotingCoordFlow>
 
     var body: some View {
@@ -63,6 +72,34 @@ struct VotingCoordFlowBackdrop: View {
         .applyScreenBackground()
         .screenTitle(String(localizable: .coinVoteCommonScreenTitle))
         .zashiBack { store.send(.dismissFlow) }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    store.send(.openConfigSettings)
+                } label: {
+                    settingsButtonIcon()
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localizable: .coinVotePollsListChainConfigAccessibility))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func settingsButtonIcon() -> some View {
+        let icon = Asset.Assets.Icons.settings2.image
+            .zImage(size: 20, style: Design.Btns.Ghost.fg)
+
+        if #available(iOS 26.0, *) {
+            icon
+        } else {
+            icon
+                .padding(8)
+                .background {
+                    RoundedRectangle(cornerRadius: Design.Radius._md)
+                        .fill(Design.Btns.Ghost.bg.color(colorScheme))
+                }
+        }
     }
 }
 

--- a/secant/Sources/Features/Voting/Results/ResultsView.swift
+++ b/secant/Sources/Features/Voting/Results/ResultsView.swift
@@ -35,7 +35,7 @@ struct ResultsView: View {
 
                     if let tallyError {
                         VStack(alignment: .leading, spacing: 8) {
-                            Text("Couldn't load results")
+                            Text(localizable: .coinVoteResultsLoadErrorTitle)
                                 .zFont(.semiBold, size: 16, style: Design.Text.primary)
                                 .tracking(-0.256)
 
@@ -54,12 +54,12 @@ struct ResultsView: View {
                     } else if !loaded {
                         HStack(spacing: 8) {
                             ProgressView().scaleEffect(0.75)
-                            Text("Loading results…")
+                            Text(localizable: .coinVoteResultsLoading)
                                 .zFont(.medium, size: 14, style: Design.Text.tertiary)
                         }
                         .padding(.top, 8)
                     } else if proposals.isEmpty {
-                        Text("No proposals in this round")
+                        Text(localizable: .coinVoteResultsNoProposalsInRound)
                             .zFont(.medium, size: 14, style: Design.Text.tertiary)
                     } else {
                         ForEach(proposals) { proposal in
@@ -101,7 +101,7 @@ struct ResultsView: View {
                     )
                 }
             } else {
-                Text("No votes recorded")
+                Text(localizable: .coinVoteResultsNoVotesRecorded)
                     .zFont(.medium, size: 14, style: Design.Text.tertiary)
             }
         }
@@ -121,7 +121,7 @@ struct ResultsView: View {
             Text(label)
                 .zFont(winning ? .semiBold : .medium, size: 14, style: Design.Text.primary)
             Spacer()
-            Text("\(Int(pct * 100))%")
+            Text(localizable: .coinVoteResultsPercentValue(String(Int(pct * 100))))
                 .zFont(.medium, size: 14, style: Design.Text.tertiary)
         }
         .padding(.vertical, 4)

--- a/secant/Sources/Features/Voting/Tallying/TallyingView.swift
+++ b/secant/Sources/Features/Voting/Tallying/TallyingView.swift
@@ -29,9 +29,9 @@ struct TallyingView: View {
                 HStack(spacing: 12) {
                     ProgressView()
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Tallying in progress")
+                        Text(localizable: .coinVoteTallyingTitleInProgress)
                             .zFont(.semiBold, size: 16, style: Design.Text.primary)
-                        Text("Voting has closed. Final results will appear here once the helpers finish tallying.")
+                        Text(localizable: .coinVoteTallyingBodyInProgress)
                             .zFont(.medium, size: 14, style: Design.Text.tertiary)
                             .fixedSize(horizontal: false, vertical: true)
                     }

--- a/secant/Sources/Features/Voting/WalletSyncing/WalletSyncingView.swift
+++ b/secant/Sources/Features/Voting/WalletSyncing/WalletSyncingView.swift
@@ -32,7 +32,7 @@ struct WalletSyncingView: View {
                         .progressViewStyle(.linear)
                         .padding(.horizontal, 24)
 
-                    Text("Catching up to round snapshot")
+                    Text(localizable: .coinVoteWalletSyncingCatchingUp)
                         .zFont(.semiBold, size: 18, style: Design.Text.primary)
                     Text("\(scanned) / \(snapshot)")
                         .zFont(.medium, size: 14, style: Design.Text.tertiary)


### PR DESCRIPTION
## Summary

Restores agency-built voting screens that were inadvertently dropped during the MOB-1105 reducer rewrite, plus a localization pass on hard-coded strings introduced along the way.

**This PR contains no behavior changes** — no new actions, no new state, no new routing. Pure UI + locale. The behavioral follow-up is stacked as **MOB-1105/submission-flow** (opened separately, targets this branch).

## What's in this PR

| File | Change |
|---|---|
| `ConfirmSubmission/ConfirmSubmissionView.swift` | Agency single-screen state-flip layout — Zashi/Keystone header icons, Poll/Memo card on `.idle`, Poll/Voting-power card on in-flight/completed, monotonic progress bar, `votingSheet`-based error presentation. Driven entirely by existing `BatchSubmissionStatus`. |
| `HowToVote/HowToVoteView.swift` | Redesigned intro layout. |
| `NoRounds/NoRoundsView.swift` | Cosmetic refresh. |
| `Tallying/`, `Results/`, `Ineligible/`, `WalletSyncing/` views | Minor cosmetic alignment with Figma. |
| `DelegationSigning/DelegationSigningStore.swift` | Replace hard-coded English strings with localized catalog keys. |
| `VotingModels/Proposal.swift` | Optional `VoteOption.description` field (additive, default `nil`) for policy-heavy polls (NU7, NSM). |
| `VotingAPIClient/VotingAPIClientLiveKey.swift` | Parse the new `description` field on the option JSON. |
| `VotingCryptoClient/VotingCryptoClientLiveKey.swift` | Rename underscore param to `roundId` (passthrough rename, no behavior change). |
| `Localizable.xcstrings` | ~80 new `coinVote.*` keys. |

## Reviewer notes — local SDK setup

Voting consumes FFI from the local `zcash-swift-wallet-sdk` checkout that includes the `zcash_voting = 0.10.1` bump (PR [zcash#1744](https://github.com/zcash/zcash-swift-wallet-sdk/pull/1744)). Until that PR lands and is tagged, every developer/reviewer needs:

1. Sibling clone of the SDK at `../zcash-swift-wallet-sdk`, checked out on a branch with `zcash_voting = 0.10.1`.
2. `make rebuild-ffi` inside the SDK to regenerate `libzcashlc.xcframework`.
3. Xcode → File → Packages → Reset Package Caches.

The Xcode `XCLocalSwiftPackageReference` already points at `../zcash-swift-wallet-sdk` on this branch's parent (integration); this PR doesn't touch the project file.

## Test plan

- [ ] Build the `secant-testnet` scheme — must succeed.
- [ ] Launch the voting flow against staging, observe the ConfirmSubmissionView four states match the Figma:
  - [ ] Resting: icon + thumbs-up, Poll/Memo card, "Confirm" CTA.
  - [ ] Authorizing: spinner-tinted icon, Poll/Voting-power card, "Authorizing…" progress, disabled CTA.
  - [ ] Submitting N of M: progress text reflects per-vote counter.
  - [ ] Completed: green checkmark seal, "Submission Confirmed!" header, Done CTA.
- [ ] How To Vote / No Rounds / Ineligible / Wallet Syncing screens render correctly.
- [ ] Verify localization: switch system language to Spanish, confirm strings render.