### PR TITLE
[CI]: add Linear release tracking workflow

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,28 @@
+name: Linear release tracking
+
+# Fires on every release tag push (`<major>.<minor>.<patch>`, e.g. `3.5.2`).
+# The single job runs Linear's release action, which scans commits since the
+# previous tag for `MOB-###` references and creates a matching release under
+# the iOS Linear pipeline (Settings → Releases → zodl-ios in Linear).
+#
+# Requires the LINEAR_ACCESS_KEY repo secret, generated against the iOS
+# pipeline in Linear's UI.
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  linear-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
+
+      - name: Create Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/linear-release.yml` — a minimal workflow that fires on `<major>.<minor>.<patch>` tag push and runs `linear/linear-release-action@v0`
- Tag pattern matches existing iOS release tag style (e.g. `3.5.2`, `3.4.1`, ...)
- Reads the `LINEAR_ACCESS_KEY` repo secret (configured against the iOS pipeline in Linear)
- Standalone workflow (iOS doesn't have an existing release workflow to hook into — release builds go through Xcode Cloud / fastlane elsewhere)

## Behaviour

On the next iOS tag push, the action scans commits since the previous tag for `MOB-###` references and creates a matching release under the Linear `zodl-ios` pipeline. Existing release flow is unchanged.

## Test plan
- [ ] Wait for the next iOS release tag and confirm the Linear release shows up under the Mobile team's Releases tab with the expected `MOB-###` issues attached
