### PR TITLE
[TEST]: added more Maestro TagIDs

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -144,9 +144,37 @@ jobs:
           # XCUITest driver build/install can take a few minutes on CI;
           # default 60s timeout isn't enough on a cold runner.
           MAESTRO_DRIVER_STARTUP_TIMEOUT: 300000
+
+          # Wallet config consumed by scripts/run-smoke-ios.sh — the
+          # wrapper sources .env locally, but on CI we read each value
+          # from GitHub Secrets / repo variables instead. The wrapper
+          # resolves ZODL_TEST_DIRECTION (AUTO_ALTERNATE flips a state
+          # file each run so sender/receiver rotate), pre-splits the
+          # chosen seed into ZODL_WORD_1..24, and passes everything to
+          # Maestro via --env=KEY=VAL.
+          ZODL_TEST_SEED_ANDROID: ${{ secrets.ZODL_TEST_SEED_ANDROID }}
+          ZODL_TEST_BIRTHDAY_ANDROID: ${{ secrets.ZODL_TEST_BIRTHDAY_ANDROID }}
+          ZODL_TEST_ADDRESS_ANDROID: ${{ secrets.ZODL_TEST_ADDRESS_ANDROID }}
+          ZODL_TEST_CONTACT_NAME_ANDROID: ${{ vars.ZODL_TEST_CONTACT_NAME_ANDROID || 'Android Shield' }}
+          ZODL_TEST_SEED_IOS: ${{ secrets.ZODL_TEST_SEED_IOS }}
+          ZODL_TEST_BIRTHDAY_IOS: ${{ secrets.ZODL_TEST_BIRTHDAY_IOS }}
+          ZODL_TEST_ADDRESS_IOS: ${{ secrets.ZODL_TEST_ADDRESS_IOS }}
+          ZODL_TEST_CONTACT_NAME_IOS: ${{ vars.ZODL_TEST_CONTACT_NAME_IOS || 'iOS Shield' }}
+          ZODL_TEST_DIRECTION: ${{ vars.ZODL_TEST_DIRECTION || 'AUTO_ALTERNATE' }}
+          ZODL_TEST_SEND_AMOUNT: ${{ vars.ZODL_TEST_SEND_AMOUNT || '0.005' }}
+          ZODL_TEST_BALANCE_MIN: ${{ vars.ZODL_TEST_BALANCE_MIN || '1.3' }}
+          ZODL_TEST_BALANCE_WARN: ${{ vars.ZODL_TEST_BALANCE_WARN || '1.36' }}
+          ZODL_TEST_CROSSPAY_TARGET_ADDRESS: ${{ vars.ZODL_TEST_CROSSPAY_TARGET_ADDRESS || '0xf90bd7c30fd538efde8729ea61fdf20920ed3171' }}
+          ZODL_TEST_CROSSPAY_TARGET_NAME: ${{ vars.ZODL_TEST_CROSSPAY_TARGET_NAME || 'USDC Base' }}
+          ZODL_TEST_CROSSPAY_CHAIN: ${{ vars.ZODL_TEST_CROSSPAY_CHAIN || 'BASE' }}
+          ZODL_TEST_CROSSPAY_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_AMOUNT || '0.5' }}
+
+          # Cache the AUTO_ALTERNATE state outside $HOME default so that
+          # actions/cache (if added later) can persist it between runs.
+          ZODL_TEST_STATE_DIR: ${{ github.workspace }}/.zodl-qa-state
         run: |
-          maestro test zodl-qa/maestro/smoke/ \
-            --include-tags="ios"
+          chmod +x zodl-qa/scripts/run-smoke-ios.sh
+          ./zodl-qa/scripts/run-smoke-ios.sh
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -167,7 +167,8 @@ jobs:
           ZODL_TEST_CROSSPAY_TARGET_ADDRESS: ${{ vars.ZODL_TEST_CROSSPAY_TARGET_ADDRESS || '0xf90bd7c30fd538efde8729ea61fdf20920ed3171' }}
           ZODL_TEST_CROSSPAY_TARGET_NAME: ${{ vars.ZODL_TEST_CROSSPAY_TARGET_NAME || 'USDC Base' }}
           ZODL_TEST_CROSSPAY_CHAIN: ${{ vars.ZODL_TEST_CROSSPAY_CHAIN || 'BASE' }}
