### PR TITLE
Fix remaining Swift 6 concurrency warnings

### DIFF
--- a/secant/Sources/Features/AddressBook/AddressBookStore.swift
+++ b/secant/Sources/Features/AddressBook/AddressBookStore.swift
@@ -356,7 +356,7 @@ struct AddressBook {
                 if requestToSync {
                     return .run { send in
                         do {
-                            let result = try await addressBook.syncContacts(account.account, abContacts)
+                            let result = try addressBook.syncContacts(account.account, abContacts)
                             let syncedContacts = result.contacts
                             if result.remoteStoreResult == .failure {
                                 // TODO: [#1408] error handling https://github.com/Electric-Coin-Company/zashi-ios/issues/1408

--- a/secant/Sources/Features/AddressDetails/AddressDetailsStore.swift
+++ b/secant/Sources/Features/AddressDetails/AddressDetailsStore.swift
@@ -99,26 +99,27 @@ struct AddressDetails {
                 return .none
 
             case .generateQRCode:
-                return .publisher {
-                    QRCodeGenerator.generate(
-                        from: state.address.data,
-                        maxPrivacy: state.maxPrivacy,
+                let color = Asset.Colors.primary.systemColor
+                return .run { [data = state.address.data, maxPrivacy = state.maxPrivacy] send in
+                    let image = await QRCodeGenerator.generate(
+                        from: data,
+                        maxPrivacy: maxPrivacy,
                         vendor: .zashi,
-                        color: Asset.Colors.primary.systemColor
+                        color: color
                     )
-                    .map(Action.rememberQR)
+                    await send(.rememberQR(image))
                 }
                 .cancellable(id: state.cancelId)
-                
+
             case .generateEnlargedQRCode:
-                return .publisher {
-                    QRCodeGenerator.generate(
-                        from: state.address.data,
-                        maxPrivacy: state.maxPrivacy,
+                return .run { [data = state.address.data, maxPrivacy = state.maxPrivacy] send in
+                    let image = await QRCodeGenerator.generate(
+                        from: data,
+                        maxPrivacy: maxPrivacy,
                         vendor: .zashi,
                         color: .black
                     )
-                    .map(Action.rememberEnlargedQR)
+                    await send(.rememberEnlargedQR(image))
                 }
                 .cancellable(id: state.cancelId)
 

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -259,12 +259,12 @@ extension ScanCoordFlow {
                     return .send(.requestZecFailed)
                 }
                 
-                return .run { [state] send in
-                    guard let recipient = state.recipient else {
+                return .run { [recipient = state.recipient, amount = state.amount, memo = state.memo] send in
+                    guard let recipient else {
                         return
                     }
                     do {
-                        let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, state.amount, state.memo)
+                        let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, amount, memo)
                         await send(.proposalResolved(proposal))
                     } catch {
                         await send(.requestZecFailed)

--- a/secant/Sources/Features/DisconnectHWWallet/DisconnectHWWalletStore.swift
+++ b/secant/Sources/Features/DisconnectHWWallet/DisconnectHWWalletStore.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
-import MessageUI
+@preconcurrency import MessageUI
 
 @Reducer
 struct DisconnectHWWallet {
@@ -54,7 +54,8 @@ struct DisconnectHWWallet {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                state.canSendMail = MFMailComposeViewController.canSendMail()
+                // TCA Store is @MainActor; reducer body always runs on main.
+                state.canSendMail = MainActor.assumeIsolated { MFMailComposeViewController.canSendMail() }
                 return .none
 
             case .binding:

--- a/secant/Sources/Features/Home/HomeView.swift
+++ b/secant/Sources/Features/Home/HomeView.swift
@@ -357,6 +357,8 @@ extension Home.State {
 }
 
 extension Home {
+    // StoreOf<Home>.init is @MainActor (TCA 1.14+); factories must be too.
+    @MainActor
     static var placeholder: StoreOf<Home> {
         StoreOf<Home>(
             initialState: .initial
@@ -365,6 +367,7 @@ extension Home {
         }
     }
 
+    @MainActor
     static var error: StoreOf<Home> {
         StoreOf<Home>(
             initialState: .init(

--- a/secant/Sources/Features/OSStatusError/OSStatusErrorStore.swift
+++ b/secant/Sources/Features/OSStatusError/OSStatusErrorStore.swift
@@ -50,7 +50,8 @@ struct OSStatusError {
                 
             case .sendSupportMail:
                 let supportData = SupportDataGenerator.generateOSStatusError(osStatus: state.osStatus)
-                if MFMailComposeViewController.canSendMail() {
+                // TCA Store is @MainActor; reducer body always runs on main.
+                if MainActor.assumeIsolated({ MFMailComposeViewController.canSendMail() }) {
                     state.supportData = supportData
                 } else {
                     state.message = supportData.message

--- a/secant/Sources/Features/RequestZec/RequestZecStore.swift
+++ b/secant/Sources/Features/RequestZec/RequestZecStore.swift
@@ -112,14 +112,15 @@ struct RequestZec {
                         
                         let encryptedOutput = ZIP321.request(payment, formattingOptions: .useEmptyParamIndex(omitAddressLabel: true))
                         state.encryptedOutput = encryptedOutput
-                        return .publisher {
-                            QRCodeGenerator.generate(
+                        let color = Asset.Colors.primary.systemColor
+                        return .run { [maxPrivacy = state.maxPrivacy] send in
+                            let image = await QRCodeGenerator.generate(
                                 from: encryptedOutput,
-                                maxPrivacy: state.maxPrivacy,
+                                maxPrivacy: maxPrivacy,
                                 vendor: .zashi,
-                                color: Asset.Colors.primary.systemColor
+                                color: color
                             )
-                            .map(Action.rememberQR)
+                            await send(.rememberQR(image))
                         }
                         .cancellable(id: state.cancelId)
                     } catch {
@@ -127,7 +128,7 @@ struct RequestZec {
                     }
                 }
                 return .none
-                
+
             case .generateEnlargedQRCode:
                 if let recipient = RecipientAddress(value: state.address.data, context: ParserContext.from(networkType: zcashSDKEnvironment.network().networkType)) {
                     do {
@@ -142,14 +143,14 @@ struct RequestZec {
                         
                         let encryptedOutput = ZIP321.request(payment, formattingOptions: .useEmptyParamIndex(omitAddressLabel: true))
                         state.encryptedOutput = encryptedOutput
-                        return .publisher {
-                            QRCodeGenerator.generate(
+                        return .run { [maxPrivacy = state.maxPrivacy] send in
+                            let image = await QRCodeGenerator.generate(
                                 from: encryptedOutput,
-                                maxPrivacy: state.maxPrivacy,
+                                maxPrivacy: maxPrivacy,
                                 vendor: .zashi,
                                 color: .black
                             )
-                            .map(Action.rememberEnlargedQR)
+                            await send(.rememberEnlargedQR(image))
                         }
                         .cancellable(id: state.cancelId)
                     } catch {

--- a/secant/Sources/Features/ResyncWallet/ResyncWalletStore.swift
+++ b/secant/Sources/Features/ResyncWallet/ResyncWalletStore.swift
@@ -52,7 +52,8 @@ struct ResyncWallet {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                state.canSendMail = MFMailComposeViewController.canSendMail()
+                // TCA Store is @MainActor; reducer body always runs on main.
+                state.canSendMail = MainActor.assumeIsolated { MFMailComposeViewController.canSendMail() }
                 state.birthday = try? walletStorage.exportWallet().birthday?.value()
                 if let birthday = state.birthday, let timeInterval = sdkSynchronizer.estimateTimestamp(birthday) {
                     let date = Date(timeIntervalSince1970: timeInterval)

--- a/secant/Sources/Features/Root/RootShieldingProcessor.swift
+++ b/secant/Sources/Features/Root/RootShieldingProcessor.swift
@@ -57,7 +57,8 @@ extension Root {
                 
                 \(supportData.message)
                 """
-                if MFMailComposeViewController.canSendMail() {
+                // TCA Store is @MainActor; reducer body always runs on main.
+                if MainActor.assumeIsolated({ MFMailComposeViewController.canSendMail() }) {
                     state.supportData = supportData
                 } else {
                     state.messageShareBinding = supportData.message

--- a/secant/Sources/Features/Root/RootView.swift
+++ b/secant/Sources/Features/Root/RootView.swift
@@ -474,6 +474,8 @@ extension Root.State {
 }
 
 extension Root {
+    // StoreOf<Root>.init is @MainActor (TCA 1.14+); factory must be too.
+    @MainActor
     static var placeholder: StoreOf<Root> {
         StoreOf<Root>(
             initialState: .initial

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -206,7 +206,8 @@ struct SendConfirmation {
                 state.randomFailureIconIndex = Int.random(in: 1...3)
                 state.randomResubmissionIconIndex = Int.random(in: 1...2)
                 state.isTransparentAddress = derivationTool.isTransparentAddress(state.address, zcashSDKEnvironment.network().networkType)
-                state.canSendMail = MFMailComposeViewController.canSendMail()
+                // TCA Store is @MainActor; reducer body always runs on main.
+                state.canSendMail = MainActor.assumeIsolated { MFMailComposeViewController.canSendMail() }
                 state.alias = nil
                 for contact in state.addressBookContacts.contacts {
                     if contact.address == state.address {

--- a/secant/Sources/Features/SendFeedback/SendFeedbackStore.swift
+++ b/secant/Sources/Features/SendFeedback/SendFeedbackStore.swift
@@ -53,7 +53,8 @@ struct SendFeedback {
                 // __LD TESTED
                 state.memoState.text = ""
                 state.selectedRating = 4
-                state.canSendMail = MFMailComposeViewController.canSendMail()
+                // TCA Store is @MainActor; reducer body always runs on main.
+                state.canSendMail = MainActor.assumeIsolated { MFMailComposeViewController.canSendMail() }
                 return .none
 
             case .sendTapped:

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -312,21 +312,29 @@ struct SendForm {
                     return .none
                 }
                 state.amount = state.isLatestInputFiat ? state.amount.roundToAvoidDustSpend() : state.amount
-                return .run { [state, confirmationType] send in
+                return .run { [
+                    address = state.address,
+                    isValidTransparentAddress = state.isValidTransparentAddress,
+                    isValidTexAddress = state.isValidTexAddress,
+                    addMemoState = state.addMemoState,
+                    memoText = state.memoState.text,
+                    amount = state.amount,
+                    confirmationType
+                ] send in
                     do {
-                        let recipient = try Recipient(state.address.data, network: zcashSDKEnvironment.network().networkType)
-                        
+                        let recipient = try Recipient(address.data, network: zcashSDKEnvironment.network().networkType)
+
                         let memo: Memo?
-                        if state.isValidTransparentAddress || state.isValidTexAddress {
+                        if isValidTransparentAddress || isValidTexAddress {
                             memo = nil
-                        } else if let memoText = state.addMemoState ? state.memoState.text : nil {
-                            memo = memoText.isEmpty ? nil : try Memo(string: memoText)
+                        } else if let candidate = addMemoState ? memoText : nil {
+                            memo = candidate.isEmpty ? nil : try Memo(string: candidate)
                         } else {
                             memo = nil
                         }
 
-                        let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, state.amount, memo)
-                        
+                        let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, amount, memo)
+
                         await send(.proposal(proposal))
                         await send(.confirmationRequired(confirmationType))
                     } catch {

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -260,7 +260,8 @@ struct SmartBanner {
                 
                 \(supportData.message)
                 """
-                if MFMailComposeViewController.canSendMail() {
+                // TCA Store is @MainActor; reducer body always runs on main.
+                if MainActor.assumeIsolated({ MFMailComposeViewController.canSendMail() }) {
                     state.supportData = supportData
                 } else {
                     state.messageToBeShared = supportData.message

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -1056,31 +1056,30 @@ struct SwapAndPay {
                 guard let depositAddress = state.quote?.depositAddress else {
                     return .none
                 }
+                let color = Asset.Colors.primary.systemColor
                 return .run { send in
-                    for await image in QRCodeGenerator.generate(
+                    let image = await QRCodeGenerator.generate(
                         from: depositAddress,
                         vendor: .zashi,
-                        color: Asset.Colors.primary.systemColor,
+                        color: color,
                         overlayedWithZcashLogo: false
-                    ).values {
-                        await send(.rememberQR(image))
-                    }
+                    )
+                    await send(.rememberQR(image))
                 }
                 .cancellable(id: state.QRCancelId)
-                
+
             case .generateEnlargedQRCode:
                 guard let depositAddress = state.quote?.depositAddress else {
                     return .none
                 }
                 return .run { send in
-                    for await image in QRCodeGenerator.generate(
+                    let image = await QRCodeGenerator.generate(
                         from: depositAddress,
                         vendor: .zashi,
                         color: .black,
                         overlayedWithZcashLogo: false
-                    ).values {
-                        await send(.rememberEnlargedQR(image))
-                    }
+                    )
+                    await send(.rememberEnlargedQR(image))
                 }
                 .cancellable(id: state.QRCancelId)
 

--- a/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
+++ b/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
@@ -254,7 +254,8 @@ struct TransactionDetails {
             switch action {
             case .onAppear:
                 // __LD TESTED
-                state.canSendMail = MFMailComposeViewController.canSendMail()
+                // TCA Store is @MainActor; reducer body always runs on main.
+                state.canSendMail = MainActor.assumeIsolated { MFMailComposeViewController.canSendMail() }
                 state.messageToBeShared = nil
                 state.supportData = nil
                 state.isSwap = userMetadataProvider.isSwapTransaction(state.transaction.zAddress ?? "")

--- a/secant/Sources/Features/ZecKeyboard/ZecKeyboardStore.swift
+++ b/secant/Sources/Features/ZecKeyboard/ZecKeyboardStore.swift
@@ -91,8 +91,11 @@ struct ZecKeyboard {
                     return .none
                 }
 
-                let impactFeedback = UIImpactFeedbackGenerator(style: .light)
-                impactFeedback.impactOccurred()
+                // TCA Store is @MainActor; reducer body always runs on main. UIImpactFeedbackGenerator is @MainActor.
+                MainActor.assumeIsolated {
+                    let impactFeedback = UIImpactFeedbackGenerator(style: .light)
+                    impactFeedback.impactOccurred()
+                }
 
                 // backspace
                 if index == 11 {

--- a/secant/Sources/UIComponents/Buttons/ZashiButton.swift
+++ b/secant/Sources/UIComponents/Buttons/ZashiButton.swift
@@ -41,8 +41,8 @@ struct ZashiButton<PrefixContent, AccessoryContent>: View where PrefixContent: V
         horizontalPadding: CGFloat = 18,
         verticalPadding: CGFloat = 12,
         minHeight: CGFloat? = nil,
-        prefixView: PrefixContent? = EmptyView(),
-        accessoryView: AccessoryContent? = EmptyView(),
+        prefixView: PrefixContent?,
+        accessoryView: AccessoryContent?,
         action: @escaping () -> Void
     ) {
         self.title = title
@@ -201,6 +201,86 @@ struct ZashiButton<PrefixContent, AccessoryContent>: View where PrefixContent: V
             ? Design.Btns.Ghost.bg
             : Design.Btns.Ghost.bgDisabled
         }
+    }
+}
+
+extension ZashiButton where PrefixContent == EmptyView, AccessoryContent == EmptyView {
+    init(
+        _ title: String,
+        type: `Type` = .primary,
+        infinityWidth: Bool = true,
+        fontSize: CGFloat = 16,
+        horizontalPadding: CGFloat = 18,
+        verticalPadding: CGFloat = 12,
+        minHeight: CGFloat? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.init(
+            title,
+            type: type,
+            infinityWidth: infinityWidth,
+            fontSize: fontSize,
+            horizontalPadding: horizontalPadding,
+            verticalPadding: verticalPadding,
+            minHeight: minHeight,
+            prefixView: nil,
+            accessoryView: nil,
+            action: action
+        )
+    }
+}
+
+extension ZashiButton where PrefixContent == EmptyView {
+    init(
+        _ title: String,
+        type: `Type` = .primary,
+        infinityWidth: Bool = true,
+        fontSize: CGFloat = 16,
+        horizontalPadding: CGFloat = 18,
+        verticalPadding: CGFloat = 12,
+        minHeight: CGFloat? = nil,
+        accessoryView: AccessoryContent,
+        action: @escaping () -> Void
+    ) {
+        self.init(
+            title,
+            type: type,
+            infinityWidth: infinityWidth,
+            fontSize: fontSize,
+            horizontalPadding: horizontalPadding,
+            verticalPadding: verticalPadding,
+            minHeight: minHeight,
+            prefixView: nil,
+            accessoryView: accessoryView,
+            action: action
+        )
+    }
+}
+
+extension ZashiButton where AccessoryContent == EmptyView {
+    init(
+        _ title: String,
+        type: `Type` = .primary,
+        infinityWidth: Bool = true,
+        fontSize: CGFloat = 16,
+        horizontalPadding: CGFloat = 18,
+        verticalPadding: CGFloat = 12,
+        minHeight: CGFloat? = nil,
+        prefixView: PrefixContent,
+        action: @escaping () -> Void
+    ) {
+        self.init(
+            title,
+            type: type,
+            infinityWidth: infinityWidth,
+            fontSize: fontSize,
+            horizontalPadding: horizontalPadding,
+            verticalPadding: verticalPadding,
+            minHeight: minHeight,
+            prefixView: prefixView,
+            accessoryView: nil,
+            action: action
+        )
     }
 }
 

--- a/secant/Sources/UIComponents/Overlays/SplashView.swift
+++ b/secant/Sources/UIComponents/Overlays/SplashView.swift
@@ -47,7 +47,7 @@ final class SplashManager: ObservableObject {
                 authenticate()
             } else {
                 Task {
-                    await self.spinTheWheel()
+                    self.spinTheWheel()
                 }
             }
         }
@@ -57,12 +57,12 @@ final class SplashManager: ObservableObject {
         @Dependency(\.localAuthentication) var localAuthentication
 
         authenticationDidntSucceed = false
-        
+
         Task {
             if await !localAuthentication.authenticate() {
-                await self.authenticationFailed()
+                self.authenticationFailed()
             } else {
-                await self.spinTheWheel()
+                self.spinTheWheel()
             }
         }
     }

--- a/secant/Sources/UIComponents/Overlays/SplashView.swift
+++ b/secant/Sources/UIComponents/Overlays/SplashView.swift
@@ -74,7 +74,8 @@ final class SplashManager: ObservableObject {
     @MainActor func spinTheWheel() {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { timer in
-            if self.isOn {
+            // Timer was scheduled from @MainActor spinTheWheel(); fires on main run loop.
+            if MainActor.assumeIsolated({ self.isOn }) {
                 Task { @MainActor in
                     self.tick()
 

--- a/secant/Sources/Utils/Bindings.swift
+++ b/secant/Sources/Utils/Bindings.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import CasePaths
 
 /// taken largely from: https://github.com/pointfreeco/episode-code-samples/blob/main/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/SwiftUIHelpers.swift
+// Binding is @MainActor in SwiftUI; helpers must match so captures into the
+// @Sendable get/set closures of Binding.init are allowed.
+@MainActor
 extension Binding {
     func isPresent<Wrapped>() -> Binding<Bool>
     where Value == Wrapped? {

--- a/secant/Sources/Utils/QRCodeGenerator.swift
+++ b/secant/Sources/Utils/QRCodeGenerator.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-@preconcurrency import Combine
 import CoreImage.CIFilterBuiltins
 import SwiftUI
 
@@ -14,8 +13,8 @@ enum QRCodeGenerator {
     enum QRCodeError: Error {
         case failedToGenerate
     }
-    
-    enum Vendor: Equatable {
+
+    enum Vendor: Equatable, Sendable {
         case keystone
         case zashi
     }
@@ -26,20 +25,16 @@ enum QRCodeGenerator {
         vendor: Vendor = .zashi,
         color: UIColor = Asset.Colors.primary.systemColor,
         overlayedWithZcashLogo: Bool = true
-    ) -> Future<CGImage?, Never> {
-        Future<CGImage?, Never> { promise in
-            DispatchQueue.global().async {
-                let image = generateCode(
-                    from: string,
-                    maxPrivacy: maxPrivacy,
-                    vendor: vendor,
-                    color: color,
-                    overlayedWithZcashLogo: overlayedWithZcashLogo
-                )
-                
-                return promise(.success(image))
-            }
-        }
+    ) async -> CGImage? {
+        await Task.detached(priority: .userInitiated) {
+            generateCode(
+                from: string,
+                maxPrivacy: maxPrivacy,
+                vendor: vendor,
+                color: color,
+                overlayedWithZcashLogo: overlayedWithZcashLogo
+            )
+        }.value
     }
 
     static func generateCode(


### PR DESCRIPTION
## Summary

Follow-up to #1772 (Enable Swift 6). With `SWIFT_VERSION = 6.0` the project compiled but emitted strict-concurrency warnings. This PR clears them without behavior changes; one approved API change to `QRCodeGenerator.generate` is the only public-surface modification.

## Changes

- **MainActor-isolated calls in reducers**: wrap `MFMailComposeViewController.canSendMail()` and `UIImpactFeedbackGenerator(...).impactOccurred()` in `MainActor.assumeIsolated`. TCA's `Store` is `@MainActor` since 1.14 so reducer bodies always run on main, but the `Reducer` protocol itself is nonisolated, so the compiler needs the hint.
- **Static `Store` factories**: mark `Home.placeholder`, `Home.error`, and `Root.*` placeholder factories `@MainActor` to match `StoreOf<...>.init`.
- **`Binding` extension**: mark `Utils/Bindings.swift` extension `@MainActor` so captures into `Binding.init`'s `@Sendable` get/set closures are allowed.
- **Effect captures**: narrow `[state]` captures to specific fields in `SendForm` and `ScanCoordFlow` so `State` doesn't need to be `Sendable`.
- **`SplashView` timer**: read `isOn` via `MainActor.assumeIsolated` inside the `Timer.scheduledTimer` closure (timer was scheduled from `@MainActor` and fires on the main run loop).
- **`QRCodeGenerator.generate` (API change)**: converted from `Combine.Future<CGImage?, Never>` to `async () -> CGImage?`. All 6 call sites updated to use `.run { send in ... }` effects instead of `.publisher { future.map(...) }`.
- **`ZashiButton`**: replaced default-expression-based parameter inference with constrained extensions so Swift 6 isolation crossings don't trip on default values.
- **Drop redundant `await`s** on non-async calls in AddressBook and Splash.

## Out of scope

Non-concurrency warnings (TCA deprecations, iOS deprecations, dead code) — follow-up PR.

## Test plan

- [ ] Unit tests green on CI
- [ ] Manual smoke on testnet: launch, send, scan address, request ZEC, swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)