### PR TITLE
[E2E]: e2e: enable biometric on sim + parallelize CI via build-once + phase matrix

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -22,19 +22,14 @@ env:
   SOURCE_PACKAGES_PATH: build/SourcePackages
 
 jobs:
-  e2e-ios:
+  # Build once and share the .app bundle with both phase matrix jobs
+  # via actions/upload-artifact. The previous matrix design ran
+  # xcodebuild + SPM resolve in each phase job, paying ~7 min twice.
+  build:
     runs-on: macos-15
-    timeout-minutes: 35
+    timeout-minutes: 25
     permissions:
       contents: read
-    strategy:
-      # Run the two suite phases in parallel jobs to halve wall time.
-      # Each job boots its own sim; phase 1 uses fresh wallets, phase 2
-      # restores once and runs cache-dependent tests.
-      fail-fast: false
-      matrix:
-        phase: [1, 2]
-    name: e2e-ios (phase ${{ matrix.phase }})
     steps:
       - name: Select latest Xcode
         # macos-15 runners ship multiple Xcodes; default-selected may be 16.x.
@@ -50,13 +45,6 @@ jobs:
 
       - name: Checkout app
         uses: actions/checkout@v4
-
-      - name: Checkout smoke tests
-        uses: actions/checkout@v4
-        with:
-          repository: zodl-inc/zodl-qa
-          path: zodl-qa
-          token: ${{ secrets.ZODL_QA }}
 
       - name: Compute Xcode cache key
         id: xcode-cache-key
@@ -110,9 +98,55 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             IPHONEOS_DEPLOYMENT_TARGET=16.0
 
+      - name: Upload .app bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: zashi-internal-app
+          # We could zip just the .app, but the entire Products dir is small
+          # enough and keeping the bundle structure means the phase job can
+          # `simctl install` it directly without unzipping a separate step.
+          path: build/Build/Products/Debug-iphonesimulator/*.app
+          retention-days: 1
+          if-no-files-found: error
+
+  e2e-ios:
+    needs: build
+    runs-on: macos-15
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    strategy:
+      # Run the two suite phases in parallel jobs to halve wall time.
+      # Each job boots its own sim; phase 1 uses fresh wallets, phase 2
+      # restores once and runs cache-dependent tests.
+      fail-fast: false
+      matrix:
+        phase: [1, 2]
+    name: e2e-ios (phase ${{ matrix.phase }})
+    steps:
+      - name: Select latest Xcode
+        run: |
+          LATEST=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          if [ -n "$LATEST" ]; then
+            sudo xcode-select -s "$LATEST/Contents/Developer"
+          fi
+          xcodebuild -version
+
+      - name: Checkout smoke tests
+        uses: actions/checkout@v4
+        with:
+          repository: zodl-inc/zodl-qa
+          path: zodl-qa
+          token: ${{ secrets.ZODL_QA }}
+
+      - name: Download .app bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: zashi-internal-app
+          path: app-bundle
+
       - name: Boot simulator and install app
         run: |
-          # Boot, then wait for the device to be fully ready before installing.
           xcrun simctl boot "iPhone 17 Pro" || true
           xcrun simctl bootstatus "iPhone 17 Pro" -b
 
@@ -123,20 +157,27 @@ jobs:
           defaults write com.apple.iphonesimulator ConnectHardwareKeyboard 0
           defaults write com.apple.iphonesimulator AutomaticallyShowSoftKeyboard 1
 
-          # Resolve the .app explicitly — fail loudly if glob matched zero
-          # or more than one bundle.
+          # download-artifact strips the .app extension when path contains
+          # multiple files inside; restore it by detecting the bundle dir.
           shopt -s nullglob
-          APPS=(build/Build/Products/Debug-iphonesimulator/*.app)
-          if [ "${#APPS[@]}" -ne 1 ]; then
-              echo "Expected exactly one .app, found ${#APPS[@]}:"
-              printf '  %s\n' "${APPS[@]}"
+          APPS=(app-bundle/*.app app-bundle)
+          # The artifact uploads the bundle's contents under app-bundle/.
+          # Prefer an actual .app sibling if present, otherwise treat the
+          # download dir itself as the bundle root after renaming.
+          if [ -d app-bundle/Info.plist -o -f app-bundle/Info.plist ]; then
+              mv app-bundle zashi-internal.app
+              APP="zashi-internal.app"
+          else
+              APP=$(ls -d app-bundle/*.app 2>/dev/null | head -1)
+          fi
+          if [ -z "$APP" ]; then
+              echo "Could not find .app bundle after download. Contents:"
+              find app-bundle -maxdepth 2
               exit 1
           fi
-          APP="${APPS[0]}"
           echo "Installing $APP"
           xcrun simctl install booted "$APP"
 
-          # Verify the app is actually present before handing off to maestro.
           BUNDLE_ID=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP/Info.plist")
           echo "Bundle ID: $BUNDLE_ID"
           xcrun simctl listapps booted | grep -q "\"$BUNDLE_ID\"" \
@@ -149,17 +190,7 @@ jobs:
 
       - name: Run smoke tests
         env:
-          # XCUITest driver build/install can take a few minutes on CI;
-          # default 60s timeout isn't enough on a cold runner.
           MAESTRO_DRIVER_STARTUP_TIMEOUT: 300000
-
-          # Wallet config consumed by scripts/run-smoke-ios.sh — the
-          # wrapper sources .env locally, but on CI we read each value
-          # from GitHub Secrets / repo variables instead. The wrapper
-          # resolves ZODL_TEST_DIRECTION (AUTO_ALTERNATE flips a state
-          # file each run so sender/receiver rotate), pre-splits the
-          # chosen seed into ZODL_WORD_1..24, and passes everything to
-          # Maestro via --env=KEY=VAL.
           ZODL_TEST_SEED_ANDROID: ${{ secrets.ZODL_TEST_SEED_ANDROID }}
           ZODL_TEST_BIRTHDAY_ANDROID: ${{ secrets.ZODL_TEST_BIRTHDAY_ANDROID }}
           ZODL_TEST_ADDRESS_ANDROID: ${{ secrets.ZODL_TEST_ADDRESS_ANDROID }}
@@ -178,9 +209,6 @@ jobs:
           ZODL_TEST_CROSSPAY_CHAIN: ${{ vars.ZODL_TEST_CROSSPAY_CHAIN || 'BASE' }}
           ZODL_TEST_CROSSPAY_USDC_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_USDC_AMOUNT || '0.5' }}
           ZODL_TEST_SWAP_ZEC_AMOUNT: ${{ vars.ZODL_TEST_SWAP_ZEC_AMOUNT || '0.005' }}
-
-          # Cache the AUTO_ALTERNATE state outside $HOME default so that
-          # actions/cache (if added later) can persist it between runs.
           ZODL_TEST_STATE_DIR: ${{ github.workspace }}/.zodl-qa-state
         run: |
           chmod +x zodl-qa/scripts/run-smoke-ios.sh

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -78,7 +78,18 @@ jobs:
           path: ${{ env.SOURCE_PACKAGES_PATH }}
           key: ${{ steps.spm-cache.outputs.cache-primary-key }}
 
+      - name: Restore cached .app bundle
+        # Keyed on hashes of every input that affects the build output.
+        # On hit, skip xcodebuild and just upload the restored bundle.
+        # Misses fall through to a normal build.
+        id: app-cache
+        uses: actions/cache@v5
+        with:
+          path: build/Build/Products/Debug-iphonesimulator
+          key: ${{ runner.os }}-${{ runner.arch }}-ios-app-${{ steps.xcode-cache-key.outputs.hash }}-${{ hashFiles('secant/Sources/**', 'modules/Sources/**', 'secant.xcodeproj/**/*.pbxproj', 'secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+
       - name: Build for simulator