-          ZODL_TEST_CROSSPAY_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_AMOUNT || '0.5' }}
+          ZODL_TEST_CROSSPAY_USDC_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_USDC_AMOUNT || '0.5' }}
+          ZODL_TEST_SWAP_ZEC_AMOUNT: ${{ vars.ZODL_TEST_SWAP_ZEC_AMOUNT || '0.005' }}
 
           # Cache the AUTO_ALTERNATE state outside $HOME default so that
           # actions/cache (if added later) can persist it between runs.

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		34AA6F692F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA6F6A2F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA6F6B2F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
+		A6614A6838412195D1C0036E /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA6F6C2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA6F6D2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA6F6E2F85774F00D244E2 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 34AA6D2C2F85774F00D244E2 /* Inter-SemiBold.otf */; };
@@ -864,6 +865,7 @@
 		34AA71372F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA71382F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA71392F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
+		A3150A056C1A6B467B9F30BC /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA713A2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA713B2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA713C2F85774F00D244E2 /* SwapAndPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CF82F85774F00D244E2 /* SwapAndPayStore.swift */; };
@@ -1261,6 +1263,7 @@
 		34AA72CD2F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA72CE2F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA72CF2F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
+		38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA72D02F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA72D12F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA72D22F85774F00D244E2 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 34AA6D2C2F85774F00D244E2 /* Inter-SemiBold.otf */; };
@@ -1710,6 +1713,7 @@
 		34AA749B2F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA749C2F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA749D2F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
+		92244D487F7EABE1C7B8EE6C /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA749E2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA749F2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA74A02F85774F00D244E2 /* SwapAndPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CF82F85774F00D244E2 /* SwapAndPayStore.swift */; };
@@ -2107,6 +2111,7 @@
 		34AA76312F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA76322F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA76332F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
+		B162C19E08D002B2D9B020A9 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA76342F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA76352F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA76362F85774F00D244E2 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 34AA6D2C2F85774F00D244E2 /* Inter-SemiBold.otf */; };
@@ -3039,6 +3044,7 @@
 		34AA6DBA2F85774F00D244E2 /* TCALoggerReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCALoggerReducer.swift; sourceTree = "<group>"; };
 		34AA6DBB2F85774F00D244E2 /* TCALogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCALogging.swift; sourceTree = "<group>"; };
 		34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
+		0F94E337360CE50FACFB04CE /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
 		34AA6DBE2F85774F00D244E2 /* Array+Chunked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Chunked.swift"; sourceTree = "<group>"; };
 		34AA6DBF2F85774F00D244E2 /* BalanceFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceFormatter.swift; sourceTree = "<group>"; };
 		34AA6DC02F85774F00D244E2 /* Bindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bindings.swift; sourceTree = "<group>"; };
@@ -4848,6 +4854,7 @@
 			isa = PBXGroup;
 			children = (
 				34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */,
+				0F94E337360CE50FACFB04CE /* AccessibilityID.swift */,
 				34AA6DBE2F85774F00D244E2 /* Array+Chunked.swift */,
 				34AA6DBF2F85774F00D244E2 /* BalanceFormatter.swift */,
 				34AA6DC02F85774F00D244E2 /* Bindings.swift */,
@@ -6753,6 +6760,7 @@
 				34AA749B2F85774F00D244E2 /* SettingsCoordinator.swift in Sources */,
 				34AA749C2F85774F00D244E2 /* GlobalNavBar.swift in Sources */,
 				34AA749D2F85774F00D244E2 /* AnyDecodable.swift in Sources */,
+				92244D487F7EABE1C7B8EE6C /* AccessibilityID.swift in Sources */,
 				34AA749E2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */,
 				9EEBF82C2FBC64CE00DD38DB /* ProposalListStore.swift in Sources */,
 				34AA749F2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */,
@@ -7217,6 +7225,7 @@
 				34AA71372F85774F00D244E2 /* SettingsCoordinator.swift in Sources */,
 				34AA71382F85774F00D244E2 /* GlobalNavBar.swift in Sources */,
 				34AA71392F85774F00D244E2 /* AnyDecodable.swift in Sources */,
+				A3150A056C1A6B467B9F30BC /* AccessibilityID.swift in Sources */,
 				34AA713A2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */,
 				9EEBF82A2FBC64CE00DD38DB /* ProposalListStore.swift in Sources */,
 				34AA713B2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */,
@@ -7701,6 +7710,7 @@
 				34AA76312F85774F00D244E2 /* SettingsCoordinator.swift in Sources */,
 				34AA76322F85774F00D244E2 /* GlobalNavBar.swift in Sources */,
 				34AA76332F85774F00D244E2 /* AnyDecodable.swift in Sources */,
