### PR TITLE
[#MOB-1320] Voting: keep screen awake during submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Changed
 - Default server set to zec.rocks.
+- We now keep the screen awake while you're submitting Coinholder Polling votes — including the Keystone QR signing step — so the device doesn't lock mid-submission.
 
 ## 3.5.0 build 1 (2026-05-27)
 

--- a/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
+++ b/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
@@ -92,6 +92,15 @@ struct ConfirmSubmissionView: View {
                 },
                 visualStyle: .unverifiedWarning
             )
+            // Authorization + per-proposal submission can take several seconds
+            // to tens of seconds; if the device locks mid-flight the user is
+            // left with no visible progress and may not realize submission is
+            // continuing. Keep the display awake while we're working.
+            .onAppear { UIApplication.shared.isIdleTimerDisabled = status.isInFlight }
+            .onChange(of: status.isInFlight) { newValue in
+                UIApplication.shared.isIdleTimerDisabled = newValue
+            }
+            .onDisappear { UIApplication.shared.isIdleTimerDisabled = false }
         }
     }
 

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -114,6 +114,11 @@ struct DelegationSigningView: View {
                     }
                 }
             }
+            // While this screen is up the user typically steps away to fetch
+            // and use their Keystone — keep the display awake so the QR stays
+            // visible and the submission flow stays foregrounded.
+            .onAppear { UIApplication.shared.isIdleTimerDisabled = true }
+            .onDisappear { UIApplication.shared.isIdleTimerDisabled = false }
         }
     }
 


### PR DESCRIPTION
## Summary

Authorization + per-proposal vote submission can take several seconds to tens of seconds. If the device locks mid-flight the user loses visible progress, and the Keystone hand-off (PCZT prep → user scans signed QR back) can be interrupted because the screen sleeps while the user is fetching their hardware wallet. This change keeps the display awake unconditionally for the duration of the relevant screens.

- **`ConfirmSubmissionView`** — flips `UIApplication.shared.isIdleTimerDisabled` based on `BatchSubmissionStatus.isInFlight` (true while `.authorizing` / `.submitting`, false otherwise). `.onAppear` syncs with the current status (covers entering mid-flight), `.onChange(of: status.isInFlight)` toggles on transitions, `.onDisappear` always restores to `false` as a safety net.
- **`DelegationSigningView`** — keeps the display awake for the full lifetime of the Keystone QR signing screen via plain `.onAppear` / `.onDisappear`. This is the gap between the `Keystone PCZT prep` background task ending and the user scanning the signed QR back — previously the screen could lock while the user walked away to fetch their Keystone.

No power-cable / battery-state / WiFi conditions — straight `UIApplication.shared.isIdleTimerDisabled` flag flip. The existing `AutolockHandlerClient` is battery-aware by design (restore/sync use case); voting submission is short-lived and time-critical, so we keep this independent and unconditional.

## Test plan

- [ ] Open `ConfirmSubmissionView` in idle (reviewing votes), set device auto-lock to 30s — screen locks normally.
- [ ] Tap Confirm on a Zashi wallet — screen stays awake through `.authorizing` and `.submitting`, until `.completed`/failure/back-out. Sleep behavior returns to normal afterward.
- [ ] On a Keystone wallet, tap Confirm — `DelegationSigningView` is pushed and the screen stays awake the entire time the QR is shown (try setting auto-lock to 30s and walk away for 1+ minute, then return — screen is still on, QR still visible).
- [ ] After Keystone signing completes and `ConfirmSubmissionView` re-takes the screen in `.submitting`, display continues to stay awake until completion.
- [ ] Background the app during submission, then foreground — `.onDisappear`/`.onAppear` re-sync the flag without leaving the device permanently awake.
- [ ] Navigate away from the submission screens to other parts of the app — auto-lock works normally everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)