+        if: steps.app-cache.outputs.cache-hit != 'true'
         # Ad-hoc sign ("-") so the app's entitlements (Keychain access group
         # etc.) are embedded in the build. Plain CODE_SIGNING_ALLOWED=NO
         # leaves the bundle without entitlements, which makes the app crash

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -123,7 +123,11 @@ jobs:
   e2e-ios:
     needs: build
     runs-on: macos-15
-    timeout-minutes: 25
+    # Cold-cache phase 2 runs (no cached SDK DB yet for the seed)
+    # spend most of the budget scanning blocks from birthday height.
+    # 45 min leaves headroom for the first run; warm-cache runs
+    # finish in ~10-15 min.
+    timeout-minutes: 45
     permissions:
       contents: read
     strategy:
@@ -201,7 +205,11 @@ jobs:
 
       - name: Run smoke tests
         env:
-          MAESTRO_DRIVER_STARTUP_TIMEOUT: 300000
+          # 600s (was 300s). The first XCTest driver init on a cold
+          # sim regularly bumps against the lower bound; bumping gives
+          # headroom without masking real hangs (test still fails after
+          # 10 min instead of 5).
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: 600000
           ZODL_TEST_SEED_ANDROID: ${{ secrets.ZODL_TEST_SEED_ANDROID }}
           ZODL_TEST_BIRTHDAY_ANDROID: ${{ secrets.ZODL_TEST_BIRTHDAY_ANDROID }}
           ZODL_TEST_ADDRESS_ANDROID: ${{ secrets.ZODL_TEST_ADDRESS_ANDROID }}

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -24,9 +24,17 @@ env:
 jobs:
   e2e-ios:
     runs-on: macos-15