+				B162C19E08D002B2D9B020A9 /* AccessibilityID.swift in Sources */,
 				34AA76342F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */,
 				9EEBF8292FBC64CE00DD38DB /* ProposalListStore.swift in Sources */,
 				34AA76352F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */,
@@ -8165,6 +8175,7 @@
 				34AA72CD2F85774F00D244E2 /* SettingsCoordinator.swift in Sources */,
 				34AA72CE2F85774F00D244E2 /* GlobalNavBar.swift in Sources */,
 				34AA72CF2F85774F00D244E2 /* AnyDecodable.swift in Sources */,
+				38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */,
 				34AA72D02F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */,
 				9EEBF82B2FBC64CE00DD38DB /* ProposalListStore.swift in Sources */,
 				34AA72D12F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */,
@@ -8629,6 +8640,7 @@
 				34AA6F692F85774F00D244E2 /* SettingsCoordinator.swift in Sources */,
 				34AA6F6A2F85774F00D244E2 /* GlobalNavBar.swift in Sources */,
 				34AA6F6B2F85774F00D244E2 /* AnyDecodable.swift in Sources */,
+				A6614A6838412195D1C0036E /* AccessibilityID.swift in Sources */,
 				34AA6F6C2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */,
 				9EEBF8282FBC64CE00DD38DB /* ProposalListStore.swift in Sources */,
 				34AA6F6D2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */,

--- a/secant/Sources/Features/AddressBook/AddressBookContactView.swift
+++ b/secant/Sources/Features/AddressBook/AddressBookContactView.swift
@@ -33,7 +33,7 @@ struct AddressBookContactView: View {
                 )
                 .padding(.top, 20)
                 .focused($isAddressFocused)
-                .accessibilityIdentifier("addressBookContact.walletAddressField")
+                .accessibilityIdentifier(AccessibilityID.AddressBookContact.walletAddressField)
 
                 ZashiTextField(
                     text: $store.name,
@@ -44,7 +44,7 @@ struct AddressBookContactView: View {
                 .padding(.top, 20)
                 .padding(.bottom, (store.context != .send || store.isEditingContactWithChain) ? 0 : 20)
                 .focused($isNameFocused)
-                .accessibilityIdentifier("addressBookContact.contactNameField")
+                .accessibilityIdentifier(AccessibilityID.AddressBookContact.contactNameField)
 
                 if store.context != .send || store.isEditingContactWithChain {
                     if store.isValidZcashAddress && store.context != .swap {
@@ -114,7 +114,7 @@ struct AddressBookContactView: View {
                                         .fill(Design.Inputs.Default.bg.color(colorScheme))
                                 )
                             }
-                            .accessibilityIdentifier("addressBookContact.chainSelector")
+                            .accessibilityIdentifier(AccessibilityID.AddressBookContact.chainSelector)
                         }
                         .padding(.top, 20)
                         .focused($isChainIdFocused)
@@ -127,14 +127,14 @@ struct AddressBookContactView: View {
                     store.send(.saveButtonTapped)
                 }
                 .disabled(store.isSaveButtonDisabled)
-                .accessibilityIdentifier("addressBookContact.saveButton")
+                .accessibilityIdentifier(AccessibilityID.AddressBookContact.saveButton)
                 .padding(.bottom, store.editId != nil ? 0 : 24)
 
                 if store.editId != nil {
                     ZashiButton(String(localizable: .generalDelete), type: .destructive1) {
                         store.send(.deleteId(store.uniqueId))
                     }
-                    .accessibilityIdentifier("addressBookContact.deleteButton")
+                    .accessibilityIdentifier(AccessibilityID.AddressBookContact.deleteButton)
                     .padding(.bottom, 24)
                 }
             }

--- a/secant/Sources/Features/AddressBook/AddressBookContactView.swift
+++ b/secant/Sources/Features/AddressBook/AddressBookContactView.swift
@@ -33,6 +33,7 @@ struct AddressBookContactView: View {
                 )
                 .padding(.top, 20)
                 .focused($isAddressFocused)
+                .accessibilityIdentifier("addressBookContact.walletAddressField")
 
                 ZashiTextField(
                     text: $store.name,
@@ -43,6 +44,7 @@ struct AddressBookContactView: View {
                 .padding(.top, 20)
                 .padding(.bottom, (store.context != .send || store.isEditingContactWithChain) ? 0 : 20)
                 .focused($isNameFocused)
+                .accessibilityIdentifier("addressBookContact.contactNameField")
 
                 if store.context != .send || store.isEditingContactWithChain {
                     if store.isValidZcashAddress && store.context != .swap {
@@ -112,6 +114,7 @@ struct AddressBookContactView: View {
                                         .fill(Design.Inputs.Default.bg.color(colorScheme))
                                 )
                             }
+                            .accessibilityIdentifier("addressBookContact.chainSelector")
                         }
                         .padding(.top, 20)
                         .focused($isChainIdFocused)
@@ -124,12 +127,14 @@ struct AddressBookContactView: View {
                     store.send(.saveButtonTapped)
                 }
                 .disabled(store.isSaveButtonDisabled)
+                .accessibilityIdentifier("addressBookContact.saveButton")
                 .padding(.bottom, store.editId != nil ? 0 : 24)
 
                 if store.editId != nil {
                     ZashiButton(String(localizable: .generalDelete), type: .destructive1) {
                         store.send(.deleteId(store.uniqueId))
                     }
+                    .accessibilityIdentifier("addressBookContact.deleteButton")
                     .padding(.bottom, 24)
                 }
             }

--- a/secant/Sources/Features/AddressBook/AddressBookView.swift
+++ b/secant/Sources/Features/AddressBook/AddressBookView.swift
@@ -83,7 +83,7 @@ struct AddressBookView: View {
                         Text(localizable: .addressBookScanAddress)
                     }
                 }
-                .accessibilityIdentifier("addressBook.scanEntry")
+                .accessibilityIdentifier(AccessibilityID.AddressBook.scanEntry)
 
                 Button {
                     store.send(.addManualButtonTapped)
@@ -95,7 +95,7 @@ struct AddressBookView: View {
                         Text(localizable: .addressBookManualEntry)
                     }
                 }
-                .accessibilityIdentifier("addressBook.manualEntry")
+                .accessibilityIdentifier(AccessibilityID.AddressBook.manualEntry)
             } label: {
                 ZashiButton(
                     String(localizable: .addressBookAddNewContact),
@@ -111,7 +111,7 @@ struct AddressBookView: View {
                 .padding(.bottom, 24)
                 .padding(.top, 8)
             }
-            .accessibilityIdentifier("addressBook.addContact")
+            .accessibilityIdentifier(AccessibilityID.AddressBook.addContact)
         }
     }
     

