### PR TITLE
[MOB-1335] Remove decommissioned servers and migrate affected users to default

### DIFF
--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -2561,6 +2561,7 @@
 		AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00212D00000100000002 /* VotingHelpersTests.swift */; };
 		AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00222D00000100000002 /* VotingCoordFlowCoordinatorTests.swift */; };
 		AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00232D00000100000002 /* VotingServiceConfigTests.swift */; };
+		34D06C912FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D06C902FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift */; };
 		B162C19E08D002B2D9B020A9 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 /* End PBXBuildFile section */
 
@@ -7196,6 +7197,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				34D06C912FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift in Sources */,
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
 				AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -415,7 +415,6 @@
 		34AA6F692F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA6F6A2F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA6F6B2F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
-		A6614A6838412195D1C0036E /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA6F6C2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA6F6D2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA6F6E2F85774F00D244E2 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 34AA6D2C2F85774F00D244E2 /* Inter-SemiBold.otf */; };
@@ -865,7 +864,6 @@
 		34AA71372F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA71382F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA71392F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
-		A3150A056C1A6B467B9F30BC /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA713A2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA713B2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA713C2F85774F00D244E2 /* SwapAndPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CF82F85774F00D244E2 /* SwapAndPayStore.swift */; };
@@ -1263,7 +1261,6 @@
 		34AA72CD2F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA72CE2F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA72CF2F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
-		38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA72D02F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA72D12F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA72D22F85774F00D244E2 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 34AA6D2C2F85774F00D244E2 /* Inter-SemiBold.otf */; };
@@ -1713,7 +1710,6 @@
 		34AA749B2F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA749C2F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA749D2F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
-		92244D487F7EABE1C7B8EE6C /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA749E2F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA749F2F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA74A02F85774F00D244E2 /* SwapAndPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CF82F85774F00D244E2 /* SwapAndPayStore.swift */; };
@@ -2111,7 +2107,6 @@
 		34AA76312F85774F00D244E2 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CE92F85774F00D244E2 /* SettingsCoordinator.swift */; };
 		34AA76322F85774F00D244E2 /* GlobalNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C9D2F85774F00D244E2 /* GlobalNavBar.swift */; };
 		34AA76332F85774F00D244E2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */; };
-		B162C19E08D002B2D9B020A9 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		34AA76342F85774F00D244E2 /* ReviewRequestTestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C152F85774F00D244E2 /* ReviewRequestTestKey.swift */; };
 		34AA76352F85774F00D244E2 /* LogsHandlerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6BF22F85774F00D244E2 /* LogsHandlerInterface.swift */; };
 		34AA76362F85774F00D244E2 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 34AA6D2C2F85774F00D244E2 /* Inter-SemiBold.otf */; };
@@ -2335,10 +2330,8 @@
 		37D0F0000000000000000022 /* RoundAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0F0000000000000000002 /* RoundAuthenticator.swift */; };
 		37D0F0000000000000000023 /* RoundAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0F0000000000000000002 /* RoundAuthenticator.swift */; };
 		37D0F0000000000000000024 /* RoundAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0F0000000000000000002 /* RoundAuthenticator.swift */; };
-		9E0C0D702AFB842B00D69A16 /* TransactionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0C0D6F2AFB842B00D69A16 /* TransactionStateTests.swift */; };
-		9E139AAF2B07B3A600D104B8 /* ZatoshiStringRepresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E139AAE2B07B3A600D104B8 /* ZatoshiStringRepresentationTests.swift */; };
-		9E1FAFB72AF2C6D40084CA3D /* PrivateDataConsentSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1FAFB62AF2C6D40084CA3D /* PrivateDataConsentSnapshotTests.swift */; };
-		9E1FAFBA2AF2C7F20084CA3D /* PrivateDataConsentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1FAFB92AF2C7F20084CA3D /* PrivateDataConsentTests.swift */; };
+		38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
+		92244D487F7EABE1C7B8EE6C /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		9E2706672AFF99F5000DA6EC /* ReadTransactionsStorageModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9E2706652AFF99F5000DA6EC /* ReadTransactionsStorageModel.xcdatamodeld */; };
 		9E2706682AFF99F5000DA6EC /* ReadTransactionsStorageModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9E2706652AFF99F5000DA6EC /* ReadTransactionsStorageModel.xcdatamodeld */; };
 		9E27153F2F88FB2000046B74 /* WalletStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E27153E2F88FB1E00046B74 /* WalletStatus.swift */; };
