### PR TITLE
[MOB-1119] Update text on Smart banner related to unshielded funds

### DIFF
--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -3013,6 +3013,23 @@
         }
       }
     },
+    "coinVote.delegationSigning.awaitingWeightSummary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC signed · %@ ZEC awaiting"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC signed · %@ ZEC awaiting"
+          }
+        }
+      }
+    },
     "coinVote.delegationSigning.buildingBundleRequest" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3043,23 +3060,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Building delegation request..."
-          }
-        }
-      }
-    },
-    "coinVote.delegationSigning.awaitingWeightSummary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC signed · %@ ZEC awaiting"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC signed · %@ ZEC awaiting"
           }
         }
       }
@@ -3404,6 +3404,40 @@
         }
       }
     },
+    "coinVote.delegationSigning.signatureRejectedOk" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
+    "coinVote.delegationSigning.signatureRejectedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
+          }
+        }
+      }
+    },
     "coinVote.delegationSigning.signedProgress" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3604,40 +3638,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continue without the remaining %@ ZEC."
-          }
-        }
-      }
-    },
-    "coinVote.delegationSigning.signatureRejectedOk" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        }
-      }
-    },
-    "coinVote.delegationSigning.signatureRejectedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something Went Wrong"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something Went Wrong"
           }
         }
       }
@@ -13895,23 +13895,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saldo No Protegido"
-          }
-        }
-      }
-    },
-    "smartBanner.content.shield.titleShorter" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transparent Balance"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saldo Transparente"
           }
         }
       }

--- a/secant/Sources/Features/SmartBanner/SmartBannerContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerContent.swift
@@ -180,13 +180,8 @@ extension SmartBannerView {
                 .padding(.trailing, 12)
             
             VStack(alignment: .leading, spacing: 2) {
-                ViewThatFits {
-                    Text(localizable: .smartBannerContentShieldTitle)
-                        .zFont(.medium, size: 14, color: titleStyle())
-
-                    Text(localizable: .smartBannerContentShieldTitleShorter)
-                        .zFont(.medium, size: 14, color: titleStyle())
-                }
+                Text(localizable: .smartBannerContentShieldTitle)
+                    .zFont(.medium, size: 14, color: titleStyle())
                 
                 ZatoshiText(store.transparentBalance, .expanded, store.tokenName)
                     .zFont(.medium, size: 12, color: infoStyle())


### PR DESCRIPTION
- Updated to latest alpha SDK.
- Removed Text from smart banner that used `.smartBannerContentShieldTitleShorter` because this one was using old text. And  `.smartBannerContentShieldTitle` text was already using new text. So I removed old text from strings catalogue and also the Text using the shorter title. Because we would have two same texts next to each other.