--- a/secant/Sources/Features/AddressBook/AddressBookView.swift
+++ b/secant/Sources/Features/AddressBook/AddressBookView.swift
@@ -83,6 +83,7 @@ struct AddressBookView: View {
                         Text(localizable: .addressBookScanAddress)
                     }
                 }
+                .accessibilityIdentifier("addressBook.scanEntry")
 
                 Button {
                     store.send(.addManualButtonTapped)
@@ -94,6 +95,7 @@ struct AddressBookView: View {
                         Text(localizable: .addressBookManualEntry)
                     }
                 }
+                .accessibilityIdentifier("addressBook.manualEntry")
             } label: {
                 ZashiButton(
                     String(localizable: .addressBookAddNewContact),
@@ -103,12 +105,13 @@ struct AddressBookView: View {
                             .resizable()
                             .frame(width: 20, height: 20)
                 ) {
-                    
+
                 }
                 .screenHorizontalPadding()
                 .padding(.bottom, 24)
                 .padding(.top, 8)
             }
+            .accessibilityIdentifier("addressBook.addContact")
         }
     }
     

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowView.swift
@@ -45,13 +45,13 @@ struct RestoreWalletCoordFlowView: View {
                     ) {
                         store.send(.importExistingWallet)
                     }
-                    .accessibilityIdentifier("onboarding.restoreWallet")
+                    .accessibilityIdentifier(AccessibilityID.Onboarding.restoreWallet)
                     .padding(.bottom, 8)
 
                     ZashiButton(String(localizable: .plainOnboardingButtonCreateNewWallet)) {
                         store.send(.createNewWalletTapped)
                     }
-                    .accessibilityIdentifier("onboarding.createWallet")
+                    .accessibilityIdentifier(AccessibilityID.Onboarding.createWallet)
                     .padding(.bottom, 24)
                 }
                 .screenHorizontalPadding()

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowView.swift
@@ -45,11 +45,13 @@ struct RestoreWalletCoordFlowView: View {
                     ) {
                         store.send(.importExistingWallet)
                     }
+                    .accessibilityIdentifier("onboarding.restoreWallet")
                     .padding(.bottom, 8)
-                    
+
                     ZashiButton(String(localizable: .plainOnboardingButtonCreateNewWallet)) {
                         store.send(.createNewWalletTapped)
                     }
