### PR TITLE
[#MOB-1105] Draft Keystone bundle UI handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+## 3.5.0 build 1 (2026-05-27)
+
+### Added
+- Coinholder Polling lets you vote on Zcash governance privately, right from your Zodl and Keystone wallets.
+
 ## 3.4.1 build 1 (2026-05-18)
 
 ### Changed

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -3047,6 +3047,23 @@
         }
       }
     },
+    "coinVote.delegationSigning.awaitingWeightSummary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC signed · %@ ZEC awaiting"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC signed · %@ ZEC awaiting"
+          }
+        }
+      }
+    },
     "coinVote.delegationSigning.bundleProgress" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3070,13 +3087,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bundle %@ of %@"
+            "value" : "Signature %@ of %@"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bundle %@ of %@"
+            "value" : "Signature %@ of %@"
           }
         }
       }
@@ -3308,13 +3325,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scan Signature"
+            "value" : "Scan signature"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scan Signature"
+            "value" : "Scan signature"
           }
         }
       }
@@ -3393,13 +3410,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ ZEC Authorized - %@ ZEC Pending"
+            "value" : "%@ ZEC Signed · %@ ZEC Pending"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ ZEC Authorized - %@ ZEC Pending"
+            "value" : "%@ ZEC Signed · %@ ZEC Pending"
           }
         }
       }
@@ -3519,6 +3536,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Skip remaining bundles"
+          }
+        }
+      }
+    },
+    "coinVote.delegationSigning.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorize Vote"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorize Vote"
           }
         }
       }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -3608,6 +3608,40 @@
         }
       }
     },
+    "coinVote.delegationSigning.signatureRejectedOk" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
+    "coinVote.delegationSigning.signatureRejectedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
+          }
+        }
+      }
+    },
     "coinVote.delegationSigning.wrongSignature" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Resources/WhatsNew/whatsNew.json