@@ -2347,41 +2340,7 @@
 		9E2715422F88FB2000046B74 /* WalletStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E27153E2F88FB1E00046B74 /* WalletStatus.swift */; };
 		9E2715432F88FB2000046B74 /* WalletStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E27153E2F88FB1E00046B74 /* WalletStatus.swift */; };
 		9E2F1C8C280ED6A7004E65FE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E2F1C8B280ED6A7004E65FE /* LaunchScreen.storyboard */; };
-		9E34519529C4A4BF00177D16 /* ReceiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E207C382966EF87003E2C9B /* ReceiveTests.swift */; };
 		9E34519629C4A4D800177D16 /* secantUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4E7A2526B364180058B01E /* secantUITests.swift */; };
-		9E34519729C4A51100177D16 /* RecoveryPhraseBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFE93DE272C6D4B000FCCA5 /* RecoveryPhraseBackupTests.swift */; };
-		9E34519A29C4A52F00177D16 /* BalanceBreakdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E94C61F28AA7DEE008256E9 /* BalanceBreakdownTests.swift */; };
-		9E34519B29C4A90700177D16 /* DeeplinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAB4675285B5C7C002904A0 /* DeeplinkTests.swift */; };
-		9E34519C29C4A91A00177D16 /* HomeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3911382848AD500073DD9A /* HomeTests.swift */; };
-		9E34519D29C8484D00177D16 /* HomeFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341B30BA29B78D1000697081 /* HomeFeatureFlagTests.swift */; };
-		9E34519E29C849B400177D16 /* WalletConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F039B229ABCE8500CF0053 /* WalletConfigProviderTests.swift */; };
-		9E34519F29C849D300177D16 /* ImportWalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E391123283E4CAC0073DD9A /* ImportWalletTests.swift */; };
-		9E3451A029C84A2D00177D16 /* MultiLineTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6713F02897F81B00A6796F /* MultiLineTextFieldTests.swift */; };
-		9E3451A629C84B6600177D16 /* RootTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAFEB812805793200199FC9 /* RootTests.swift */; };
-		9E3451A729C84E9900177D16 /* AppInitializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E391131284644580073DD9A /* AppInitializationTests.swift */; };
-		9E3451A829C84EAF00177D16 /* DebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E852D6429B0A86300CF4AC1 /* DebugTests.swift */; };
-		9E3451A929C84EC000177D16 /* ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E01F8272833CDA0000EFC57 /* ScanTests.swift */; };
-		9E3451AE29C84F2800177D16 /* SendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5BF643281FEC9900BA3F17 /* SendTests.swift */; };
-		9E3451AF29C855B200177D16 /* SensitiveDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E612C7829913F3600D09B09 /* SensitiveDataTests.swift */; };
-		9E3451B029C855E600177D16 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E66129D288938A300C75B70 /* SettingsTests.swift */; };
-		9E3451B129C8565500177D16 /* UserPreferencesStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EF8135B27ECC25E0075AF48 /* UserPreferencesStorageTests.swift */; };
-		9E3451B229C8565500177D16 /* SecItemClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAFEB852805A23100199FC9 /* SecItemClientTests.swift */; };
-		9E3451B429C8565500177D16 /* WalletStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EF8135A27ECC25E0075AF48 /* WalletStorageTests.swift */; };
-		9E3451B529C8565500177D16 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0F574A2980260D005304FA /* LoggerTests.swift */; };
-		9E3451B629C8565500177D16 /* ZatoshiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E39112D283F91600073DD9A /* ZatoshiTests.swift */; };
-		9E3451B729C8565500177D16 /* DatabaseFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E02B56B27FED475005B809B /* DatabaseFilesTests.swift */; };
-		9E3451B829C856E700177D16 /* TransactionListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5BF63E2819542C00BA3F17 /* TransactionListTests.swift */; };
-		9E3451B929C857C000177D16 /* ReceiveSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E207C352966EC77003E2C9B /* ReceiveSnapshotTests.swift */; };
-		9E3451BA29C857C500177D16 /* BalanceBreakdownSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E94C62228AA7EE0008256E9 /* BalanceBreakdownSnapshotTests.swift */; };
-		9E3451BB29C857C800177D16 /* HomeSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9ECC8C28589E150099D5A2 /* HomeSnapshotTests.swift */; };
-		9E3451BC29C857C800177D16 /* NotEnoughFeeSpaceSnapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3448CB3628E485CB006ADEDB /* NotEnoughFeeSpaceSnapshots.swift */; };
-		9E3451BD29C857CC00177D16 /* ImportWalletSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9ECC9428589E150099D5A2 /* ImportWalletSnapshotTests.swift */; };
-		9E3451C029C857D400177D16 /* RecoveryPhraseDisplaySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9ECC9028589E150099D5A2 /* RecoveryPhraseDisplaySnapshotTests.swift */; };
-		9E3451C229C857DB00177D16 /* TransactionSendingSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34429C6D28E703CD00F2B929 /* TransactionSendingSnapshotTests.swift */; };
-		9E3451C329C857DD00177D16 /* SettingsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7225F02889539300DF7F17 /* SettingsSnapshotTests.swift */; };
-		9E3451C429C857DF00177D16 /* View+UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E92AF0728530EBF007367AD /* View+UIImage.swift */; };
-		9E3451C529C857E400177D16 /* TransactionListSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7CB6112869882D00A02233 /* TransactionListSnapshotTests.swift */; };
-		9E3451C629C857E700177D16 /* WelcomeSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9ECC8E28589E150099D5A2 /* WelcomeSnapshotTests.swift */; };
 		9E41FFA82CB2814500783CFD /* ReadTransactionsStorageModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9E2706652AFF99F5000DA6EC /* ReadTransactionsStorageModel.xcdatamodeld */; };
 		9E41FFAF2CB2814500783CFD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0D4E7A0F26B364180058B01E /* Preview Assets.xcassets */; };
 		9E41FFB02CB2814500783CFD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E2F1C8B280ED6A7004E65FE /* LaunchScreen.storyboard */; };