+                    .accessibilityIdentifier("onboarding.createWallet")
                     .padding(.bottom, 24)
                 }
                 .screenHorizontalPadding()

--- a/secant/Sources/Features/Home/GlobalNavBar.swift
+++ b/secant/Sources/Features/Home/GlobalNavBar.swift
@@ -27,6 +27,7 @@ extension HomeView {
                 }
 #endif
         }
+        .accessibilityIdentifier("home.moreButton")
     }
     
     @ViewBuilder func hideBalancesButton() -> some View {

--- a/secant/Sources/Features/Home/GlobalNavBar.swift
+++ b/secant/Sources/Features/Home/GlobalNavBar.swift
@@ -27,7 +27,7 @@ extension HomeView {
                 }
 #endif
         }
-        .accessibilityIdentifier("home.moreButton")
+        .accessibilityIdentifier(AccessibilityID.Home.moreButton)
     }
     
     @ViewBuilder func hideBalancesButton() -> some View {

--- a/secant/Sources/Features/Home/HomeView.swift
+++ b/secant/Sources/Features/Home/HomeView.swift
@@ -37,7 +37,7 @@ struct HomeView: View {
                     ) {
                         store.send(.receiveScreenRequested)
                     }
-                    .accessibilityIdentifier("home.receiveButton")
+                    .accessibilityIdentifier(AccessibilityID.Home.receiveButton)
 
                     Spacer(minLength: 8)
 
@@ -47,7 +47,7 @@ struct HomeView: View {
                     ) {
                         store.send(.sendTapped)
                     }
-                    .accessibilityIdentifier("home.sendButton")
+                    .accessibilityIdentifier(AccessibilityID.Home.sendButton)
 
                     Spacer(minLength: 8)
 
@@ -57,7 +57,7 @@ struct HomeView: View {
                     ) {
                         store.send(.payWithNearTapped)
                     }
-                    .accessibilityIdentifier("home.payButton")
+                    .accessibilityIdentifier(AccessibilityID.Home.payButton)
 
                     Spacer(minLength: 8)
 
@@ -67,7 +67,7 @@ struct HomeView: View {
                     ) {
                         store.send(.swapWithNearTapped)
                     }
-                    .accessibilityIdentifier("home.swapButton")
+                    .accessibilityIdentifier(AccessibilityID.Home.swapButton)
                 }
                 .zFont(.medium, size: 12, style: Design.Text.primary)
                 .padding(.top, 24)

--- a/secant/Sources/Features/Home/HomeView.swift
+++ b/secant/Sources/Features/Home/HomeView.swift
@@ -37,6 +37,7 @@ struct HomeView: View {
                     ) {
                         store.send(.receiveScreenRequested)
                     }
+                    .accessibilityIdentifier("home.receiveButton")
 
                     Spacer(minLength: 8)
 
@@ -46,6 +47,7 @@ struct HomeView: View {
                     ) {
                         store.send(.sendTapped)
                     }
+                    .accessibilityIdentifier("home.sendButton")
 
                     Spacer(minLength: 8)
 
@@ -55,6 +57,7 @@ struct HomeView: View {
                     ) {
                         store.send(.payWithNearTapped)
                     }
+                    .accessibilityIdentifier("home.payButton")
 
                     Spacer(minLength: 8)
 
@@ -64,6 +67,7 @@ struct HomeView: View {
                     ) {
                         store.send(.swapWithNearTapped)
                     }
+                    .accessibilityIdentifier("home.swapButton")
                 }
                 .zFont(.medium, size: 12, style: Design.Text.primary)
                 .padding(.top, 24)

--- a/secant/Sources/Features/Home/MoreSheet.swift
+++ b/secant/Sources/Features/Home/MoreSheet.swift
@@ -48,7 +48,7 @@ extension HomeView {
             ) {
                 store.send(.moreInMoreTapped)
             }
