### PR TITLE
[E2E]: bump runner to macos-26 to match local dev macOS

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -26,7 +26,7 @@ jobs:
   # via actions/upload-artifact. The previous matrix design ran
   # xcodebuild + SPM resolve in each phase job, paying ~7 min twice.
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 25
     permissions:
       contents: read
@@ -122,7 +122,7 @@ jobs:
 
   e2e-ios:
     needs: build
-    runs-on: macos-15
+    runs-on: macos-26
     # Cold-cache phase 2 runs (no cached SDK DB yet for the seed)
     # spend most of the budget scanning blocks from birthday height.
     # 45 min leaves headroom for the first run; warm-cache runs


### PR DESCRIPTION
Stacked on top of #1808 (parallelize / biometric-toggle PR).

## What

Bump the CI iOS runner from `macos-15` to **`macos-26`** so it matches what devs actually run locally (macOS Tahoe 26). Brings the iOS sim runtime + Xcode version in line with the dev environment.

## Why

The runner version affects:
- Xcode version (newer = closer to what devs use)
- Sim runtime (iOS 26.x sims on macos-26 vs iOS 26.x on macos-15 behave differently — XCTest driver startup time, SwiftUI hit-testing on cold sim, etc.)
- The Maestro driver image's compatibility with the underlying XCTest framework

We've burned a lot of debug cycles this week chasing iOS-26-only quirks on macos-15 runners (Face ID overshoot to Springboard, SwiftUI tap not landing on cold sim). Matching the dev environment closes that gap.

## What changed

Both `runs-on: macos-15` lines (build job + e2e-phase matrix) flipped to `macos-26`.

## Out of scope (now)

This branch previously carried a "persist wallet direction across CI runs via GH repo variable" commit. We dropped that — instead each platform's wrapper now hardcodes its own direction (Android: `ANDROID_TO_IOS`, iOS: `IOS_TO_ANDROID`), each platform tests its native send path against its own seed. That's the realistic config. The wrapper change is in `zodl-qa` main; nothing in this repo depends on it.

## Test plan
- [ ] CI green on this branch
- [ ] Sim version in run log shows iOS 26.x on macos-26 host