@@ -2390,7 +2349,6 @@
 		9E41FFB32CB2814500783CFD /* whatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E6C98472BF4C65F00EACDCB /* whatsNew.json */; };
 		9E41FFB52CB2814500783CFD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 9EDDAF6C2BA2D71700A69A07 /* PrivacyInfo.xcprivacy */; };
 		9E41FFB62CB2814500783CFD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E5AAEBF2A67CEC4003F283D /* Colors.xcassets */; };
-		9E46919A2AD5735E0082D7DF /* TabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4691992AD5735E0082D7DF /* TabsTests.swift */; };
 		9E4841532F869F5F00D0649B /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9E4841522F869F5F00D0649B /* ZcashLightClientKit */; };
 		9E4841542F869F5F00D0649B /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9E4841522F869F5F00D0649B /* ZcashLightClientKit */; };
 		9E4841552F869F5F00D0649B /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9E4841522F869F5F00D0649B /* ZcashLightClientKit */; };
@@ -2410,7 +2368,6 @@
 		9E48425D2F8E940A002DA90E /* VotingErrorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E48425A2F8E940A002DA90E /* VotingErrorSheet.swift */; };
 		9E48425E2F8E940A002DA90E /* VotingErrorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E48425A2F8E940A002DA90E /* VotingErrorSheet.swift */; };
 		9E48425F2F8E940A002DA90E /* VotingErrorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E48425A2F8E940A002DA90E /* VotingErrorSheet.swift */; };
-		9E4938D82ACE8E8F003C4C1D /* SecurityWarningSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4938D72ACE8E8F003C4C1D /* SecurityWarningSnapshotTests.swift */; };
 		9E4AB2A42BA1BEE900F5D6DB /* ReadTransactionsStorageModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9E2706652AFF99F5000DA6EC /* ReadTransactionsStorageModel.xcdatamodeld */; };
 		9E4AB2AF2BA1BEE900F5D6DB /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0D4E7A0F26B364180058B01E /* Preview Assets.xcassets */; };
 		9E4AB2B02BA1BEE900F5D6DB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E2F1C8B280ED6A7004E65FE /* LaunchScreen.storyboard */; };
@@ -2429,7 +2386,6 @@
 		9E5AB47A2C94777800065483 /* whatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E6C98472BF4C65F00EACDCB /* whatsNew.json */; };
 		9E5AB47C2C94777800065483 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 9EDDAF6C2BA2D71700A69A07 /* PrivacyInfo.xcprivacy */; };
 		9E5AB47D2C94777800065483 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E5AAEBF2A67CEC4003F283D /* Colors.xcassets */; };