+++ b/secant/Resources/WhatsNew/whatsNew.json
@@ -1,6 +1,19 @@
 {
     "releases": [
         {
+            "version": "3.5.0",
+            "date": "27-05-2026",
+            "timestamp": 1779388800,
+            "sections": [
+                {
+                    "title": "Added:",
+                    "bulletpoints": [
+                        "Coinholder Polling lets you vote on Zcash governance privately, right from your Zodl and Keystone wallets."
+                    ]
+                }
+            ]
+        },
+        {
             "version": "3.4.1",
             "date": "18-05-2026",
             "timestamp": 1778606653,

--- a/secant/Resources/WhatsNew/whatsNew_es.json
+++ b/secant/Resources/WhatsNew/whatsNew_es.json
@@ -1,6 +1,19 @@
 {
     "releases": [
         {
+            "version": "3.5.0",
+            "date": "27-05-2026",
+            "timestamp": 1779388800,
+            "sections": [
+                {
+                    "title": "Añadido:",
+                    "bulletpoints": [
+                        "Coinholder Polling te permite votar en la gobernanza de Zcash de forma privada, directamente desde tus billeteras Zodl y Keystone."
+                    ]
+                }
+            ]
+        },
+        {
             "version": "3.4.1",
             "date": "18-05-2026",
             "timestamp": 1778606653,

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -465,8 +465,11 @@ extension VotingCoordFlow {
                 }
                 return .none
 
-            case .submissionAlert,
-                 .keystoneSignatureRejectionAlert:
+            case .submissionAlert:
+                return .none
+
+            case .dismissKeystoneSignatureRejectionSheet:
+                state.keystoneSignatureRejectionSheet = nil
                 return .none
 
             // MARK: - Stage 5: submission pipeline
@@ -682,7 +685,7 @@ extension VotingCoordFlow {
                 mutateSession(&state, roundId: roundId) { roundSession in
                     roundSession.keystoneSigningStatus = .awaitingSignature
                 }
-                state.keystoneSignatureRejectionAlert = .keystoneSignatureRejected(message)
+                state.keystoneSignatureRejectionSheet = State.KeystoneSignatureRejectionSheet(message: message)
                 return .none
 
             case let .keystoneShowSigningScreen(roundId):
@@ -3705,17 +3708,6 @@ extension AlertState where Action == Never {
         }
     }
 
-    static func keystoneSignatureRejected(_ message: String) -> AlertState {
-        AlertState {
-            TextState(String(localizable: .coinVoteErrorTitle))
-        } actions: {
-            ButtonState(role: .cancel) {
-                TextState(String(localizable: .generalOk))
-            }
-        } message: {
-            TextState(message)
-        }
-    }
 }
 
 extension AlertState where Action == VotingCoordFlow.Action {

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
@@ -148,9 +148,14 @@ struct VotingCoordFlow {
         /// `RoundSession.batchSubmissionStatus`.
         @Presents var submissionAlert: AlertState<Never>?
 
-        /// Blocking acknowledgement for an invalid Keystone signed-PCZT scan
-        /// during the multi-bundle signing loop.
-        @Presents var keystoneSignatureRejectionAlert: AlertState<Never>?
+        /// Blocking acknowledgement sheet for an invalid Keystone signed-PCZT
+        /// scan during the multi-bundle signing loop. The message is fully
+        /// composed up-front from the localized rejection-reason string.
+        var keystoneSignatureRejectionSheet: KeystoneSignatureRejectionSheet?
+
+        struct KeystoneSignatureRejectionSheet: Equatable {
+            let message: String
+        }
 
         /// Sheet state for the Keystone QR scan that captures the signed
         /// PCZT from the device. Lifecycle is bound to the delegation
@@ -264,7 +269,7 @@ struct VotingCoordFlow {
         case tallyResultsLoaded(roundId: String, results: [UInt32: TallyResult])
         case tallyResultsFailed(roundId: String, message: String)
         case submissionAlert(PresentationAction<Never>)
-        case keystoneSignatureRejectionAlert(PresentationAction<Never>)
+        case dismissKeystoneSignatureRejectionSheet
 
         // MARK: - Stage 5: submission pipeline
 
@@ -378,7 +383,6 @@ struct VotingCoordFlow {
         coordinatorReduce()
             .forEach(\.path, action: \.path)
             .ifLet(\.$submissionAlert, action: \.submissionAlert)
-            .ifLet(\.$keystoneSignatureRejectionAlert, action: \.keystoneSignatureRejectionAlert)
             .ifLet(\.$keystoneScan, action: \.keystoneScan) {
                 Scan()
             }

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowView.swift
@@ -69,8 +69,19 @@ struct VotingCoordFlowView: View {
                 }
             }
             .alert($store.scope(state: \.submissionAlert, action: \.submissionAlert))
-            .alert($store.scope(state: \.keystoneSignatureRejectionAlert, action: \.keystoneSignatureRejectionAlert))
             .alert($store.scope(state: \.skipBundlesAlert, action: \.skipBundlesAlert))
+            .votingSheet(
+                isPresented: keystoneSignatureRejectionBinding,
+                title: String(localizable: .coinVoteDelegationSigningSignatureRejectedTitle),
+                message: store.keystoneSignatureRejectionSheet?.message ?? "",
+                primary: .init(
+                    title: String(localizable: .coinVoteDelegationSigningSignatureRejectedOk),
+                    style: .primary
+                ) {
+                    store.send(.dismissKeystoneSignatureRejectionSheet)
+                },
+                secondary: nil
+            )
             .votingSheet(
                 isPresented: pollClosedSheetBinding,
                 title: String(localizable: .coinVotePollClosedSheetTitle),
@@ -100,6 +111,17 @@ struct VotingCoordFlowView: View {
             set: { newValue in
                 if !newValue {
                     store.send(.dismissPollClosedAlert)
+                }
+            }
+        )
+    }
+
+    private var keystoneSignatureRejectionBinding: Binding<Bool> {
+        Binding(
+            get: { store.keystoneSignatureRejectionSheet != nil },
+            set: { newValue in
+                if !newValue {
+                    store.send(.dismissKeystoneSignatureRejectionSheet)
                 }
             }
         )

--- a/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
+++ b/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
@@ -169,11 +169,13 @@ struct ConfirmSubmissionView: View {
                 value: pollTitle
             )
 
-            detailsDivider()
-
-            if isIdle && !isKeystoneUser {
+            if isIdle && isKeystoneUser {
+                EmptyView()
+            } else if isIdle {
+                detailsDivider()
                 memoRow(pollTitle: pollTitle, weightString: weightString)
             } else {
+                detailsDivider()
                 detailRow(
                     label: String(localizable: .coinVoteConfirmSubmissionDetailVotingPower),
                     value: String(localizable: .coinVoteConfirmSubmissionDetailVotingPowerValue(weightString))

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -35,6 +35,8 @@ struct DelegationSigningView: View {
     @Perception.Bindable var store: StoreOf<VotingCoordFlow>
     let roundId: String
 
+    @State private var isQRCodeEnlarged = false
+
     var body: some View {
         WithPerceptionTracking {
             let session = store.roundCache[roundId]
@@ -93,6 +95,19 @@ struct DelegationSigningView: View {
                 store: store.scope(state: \.$keystoneScan, action: \.keystoneScan)
             ) { scanStore in
                 ScanView(store: scanStore, popoverRatio: 1.075)
+            }
+            .enlargeQR(isPresented: $isQRCodeEnlarged) {
+                Group {
+                    if let pczt = store.roundCache[roundId]?.pendingUnsignedDelegationPczt,
+                       let encoder = sdkSynchronizer.urEncoderForPCZT(pczt) {
+                        AnimatedQRCode(urEncoder: encoder, size: UIScreen.main.bounds.width - 64)
+                            .padding()
+                            .background {
+                                RoundedRectangle(cornerRadius: Design.Radius._4xl)
+                                    .fill(Color.white)
+                            }
+                    }
+                }
             }
         }
     }
@@ -163,9 +178,15 @@ struct DelegationSigningView: View {
 
             case .awaitingSignature:
                 if let pczt = store.roundCache[roundId]?.pendingUnsignedDelegationPczt,
-                   let encoder = sdkSynchronizer.urEncoderForPCZT(pczt) {
+                   let encoder = sdkSynchronizer.urEncoderForPCZT(pczt),
+                   !isQRCodeEnlarged {
                     AnimatedQRCode(urEncoder: encoder, size: 216)
                         .frame(width: 216, height: 216)
+                        .onTapGesture {
+                            withAnimation(.easeInOut) {
+                                isQRCodeEnlarged = true
+                            }
+                        }
                 } else {
                     qrStatusView(text: nil)
                 }

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -43,7 +43,11 @@ struct DelegationSigningView: View {
             let status = session?.keystoneSigningStatus ?? .idle
             let bundleCount = session?.bundleCount ?? 0
             let currentBundle = session?.currentKeystoneBundleIndex ?? 0
-            let signedBundleCount = UInt32(session?.keystoneBundleSignatures.count ?? 0)
+            // Use the resolved prefix rather than `keystoneBundleSignatures.count`
+            // so the count reflects bundles already accepted by the reducer
+            // (including any recovered after a crash) — not just the ones the
+            // user signed in the current session.
+            let signedBundleCount = session?.resolvedKeystonePrefixCount ?? 0
             let bundleWeights = Self.bundleWeightSummary(session: session)
             let pollTitle = store.allRounds.first { $0.id == roundId }?.title ?? ""
             let currentBundleMemo = Self.currentBundleMemo(
@@ -69,7 +73,8 @@ struct DelegationSigningView: View {
                             signed: signedBundleCount,
                             signedWeight: bundleWeights.signed,
                             pendingWeight: bundleWeights.pending,
-                            memo: currentBundleMemo
+                            memo: currentBundleMemo,
+                            status: status
                         )
                         .padding(.top, 24)
                     }
@@ -243,7 +248,8 @@ struct DelegationSigningView: View {
         signed: UInt32,
         signedWeight: UInt64,
         pendingWeight: UInt64,
-        memo: String?
+        memo: String?,
+        status: KeystoneSigningStatus
     ) -> some View {
         VStack(spacing: 0) {
             signatureProgressSection(
@@ -254,7 +260,7 @@ struct DelegationSigningView: View {
                 pendingWeight: pendingWeight
             )
 
-            if canUseSignedBundlesOnly(signed: signed, total: total) {
+            if canUseSignedBundlesOnly(signed: signed, total: total, status: status) {
                 detailsDivider()
                 useSignedBundlesOnlyRow(pendingWeight: pendingWeight)
             }
@@ -391,7 +397,10 @@ struct DelegationSigningView: View {
         guard let session else { return (0, 0) }
 
         let bundles = session.walletNotes.smartBundles().bundles
-        let signedCount = min(session.keystoneBundleSignatures.count, bundles.count)
+        // Drive the signed/pending split from the resolved-prefix count so
+        // recovered bundles roll into the "signed" bucket even when the
+        // current-session signature array hasn't been repopulated yet.
+        let signedCount = min(Int(session.resolvedKeystonePrefixCount), bundles.count)
         let countedBundleCount = min(Int(session.bundleCount), bundles.count)
         var signed: UInt64 = 0
         var pending: UInt64 = 0
@@ -447,7 +456,13 @@ struct DelegationSigningView: View {
         ))
     }
 
-    private func canUseSignedBundlesOnly(signed: UInt32, total: UInt32) -> Bool {
+    private func canUseSignedBundlesOnly(signed: UInt32, total: UInt32, status: KeystoneSigningStatus) -> Bool {
+        // Only surface the row while we're idle on a new bundle request — the
+        // old standalone CTA had the same gate. Without it, the row can be
+        // tapped while the next Keystone PCZT is still being prepared, which
+        // races the in-flight signing-status transitions.
+        guard status == .awaitingSignature else { return false }
+
         // Mirror the gate added on main (PR #1789 / commit 8e570578): we only
         // surface "Use signed bundles only" when the resolved bundles form a
         // contiguous prefix starting from index 0. Without that constraint,

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -286,7 +286,7 @@ struct DelegationSigningView: View {
                         .fill(Design.Surfaces.bgQuaternary.color(colorScheme))
                     Capsule()
                         .fill(Design.Text.primary.color(colorScheme))
-                        .frame(width: geometry.size.width * Self.bundleShare(total: total))
+                        .frame(width: geometry.size.width * Self.signingProgress(signed: signed, total: total))
                 }
             }
             .frame(height: 6)
@@ -403,9 +403,13 @@ struct DelegationSigningView: View {
         return min(current + 1, total)
     }
 
-    private static func bundleShare(total: UInt32) -> Double {
+    /// Fraction of bundles already signed, clamped to [0, 1]. Drives the
+    /// signing-progress capsule. Replaces an earlier `bundleShare(total:)`
+    /// that ignored `signed` and always returned `1 / total` (showing 50%
+    /// indefinitely on a 2-bundle round).
+    private static func signingProgress(signed: UInt32, total: UInt32) -> Double {
         guard total > 0 else { return 0 }
-        return min(1, 1 / Double(total))
+        return min(1, Double(signed) / Double(total))
     }
 
     private func weightSummary(signed: UInt32, signedWeight: UInt64, pendingWeight: UInt64) -> String {

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -41,6 +41,8 @@ struct DelegationSigningView: View {
             let status = session?.keystoneSigningStatus ?? .idle
             let bundleCount = session?.bundleCount ?? 0
             let currentBundle = session?.currentKeystoneBundleIndex ?? 0
+            let signedBundleCount = UInt32(session?.keystoneBundleSignatures.count ?? 0)
+            let bundleWeights = Self.bundleWeightSummary(session: session)
             let pollTitle = store.allRounds.first { $0.id == roundId }?.title ?? ""
             let currentBundleMemo = Self.currentBundleMemo(
                 session: session,
@@ -52,30 +54,28 @@ struct DelegationSigningView: View {
                 ScrollView {
                     VStack(spacing: 0) {
                         keystoneDeviceCard()
-                            .padding(.top, 40)
-
-                        if bundleCount > 1 {
-                            multiBundleProgressCard(current: currentBundle, total: bundleCount)
-                                .padding(.top, 24)
-                        }
-
-                        if let currentBundleMemo {
-                            memoCard(memo: currentBundleMemo)
-                                .padding(.top, 16)
-                        }
+                            .padding(.top, 12)
 
                         if isSigningRouteActive {
                             qrCodeSection(status: status)
-                                .padding(.top, bundleCount > 1 || currentBundleMemo != nil ? 24 : 32)
-
-                            instructionText(status: status)
-                                .padding(.top, 32)
+                                .padding(.top, 20)
                         }
+
+                        signingDetailsCard(
+                            current: currentBundle,
+                            total: bundleCount,
+                            signed: signedBundleCount,
+                            signedWeight: bundleWeights.signed,
+                            pendingWeight: bundleWeights.pending,
+                            memo: currentBundleMemo
+                        )
+                        .padding(.top, 24)
                     }
                     .padding(.horizontal, 24)
+                    .padding(.bottom, 24)
                 }
 
-                Spacer()
+                Spacer(minLength: 0)
 
                 if isSigningRouteActive {
                     actionButtons(status: status)
@@ -84,7 +84,7 @@ struct DelegationSigningView: View {
                 }
             }
             .applyScreenBackground()
-            .screenTitle(String(localizable: .coinVoteCommonConfirmation))
+            .screenTitle(String(localizable: .coinVoteDelegationSigningTitle))
             .zashiBack {
                 store.send(.delegationRejected(roundId: roundId))
             }
@@ -97,19 +97,16 @@ struct DelegationSigningView: View {
         }
     }
 
-    // MARK: - Keystone device card
+    // MARK: - Keystone Device
 
     @ViewBuilder
     private func keystoneDeviceCard() -> some View {
         HStack(spacing: 0) {
-            Asset.Assets.Partners.keystoneLogo.image
+            Asset.Assets.Brandmarks.brandmarkKeystone.image
                 .resizable()
-                .frame(width: 24, height: 24)
-                .padding(8)
-                .background {
-                    Circle().fill(Design.Surfaces.bgAlt.color(colorScheme))
-                }
-                .padding(.trailing, 12)
+                .frame(width: 40, height: 40)
+                .clipShape(Circle())
+                .padding(.trailing, 16)
 
             VStack(alignment: .leading, spacing: 0) {
                 Text(localizable: .accountsKeystone)
@@ -117,7 +114,7 @@ struct DelegationSigningView: View {
 
                 if let address = store.selectedWalletAccount?.unifiedAddress {
                     Text(address)
-                        .zFont(fontFamily: .robotoMono, size: 12, style: Design.Text.tertiary)
+                        .zFont(size: 12, style: Design.Text.tertiary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
@@ -140,165 +137,213 @@ struct DelegationSigningView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
+        .frame(maxWidth: .infinity)
         .background {
             RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+                .fill(Design.Surfaces.bgPrimary.color(colorScheme))
+                .overlay {
+                    RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                        .stroke(Design.Surfaces.strokeSecondary.color(colorScheme), lineWidth: 1)
+                }
+        }
+    }
+
+    // MARK: - QR Code
+
+    @ViewBuilder
+    private func qrCodeSection(status: KeystoneSigningStatus) -> some View {
+        ZStack {
+            switch status {
+            case .idle, .preparingRequest:
+                qrStatusView(
+                    text: status == .preparingRequest
+                        ? String(localizable: .coinVoteDelegationSigningPreparingRequestEllipsis)
+                        : nil
+                )
+
+            case .awaitingSignature:
+                if let pczt = store.roundCache[roundId]?.pendingUnsignedDelegationPczt,
+                   let encoder = sdkSynchronizer.urEncoderForPCZT(pczt) {
+                    AnimatedQRCode(urEncoder: encoder, size: 216)
+                        .frame(width: 216, height: 216)
+                } else {
+                    qrStatusView(text: nil)
+                }
+
+            case .parsingSignature:
+                qrStatusView(text: String(localizable: .coinVoteDelegationSigningParsingSignatureEllipsis))
+
+            case .finalizingAuthorization:
+                qrStatusView(text: String(localizable: .coinVoteDelegationSigningFinalizingAuthorizationEllipsis))
+
+            case .failed(let message):
+                VStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.circle")
+                        .font(.system(size: 32))
+                        .foregroundStyle(Design.Utility.ErrorRed._500.color(colorScheme))
+
+                    Text(message)
+                        .zFont(.medium, size: 13, style: Design.Text.tertiary)
+                        .multilineTextAlignment(.center)
+                    }
+                    .padding(24)
+                }
+        }
+        .frame(width: 248, height: 248)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._3xl)
+                .fill(Design.Surfaces.bgPrimary.color(colorScheme))
+                .overlay {
+                    RoundedRectangle(cornerRadius: Design.Radius._3xl)
+                        .stroke(Design.Surfaces.strokeSecondary.color(colorScheme), lineWidth: 1)
+                }
         }
     }
 
     @ViewBuilder
-    private func multiBundleProgressCard(current: UInt32, total: UInt32) -> some View {
-        HStack {
-            Text(localizable: .coinVoteDelegationSigningCurrentBundleProgress(String(current + 1), String(total)))
-                .zFont(.semiBold, size: 14, style: Design.Text.primary)
-            Spacer()
+    private func qrStatusView(text: String?) -> some View {
+        VStack(spacing: 8) {
+            ProgressView()
+            if let text {
+                Text(text)
+                    .zFont(.medium, size: 13, style: Design.Text.tertiary)
+                    .multilineTextAlignment(.center)
+            }
         }
-        .padding(Design.Spacing._xl)
-        .frame(maxWidth: .infinity)
-        .background(Design.Surfaces.bgPrimary.color(colorScheme))
-        .clipShape(RoundedRectangle(cornerRadius: Design.Radius._2xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                .stroke(Design.Surfaces.strokeSecondary.color(colorScheme), lineWidth: 1)
-        )
+        .frame(width: 216, height: 216)
+    }
+
+    // MARK: - Signing Details
+
+    @ViewBuilder
+    private func signingDetailsCard(
+        current: UInt32,
+        total: UInt32,
+        signed: UInt32,
+        signedWeight: UInt64,
+        pendingWeight: UInt64,
+        memo: String?
+    ) -> some View {
+        VStack(spacing: 0) {
+            signatureProgressSection(
+                current: current,
+                total: total,
+                signed: signed,
+                signedWeight: signedWeight,
+                pendingWeight: pendingWeight
+            )
+
+            if canUseSignedBundlesOnly(signed: signed, total: total) {
+                detailsDivider()
+                useSignedBundlesOnlyRow(pendingWeight: pendingWeight)
+            }
+
+            if let memo {
+                detailsDivider()
+                memoSection(memo)
+            }
+        }
+        .background(Design.Surfaces.bgSecondary.color(colorScheme))
+        .clipShape(RoundedRectangle(cornerRadius: Design.Radius._xl))
     }
 
     @ViewBuilder
-    private func memoCard(memo: String) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private func signatureProgressSection(
+        current: UInt32,
+        total: UInt32,
+        signed: UInt32,
+        signedWeight: UInt64,
+        pendingWeight: UInt64
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Text(localizable: .coinVoteDelegationSigningCurrentBundleProgress(
+                    String(Self.displayBundleNumber(current: current, total: total)),
+                    String(max(total, 1))
+                ))
+                .zFont(.medium, size: 14, style: Design.Text.primary)
+
+                Spacer(minLength: 8)
+
+                Text(localizable: .coinVoteDelegationSigningSignedProgress(String(signed), String(max(total, 1))))
+                    .zFont(.medium, size: 12, style: Design.Utility.HyperBlue._700)
+                    .lineLimit(1)
+                    .padding(.vertical, 2)
+                    .padding(.horizontal, 8)
+                    .background {
+                        Capsule()
+                            .fill(Design.Utility.HyperBlue._50.color(colorScheme))
+                            .overlay {
+                                Capsule()
+                                    .stroke(Design.Utility.HyperBlue._200.color(colorScheme), lineWidth: 1)
+                            }
+                    }
+            }
+
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Design.Surfaces.bgQuaternary.color(colorScheme))
+                    Capsule()
+                        .fill(Design.Text.primary.color(colorScheme))
+                        .frame(width: geometry.size.width * Self.bundleShare(total: total))
+                }
+            }
+            .frame(height: 6)
+
+            Text(weightSummary(signed: signed, signedWeight: signedWeight, pendingWeight: pendingWeight))
+                .zFont(size: 12, style: Design.Text.tertiary)
+                .lineLimit(1)
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private func useSignedBundlesOnlyRow(pendingWeight: UInt64) -> some View {
+        Button {
+            store.send(.skipRemainingKeystoneBundles(roundId: roundId))
+        } label: {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(localizable: .coinVoteDelegationSigningUseSignedBundlesOnly)
+                        .zFont(.medium, size: 14, style: Design.Text.primary)
+                        .lineLimit(1)
+
+                    Text(localizable: .coinVoteDelegationSigningUseSignedBundlesOnlySubtitle(Self.formatZec(pendingWeight)))
+                        .zFont(size: 12, style: Design.Text.tertiary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                Asset.Assets.chevronRight.image
+                    .zImage(size: 20, style: Design.Text.primary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, minHeight: 60)
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func memoSection(_ memo: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
             Text(localizable: .coinVoteDelegationSigningMemo)
                 .zFont(size: 14, style: Design.Text.tertiary)
 
             Text(memo)
-                .zFont(.medium, size: 13, style: Design.Text.primary)
+                .zFont(.medium, size: 12, style: Design.Text.primary)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .padding(Design.Spacing._xl)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Design.Surfaces.bgPrimary.color(colorScheme))
-        .clipShape(RoundedRectangle(cornerRadius: Design.Radius._2xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                .stroke(Design.Surfaces.strokeSecondary.color(colorScheme), lineWidth: 1)
-        )
     }
 
-    // MARK: - QR
-
-    @ViewBuilder
-    private func qrCodeSection(status: KeystoneSigningStatus) -> some View {
-        switch status {
-        case .idle, .preparingRequest:
-            VStack {
-                ProgressView()
-                    .padding(.bottom, 8)
-                if case .preparingRequest = status {
-                    Text(localizable: .coinVoteDelegationSigningPreparingRequestEllipsis)
-                        .zFont(.medium, size: 13, style: Design.Text.tertiary)
-                        .multilineTextAlignment(.center)
-                }
-            }
-            .frame(width: 216, height: 216)
-            .padding(24)
-            .background {
-                RoundedRectangle(cornerRadius: Design.Radius._xl)
-                    .fill(Asset.Colors.ZDesign.Base.bone.color)
-                    .background {
-                        RoundedRectangle(cornerRadius: Design.Radius._xl)
-                            .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
-                    }
-            }
-
-        case .awaitingSignature:
-            if let pczt = store.roundCache[roundId]?.pendingUnsignedDelegationPczt,
-               let encoder = sdkSynchronizer.urEncoderForPCZT(pczt) {
-                AnimatedQRCode(urEncoder: encoder, size: 216)
-                    .padding(24)
-                    .background {
-                        RoundedRectangle(cornerRadius: Design.Radius._xl)
-                            .fill(Asset.Colors.ZDesign.Base.bone.color)
-                            .background {
-                                RoundedRectangle(cornerRadius: Design.Radius._xl)
-                                    .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
-                            }
-                    }
-            } else {
-                ProgressView()
-                    .frame(width: 216, height: 216)
-            }
-
-        case .parsingSignature:
-            VStack {
-                ProgressView()
-                Text(localizable: .coinVoteDelegationSigningParsingSignatureEllipsis)
-                    .zFont(.medium, size: 13, style: Design.Text.tertiary)
-                    .multilineTextAlignment(.center)
-                    .padding(.top, 8)
-            }
-            .frame(width: 216, height: 216)
-            .padding(24)
-            .background {
-                RoundedRectangle(cornerRadius: Design.Radius._xl)
-                    .fill(Asset.Colors.ZDesign.Base.bone.color)
-                    .background {
-                        RoundedRectangle(cornerRadius: Design.Radius._xl)
-                            .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
-                    }
-            }
-
-        case .finalizingAuthorization:
-            VStack {
-                ProgressView()
-                Text(localizable: .coinVoteDelegationSigningFinalizingAuthorizationEllipsis)
-                    .zFont(.medium, size: 13, style: Design.Text.tertiary)
-                    .multilineTextAlignment(.center)
-                    .padding(.top, 8)
-            }
-            .frame(width: 216, height: 216)
-            .padding(24)
-            .background {
-                RoundedRectangle(cornerRadius: Design.Radius._xl)
-                    .fill(Asset.Colors.ZDesign.Base.bone.color)
-                    .background {
-                        RoundedRectangle(cornerRadius: Design.Radius._xl)
-                            .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
-                    }
-            }
-
-        case .failed(let message):
-            VStack {
-                Image(systemName: "exclamationmark.circle")
-                    .font(.system(size: 32))
-                    .foregroundStyle(Design.Utility.ErrorRed._500.color(colorScheme))
-                    .padding(.bottom, 8)
-                Text(message)
-                    .zFont(.medium, size: 13, style: Design.Text.tertiary)
-                    .multilineTextAlignment(.center)
-            }
-            .frame(width: 216, height: 216)
-            .padding(24)
-            .background {
-                RoundedRectangle(cornerRadius: Design.Radius._xl)
-                    .fill(Asset.Colors.ZDesign.Base.bone.color)
-                    .background {
-                        RoundedRectangle(cornerRadius: Design.Radius._xl)
-                            .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
-                    }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func instructionText(status: KeystoneSigningStatus) -> some View {
-        switch status {
-        case .awaitingSignature:
-            Text(localizable: .coinVoteDelegationSigningScanSignedPCZTInstruction)
-                .zFont(.medium, size: 14, style: Design.Text.primary)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-        default:
-            EmptyView()
-        }
+    private func detailsDivider() -> some View {
+        Design.Surfaces.strokeSecondary.color(colorScheme)
+            .frame(height: 1)
     }
 
     // MARK: - Memo
@@ -321,6 +366,66 @@ struct DelegationSigningView: View {
         return votingAuthorizationMemo(pollTitle: pollTitle, rawWeight: bundleTotal)
     }
 
+    private static func bundleWeightSummary(session: RoundSession?) -> (signed: UInt64, pending: UInt64) {
+        guard let session else { return (0, 0) }
+
+        let bundles = session.walletNotes.smartBundles().bundles
+        let signedCount = min(session.keystoneBundleSignatures.count, bundles.count)
+        let countedBundleCount = min(Int(session.bundleCount), bundles.count)
+        var signed: UInt64 = 0
+        var pending: UInt64 = 0
+
+        for index in 0..<countedBundleCount {
+            let rawWeight = bundles[index].reduce(UInt64(0)) { $0 + $1.value }
+            if index < signedCount {
+                signed += quantizeWeight(rawWeight)
+            } else {
+                pending += quantizeWeight(rawWeight)
+            }
+        }
+
+        return (signed, pending)
+    }
+
+    private static func formatZec(_ zatoshi: UInt64) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 3
+        formatter.maximumFractionDigits = 3
+        formatter.usesGroupingSeparator = true
+
+        let value = Double(zatoshi) / 100_000_000.0
+        return formatter.string(from: NSNumber(value: value)) ?? "0.000"
+    }
+
+    private static func displayBundleNumber(current: UInt32, total: UInt32) -> UInt32 {
+        guard total > 0 else { return 1 }
+        return min(current + 1, total)
+    }
+
+    private static func bundleShare(total: UInt32) -> Double {
+        guard total > 0 else { return 0 }
+        return min(1, 1 / Double(total))
+    }
+
+    private func weightSummary(signed: UInt32, signedWeight: UInt64, pendingWeight: UInt64) -> String {
+        if signed == 0 {
+            return String(localizable: .coinVoteDelegationSigningAwaitingWeightSummary(
+                Self.formatZec(signedWeight),
+                Self.formatZec(pendingWeight)
+            ))
+        }
+
+        return String(localizable: .coinVoteDelegationSigningSignedWeightSummary(
+            Self.formatZec(signedWeight),
+            Self.formatZec(pendingWeight)
+        ))
+    }
+
+    private func canUseSignedBundlesOnly(signed: UInt32, total: UInt32) -> Bool {
+        total > 1 && signed > 0 && signed < total
+    }
+
     private static func isSigningRouteActive(
         _ path: StackState<VotingCoordFlow.Path.State>,
         roundId: String
@@ -339,19 +444,8 @@ struct DelegationSigningView: View {
     private func actionButtons(status: KeystoneSigningStatus) -> some View {
         switch status {
         case .awaitingSignature:
-            VStack(spacing: 12) {
-                ZashiButton(String(localizable: .coinVoteDelegationSigningScanSignedPCZTCTA)) {
-                    store.send(.openKeystoneSignatureScan)
-                }
-                if (store.roundCache[roundId]?.bundleCount ?? 0) > 1
-                    && !(store.roundCache[roundId]?.keystoneBundleSignatures.isEmpty ?? true) {
-                    ZashiButton(
-                        String(localizable: .coinVoteDelegationSigningSkipRemainingBundlesCTA),
-                        type: .tertiary
-                    ) {
-                        store.send(.skipRemainingKeystoneBundles(roundId: roundId))
-                    }
-                }
+            ZashiButton(String(localizable: .coinVoteDelegationSigningScanSignature)) {
+                store.send(.openKeystoneSignatureScan)
             }
         case .failed:
             ZashiButton(String(localizable: .coinVoteCommonGoBack)) {

--- a/secantTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/secantTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -418,12 +418,12 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
 
         store.send(.keystoneScan(.presented(.foundVotingDelegationPCZT(Data([0x0A])))))
         await waitForStore {
-            store.state.keystoneSignatureRejectionAlert == .keystoneSignatureRejected(expectedMessage)
+            store.state.keystoneSignatureRejectionSheet?.message == expectedMessage
         }
 
         let session = tryUnwrap(store.state.roundCache[roundId])
         XCTAssertNil(store.state.keystoneScan)
-        XCTAssertEqual(store.state.keystoneSignatureRejectionAlert, .keystoneSignatureRejected(expectedMessage))
+        XCTAssertEqual(store.state.keystoneSignatureRejectionSheet?.message, expectedMessage)
         XCTAssertEqual(session.keystoneSigningStatus, .awaitingSignature)
         XCTAssertEqual(session.currentKeystoneBundleIndex, 1)
         XCTAssertNotNil(session.pendingVotingPczt)
@@ -450,12 +450,12 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
 
         store.send(.keystoneScan(.presented(.foundVotingDelegationPCZT(Data([0x0B])))))
         await waitForStore {
-            store.state.keystoneSignatureRejectionAlert == .keystoneSignatureRejected(expectedMessage)
+            store.state.keystoneSignatureRejectionSheet?.message == expectedMessage
         }
 
         let session = tryUnwrap(store.state.roundCache[roundId])
         XCTAssertNil(store.state.keystoneScan)
-        XCTAssertEqual(store.state.keystoneSignatureRejectionAlert, .keystoneSignatureRejected(expectedMessage))
+        XCTAssertEqual(store.state.keystoneSignatureRejectionSheet?.message, expectedMessage)
         XCTAssertEqual(session.keystoneSigningStatus, .awaitingSignature)
         XCTAssertEqual(session.currentKeystoneBundleIndex, 1)
         XCTAssertNotNil(session.pendingVotingPczt)


### PR DESCRIPTION
## Summary

- Matches the Keystone voting confirmation details to the Figma design.
- Reworks the Keystone bundle signing screen around the Figma layout.
- Keeps the existing per-bundle memo implementation intact, so the memo shown in
  the app should continue to match what Keystone displays for each bundle.

## Handoff note

I am sharing this draft with @LukasKorba because Lukas is taking over the
implementation. This gives him a concrete snapshot to decide whether to build on
top of this work or restart from scratch.

This is not a release blocker. It can be treated as a quick follow-up if the
current release path is already locked.

## Verification

- Built zashi-internal for the iOS simulator with code signing disabled.
- Ran focused voting tests:
  - VotingCoordFlowCoordinatorTests
  - VotingHelpersTests
- Result: 23 tests passed, 0 failures.