-            .accessibilityIdentifier("moreSheet.moreInMore")
+            .accessibilityIdentifier(AccessibilityID.MoreSheet.moreInMore)
             .padding(.bottom, 24)
 
             HStack(alignment: .top, spacing: 0) {

--- a/secant/Sources/Features/Home/MoreSheet.swift
+++ b/secant/Sources/Features/Home/MoreSheet.swift
@@ -48,6 +48,7 @@ extension HomeView {
             ) {
                 store.send(.moreInMoreTapped)
             }
+            .accessibilityIdentifier("moreSheet.moreInMore")
             .padding(.bottom, 24)
 
             HStack(alignment: .top, spacing: 0) {

--- a/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
+++ b/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
@@ -65,7 +65,7 @@ struct RecoveryPhraseDisplayView: View {
                             ) {
                                 store.send(.seedSavedTapped)
                             }
-                            .accessibilityIdentifier("recoveryPhrase.confirmButton")
+                            .accessibilityIdentifier(AccessibilityID.RecoveryPhrase.confirmButton)
                             .padding(.bottom, 24)
                         } else {
                             ZashiButton(

--- a/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
+++ b/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
@@ -65,6 +65,7 @@ struct RecoveryPhraseDisplayView: View {
                             ) {
                                 store.send(.seedSavedTapped)
                             }
+                            .accessibilityIdentifier("recoveryPhrase.confirmButton")
                             .padding(.bottom, 24)
                         } else {
                             ZashiButton(

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationView.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationView.swift
@@ -182,6 +182,7 @@ struct SendConfirmationView: View {
                         ZashiButton(String(localizable: .generalSend)) {
                             store.send(.sendTapped)
                         }
+                        .accessibilityIdentifier(AccessibilityID.SendConfirmation.sendButton)
                         .screenHorizontalPadding()
                         .padding(.bottom, 24)
                     }

--- a/secant/Sources/Features/SendForm/SendFormView.swift
+++ b/secant/Sources/Features/SendForm/SendFormView.swift
@@ -63,7 +63,8 @@ struct SendFormView: View {
                                                             fieldButton(
                                                                 icon: store.isNotAddressInAddressBook
                                                                 ? Asset.Assets.Icons.userPlus.image
-                                                                : Asset.Assets.Icons.user.image
+                                                                : Asset.Assets.Icons.user.image,
+                                                                identifier: AccessibilityID.SendForm.addToContactsButton
                                                             ) {
                                                                 if store.isNotAddressInAddressBook {
                                                                     store.send(.addNewContactTapped(store.address))
@@ -71,8 +72,11 @@ struct SendFormView: View {
                                                                     store.send(.addressBookTapped)
                                                                 }
                                                             }
-                                                            
-                                                            fieldButton(icon: Asset.Assets.Icons.qr.image) {
+
+                                                            fieldButton(
+                                                                icon: Asset.Assets.Icons.qr.image,
+                                                                identifier: AccessibilityID.SendForm.scanButton
+                                                            ) {
                                                                 store.send(.scanTapped)
                                                             }
                                                         }
@@ -171,6 +175,7 @@ struct SendFormView: View {
                                         }
                                         .disabled(!store.isValidForm)
                                         .padding(.top, 40)
+                                        .accessibilityIdentifier(AccessibilityID.SendForm.reviewButton)
                                     }
                                 }
                                 .screenHorizontalPadding()
@@ -279,13 +284,14 @@ struct SendFormView: View {
         }
     }
     
-    private func fieldButton(icon: Image, _ action: @escaping () -> Void) -> some View {
+    private func fieldButton(icon: Image, identifier: String = "", _ action: @escaping () -> Void) -> some View {
         Button {
             action()
         } label: {
             icon
                 .zImage(size: 20, style: Design.Inputs.Default.label)
         }
+        .accessibilityIdentifier(identifier)
         .padding(8)
         .background {
             RoundedRectangle(cornerRadius: Design.Radius._md)

--- a/secant/Sources/Features/Settings/SettingsView.swift
+++ b/secant/Sources/Features/Settings/SettingsView.swift
@@ -22,7 +22,7 @@ struct SettingsView: View {
                             ) {
                                 store.send(.addressBookAccessCheck)
                             }
-                            .accessibilityIdentifier("settings.addressBook")
+                            .accessibilityIdentifier(AccessibilityID.Settings.addressBook)
 
 
                             if store.isEnoughFreeSpaceMode {

--- a/secant/Sources/Features/Settings/SettingsView.swift
+++ b/secant/Sources/Features/Settings/SettingsView.swift
@@ -22,7 +22,9 @@ struct SettingsView: View {
                             ) {
                                 store.send(.addressBookAccessCheck)
                             }
-                            
+                            .accessibilityIdentifier("settings.addressBook")
+
+
                             if store.isEnoughFreeSpaceMode {
                                 ActionRow(
                                     icon: Asset.Assets.Icons.currencyDollar.image,

--- a/secant/Sources/Features/SwapAndPayForm/CrossPayForm.swift
+++ b/secant/Sources/Features/SwapAndPayForm/CrossPayForm.swift
@@ -34,7 +34,8 @@ extension SwapAndPayForm {
                                 } label: {
                                     ticker(asset: store.selectedAsset, crosspay: true, colorScheme)
                                 }
-                                
+                                .accessibilityIdentifier(AccessibilityID.CrossPayForm.assetSelectButton)
+
                                 Spacer()
                             }
                             
@@ -136,6 +137,7 @@ extension SwapAndPayForm {
                                 ZashiButton(String(localizable: .sendReview)) {
                                     store.send(.getQuoteTapped)
                                 }
+                                .accessibilityIdentifier(AccessibilityID.CrossPayForm.reviewButton)
                                 .padding(.top, keyboardVisible ? 40 : 0)
                                 .padding(.bottom, 56)
                                 .disabled(!store.isValidForm)

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayForm.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayForm.swift
@@ -84,7 +84,8 @@ struct SwapAndPayForm: View {
                             fieldButton(
                                 icon: store.isNotAddressInAddressBook
                                 ? Asset.Assets.Icons.userPlus.image
-                                : Asset.Assets.Icons.user.image
+                                : Asset.Assets.Icons.user.image,
+                                identifier: AccessibilityID.SwapAndPayForm.addToContactsButton
                             ) {
                                 if store.isNotAddressInAddressBook {
                                     store.send(.notInAddressBookButtonTapped(store.address))
@@ -92,8 +93,11 @@ struct SwapAndPayForm: View {
                                     store.send(.addressBookRequested)
                                 }
                             }
-                            
-                            fieldButton(icon: Asset.Assets.Icons.qr.image) {
+
+                            fieldButton(
+                                icon: Asset.Assets.Icons.qr.image,
+                                identifier: AccessibilityID.SwapAndPayForm.scanButton
+                            ) {
                                 store.send(.scanTapped)
                             }
                         }
@@ -174,13 +178,14 @@ struct SwapAndPayForm: View {
         }
     }
 
-    func fieldButton(icon: Image, _ action: @escaping () -> Void) -> some View {
+    func fieldButton(icon: Image, identifier: String = "", _ action: @escaping () -> Void) -> some View {
         Button {
             action()
         } label: {
             icon
                 .zImage(size: 20, style: Design.Inputs.Default.label)
         }
+        .accessibilityIdentifier(identifier)
         .padding(8)
         .background {
             RoundedRectangle(cornerRadius: Design.Radius._md)

--- a/secant/Sources/Features/SwapAndPayForm/SwapForm.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapForm.swift
@@ -100,6 +100,7 @@ extension SwapAndPayForm {
                                 ZashiButton(String(localizable: .swapAndPayGetQuote)) {
                                     store.send(.getQuoteTapped)
                                 }
+                                .accessibilityIdentifier(AccessibilityID.SwapForm.reviewButton)
                                 .padding(.bottom, 56)
                                 .disabled(!store.isValidForm)
                             }
@@ -414,6 +415,7 @@ extension SwapAndPayForm {
                     } label: {
                         ticker(asset: store.selectedAsset, crosspay: false, colorScheme)
                     }
+                    .accessibilityIdentifier(AccessibilityID.SwapForm.assetSelectButton)
 
                     Spacer()
                 }
@@ -546,6 +548,7 @@ extension SwapAndPayForm {
                             }
                     }
             }
+            .accessibilityIdentifier(AccessibilityID.SwapForm.changeModeButton)
             .disabled(store.isQuoteRequestInFlight)
             
             Design.Utility.Gray._100.color(colorScheme)

--- a/secant/Sources/UIComponents/Toolbar/ZashiBack.swift
+++ b/secant/Sources/UIComponents/Toolbar/ZashiBack.swift
@@ -40,6 +40,7 @@ struct ZashiBackModifier: ViewModifier {
                             }
                         }
                         .disabled(disabled)
+                        .accessibilityIdentifier("navigation.back")
                     }
                 }
         }

--- a/secant/Sources/UIComponents/Toolbar/ZashiBack.swift
+++ b/secant/Sources/UIComponents/Toolbar/ZashiBack.swift
@@ -40,7 +40,7 @@ struct ZashiBackModifier: ViewModifier {
                             }
                         }
                         .disabled(disabled)
-                        .accessibilityIdentifier("navigation.back")
+                        .accessibilityIdentifier(AccessibilityID.Navigation.back)
                     }
                 }
         }

--- a/secant/Sources/Utils/AccessibilityID.swift
+++ b/secant/Sources/Utils/AccessibilityID.swift
@@ -1,0 +1,48 @@
+// Accessibility identifiers used by Maestro / XCUITest to locate UI elements.
+// Keep the string values stable — they are referenced by name in zodl-qa
+// Maestro flows.
+
+enum AccessibilityID {
+    enum Navigation {
+        static let back = "navigation.back"
+    }
+
+    enum Onboarding {
+        static let createWallet = "onboarding.createWallet"
+        static let restoreWallet = "onboarding.restoreWallet"
+    }
+
+    enum Home {
+        static let receiveButton = "home.receiveButton"
+        static let sendButton = "home.sendButton"
+        static let payButton = "home.payButton"
+        static let swapButton = "home.swapButton"
+        static let moreButton = "home.moreButton"
+    }
+
+    enum MoreSheet {
+        static let moreInMore = "moreSheet.moreInMore"
+    }
+
+    enum Settings {
+        static let addressBook = "settings.addressBook"
+    }
+
+    enum AddressBook {
+        static let addContact = "addressBook.addContact"
+        static let scanEntry = "addressBook.scanEntry"
+        static let manualEntry = "addressBook.manualEntry"
+    }
+
+    enum AddressBookContact {
+        static let walletAddressField = "addressBookContact.walletAddressField"
+        static let contactNameField = "addressBookContact.contactNameField"
+        static let chainSelector = "addressBookContact.chainSelector"
+        static let saveButton = "addressBookContact.saveButton"
+        static let deleteButton = "addressBookContact.deleteButton"
+    }
+
+    enum RecoveryPhrase {
+        static let confirmButton = "recoveryPhrase.confirmButton"
+    }
+}

--- a/secant/Sources/Utils/AccessibilityID.swift
+++ b/secant/Sources/Utils/AccessibilityID.swift
@@ -48,6 +48,12 @@ enum AccessibilityID {
         static let reviewButton = "crossPayForm.reviewButton"
     }
 
+    enum SwapForm {
+        static let assetSelectButton = "swapForm.assetSelectButton"
+        static let changeModeButton = "swapForm.changeModeButton"
+        static let reviewButton = "swapForm.reviewButton"
+    }
+
     enum AddressBook {
         static let addContact = "addressBook.addContact"
         static let scanEntry = "addressBook.scanEntry"

--- a/secant/Sources/Utils/AccessibilityID.swift
+++ b/secant/Sources/Utils/AccessibilityID.swift
@@ -28,6 +28,26 @@ enum AccessibilityID {
         static let addressBook = "settings.addressBook"
     }
 
+    enum SendForm {
+        static let addToContactsButton = "sendForm.addToContactsButton"
+        static let scanButton = "sendForm.scanButton"
+        static let reviewButton = "sendForm.reviewButton"
+    }
+
+    enum SendConfirmation {
+        static let sendButton = "sendConfirmation.sendButton"
+    }
+
+    enum SwapAndPayForm {
+        static let addToContactsButton = "swapAndPayForm.addToContactsButton"
+        static let scanButton = "swapAndPayForm.scanButton"
+    }
+
+    enum CrossPayForm {
+        static let assetSelectButton = "crossPayForm.assetSelectButton"
+        static let reviewButton = "crossPayForm.reviewButton"
+    }
+
     enum AddressBook {
         static let addContact = "addressBook.addContact"
         static let scanEntry = "addressBook.scanEntry"


### PR DESCRIPTION
## Summary

Part 2 of the Maestro tag IDs work — adds the accessibility identifiers
needed for the swap-transaction smoke flow, plus a CI env var rename
to match the renamed crosspay variable and the new swap variable.

Stacks on #<p1-PR-number> (`harry/maestro-tag-ids`).

### What's added

`AccessibilityID.SwapForm` namespace in `secant/Sources/Utils/AccessibilityID.swift`:

| Identifier | Element |
|---|---|
| `swapForm.assetSelectButton` | FROM-token asset chip (opens SELECT ASSET sheet) |
| `swapForm.changeModeButton` | "switch sides" button that flips ZEC ↔ token |
| `swapForm.reviewButton` | bottom "Review" CTA |

Applied to the three call sites in `SwapForm.swift`.

### CI env vars

In `.github/workflows/e2e-smoke.yml`:
- `ZODL_TEST_CROSSPAY_AMOUNT` → `ZODL_TEST_CROSSPAY_USDC_AMOUNT` (clearer that it's USDC, not ZEC).
- New `ZODL_TEST_SWAP_ZEC_AMOUNT` for the swap test's ZEC amount.