-		9E5B8E742B46E04E00CA3616 /* RestoreWalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5B8E732B46E04E00CA3616 /* RestoreWalletTests.swift */; };
 		9E5CFD0F2CE61B7200C95713 /* sending.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E5CFD0E2CE61B7200C95713 /* sending.json */; };
 		9E5CFD102CE61B7200C95713 /* sending.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E5CFD0E2CE61B7200C95713 /* sending.json */; };
 		9E5CFD112CE61B7200C95713 /* sending.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E5CFD0E2CE61B7200C95713 /* sending.json */; };
@@ -2440,11 +2396,9 @@
 		9E5CFD172CE6215500C95713 /* sending-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E5CFD142CE6215500C95713 /* sending-dark.json */; };
 		9E5CFD182CE6215500C95713 /* sending-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E5CFD142CE6215500C95713 /* sending-dark.json */; };
 		9E5CFD192CE6215500C95713 /* sending-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E5CFD142CE6215500C95713 /* sending-dark.json */; };
-		9E683E472B0377F0002E7B5D /* WalletNukeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E683E462B0377F0002E7B5D /* WalletNukeTests.swift */; };
 		9E6C98492BF4C65F00EACDCB /* whatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E6C98472BF4C65F00EACDCB /* whatsNew.json */; };
 		9E6C984A2BF4C65F00EACDCB /* whatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E6C98472BF4C65F00EACDCB /* whatsNew.json */; };
 		9E6C984B2BF4C65F00EACDCB /* whatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E6C98472BF4C65F00EACDCB /* whatsNew.json */; };
-		9E74CCD029DC0628003D6E32 /* ReviewRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E74CCCF29DC0628003D6E32 /* ReviewRequestTests.swift */; };
 		9E89DF702CD27344002E5317 /* whatsNew_es.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E89DF6F2CD27344002E5317 /* whatsNew_es.json */; };
 		9E89DF712CD27344002E5317 /* whatsNew_es.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E89DF6F2CD27344002E5317 /* whatsNew_es.json */; };
 		9E89DF722CD27344002E5317 /* whatsNew_es.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E89DF6F2CD27344002E5317 /* whatsNew_es.json */; };
@@ -2452,11 +2406,9 @@
 		9E89DF742CD27344002E5317 /* whatsNew_es.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E89DF6F2CD27344002E5317 /* whatsNew_es.json */; };
 		9E90751E2A269BE300269308 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E90751D2A269BE300269308 /* Assets.xcassets */; };
 		9E90751F2A269BE300269308 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E90751D2A269BE300269308 /* Assets.xcassets */; };
-		9EA7ED062B7A591C005979F4 /* ZatoshiStringRepresentationCommaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA7ED052B7A591C005979F4 /* ZatoshiStringRepresentationCommaTests.swift */; };
 		9EDDAF6D2BA2D71700A69A07 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 9EDDAF6C2BA2D71700A69A07 /* PrivacyInfo.xcprivacy */; };
 		9EDDAF6E2BA2D71700A69A07 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 9EDDAF6C2BA2D71700A69A07 /* PrivacyInfo.xcprivacy */; };
 		9EDDAF6F2BA2D71700A69A07 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 9EDDAF6C2BA2D71700A69A07 /* PrivacyInfo.xcprivacy */; };
-		9EEB06C62B344F1E00EEE50F /* SyncProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB06C52B344F1E00EEE50F /* SyncProgressTests.swift */; };
 		9EEBF7752FBB053400DD38DB /* VotingMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBF7742FBB053400DD38DB /* VotingMetadata.swift */; };
 		9EEBF7762FBB053400DD38DB /* VotingMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBF7742FBB053400DD38DB /* VotingMetadata.swift */; };
 		9EEBF7772FBB053400DD38DB /* VotingMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBF7742FBB053400DD38DB /* VotingMetadata.swift */; };
@@ -2602,11 +2554,14 @@
 		9EEBF9D52FBDAE2100DD38DB /* VotingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBF9D22FBDAE2100DD38DB /* VotingHelpers.swift */; };
 		9EEBF9D62FBDAE2100DD38DB /* VotingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBF9D22FBDAE2100DD38DB /* VotingHelpers.swift */; };
 		9EEBF9D72FBDAE2100DD38DB /* VotingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBF9D22FBDAE2100DD38DB /* VotingHelpers.swift */; };
