### PR TITLE
Update static voting config pin

### DIFF
--- a/secant/Sources/Dependencies/VotingModels/StaticVotingConfig.swift
+++ b/secant/Sources/Dependencies/VotingModels/StaticVotingConfig.swift
@@ -9,8 +9,8 @@ struct StaticVotingConfig: Codable, Equatable, Sendable {
     static let supportedVersion = 1
     static let algEd25519 = "ed25519"
     static let bundledPinnedSource =
-        "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/5ed8d623e4150d383a4dac05dd6bfbdd126a5408/prod/static-voting-config.json" +
-        "?checksum=sha256:5a6bc0dce85a8ee8d6585d2a180e62f145abcfee7768c15b88de47c9a01a5738"
+        "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/2785311d45758e85567d70a1f13709fa01b62c6b/prod/static-voting-config.json" +
+        "?checksum=sha256:bed0116f961226b256a574b52461ce81d9f5294a57e190987dc155f07eb1e431"
 
     let staticConfigVersion: Int
     let dynamicConfigURL: URL


### PR DESCRIPTION
## Summary
- Updates the bundled static voting config pin to the production config at commit 2785311d45758e85567d70a1f13709fa01b62c6b.
- Pins the checksum to bed0116f961226b256a574b52461ce81d9f5294a57e190987dc155f07eb1e431.


Verify sha: https://github.com/valargroup/token-holder-voting-config/actions/runs/26486437639/job/77994827028
This commit: https://github.com/valargroup/token-holder-voting-config/commit/2785311d45758e85567d70a1f13709fa01b62c6b