### PR TITLE
[#MOB-1318] Voting: fix reported UI issues in the polling flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Changed
 - Default server set to zec.rocks.
 
+### Added
+- Tapping Enter Poll on a poll from a custom (unverified) data source now surfaces an "Unverified Poll" warning sheet, letting you go back or proceed at your own risk.
+
+### Fixed
+- We fixed the Coinholder Polling review screen so it now shows "Voted <date>" once you've submitted your ballot, instead of the round's upcoming end date.
+- We removed an unused "Review your submitted votes" subtitle from the Coinholder Polling review screen header to match the design.
+- We suppressed the Coinholder Polling "Poll Closed" sheet for users who already submitted their ballot — telling someone they can no longer vote right after voting is just noise.
+- We corrected the tally-bar colors on the Coinholder Polling answers screen: green for Yes/Support, red for No/Oppose, gray for Abstain, blue for everything else — matching the rest of the voting screens.
+- We now show a specific message when an attempt to vote fails because the same wallet has already voted from another device, instead of the generic "Check your connection" copy.
+
 ## 3.5.0 build 1 (2026-05-27)
 
 ### Added

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -4342,6 +4342,57 @@
         }
       }
     },
+    "coinVote.pollsList.unverifiedSheetMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
+          }
+        }
+      }
+    },
+    "coinVote.pollsList.unverifiedSheetProceed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proceed anyway"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proceed anyway"
+          }
+        }
+      }
+    },
+    "coinVote.pollsList.unverifiedSheetTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unverified Poll"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unverified Poll"
+          }
+        }
+      }
+    },
     "coinVote.pollsList.viewMyVotes" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4627,23 +4678,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Preparing your voting power…"
-          }
-        }
-      }
-    },
-    "coinVote.proposalList.reviewSubmitted" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review your submitted votes"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review your submitted votes"
           }
         }
       }

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -1209,10 +1209,18 @@ extension VotingCoordFlow {
                     session: session(item.session, withStatus: status)
                 )
 