+		A3150A056C1A6B467B9F30BC /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
+		A6614A6838412195D1C0036E /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00102D00000100000002 /* VotingSessionTests.swift */; };
 		AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00202D00000100000002 /* VotingAPIResponseParserTests.swift */; };
 		AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00212D00000100000002 /* VotingHelpersTests.swift */; };
 		AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00222D00000100000002 /* VotingCoordFlowCoordinatorTests.swift */; };
 		AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00232D00000100000002 /* VotingServiceConfigTests.swift */; };
+		B162C19E08D002B2D9B020A9 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2638,6 +2593,7 @@
 		0D4E7A2726B364180058B01E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0DEF4766299EA5920032708B /* secant-mainnet-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "secant-mainnet-Info.plist"; sourceTree = "<group>"; };
 		0DFE93DE272C6D4B000FCCA5 /* RecoveryPhraseBackupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseBackupTests.swift; sourceTree = "<group>"; };
+		0F94E337360CE50FACFB04CE /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
 		341B30BA29B78D1000697081 /* HomeFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFeatureFlagTests.swift; sourceTree = "<group>"; };
 		34429C6D28E703CD00F2B929 /* TransactionSendingSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSendingSnapshotTests.swift; sourceTree = "<group>"; };
 		3448CB3628E485CB006ADEDB /* NotEnoughFeeSpaceSnapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotEnoughFeeSpaceSnapshots.swift; sourceTree = "<group>"; };
@@ -3044,7 +3000,6 @@
 		34AA6DBA2F85774F00D244E2 /* TCALoggerReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCALoggerReducer.swift; sourceTree = "<group>"; };
 		34AA6DBB2F85774F00D244E2 /* TCALogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCALogging.swift; sourceTree = "<group>"; };
 		34AA6DBD2F85774F00D244E2 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
-		0F94E337360CE50FACFB04CE /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
 		34AA6DBE2F85774F00D244E2 /* Array+Chunked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Chunked.swift"; sourceTree = "<group>"; };
 		34AA6DBF2F85774F00D244E2 /* BalanceFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceFormatter.swift; sourceTree = "<group>"; };
 		34AA6DC02F85774F00D244E2 /* Bindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bindings.swift; sourceTree = "<group>"; };
@@ -3070,6 +3025,7 @@
 		34AA77022F857D3E00D244E2 /* swiftgen.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		34AA77032F857D4100D244E2 /* fonts_swift5_swiftui.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = fonts_swift5_swiftui.stencil; sourceTree = "<group>"; };
 		34AA77052F857D4100D244E2 /* assets_swift5_swiftui.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = assets_swift5_swiftui.stencil; sourceTree = "<group>"; };
+		34D06C902FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecommissionedServerMigrationTests.swift; sourceTree = "<group>"; };
 		34F039B229ABCE8500CF0053 /* WalletConfigProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletConfigProviderTests.swift; sourceTree = "<group>"; };
 		37BTC00000000000000INT01 /* BackgroundTaskClientInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskClientInterface.swift; sourceTree = "<group>"; };
 		37BTC00000000000000LIV01 /* BackgroundTaskClientLiveKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskClientLiveKey.swift; sourceTree = "<group>"; };
@@ -5459,6 +5415,7 @@
 				9EF8135B27ECC25E0075AF48 /* UserPreferencesStorageTests.swift */,
 				9EF8135A27ECC25E0075AF48 /* WalletStorageTests.swift */,
 				9E39112D283F91600073DD9A /* ZatoshiTests.swift */,
+				34D06C902FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift */,
 			);
 			path = UtilTests;
 			sourceTree = "<group>";