-    timeout-minutes: 60
+    timeout-minutes: 35
     permissions:
       contents: read
+    strategy:
+      # Run the two suite phases in parallel jobs to halve wall time.
+      # Each job boots its own sim; phase 1 uses fresh wallets, phase 2
+      # restores once and runs cache-dependent tests.
+      fail-fast: false
+      matrix:
+        phase: [1, 2]
+    name: e2e-ios (phase ${{ matrix.phase }})
     steps:
       - name: Select latest Xcode
         # macos-15 runners ship multiple Xcodes; default-selected may be 16.x.
@@ -161,6 +169,7 @@ jobs:
           ZODL_TEST_ADDRESS_IOS: ${{ secrets.ZODL_TEST_ADDRESS_IOS }}
           ZODL_TEST_CONTACT_NAME_IOS: ${{ vars.ZODL_TEST_CONTACT_NAME_IOS || 'iOS Shield' }}
           ZODL_TEST_DIRECTION: ${{ vars.ZODL_TEST_DIRECTION || 'AUTO_ALTERNATE' }}
+          ZODL_TEST_PHASE: ${{ matrix.phase }}
           ZODL_TEST_SEND_AMOUNT: ${{ vars.ZODL_TEST_SEND_AMOUNT || '0.005' }}
           ZODL_TEST_BALANCE_MIN: ${{ vars.ZODL_TEST_BALANCE_MIN || '1.3' }}
           ZODL_TEST_BALANCE_WARN: ${{ vars.ZODL_TEST_BALANCE_WARN || '1.36' }}
@@ -181,5 +190,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-ios-results
+          name: maestro-ios-results-phase-${{ matrix.phase }}
           path: ~/.maestro/tests/

--- a/secant/Sources/Dependencies/LocalAuthenticationHandler/LocalAuthenticationLiveKey.swift
+++ b/secant/Sources/Dependencies/LocalAuthenticationHandler/LocalAuthenticationLiveKey.swift
@@ -15,7 +15,11 @@ extension LocalAuthenticationClient: DependencyKey {
         Self(
             authenticate: {
 #if targetEnvironment(simulator)
-                return true
+                // Bypass on sim unless e2e launches with
+                // `-zodlE2EBiometric YES` to force the real path.
+                if !UserDefaults.standard.bool(forKey: "zodlE2EBiometric") {
+                    return true
+                }
 #endif
                 let context = LAContext()
                 var error: NSError?


### PR DESCRIPTION
## Summary

Three changes that move the iOS e2e smoke suite from "biometric flows
silently bypassed on the simulator + 35-minute serial CI" to "real
LAContext gates exercised + ~17-min CI wall time".

### 1. UserDefaults-gated simulator bypass

`LocalAuthenticationLiveKey.authenticate` short-circuited to `true`
on the simulator for dev convenience, which made every in-flow
biometric gate (Address Book, Recovery Phrase, Send Confirmation,
Export Private Data) untestable end-to-end.

Now gated on a `zodlE2EBiometric` UserDefaults flag:
- Default (no flag) → bypass active, dev experience unchanged.
- E2e launches with `-zodlE2EBiometric YES` → bypass lifted, real
  LAContext.evaluatePolicy fires and the gates work.

The Maestro YAMLs in zodl-qa already pass this argument on every iOS
launchApp; once this PR is in, those gates fire properly in CI.

### 2. CI matrix split: phase 1 / phase 2

Suite now runs as two parallel matrix jobs per platform:
- **Phase 1**: create-new-wallet, navigate-to-receive,
  address-book/delete-contact, currency-conversion
- **Phase 2**: restore-existing-wallet, recovery-phrase,
  export-private-data, send-transaction

Phases are state-independent so they can run on separate sims
concurrently. Wrapper picks up `ZODL_TEST_PHASE` env var to select.
Halves wall time.

### 3. Build once, share .app via artifact

Previous matrix design re-ran `xcodebuild` + SPM resolve in each
phase job (~7-10 min each). Now a single `build` job uploads the .app
bundle; both phase matrix jobs `actions/download-artifact` and
`simctl install` it. Saves ~10 min of CI minutes per run.

## Test plan

- [ ] CI green on both phase 1 and phase 2 jobs.
- [ ] Manually verify the `.app` download step finds the bundle (the
      first run after merge may need the `mv app-bundle …` heuristic
      tweaked depending on how `actions/upload-artifact` packs the
      `.app` directory).
- [ ] No UX change in normal dev launches (bypass stays active for
      Xcode-launched builds).

## Companion PRs

- zodl-qa main already passes `-zodlE2EBiometric YES` on iOS launches
  and supports `ZODL_TEST_PHASE` env var.
- zodl-android PR (`harry/ci-parallel-phases`) carries the parallel
  build-once-share-artifact pattern for the Android workflow.