+                // "Poll Closed" sheet is suppressed if the user has already
+                // submitted a ballot for this round — telling someone "your
+                // vote can no longer be submitted" right after they voted is
+                // jarring. In that case we silently swap their current screen
+                // for the appropriate status screen instead.
+                let hasVoted = state.voteRecords[roundId] != nil
+                    || state.roundCache[roundId]?.voteRecord != nil
+
                 switch status {
                 case .tallying:
                     let isCurrentRound = topPathRoundId(state) == roundId
-                    if activeVotingFlowRoundId(state) == roundId {
+                    if activeVotingFlowRoundId(state) == roundId, !hasVoted {
                         state.pollClosedSheet = State.PollClosedSheet(roundId: roundId, status: status)
                     } else if isCurrentRound {
                         replacePathWithStatusScreen(&state, roundId: roundId, status: status)
@@ -1226,7 +1234,7 @@ extension VotingCoordFlow {
 
                 case .finalized:
                     let isCurrentRound = topPathRoundId(state) == roundId
-                    if activeVotingFlowRoundId(state) == roundId {
+                    if activeVotingFlowRoundId(state) == roundId, !hasVoted {
                         state.pollClosedSheet = State.PollClosedSheet(roundId: roundId, status: status)
                     } else if isCurrentRound {
                         replacePathWithStatusScreen(&state, roundId: roundId, status: status)
@@ -2916,7 +2924,10 @@ extension VotingCoordFlow {
             }
             await backgroundTask.endTask(bgTaskId)
         } catch: { error, send in
-            await send(.delegationProofFailed(roundId: roundId, error: error.localizedDescription))
+            await send(.delegationProofFailed(
+                roundId: roundId,
+                error: VotingErrorMapper.userFriendlyMessage(from: error.localizedDescription)
+            ))
         }
         .cancellable(id: cancelDelegationProofId, cancelInFlight: true)
     }
@@ -2961,7 +2972,10 @@ extension VotingCoordFlow {
             try await votingCrypto.deleteSkippedBundles(roundId, signedCount)
             await send(.keystoneAllBundlesSigned(roundId: roundId))
         } catch: { error, send in
-            await send(.delegationProofFailed(roundId: roundId, error: error.localizedDescription))
+            await send(.delegationProofFailed(
+                roundId: roundId,
+                error: VotingErrorMapper.userFriendlyMessage(from: error.localizedDescription)
+            ))
         }
     }
 

--- a/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
+++ b/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
@@ -71,7 +71,10 @@ struct ConfirmSubmissionView: View {
             .votingSheet(
                 isPresented: authorizationFailedBinding(status: status),
                 title: String(localizable: .coinVoteConfirmSubmissionAuthorizationFailedTitle),
-                message: String(localizable: .coinVoteConfirmSubmissionAuthorizationFailedMessage),
+                message: failureMessage(
+                    status: status,
+                    fallback: String(localizable: .coinVoteConfirmSubmissionAuthorizationFailedMessage)
+                ),
                 primary: .init(title: String(localizable: .coinVoteCommonTryAgain), style: .primary) {
                     store.send(.retryBatchSubmission(roundId: roundId))
                 },
@@ -83,7 +86,10 @@ struct ConfirmSubmissionView: View {
             .votingSheet(
                 isPresented: submissionFailedBinding(status: status),
                 title: String(localizable: .coinVoteConfirmSubmissionSubmissionFailedTitle),
-                message: String(localizable: .coinVoteConfirmSubmissionSubmissionFailedMessage),
+                message: failureMessage(
+                    status: status,
+                    fallback: String(localizable: .coinVoteConfirmSubmissionSubmissionFailedMessage)
+                ),
                 primary: .init(title: String(localizable: .coinVoteCommonTryAgain), style: .primary) {
                     store.send(.retryBatchSubmission(roundId: roundId))
                 },
@@ -378,6 +384,24 @@ struct ConfirmSubmissionView: View {
                 }
             }
         )
+    }
+
+    /// The reducer pre-maps backend errors through `VotingErrorMapper` before
+    /// storing them in `BatchSubmissionStatus`, so when a specific user-friendly
+    /// string is available (e.g. the "nullifier already spent" → "wallet already
+    /// registered" copy) it lives directly on the status. Fall back to the
+    /// generic sheet copy only when no error string was carried.
+    private func failureMessage(status: BatchSubmissionStatus, fallback: String) -> String {
+        let storedError: String
+        switch status {
+        case .authorizationFailed(let error):
+            storedError = error
+        case .submissionFailed(let error, _, _):
+            storedError = error
+        default:
+            return fallback
+        }
+        return storedError.isEmpty ? fallback : storedError
     }
 
     // MARK: - Helpers

--- a/secant/Sources/Features/Voting/PollsList/PollsListView.swift
+++ b/secant/Sources/Features/Voting/PollsList/PollsListView.swift
@@ -19,6 +19,12 @@ struct PollsListView: View {
     @State private var loadErrorSheetPresented = true
     @State private var dismissFlowAfterLoadErrorSheetDismiss = false
 
+    /// Round id queued for entry while the "Unverified Poll" warning sheet
+    /// is showing. Set when the user taps Enter Poll on a card from a
+    /// non-default (custom) data source, then either consumed by
+    /// "Proceed anyway" or dropped by "Go back".
+    @State private var unverifiedWarningRoundId: String?
+
     let store: StoreOf<VotingCoordFlow>
 
     var body: some View {
@@ -87,7 +93,32 @@ struct PollsListView: View {
                 },
                 secondary: nil
             )
+            .votingSheet(
+                isPresented: unverifiedWarningBinding,
+                title: String(localizable: .coinVotePollsListUnverifiedSheetTitle),
+                message: String(localizable: .coinVotePollsListUnverifiedSheetMessage),
+                primary: .init(title: String(localizable: .coinVoteCommonGoBack), style: .primary) {
+                    unverifiedWarningRoundId = nil
+                },
+                secondary: .init(title: String(localizable: .coinVotePollsListUnverifiedSheetProceed), style: .secondary) {
+                    if let roundId = unverifiedWarningRoundId {
+                        unverifiedWarningRoundId = nil
+                        store.send(.roundTapped(roundId))
+                    }
+                }
+            )
         }
+    }
+
+    private var unverifiedWarningBinding: Binding<Bool> {
+        Binding(
+            get: { unverifiedWarningRoundId != nil },
+            set: { newValue in
+                if !newValue {
+                    unverifiedWarningRoundId = nil
+                }
+            }
+        )
     }
 
     private var ineligibleSheetBinding: Binding<Bool> {
@@ -456,6 +487,13 @@ struct PollsListView: View {
     private func tapPollCard(for item: RoundListItem, state: CardState) {
         switch state {
         case .active:
+            // On a custom (non-default) data source we can't confirm the
+            // poll's legitimacy from the bundled Zodl endorsement set, so
+            // warn the user before pushing them into the voting pipeline.
+            if !store.isOnDefaultConfig {
+                unverifiedWarningRoundId = item.id
+                return
+            }
             store.send(.roundTapped(item.id))
         case .voted:
             store.send(.viewMyVotesTapped(roundId: item.id))

--- a/secant/Sources/Features/Voting/ProposalList/ProposalListView.swift
+++ b/secant/Sources/Features/Voting/ProposalList/ProposalListView.swift
@@ -51,9 +51,10 @@ struct ProposalListView: View {
             let item = store.allRounds.first { $0.id == roundId }
             let proposals = item?.session.proposals ?? []
             let session = store.roundCache[roundId]
+            let voteRecord = session?.voteRecord ?? store.voteRecords[roundId]
             let weight = displayWeight(
                 session: session,
-                voteRecord: session?.voteRecord ?? store.voteRecords[roundId]
+                voteRecord: voteRecord
             )
             let pipelineReady = session?.hotkeyAddress != nil && (session?.bundleCount ?? 0) > 0
             let drafts = session?.draftVotes ?? [:]
@@ -77,6 +78,7 @@ struct ProposalListView: View {
                                 description: item?.session.description ?? "",
                                 snapshotHeight: item?.session.snapshotHeight ?? 0,
                                 voteEndTime: item?.session.voteEndTime ?? Date(),
+                                votedAt: voteRecord?.votedAt,
                                 weight: weight,
                                 ready: mode == .review || pipelineReady
                             )
@@ -148,6 +150,7 @@ struct ProposalListView: View {
         description: String,
         snapshotHeight: UInt64,
         voteEndTime: Date,
+        votedAt: Date?,
         weight: UInt64,
         ready: Bool
     ) -> some View {
@@ -168,11 +171,14 @@ struct ProposalListView: View {
             // Row 2: end date + voting power.
             // While the pipeline is still preparing, show the spinner row
             // instead so the user knows their voting power is being computed.
+            // Once the user has voted (review mode + persisted vote record),
+            // swap "Ends <date>" for "Voted <date>" using the locally-stored
+            // `votedAt` from the encrypted metadata.
             if ready {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text("\(String(localizable: .coinVoteProposalListHeaderEndsAt(formattedEndDate(voteEndTime)))) · ")
+                    Text("\(headerDateText(voteEndTime: voteEndTime, votedAt: votedAt)) · ")
                     Text("\(String(localizable: .coinVoteProposalListVotingPower(formattedZec(zatoshi: weight)))) ZEC")
-                    
+
                     Spacer()
                 }
                 .zFont(.medium, size: 12, style: Design.Text.tertiary)
@@ -195,11 +201,6 @@ struct ProposalListView: View {
             if !description.isEmpty {
                 ExpandableText(text: description, collapsedLineLimit: 2)
             }
-
-            if mode == .review {
-                Text(localizable: .coinVoteProposalListReviewSubmitted)
-                    .zFont(.medium, size: 14, style: Design.Text.tertiary)
-            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom, 8)
@@ -210,6 +211,16 @@ struct ProposalListView: View {
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("MMMdyyyy")
         return formatter.string(from: date)
+    }
+
+    /// Header date cell copy. In review mode (i.e. the user has fully
+    /// submitted a ballot) we surface the locally-known `votedAt` as
+    /// "Voted <date>"; otherwise we fall back to the upcoming end date.
+    private func headerDateText(voteEndTime: Date, votedAt: Date?) -> String {
+        if mode == .review, let votedAt {
+            return String(localizable: .coinVoteCommonVotedDate(formattedEndDate(votedAt)))
+        }
+        return String(localizable: .coinVoteProposalListHeaderEndsAt(formattedEndDate(voteEndTime)))
     }
 
     /// Voting power is stored as UInt64 zatoshi; the header copy shows ZEC.

--- a/secant/Sources/Features/Voting/Results/ResultsView.swift
+++ b/secant/Sources/Features/Voting/Results/ResultsView.swift
@@ -366,11 +366,11 @@ struct ResultsView: View {
         }
     }
 
-    /// Inline restoration of the legacy `tallyEntryColor` helper that lived
-    /// in the deleted `VotingComponents.swift`. Looks the option up on the
-    /// proposal so Abstain stays HyperBlue; falls back to a synthetic
-    /// `VoteOption` for entries whose decision index isn't in
-    /// `proposal.options` (e.g. legacy Support/Oppose).
+    /// Pick the tally-bar color for an option. Looks the option up on the
+    /// proposal so the label-based mapping in `voteOptionColor` can fire;
+    /// falls back to a synthetic `VoteOption` for entries whose decision
+    /// index isn't in `proposal.options` (e.g. legacy Support / Oppose
+    /// rounds).
     private func tallyEntryColor(
         decision: UInt32,
         proposal: VotingProposal,
@@ -378,42 +378,30 @@ struct ResultsView: View {
     ) -> Color {
         let option = proposal.options.first { $0.index == decision }
             ?? VoteOption(index: decision, label: fallbackLabel)
-        return Self.voteOptionColor(
-            for: option,
-            total: proposal.options.count,
-            colorScheme: colorScheme
-        )
+        return Self.voteOptionColor(for: option, colorScheme: colorScheme)
     }
 
-    /// Inline restoration of the legacy `voteOptionColor` palette. Abstain
-    /// is HyperBlue regardless of how many options the proposal has so the
-    /// color stays stable. Two-option proposals keep the classic green
-    /// (Support) / red (Oppose) look. 3+ non-abstain options rotate
-    /// through a palette that deliberately excludes HyperBlue.
-    static func voteOptionColor(
-        for option: VoteOption,
-        total: Int,
-        colorScheme: ColorScheme
-    ) -> Color {
-        if option.label.localizedCaseInsensitiveContains("abstain") {
-            return Design.Utility.HyperBlue._700.color(colorScheme)
+    /// Color mapping per product spec:
+    ///   • Yes / Support → SuccessGreen
+    ///   • No  / Oppose  → ErrorRed
+    ///   • Abstain       → Gray
+    ///   • everything else → HyperBlue
+    /// Mirrors `ProposalListView.pillTone(for:)` so the same answer renders
+    /// with the same color across the voting screens.
+    /// Matches against the literal English option label until the voting
+    /// metadata exposes a typed option-kind (same caveat as
+    /// `ProposalListView.pillTone`).
+    static func voteOptionColor(for option: VoteOption, colorScheme: ColorScheme) -> Color {
+        switch option.label.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "yes", "support":
+            return Design.Utility.SuccessGreen._500.color(colorScheme)
+        case "no", "oppose":
+            return Design.Utility.ErrorRed._500.color(colorScheme)
+        case "abstain":
+            return Design.Utility.Gray._500.color(colorScheme)
+        default:
+            return Design.Utility.HyperBlue._500.color(colorScheme)
         }
-        if total == 2 {
-            return option.index == 0
-                ? Design.Utility.SuccessGreen._500.color(colorScheme)
-                : Design.Utility.ErrorRed._500.color(colorScheme)
-        }
-        let palette: [Color] = [
-            Design.Utility.SuccessGreen._500.color(colorScheme),
-            Design.Utility.ErrorRed._500.color(colorScheme),
-            Design.Utility.Purple._500.color(colorScheme),
-            Design.Utility.WarningYellow._500.color(colorScheme),
-            Design.Utility.Indigo._500.color(colorScheme),
-            Design.Utility.Brand._500.color(colorScheme),
-            Design.Utility.Gray._500.color(colorScheme),
-            Design.Utility.Indigo._700.color(colorScheme)
-        ]
-        return palette[Int(option.index) % palette.count]
     }
 
     // MARK: - ZEC formatting

--- a/secant/Sources/Features/Voting/VotingHelpers.swift
+++ b/secant/Sources/Features/Voting/VotingHelpers.swift
@@ -418,7 +418,11 @@ enum VotingErrorMapper {
 
     // swiftlint:disable:next cyclomatic_complexity
     static func userFriendlyMessage(from rawError: String) -> String {
-        if rawError.contains("nullifier already spent") {
+        // Mirrors Android (`VotingErrorMapper.kt`): both substrings,
+        // case-insensitive — robust to wording variants like
+        // "Nullifier was already spent" vs "nullifier already spent".
+        if rawError.localizedCaseInsensitiveContains("nullifier")
+            && rawError.localizedCaseInsensitiveContains("spent") {
             return String(localizable: .coinVoteStoreUserErrorNullifierAlreadySpent)
         }
         if rawError.contains("vote round is not active") {


### PR DESCRIPTION
## Summary

Bundled fixes for six UI/UX issues reported against the Coinholder Polling flow after the 3.5.0 release.

- **Review screen header** — shows "Voted <date>" once a ballot is submitted, using the locally persisted `votedAt` from the encrypted vote metadata, instead of the round's upcoming end date.
- **Review screen subtitle removed** — dropped the unused "Review your submitted votes" line to match the design.
- **Unverified poll warning sheet** — tapping Enter Poll on a poll from a custom (non-default) data source now surfaces a Figma-matched warning sheet with Go back (primary) / Proceed anyway (secondary). Brings iOS to parity with Android.
- **Poll Closed sheet gated by `hasVoted`** — the post-deadline "your vote can no longer be submitted" sheet is now suppressed for users who already submitted their ballot. Telling someone they can't vote right after voting is just noise.
- **Tally-bar colors on the answers screen** — green for Yes/Support, red for No/Oppose, gray for Abstain, blue for everything else. Matches the product/design guidance and the rest of the voting screens.
- **Specific error when the same wallet already voted from another device** — when the backend returns a nullifier-already-spent error during authorization/submission, the sheet now shows the dedicated "wallet already registered for this voting round" copy instead of the generic "Check your connection and try again." Mirrors Android: detection now uses case-insensitive `contains("nullifier") && contains("spent")`; the two Keystone-flow `delegationProofFailed` sites now pre-map through `VotingErrorMapper` so `BatchSubmissionStatus.authorizationFailed(error:)` consistently carries a user-friendly string; the view shows that string directly and falls back to the generic copy only when empty.

## Test plan

- [ ] Vote on a poll, return to the review screen — header reads "Voted <date>", no "Review your submitted votes" subtitle present.
- [ ] Configure a custom (non-default) voting data source, tap Enter Poll on any poll — warning sheet appears with Go back / Proceed anyway; Go back returns to the list; Proceed anyway enters the poll.
- [ ] Let a round transition to `.tallying`/`.finalized` while not having voted — Poll Closed sheet appears as before. After voting, transition the round — Poll Closed sheet is suppressed.
- [ ] Open the answers screen on a poll with Yes/No/Abstain options — Yes is green, No is red, Abstain is gray, custom labels render blue.
- [ ] On a Zashi wallet, vote on round X from device A, then attempt to vote on the same wallet on device B — failure sheet shows "This wallet has already been registered for this voting round..." copy (EN + ES).
- [ ] Repeat the same scenario with a Keystone wallet (covers the `:2927` Keystone delegation-proof path) — same specific copy.
- [ ] Other voting-failure paths (e.g. unreachable lightwalletd) still show their existing user-friendly messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)