@@ -9682,7 +9639,7 @@
 			repositoryURL = "https://github.com/zcash/zcash-swift-wallet-sdk.git";
 			requirement = {
 				kind = revision;
-				revision = 909c7c5743f14a211f9f69f97ed08c05b55c2cd5;
+				revision = 381f2dee38d2db28d7c642dc11ec7e1e83399b55;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -492,7 +492,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zcash/zcash-swift-wallet-sdk.git",
       "state" : {
-        "revision" : "909c7c5743f14a211f9f69f97ed08c05b55c2cd5"
+        "revision" : "381f2dee38d2db28d7c642dc11ec7e1e83399b55"
       }
     }
   ],

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
@@ -98,9 +98,7 @@ extension ZcashSDKEnvironment {
                 LightWalletEndpoint(address: "eu.zec.rocks", port: 443),
                 LightWalletEndpoint(address: "ap.zec.rocks", port: 443),
                 LightWalletEndpoint(address: "us.zec.stardust.rest", port: 443),
-                LightWalletEndpoint(address: "eu.zec.stardust.rest", port: 443),
-                LightWalletEndpoint(address: "eu2.zec.stardust.rest", port: 443),
-                LightWalletEndpoint(address: "jp.zec.stardust.rest", port: 443)
+                LightWalletEndpoint(address: "eu.zec.stardust.rest", port: 443)
             ]
         )
         

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
@@ -38,7 +38,8 @@ extension ZcashSDKEnvironment: DependencyKey {
 extension ZcashSDKEnvironment {
     static func serverConfig(for network: NetworkType) -> UserPreferencesStorage.ServerConfig {
         migrateVersion1IfNeeded()
-        
+        migrateDecommissionedServersIfNeeded(for: network)
+
         guard let serverConfig = storedServerConfig() else {
             return defaultEndpoint(for: network).serverConfig()
         }
@@ -95,6 +96,26 @@ extension ZcashSDKEnvironment {
         }
     }
     
+    static func migrateDecommissionedServersIfNeeded(for network: NetworkType) {
+        @Dependency(\.userStoredPreferences) var userStoredPreferences
+
+        // Intentionally kept separate from `endpoints(...)`: these hosts have been removed from the
+        // endpoint list, and we migrate any user whose stored server matches one of these exact
+        // "host:port" values precisely because the server no longer appears there. Add future
+        // decommissioned servers here as "host:port".
+        let decommissionedServers: Set<String> = [
+            "eu2.zec.stardust.rest:443",
+            "jp.zec.stardust.rest:443"
+        ]
+
+        guard let serverConfig = userStoredPreferences.server() else { return }
+
+        if decommissionedServers.contains(serverConfig.serverString()) {
+            let defaultConfig = defaultEndpoint(for: network).serverConfig()
+            try? userStoredPreferences.setServer(defaultConfig)
+        }
+    }
+
     static func storedServerConfig() -> UserPreferencesStorage.ServerConfig? {
         @Dependency(\.userStoredPreferences) var userStoredPreferences
         return userStoredPreferences.server()

--- a/secantTests/UtilTests/DecommissionedServerMigrationTests.swift
+++ b/secantTests/UtilTests/DecommissionedServerMigrationTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zashi_internal
 
@@ -21,5 +22,216 @@ final class DecommissionedServerMigrationTests: XCTestCase {
         let mainnetServers = ZcashSDKEnvironment.servers(for: .mainnet)
         XCTAssertFalse(mainnetServers.contains(.hardcoded("eu2.zec.stardust.rest:443")), "eu2 must be removed from servers(for:)")
         XCTAssertFalse(mainnetServers.contains(.hardcoded("jp.zec.stardust.rest:443")), "jp must be removed from servers(for:)")
+    }
+
+    // MARK: - Helpers
+
+    private static let suiteName = "DecommissionedServerMigrationTests"
+
+    /// A real `UserPreferencesStorage` backed by an isolated, cleared UserDefaults suite (stateful).
+    private func makeStorage() throws -> UserPreferencesStorage {
+        let suite = try XCTUnwrap(UserDefaults(suiteName: Self.suiteName))
+        let storage = UserPreferencesStorage(
+            defaultExchangeRate: Data(),
+            defaultServer: Data(),
+            userDefaults: .live(userDefaults: suite)
+        )
+        storage.removeAll()
+        return storage
+    }
+
+    /// Wraps the storage in a `UserPreferencesStorageClient`, mirroring `UserPreferencesStorageLive.live()`.
+    private func client(_ storage: UserPreferencesStorage) -> UserPreferencesStorageClient {
+        UserPreferencesStorageClient(
+            server: { storage.server },
+            setServer: { try storage.setServer($0) },
+            exchangeRate: { storage.exchangeRate },
+            setExchangeRate: { try storage.setExchangeRate($0) },
+            removeAll: { storage.removeAll() }
+        )
+    }
+
+    private var mainnetDefault: UserPreferencesStorage.ServerConfig {
+        UserPreferencesStorage.ServerConfig(host: "zec.rocks", port: 443, isCustom: false)
+    }
+
+    // MARK: - Rule 1: default server -> no migration
+
+    func test_noStoredServer_noMigration() throws {
+        let storage = try makeStorage()
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertNil(storage.server)
+    }
+
+    func test_storedDefaultServer_noMigration() throws {
+        let storage = try makeStorage()
+        try storage.setServer(mainnetDefault)
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, mainnetDefault)
+    }
+
+    // MARK: - Rule 2: manual server, not removed -> no migration
+
+    func test_manualServerNotRemoved_noMigration() throws {
+        let storage = try makeStorage()
+        let original = UserPreferencesStorage.ServerConfig(host: "na.zec.rocks", port: 443, isCustom: false)
+        try storage.setServer(original)
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, original)
+    }
+
+    // MARK: - Rule 3: manual server, removed -> migrate to default
+
+    func test_manualServerRemoved_eu2_migratesToDefault() throws {
+        let storage = try makeStorage()
+        try storage.setServer(UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 443, isCustom: false))
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, mainnetDefault)
+    }
+
+    func test_manualServerRemoved_jp_migratesToDefault() throws {
+        let storage = try makeStorage()
+        try storage.setServer(UserPreferencesStorage.ServerConfig(host: "jp.zec.stardust.rest", port: 443, isCustom: false))
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, mainnetDefault)
+    }
+
+    // MARK: - Rule 4: custom server, other URL -> no migration
+
+    func test_customServerOther_noMigration() throws {
+        let storage = try makeStorage()
+        let original = UserPreferencesStorage.ServerConfig(host: "my.custom.node", port: 443, isCustom: true)
+        try storage.setServer(original)
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, original)
+    }
+
+    // MARK: - Rule 5: custom server, exact decommissioned URL -> migrate to default
+
+    func test_customServerExact_eu2_migratesToDefault() throws {
+        let storage = try makeStorage()
+        try storage.setServer(UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 443, isCustom: true))
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, mainnetDefault)
+    }
+
+    func test_customServerExact_jp_migratesToDefault() throws {
+        let storage = try makeStorage()
+        try storage.setServer(UserPreferencesStorage.ServerConfig(host: "jp.zec.stardust.rest", port: 443, isCustom: true))
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, mainnetDefault)
+    }
+
+    // MARK: - Edge: decommissioned host on a non-443 port -> no migration ("exactly :443")
+
+    func test_customDecommissionedHost_nonDefaultPort_noMigration() throws {
+        let storage = try makeStorage()
+        let original = UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 9067, isCustom: true)
+        try storage.setServer(original)
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, original)
+    }
+
+    // MARK: - Edge: testnet user on a decommissioned custom URL -> migrate to testnet default
+
+    func test_testnetCustomDecommissioned_migratesToTestnetDefault() throws {
+        let storage = try makeStorage()
+        try storage.setServer(UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 443, isCustom: true))
+
+        withDependencies {
+            $0.userStoredPreferences = client(storage)
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .testnet)
+        }
+
+        XCTAssertEqual(storage.server, UserPreferencesStorage.ServerConfig(host: "testnet.zec.rocks", port: 443, isCustom: false))
+    }
+
+    // MARK: - Idempotency
+
+    func test_migrationIsIdempotent() throws {
+        let storage = try makeStorage()
+        try storage.setServer(UserPreferencesStorage.ServerConfig(host: "jp.zec.stardust.rest", port: 443, isCustom: true))
+
+        let prefsClient = client(storage)
+        withDependencies {
+            $0.userStoredPreferences = prefsClient
+        } operation: {
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+            ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
+        }
+
+        XCTAssertEqual(storage.server, mainnetDefault)
+    }
+
+    // MARK: - Integration: serverConfig(for:) returns the default after migrating
+
+    func test_serverConfig_returnsDefault_afterMigratingDecommissionedServer() throws {
+        let storage = try makeStorage()
+        try storage.setServer(UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 443, isCustom: false))
+
+        let result = withDependencies {
+            $0.userStoredPreferences = client(storage)
+            $0.userDefaults = .noOp
+        } operation: {
+            ZcashSDKEnvironment.serverConfig(for: .mainnet)
+        }
+
+        XCTAssertEqual(result, mainnetDefault, "serverConfig(for:) must return the default that the SDK Initializer will use")
+        XCTAssertEqual(storage.server, mainnetDefault, "the migration must be persisted")
     }
 }

