### PR TITLE
Fix first-run auto-server migration for non-custom servers

### DIFF
--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
@@ -59,21 +59,19 @@ extension ZcashSDKEnvironment {
     }
 
     /// One-time initialization of the Automatic/Manual flag based on the user's existing server:
-    /// - no stored server, or it equals the default endpoint -> Automatic
-    /// - a custom server, or a non-default server -> Manual (preserve the explicit/private choice)
+    /// - no stored server, or any non-custom server (the default, a known list server, or a legacy
+    ///   built-in host) -> Automatic
+    /// - only a user-entered custom server -> Manual (preserve the explicit choice)
     static func initializeAutomaticServerSelectionIfNeeded(for network: NetworkType) {
         @Dependency(\.userStoredPreferences) var userStoredPreferences
 
         guard userStoredPreferences.automaticServerSelection() == nil else { return }
 
-        var enableAutomatic = true
-        if let stored = userStoredPreferences.server() {
-            let normalized = normalizedStoredServerConfig(stored)
-            let defaultEndpoint = defaultEndpoint(for: network)
-            enableAutomatic = !normalized.isCustom
-                && normalized.host == defaultEndpoint.host
-                && normalized.port == defaultEndpoint.port
-        }
+        // Automatic unless the user explicitly entered a custom server. Keyed off the raw stored
+        // `isCustom` flag (not the display-normalized one) so legacy built-in hosts such as
+        // *.zcash-infra.com -- stored non-custom but normalized to "custom" for the Server Setup UI --
+        // still migrate to Automatic. Only a user-typed custom host stays on Manual.
+        let enableAutomatic = userStoredPreferences.server()?.isCustom != true
 
         userStoredPreferences.setAutomaticServerSelection(enableAutomatic)
     }

--- a/zodlTests/UtilTests/AutomaticServerSelectionMigrationTests.swift
+++ b/zodlTests/UtilTests/AutomaticServerSelectionMigrationTests.swift
@@ -38,9 +38,19 @@ final class AutomaticServerSelectionMigrationTests: XCTestCase {
         XCTAssertEqual(runMigration(network: .mainnet, server: config), false)
     }
 
-    func testNonDefaultKnownServerSelectsManual() {
+    func testNonDefaultKnownServerEnablesAutomatic() {
+        // A known server picked from the old server list is stored as non-custom; with no
+        // user-entered custom server, the user migrates to Automatic.
         let config = UserPreferencesStorage.ServerConfig(host: "na.zec.rocks", port: 443, isCustom: false)
-        XCTAssertEqual(runMigration(network: .mainnet, server: config), false)
+        XCTAssertEqual(runMigration(network: .mainnet, server: config), true)
+    }
+
+    func testLegacyBuiltInServerEnablesAutomatic() {
+        // A legacy built-in host (e.g. *.zcash-infra.com) was never a user-typed custom server: it is
+        // stored non-custom, so it migrates to Automatic even though it no longer appears in the list
+        // and is display-normalized to "custom" elsewhere.
+        let config = UserPreferencesStorage.ServerConfig(host: "lwd1.zcash-infra.com", port: 443, isCustom: false)
+        XCTAssertEqual(runMigration(network: .mainnet, server: config), true)
     }
 
     func testRunsOnlyOnce() {


### PR DESCRIPTION
## Problem

On the first run of the auto-server-selection build, a user who hasn't selected a custom server should be switched to **Automatic**. A few testers without a custom server were left on **Manual**.

## Root cause

The first-run migration (`initializeAutomaticServerSelectionIfNeeded`) enabled Automatic only when the stored server was non-custom **and exactly equal to the current default endpoint** (`zec.rocks:443`), and it read the *display-normalized* `isCustom` flag (which force-marks legacy `*.zcash-infra.com` hosts as custom). So two non-custom buckets were wrongly kept on Manual:

- known non-default servers picked from the old list (`na.zec.rocks`, `us.zec.stardust.rest`, …) — stored `isCustom: false`, but failed the `host == default` check;
- legacy built-in `*.zcash-infra.com` hosts — stored `isCustom: false`, but normalized to "custom".

## Fix

Key the decision off the **raw** stored `isCustom` flag only:

```swift
let enableAutomatic = userStoredPreferences.server()?.isCustom != true
```

- no stored server / default / known list server / legacy built-in host → **Automatic**
- only a user-typed custom host → **Manual** (preserved)
- still runs once (guarded by the `nil` flag), so 2nd-and-later runs keep whatever the user selected.

## Tests

- Updated `testNonDefaultKnownServerSelectsManual` → `…EnablesAutomatic` (it had locked in the bug).
- Added `testLegacyBuiltInServerEnablesAutomatic` (a `*.zcash-infra.com` host → Automatic).
- `AutomaticServerSelectionMigrationTests`, `DecommissionedServerMigrationTests`, storage and auto-select-client suites all pass (24/24).

## Note

Fix-forward only: testers who already ran a buggy build are past their first run, so the once-only guard correctly leaves their stored choice untouched — they can switch to Automatic once in **Settings → Server**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
