### PR TITLE
[#MOB-1105] Zashi 3.5.0 release notes: Coinholder Polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+## 3.5.0 build 1 (2026-05-27)
+
+### Added
+- Coinholder Polling lets you vote on Zcash governance privately, right from your Zodl and Keystone wallets.
+
 ## 3.4.1 build 1 (2026-05-18)
 
 ### Changed

--- a/secant/Resources/WhatsNew/whatsNew.json
+++ b/secant/Resources/WhatsNew/whatsNew.json
@@ -1,6 +1,19 @@
 {
     "releases": [
         {
+            "version": "3.5.0",
+            "date": "27-05-2026",
+            "timestamp": 1779388800,
+            "sections": [
+                {
+                    "title": "Added:",
+                    "bulletpoints": [
+                        "Coinholder Polling lets you vote on Zcash governance privately, right from your Zodl and Keystone wallets."
+                    ]
+                }
+            ]
+        },
+        {
             "version": "3.4.1",
             "date": "18-05-2026",
             "timestamp": 1778606653,

--- a/secant/Resources/WhatsNew/whatsNew_es.json
+++ b/secant/Resources/WhatsNew/whatsNew_es.json
@@ -1,6 +1,19 @@
 {
     "releases": [
         {
+            "version": "3.5.0",
+            "date": "27-05-2026",
+            "timestamp": 1779388800,
+            "sections": [
+                {
+                    "title": "Añadido:",
+                    "bulletpoints": [
+                        "Coinholder Polling te permite votar en la gobernanza de Zcash de forma privada, directamente desde tus billeteras Zodl y Keystone."
+                    ]
+                }
+            ]
+        },
+        {
             "version": "3.4.1",
             "date": "18-05-2026",
             "timestamp": 1778606653,


### PR DESCRIPTION
## Summary

Release notes for the 3.5.0 build that introduces Coinholder Polling.

- \`CHANGELOG.md\` — new 3.5.0 entry with the headline "Added" bullet.
- \`secant/Resources/WhatsNew/whatsNew.json\` — EN release section.
- \`secant/Resources/WhatsNew/whatsNew_es.json\` — ES release section.

Both What's New JSON files validated; project still builds clean.

## Test plan

- [ ] On a fresh install / update, the What's New sheet renders the 3.5.0 entry with the Coinholder Polling bullet (EN locale).
- [ ] Same on a Spanish device — the ES copy ("Añadido: …directamente desde tus billeteras Zodl y Keystone.") renders.
- [ ] Changelog file in the repo lists 3.5.0 above 3.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)