--- a/secantTests/UtilTests/DecommissionedServerMigrationTests.swift
+++ b/secantTests/UtilTests/DecommissionedServerMigrationTests.swift
@@ -1,0 +1,25 @@
+//
+//  DecommissionedServerMigrationTests.swift
+//  secantTests
+//
+//  Created on 2026-06-05.
+//
+
+import XCTest
+@preconcurrency import ZcashLightClientKit
+@testable import zashi_internal
+
+final class DecommissionedServerMigrationTests: XCTestCase {
+    // MARK: - Removal of decommissioned servers
+
+    func test_endpoints_doNotContainDecommissionedServers() {
+        let hosts = ZcashSDKEnvironment.endpoints().map { $0.host }
+
+        XCTAssertFalse(hosts.contains("eu2.zec.stardust.rest"), "eu2.zec.stardust.rest must be removed from endpoints()")
+        XCTAssertFalse(hosts.contains("jp.zec.stardust.rest"), "jp.zec.stardust.rest must be removed from endpoints()")
+
+        let mainnetServers = ZcashSDKEnvironment.servers(for: .mainnet)
+        XCTAssertFalse(mainnetServers.contains(.hardcoded("eu2.zec.stardust.rest:443")), "eu2 must be removed from servers(for:)")
+        XCTAssertFalse(mainnetServers.contains(.hardcoded("jp.zec.stardust.rest:443")), "jp must be removed from servers(for:)")
+    }
+}


### PR DESCRIPTION
## Summary

- Remove the two decommissioned lightwalletd servers `eu2.zec.stardust.rest` and `jp.zec.stardust.rest` from `ZcashSDKEnvironment.endpoints(skipDefault:)` (they also disappear from the Server setup picker automatically).
- Add `migrateDecommissionedServersIfNeeded(for:)`, invoked from `serverConfig(for:)` right after the existing `migrateVersion1IfNeeded()`. Any user whose stored server is **exactly** `eu2.zec.stardust.rest:443` or `jp.zec.stardust.rest:443` is migrated to the network default. Because this runs at the moment the endpoint is read — **before the SDK `Initializer` is built** — the decommissioned (dead) host is never contacted.

## Migration behavior

The five cases collapse to one check on the stored `host:port` string (the `isCustom` flag is intentionally ignored):

| Stored server | Action |
|---|---|
| Default (no stored config, or `zec.rocks:443`) | none |
| Manual pick, not removed (e.g. `na.zec.rocks:443`) | none |
| Manual pick = `eu2`/`jp …:443` | → network default |
| Custom URL, other host | none |
| Custom URL = exactly `eu2`/`jp …:443` | → network default |

- Persisted via `userStoredPreferences.setServer(...)`; idempotent (a migrated user lands on `zec.rocks:443`, which is no longer in the set).
- A decommissioned host on a non-443 port is intentionally **not** migrated ("exactly :443").
- Migrates to the network-appropriate default (mainnet `zec.rocks:443`, testnet `testnet.zec.rocks:443`).

## Verification

- ✅ App build passes (0 errors).
- ⚠️ Unit tests (`DecommissionedServerMigrationTests`, 13 tests covering all 5 rules + edge cases + idempotency + an integration test through `serverConfig(for:)`) are included as executable documentation, but **were not run**: the `secantTests` target does not currently build project-wide due to the in-progress rebrand (split `secant_testnet` / `zashi_internal` module imports). They should pass once that target is repaired.

## Note on branch scope

This branch also carries two unrelated/supporting items that predate the feature commits:
- `Update SDK` — the dependency/SDK bump made to get the project compiling.
- `docs/superpowers/` — the design spec and implementation plan for this change.

## Manual test plan

- [ ] On a build pointed at `eu2.zec.stardust.rest:443` (manual pick or custom URL), relaunch and confirm the wallet is now on the default server and syncs.
- [ ] Repeat for `jp.zec.stardust.rest:443`.
- [ ] Confirm a user on a different custom server (e.g. `eu2.zec.stardust.rest:9067` or an unrelated host) is left untouched.
- [ ] Confirm a user already on the default or another listed server is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)