### PR TITLE
Migrate zodlTests from XCTest to Swift Testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Zodl (formerly Zashi) is an iOS Zcash wallet built with SwiftUI and The Composab
 
 **Build:** Open `secant.xcworkspace` in Xcode and build the desired target.
 
-**Tests:** Run `secantTests` target in Xcode. Tests use TCA's test store with dependency injection (`.noOp`, `.mockEmptyDisk`, etc.). Snapshot tests are in `secantTests/SnapshotTests/`.
+**Tests:** Run the `zodlTests` target in Xcode (scheme `zodl-internal`). All tests use **Swift Testing** (`@Suite` / `@Test` / `#expect` / `#require`) — **write every new test in Swift Testing, never XCTest.** Tests use TCA's `TestStore` with dependency injection (`.noOp`, `withDependencies`, etc.). Swift Testing runs suites in parallel by default, so mark any suite that mutates process-global state (named `UserDefaults` suites, the OSLog store, shared singletons / TCA `@Shared` state) with `@Suite(.serialized)`.
 
 **Linting:** SwiftLint runs as a build phase. Config: `.swiftlint.yml` (app code) and `.swiftlint_tests.yml` (tests, more relaxed). Key enforced rules: no string concatenation (use interpolation), no `NSLog`, no `print`/`debugPrint` in app code, TODOs must reference issue numbers (`TODO: [#123]`).
 

--- a/zodlTests/BackupFlowTests/RecoveryPhraseBackupTests.swift
+++ b/zodlTests/BackupFlowTests/RecoveryPhraseBackupTests.swift
@@ -5,14 +5,14 @@
 //  Created by Francisco Gindre on 10/29/21.
 //
 
-import XCTest
+import Testing
 @testable import zodl_internal
 
-class RecoveryPhraseBackupTests: XCTestCase {
+@Suite struct RecoveryPhraseBackupTests {
     /// `RecoveryPhrase.toGroups()` always splits the phrase into three equal groups
     /// (designed for the 3-column visual layout on the backup screen). For a 24-word
     /// BIP39 phrase that's three groups of eight words each.
-    func testGiven24WordsBIP39ChunkItIntoThirds() throws {
+    @Test func given24WordsBIP39ChunkItIntoThirds() throws {
         let words = [
             // group 0
             "bring", "salute", "thank",
@@ -29,17 +29,17 @@ class RecoveryPhraseBackupTests: XCTestCase {
 
         let chunks = phrase.toGroups()
 
-        XCTAssertEqual(chunks.count, 3)
-        XCTAssertEqual(chunks[0].startIndex, 0)
-        XCTAssertEqual(chunks[0].words, [
+        #expect(chunks.count == 3)
+        #expect(chunks[0].startIndex == 0)
+        #expect(chunks[0].words == [
             "bring", "salute", "thank", "require", "spirit", "toe", "boil", "hill"
         ].map { $0.redacted })
-        XCTAssertEqual(chunks[1].startIndex, 8)
-        XCTAssertEqual(chunks[1].words, [
+        #expect(chunks[1].startIndex == 8)
+        #expect(chunks[1].words == [
             "casino", "trophy", "drink", "frown", "bird", "grit", "close", "morning"
         ].map { $0.redacted })
-        XCTAssertEqual(chunks[2].startIndex, 16)
-        XCTAssertEqual(chunks[2].words, [
+        #expect(chunks[2].startIndex == 16)
+        #expect(chunks[2].words == [
             "bind", "cancel", "daughter", "salon", "quit", "pizza", "just", "garlic"
         ].map { $0.redacted })
     }

--- a/zodlTests/CurrencyConversionTests/CurrencyConversionTests.swift
+++ b/zodlTests/CurrencyConversionTests/CurrencyConversionTests.swift
@@ -5,215 +5,102 @@
 //  Created by Cosmos on 18.05.2026.
 //
 
-import XCTest
+import Testing
+import Foundation
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-
-class CurrencyConversionTests: XCTestCase {
-
-    func testInitRoundsRatioToSixDecimals() {
+@Suite struct CurrencyConversionTests {
+    @Test func initRoundsRatioToSixDecimals() {
         let conversion = CurrencyConversion(.usd, ratio: 1.123456789, timestamp: 0)
 
-        XCTAssertEqual(
-            conversion.ratio,
-            1.123456,
-            accuracy: 0.0000001,
+        #expect(
+            abs(conversion.ratio - 1.123456) <= 0.0000001,
             "CurrencyConversion tests: `testInitRoundsRatioToSixDecimals` ratio is expected to be 1.123456 but it is \(conversion.ratio)"
         )
     }
 
-    func testInitPreservesExactRatioWithinPrecision() {
+    @Test func initPreservesExactRatioWithinPrecision() {
         let conversion = CurrencyConversion(.usd, ratio: 50.5, timestamp: 0)
 
-        XCTAssertEqual(
-            conversion.ratio,
-            50.5,
-            accuracy: 0.0000001,
+        #expect(
+            abs(conversion.ratio - 50.5) <= 0.0000001,
             "CurrencyConversion tests: `testInitPreservesExactRatioWithinPrecision` ratio is expected to be 50.5 but it is \(conversion.ratio)"
         )
     }
 
-    func testInitPreservesTimestamp() {
+    @Test func initPreservesTimestamp() {
         let timestamp: TimeInterval = 1700000000
         let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: timestamp)
 
-        XCTAssertEqual(
-            conversion.timestamp,
-            timestamp,
+        #expect(
+            conversion.timestamp == timestamp,
             "CurrencyConversion tests: `testInitPreservesTimestamp` timestamp is expected to be \(timestamp) but it is \(conversion.timestamp)"
         )
     }
 
-    func testInitPreservesISO4217() {
+    @Test func initPreservesISO4217() {
         let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
 
-        XCTAssertEqual(
-            conversion.iso4217,
-            .usd,
+        #expect(
+            conversion.iso4217 == .usd,
             "CurrencyConversion tests: `testInitPreservesISO4217` iso4217 is expected to be .usd but it is \(conversion.iso4217)"
         )
     }
 
-    func testConvertZatoshiToDoubleOneZecAtRatio30() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-        let oneZEC = Zatoshi(100_000_000)
+    @Test(arguments: zatoshiToDoubleCases)
+    func convertZatoshiToDouble(_ testCase: ZatoshiToDoubleCase) {
+        let conversion = CurrencyConversion(.usd, ratio: testCase.ratio, timestamp: 0)
 
-        let result: Double = conversion.convert(oneZEC)
+        let result: Double = conversion.convert(Zatoshi(testCase.zatoshi))
 
-        XCTAssertEqual(
-            result,
-            30.0,
-            accuracy: 0.01,
-            "CurrencyConversion tests: `testConvertZatoshiToDoubleOneZecAtRatio30` result is expected to be 30.0 but it is \(result)"
+        #expect(
+            abs(result - testCase.expected) <= testCase.accuracy,
+            "CurrencyConversion tests: convert(\(testCase.zatoshi) zatoshi @ ratio \(testCase.ratio)) is expected to be \(testCase.expected) but it is \(result)"
         )
     }
 
-    func testConvertZatoshiToDoubleHalfZecAtRatio100() {
-        let conversion = CurrencyConversion(.usd, ratio: 100.0, timestamp: 0)
-        let halfZEC = Zatoshi(50_000_000)
-
-        let result: Double = conversion.convert(halfZEC)
-
-        XCTAssertEqual(
-            result,
-            50.0,
-            accuracy: 0.01,
-            "CurrencyConversion tests: `testConvertZatoshiToDoubleHalfZecAtRatio100` result is expected to be 50.0 but it is \(result)"
-        )
-    }
-
-    func testConvertZatoshiToDoubleZeroZatoshi() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-        let zero = Zatoshi(0)
-
-        let result: Double = conversion.convert(zero)
-
-        XCTAssertEqual(
-            result,
-            0.0,
-            accuracy: 0.0001,
-            "CurrencyConversion tests: `testConvertZatoshiToDoubleZeroZatoshi` result is expected to be 0.0 but it is \(result)"
-        )
-    }
-
-    func testConvertZatoshiToDoubleSmallAmount() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-        let oneZatoshi = Zatoshi(1)
-
-        let result: Double = conversion.convert(oneZatoshi)
-
-        XCTAssertEqual(
-            result,
-            0.0000003,
-            accuracy: 0.00000001,
-            "CurrencyConversion tests: `testConvertZatoshiToDoubleSmallAmount` result is expected to be 0.0000003 but it is \(result)"
-        )
-    }
-
-    func testConvertZatoshiToDoubleLargeAmount() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-        let tenThousandZEC = Zatoshi(10_000 * 100_000_000)
-
-        let result: Double = conversion.convert(tenThousandZEC)
-
-        XCTAssertEqual(
-            result,
-            300_000.0,
-            accuracy: 0.01,
-            "CurrencyConversion tests: `testConvertZatoshiToDoubleLargeAmount` result is expected to be 300000.0 but it is \(result)"
-        )
-    }
-
-    func testConvertZatoshiToStringFormatsAsCurrency() {
+    @Test func convertZatoshiToStringFormatsAsCurrency() {
         let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
         let oneZEC = Zatoshi(100_000_000)
 
         let result: String = conversion.convert(oneZEC)
 
-        XCTAssertFalse(
-            result.isEmpty,
+        #expect(
+            !result.isEmpty,
             "CurrencyConversion tests: `testConvertZatoshiToStringFormatsAsCurrency` is expected to produce a non-empty string"
         )
-        XCTAssertTrue(
+        #expect(
             result.contains("30") || result.contains("30.00"),
             "CurrencyConversion tests: `testConvertZatoshiToStringFormatsAsCurrency` is expected to contain the converted amount but it is \(result)"
         )
     }
 
-    func testConvertZatoshiToStringZeroAmount() {
+    @Test func convertZatoshiToStringZeroAmount() {
         let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
         let zero = Zatoshi(0)
 
         let result: String = conversion.convert(zero)
 
-        XCTAssertFalse(
-            result.isEmpty,
+        #expect(
+            !result.isEmpty,
             "CurrencyConversion tests: `testConvertZatoshiToStringZeroAmount` is expected to produce a non-empty string"
         )
     }
 
-    func testConvertCurrencyToZatoshiThirtyDollarsAtRatio30() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
+    @Test(arguments: doubleToZatoshiCases)
+    func convertCurrencyToZatoshi(_ testCase: DoubleToZatoshiCase) {
+        let conversion = CurrencyConversion(.usd, ratio: testCase.ratio, timestamp: 0)
 
-        let result = conversion.convert(30.0)
+        let result = conversion.convert(testCase.dollars)
 
-        XCTAssertEqual(
-            result.amount,
-            100_000_000,
-            "CurrencyConversion tests: `testConvertCurrencyToZatoshiThirtyDollarsAtRatio30` amount is expected to be 100000000 but it is \(result.amount)"
+        #expect(
+            result.amount == testCase.expectedAmount,
+            "CurrencyConversion tests: convert($\(testCase.dollars) @ ratio \(testCase.ratio)) amount is expected to be \(testCase.expectedAmount) but it is \(result.amount)"
         )
     }
 
-    func testConvertCurrencyToZatoshiFifteenDollarsAtRatio30() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-
-        let result = conversion.convert(15.0)
-
-        XCTAssertEqual(
-            result.amount,
-            50_000_000,
-            "CurrencyConversion tests: `testConvertCurrencyToZatoshiFifteenDollarsAtRatio30` amount is expected to be 50000000 but it is \(result.amount)"
-        )
-    }
-
-    func testConvertCurrencyToZatoshiZeroDollars() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-
-        let result = conversion.convert(0.0)
-
-        XCTAssertEqual(
-            result.amount,
-            0,
-            "CurrencyConversion tests: `testConvertCurrencyToZatoshiZeroDollars` amount is expected to be 0 but it is \(result.amount)"
-        )
-    }
-
-    func testConvertCurrencyToZatoshiOneCent() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-
-        let result = conversion.convert(0.01)
-
-        XCTAssertEqual(
-            result.amount,
-            33333,
-            "CurrencyConversion tests: `testConvertCurrencyToZatoshiOneCent` amount is expected to be 33333 but it is \(result.amount)"
-        )
-    }
-
-    func testConvertCurrencyToZatoshiLargeDollarAmount() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-
-        let result = conversion.convert(3000.0)
-
-        XCTAssertEqual(
-            result.amount,
-            10_000_000_000,
-            "CurrencyConversion tests: `testConvertCurrencyToZatoshiLargeDollarAmount` amount is expected to be 10000000000 but it is \(result.amount)"
-        )
-    }
-
-    func testRoundTripZatoshiToFiatAndBack() {
+    @Test func roundTripZatoshiToFiatAndBack() {
         let conversion = CurrencyConversion(.usd, ratio: 45.67, timestamp: 0)
         let original = Zatoshi(123_456_789)
 
@@ -221,113 +108,98 @@ class CurrencyConversionTests: XCTestCase {
         let backToZatoshi = conversion.convert(fiatValue)
 
         let diff = abs(original.amount - backToZatoshi.amount)
-        XCTAssertLessThan(
-            diff,
-            100,
+        #expect(
+            diff < 100,
             "CurrencyConversion tests: `testRoundTripZatoshiToFiatAndBack` round-trip is expected to be within 100 zatoshi but diff is \(diff)"
         )
     }
 
-    func testConvertVeryHighRatio() {
-        let conversion = CurrencyConversion(.usd, ratio: 999999.0, timestamp: 0)
-        let oneZEC = Zatoshi(100_000_000)
-
-        let result: Double = conversion.convert(oneZEC)
-
-        XCTAssertEqual(
-            result,
-            999999.0,
-            accuracy: 1.0,
-            "CurrencyConversion tests: `testConvertVeryHighRatio` result is expected to be 999999.0 but it is \(result)"
-        )
-    }
-
-    func testConvertVeryLowRatio() {
-        let conversion = CurrencyConversion(.usd, ratio: 0.001, timestamp: 0)
-        let oneZEC = Zatoshi(100_000_000)
-
-        let result: Double = conversion.convert(oneZEC)
-
-        XCTAssertEqual(
-            result,
-            0.001,
-            accuracy: 0.0001,
-            "CurrencyConversion tests: `testConvertVeryLowRatio` result is expected to be 0.001 but it is \(result)"
-        )
-    }
-
-    func testConvertNegativeZatoshi() {
-        let conversion = CurrencyConversion(.usd, ratio: 30.0, timestamp: 0)
-        let negative = Zatoshi(-100_000_000)
-
-        let result: Double = conversion.convert(negative)
-
-        XCTAssertEqual(
-            result,
-            -30.0,
-            accuracy: 0.01,
-            "CurrencyConversion tests: `testConvertNegativeZatoshi` result is expected to be -30.0 but it is \(result)"
-        )
-    }
-
-    func testCurrencyISO4217UsdCode() {
-        XCTAssertEqual(
-            CurrencyISO4217.usd.code,
-            "USD",
+    @Test func currencyISO4217UsdCode() {
+        #expect(
+            CurrencyISO4217.usd.code == "USD",
             "CurrencyConversion tests: `testCurrencyISO4217UsdCode` code is expected to be USD but it is \(CurrencyISO4217.usd.code)"
         )
     }
 
-    func testCurrencyISO4217UsdSymbol() {
-        XCTAssertEqual(
-            CurrencyISO4217.usd.symbol,
-            "$",
+    @Test func currencyISO4217UsdSymbol() {
+        #expect(
+            CurrencyISO4217.usd.symbol == "$",
             "CurrencyConversion tests: `testCurrencyISO4217UsdSymbol` symbol is expected to be $ but it is \(CurrencyISO4217.usd.symbol)"
         )
     }
 
-    func testCurrencyISO4217AllCases() {
-        XCTAssertEqual(
-            CurrencyISO4217.allCases.count,
-            1,
+    @Test func currencyISO4217AllCases() {
+        #expect(
+            CurrencyISO4217.allCases.count == 1,
             "CurrencyConversion tests: `testCurrencyISO4217AllCases` count is expected to be 1 but it is \(CurrencyISO4217.allCases.count)"
         )
-        XCTAssertTrue(
+        #expect(
             CurrencyISO4217.allCases.contains(.usd),
             "CurrencyConversion tests: `testCurrencyISO4217AllCases` is expected to contain .usd"
         )
     }
 
-    func testEquatableSameValuesAreEqual() {
+    @Test func equatableSameValuesAreEqual() {
         let a = CurrencyConversion(.usd, ratio: 30.0, timestamp: 1000)
         let b = CurrencyConversion(.usd, ratio: 30.0, timestamp: 1000)
 
-        XCTAssertEqual(
-            a,
-            b,
+        #expect(
+            a == b,
             "CurrencyConversion tests: `testEquatableSameValuesAreEqual` conversions with same values are expected to be equal"
         )
     }
 
-    func testEquatableDifferentRatioAreNotEqual() {
+    @Test func equatableDifferentRatioAreNotEqual() {
         let a = CurrencyConversion(.usd, ratio: 30.0, timestamp: 1000)
         let b = CurrencyConversion(.usd, ratio: 31.0, timestamp: 1000)
 
-        XCTAssertNotEqual(
-            a,
-            b,
+        #expect(
+            a != b,
             "CurrencyConversion tests: `testEquatableDifferentRatioAreNotEqual` conversions with different ratios are expected to not be equal"
         )
     }
 
-    func testEquatableDifferentTimestampAreNotEqual() {
+    @Test func equatableDifferentTimestampAreNotEqual() {
         let a = CurrencyConversion(.usd, ratio: 30.0, timestamp: 1000)
         let b = CurrencyConversion(.usd, ratio: 30.0, timestamp: 2000)
 
-        XCTAssertNotEqual(
-            a,
-            b,
+        #expect(
+            a != b,
             "CurrencyConversion tests: `testEquatableDifferentTimestampAreNotEqual` conversions with different timestamps are expected to not be equal"
         )
     }
 }
+
+// Homogeneous convert(Zatoshi) -> Double cases (each row was its own `testConvert*` method).
+struct ZatoshiToDoubleCase: Sendable {
+    let ratio: Double
+    let zatoshi: Int64
+    let expected: Double
+    let accuracy: Double
+}
+
+private let zatoshiToDoubleCases: [ZatoshiToDoubleCase] = [
+    ZatoshiToDoubleCase(ratio: 30.0, zatoshi: 100_000_000, expected: 30.0, accuracy: 0.01),
+    ZatoshiToDoubleCase(ratio: 100.0, zatoshi: 50_000_000, expected: 50.0, accuracy: 0.01),
+    ZatoshiToDoubleCase(ratio: 30.0, zatoshi: 0, expected: 0.0, accuracy: 0.0001),
+    ZatoshiToDoubleCase(ratio: 30.0, zatoshi: 1, expected: 0.0000003, accuracy: 0.00000001),
+    ZatoshiToDoubleCase(ratio: 30.0, zatoshi: 10_000 * 100_000_000, expected: 300_000.0, accuracy: 0.01),
+    ZatoshiToDoubleCase(ratio: 999999.0, zatoshi: 100_000_000, expected: 999999.0, accuracy: 1.0),
+    ZatoshiToDoubleCase(ratio: 0.001, zatoshi: 100_000_000, expected: 0.001, accuracy: 0.0001),
+    ZatoshiToDoubleCase(ratio: 30.0, zatoshi: -100_000_000, expected: -30.0, accuracy: 0.01)
+]
+
+// Homogeneous convert(Double) -> Zatoshi cases (each row was its own `testConvertCurrencyToZatoshi*` method).
+struct DoubleToZatoshiCase: Sendable {
+    let ratio: Double
+    let dollars: Double
+    let expectedAmount: Int64
+}
+
+private let doubleToZatoshiCases: [DoubleToZatoshiCase] = [
+    DoubleToZatoshiCase(ratio: 30.0, dollars: 30.0, expectedAmount: 100_000_000),
+    DoubleToZatoshiCase(ratio: 30.0, dollars: 15.0, expectedAmount: 50_000_000),
+    DoubleToZatoshiCase(ratio: 30.0, dollars: 0.0, expectedAmount: 0),
+    DoubleToZatoshiCase(ratio: 30.0, dollars: 0.01, expectedAmount: 33333),
+    DoubleToZatoshiCase(ratio: 30.0, dollars: 3000.0, expectedAmount: 10_000_000_000)
+]

--- a/zodlTests/DeeplinkTests/DeeplinkURLParsingTests.swift
+++ b/zodlTests/DeeplinkTests/DeeplinkURLParsingTests.swift
@@ -5,17 +5,17 @@
 //  Created by Cosmos on 18.05.2026.
 //
 
-import XCTest
+import Testing
+import Foundation
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-
-class DeeplinkURLParsingTests: XCTestCase {
-
-    func testResolveDeeplinkSimplifiedFormatValidAddress() throws {
+@Suite struct DeeplinkURLParsingTests {
+    @Test func resolveDeeplinkSimplifiedFormatValidAddress() throws {
         let address = "t1gXqfSSQt6WfpwyuCU3Wi7sSVZ66DYQ3Po"
         guard let url = URL(string: "zcash:\(address)") else {
-            return XCTFail("DeeplinkURLParsing tests: `testResolveDeeplinkSimplifiedFormatValidAddress` URL is expected to be valid")
+            Issue.record("DeeplinkURLParsing tests: `testResolveDeeplinkSimplifiedFormatValidAddress` URL is expected to be valid")
+            return
         }
 
         let result = try Deeplink.resolveDeeplinkURL(
@@ -24,27 +24,28 @@ class DeeplinkURLParsingTests: XCTestCase {
             isValidZcashAddress: { addr, _ in addr == address }
         )
 
-        XCTAssertEqual(
-            result,
-            .send(amount: 0, address: address, memo: ""),
+        #expect(
+            result == .send(amount: 0, address: address, memo: ""),
             "DeeplinkURLParsing tests: `testResolveDeeplinkSimplifiedFormatValidAddress` result is expected to be .send with address \(address) but it is \(result)"
         )
     }
 
-    func testResolveDeeplinkSimplifiedFormatInvalidAddressFallsThrough() {
+    @Test func resolveDeeplinkSimplifiedFormatInvalidAddressFallsThrough() {
         let url = URL(string: "zcash:invalidaddress123")!
 
-        XCTAssertThrowsError(
+        #expect(
+            throws: (any Error).self,
+            "DeeplinkURLParsing tests: `testResolveDeeplinkSimplifiedFormatInvalidAddressFallsThrough` is expected to throw for invalid address"
+        ) {
             try Deeplink.resolveDeeplinkURL(
                 url,
                 networkType: .testnet,
                 isValidZcashAddress: { _, _ in false }
-            ),
-            "DeeplinkURLParsing tests: `testResolveDeeplinkSimplifiedFormatInvalidAddressFallsThrough` is expected to throw for invalid address"
-        )
+            )
+        }
     }
 
-    func testResolveDeeplinkHomeURL() throws {
+    @Test func resolveDeeplinkHomeURL() throws {
         let url = URL(string: "zcash:///home")!
 
         let result = try Deeplink.resolveDeeplinkURL(
@@ -53,14 +54,13 @@ class DeeplinkURLParsingTests: XCTestCase {
             isValidZcashAddress: { _, _ in false }
         )
 
-        XCTAssertEqual(
-            result,
-            .home,
+        #expect(
+            result == .home,
             "DeeplinkURLParsing tests: `testResolveDeeplinkHomeURL` result is expected to be .home but it is \(result)"
         )
     }
 
-    func testResolveDeeplinkSendURLWithAllParams() throws {
+    @Test func resolveDeeplinkSendURLWithAllParams() throws {
         let url = URL(string: "zcash:///home/send?address=t1addr&memo=hello&amount=500000")!
 
         let result = try Deeplink.resolveDeeplinkURL(
@@ -69,14 +69,13 @@ class DeeplinkURLParsingTests: XCTestCase {
             isValidZcashAddress: { _, _ in false }
         )
 
-        XCTAssertEqual(
-            result,
-            .send(amount: 500_000, address: "t1addr", memo: "hello"),
+        #expect(
+            result == .send(amount: 500_000, address: "t1addr", memo: "hello"),
             "DeeplinkURLParsing tests: `testResolveDeeplinkSendURLWithAllParams` result is expected to be .send with amount 500000, address t1addr, memo hello but it is \(result)"
         )
     }
 
-    func testResolveDeeplinkSendURLMissingAmountDefaultsToZero() throws {
+    @Test func resolveDeeplinkSendURLMissingAmountDefaultsToZero() throws {
         let url = URL(string: "zcash:///home/send?address=t1addr&memo=test")!
 
         let result = try Deeplink.resolveDeeplinkURL(
@@ -85,14 +84,13 @@ class DeeplinkURLParsingTests: XCTestCase {
             isValidZcashAddress: { _, _ in false }
         )
 
-        XCTAssertEqual(
-            result,
-            .send(amount: 0, address: "t1addr", memo: "test"),
+        #expect(
+            result == .send(amount: 0, address: "t1addr", memo: "test"),
             "DeeplinkURLParsing tests: `testResolveDeeplinkSendURLMissingAmountDefaultsToZero` amount is expected to default to 0 but result is \(result)"
         )
     }
 
-    func testResolveDeeplinkSendURLMissingMemoDefaultsToEmpty() throws {
+    @Test func resolveDeeplinkSendURLMissingMemoDefaultsToEmpty() throws {
         let url = URL(string: "zcash:///home/send?address=t1addr&amount=100")!
 
         let result = try Deeplink.resolveDeeplinkURL(
@@ -101,14 +99,13 @@ class DeeplinkURLParsingTests: XCTestCase {
             isValidZcashAddress: { _, _ in false }
         )
 
-        XCTAssertEqual(
-            result,
-            .send(amount: 100, address: "t1addr", memo: ""),
+        #expect(
+            result == .send(amount: 100, address: "t1addr", memo: ""),
             "DeeplinkURLParsing tests: `testResolveDeeplinkSendURLMissingMemoDefaultsToEmpty` memo is expected to default to empty but result is \(result)"
         )
     }
 
-    func testResolveDeeplinkSendURLUrlEncodedMemo() throws {
+    @Test func resolveDeeplinkSendURLUrlEncodedMemo() throws {
         let url = URL(string: "zcash:///home/send?address=t1addr&memo=Hello%20World%21&amount=0")!
 
         let result = try Deeplink.resolveDeeplinkURL(
@@ -117,27 +114,28 @@ class DeeplinkURLParsingTests: XCTestCase {
             isValidZcashAddress: { _, _ in false }
         )
 
-        XCTAssertEqual(
-            result,
-            .send(amount: 0, address: "t1addr", memo: "Hello World!"),
+        #expect(
+            result == .send(amount: 0, address: "t1addr", memo: "Hello World!"),
             "DeeplinkURLParsing tests: `testResolveDeeplinkSendURLUrlEncodedMemo` memo is expected to be decoded as 'Hello World!' but result is \(result)"
         )
     }
 
-    func testResolveDeeplinkUnknownPathThrows() {
+    @Test func resolveDeeplinkUnknownPathThrows() {
         let url = URL(string: "zcash:///unknown/path")!
 
-        XCTAssertThrowsError(
+        #expect(
+            throws: (any Error).self,
+            "DeeplinkURLParsing tests: `testResolveDeeplinkUnknownPathThrows` is expected to throw for unknown path"
+        ) {
             try Deeplink.resolveDeeplinkURL(
                 url,
                 networkType: .testnet,
                 isValidZcashAddress: { _, _ in false }
-            ),
-            "DeeplinkURLParsing tests: `testResolveDeeplinkUnknownPathThrows` is expected to throw for unknown path"
-        )
+            )
+        }
     }
 
-    func testResolveDeeplinkPassesNetworkTypeToValidator() throws {
+    @Test func resolveDeeplinkPassesNetworkTypeToValidator() throws {
         let url = URL(string: "zcash:someaddress")!
         var receivedNetworkType: NetworkType?
 
@@ -150,9 +148,8 @@ class DeeplinkURLParsingTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(
-            receivedNetworkType,
-            .mainnet,
+        #expect(
+            receivedNetworkType == .mainnet,
             "DeeplinkURLParsing tests: `testResolveDeeplinkPassesNetworkTypeToValidator` network type is expected to be .mainnet but it is \(String(describing: receivedNetworkType))"
         )
     }

--- a/zodlTests/HomeTests/HomeTests.swift
+++ b/zodlTests/HomeTests/HomeTests.swift
@@ -6,18 +6,18 @@
 //
 
 @preconcurrency import Combine
-import XCTest
+import Testing
 import ComposableArchitecture
 @testable import zodl_internal
 @testable @preconcurrency import ZcashLightClientKit
 
-class HomeTests: XCTestCase {
-    @MainActor func testSynchronizerErrorBringsUpAlert() async {
+@Suite struct HomeTests {
+    @MainActor @Test func synchronizerErrorBringsUpAlert() async {
         let testError = ZcashError.synchronizerNotPrepared
 
         var state = SynchronizerState.zero
         state.syncStatus = .error(testError)
-        
+
         let store = TestStore(
             initialState: .initial
         ) {
@@ -27,7 +27,7 @@ class HomeTests: XCTestCase {
         await store.send(.synchronizerStateChanged(state.redacted))
 
         await store.receive(.showSynchronizerErrorAlert(testError))
-        
+
         await store.finish()
     }
 }

--- a/zodlTests/MemoByteCountingTests/MemoByteCountingTests.swift
+++ b/zodlTests/MemoByteCountingTests/MemoByteCountingTests.swift
@@ -5,129 +5,119 @@
 //  Created by Cosmos on 18.05.2026.
 //
 
-import XCTest
+import Testing
 @testable import zodl_internal
 
-
-class MemoByteCountingTests: XCTestCase {
-
-    func testByteLengthEmptyTextIsZero() {
+@Suite struct MemoByteCountingTests {
+    @Test func byteLengthEmptyTextIsZero() {
         let state = MessageEditor.State(charLimit: 512, text: "")
 
-        XCTAssertEqual(
-            state.byteLength,
-            0,
+        #expect(
+            state.byteLength == 0,
             "MemoByteCountingTests: `testByteLengthEmptyTextIsZero` byteLength is expected to be 0 but it is \(state.byteLength)"
         )
     }
 
-    func testByteLengthMultipleEmojiAccumulateBytes() {
+    @Test func byteLengthMultipleEmojiAccumulateBytes() {
         let text = String(repeating: "🎉", count: 10)
         let state = MessageEditor.State(charLimit: 512, text: text)
 
-        XCTAssertEqual(
-            state.byteLength,
-            40,
+        #expect(
+            state.byteLength == 40,
             "MemoByteCountingTests: `testByteLengthMultipleEmojiAccumulateBytes` byteLength is expected to be 40 but it is \(state.byteLength)"
         )
     }
 
-    func testByteLengthJapaneseTextCountsAsMultipleBytes() {
+    @Test func byteLengthJapaneseTextCountsAsMultipleBytes() {
         let state = MessageEditor.State(charLimit: 512, text: "日本語")
 
-        XCTAssertEqual(
-            state.byteLength,
-            9,
+        #expect(
+            state.byteLength == 9,
             "MemoByteCountingTests: `testByteLengthJapaneseTextCountsAsMultipleBytes` byteLength is expected to be 9 but it is \(state.byteLength)"
         )
     }
 
-    func testByteLengthSpanishAccentsCountsCorrectly() {
+    @Test func byteLengthSpanishAccentsCountsCorrectly() {
         let state = MessageEditor.State(charLimit: 512, text: "café")
 
-        XCTAssertEqual(
-            state.byteLength,
-            5,
+        #expect(
+            state.byteLength == 5,
             "MemoByteCountingTests: `testByteLengthSpanishAccentsCountsCorrectly` byteLength is expected to be 5 but it is \(state.byteLength)"
         )
     }
 
-    func testByteLengthMixedContentCountsCorrectly() {
+    @Test func byteLengthMixedContentCountsCorrectly() {
         let state = MessageEditor.State(charLimit: 512, text: "Hi 🎉 日本")
 
-        XCTAssertEqual(
-            state.byteLength,
-            14,
+        #expect(
+            state.byteLength == 14,
             "MemoByteCountingTests: `testByteLengthMixedContentCountsCorrectly` byteLength is expected to be 14 but it is \(state.byteLength)"
         )
     }
 
-    func testIsValidExactlyAtLimitIsTrue() {
+    @Test func isValidExactlyAtLimitIsTrue() {
         let text = String(repeating: "a", count: 512)
         let state = MessageEditor.State(charLimit: 512, text: text)
 
-        XCTAssertTrue(
+        #expect(
             state.isValid,
             "MemoByteCountingTests: `testIsValidExactlyAtLimitIsTrue` is expected to be true but it is \(state.isValid)"
         )
     }
 
-    func testIsValidEmojiPushingOverLimitIsFalse() {
+    @Test func isValidEmojiPushingOverLimitIsFalse() {
         let text = String(repeating: "a", count: 510) + "🎉"
         let state = MessageEditor.State(charLimit: 512, text: text)
 
-        XCTAssertFalse(
-            state.isValid,
+        #expect(
+            !state.isValid,
             "MemoByteCountingTests: `testIsValidEmojiPushingOverLimitIsFalse` is expected to be false but it is \(state.isValid)"
         )
     }
 
-    func testIsValidEmojiExactlyAtLimitIsTrue() {
+    @Test func isValidEmojiExactlyAtLimitIsTrue() {
         let text = String(repeating: "a", count: 508) + "🎉"
         let state = MessageEditor.State(charLimit: 512, text: text)
 
-        XCTAssertTrue(
+        #expect(
             state.isValid,
             "MemoByteCountingTests: `testIsValidEmojiExactlyAtLimitIsTrue` is expected to be true but it is \(state.isValid)"
         )
     }
 
-    func testIsValidEmptyTextIsTrue() {
+    @Test func isValidEmptyTextIsTrue() {
         let state = MessageEditor.State(charLimit: 512, text: "")
 
-        XCTAssertTrue(
+        #expect(
             state.isValid,
             "MemoByteCountingTests: `testIsValidEmptyTextIsTrue` is expected to be true but it is \(state.isValid)"
         )
     }
 
-    func testCharLimitTextAtLimitShowsZeroRemaining() {
+    @Test func charLimitTextAtLimitShowsZeroRemaining() {
         let text = String(repeating: "a", count: 512)
         let state = MessageEditor.State(charLimit: 512, text: text)
 
-        XCTAssertEqual(
-            state.charLimitText,
-            "0/512",
+        #expect(
+            state.charLimitText == "0/512",
             "MemoByteCountingTests: `testCharLimitTextAtLimitShowsZeroRemaining` charLimitText is expected to be \"0/512\" but it is \"\(state.charLimitText)\""
         )
     }
 
-    func testCharLimitTextEmojiCountedAsBytes() {
+    @Test func charLimitTextEmojiCountedAsBytes() {
         let state = MessageEditor.State(charLimit: 512, text: "🎉")
 
-        XCTAssertEqual(
-            state.charLimitText,
-            "508/512",
+        #expect(
+            state.charLimitText == "508/512",
             "MemoByteCountingTests: `testCharLimitTextEmojiCountedAsBytes` charLimitText is expected to be \"508/512\" but it is \"\(state.charLimitText)\""
         )
     }
 
-    func testCharLimitTextShowsRemainingBytes() {
+    @Test func charLimitTextShowsRemainingBytes() {
         let state = MessageEditor.State(charLimit: 512, text: "Hello")
 
-        XCTAssertEqual(
-            state.charLimitText,
-            "507/512",
+        #expect(
+            state.charLimitText == "507/512",
             "MemoByteCountingTests: `testCharLimitTextShowsRemainingBytes` charLimitText is expected to be \"507/512\" but it is \"\(state.charLimitText)\""
         )
     }

--- a/zodlTests/PrivateDataConsentTests/PrivateDataConsentTests.swift
+++ b/zodlTests/PrivateDataConsentTests/PrivateDataConsentTests.swift
@@ -5,19 +5,20 @@
 //  Created by Lukáš Korba on 01.11.2023.
 //
 
-import XCTest
+import Testing
+import Foundation
 import ComposableArchitecture
 @testable import zodl_internal
 
 @MainActor
-final class PrivateDataConsentTests: XCTestCase {
-    func testURLsProperlyPrepared() async throws {
+@Suite struct PrivateDataConsentTests {
+    @Test func urlsProperlyPrepared() async throws {
         let store = TestStore(
             initialState: .initial
         ) {
             PrivateDataConsent()
         }
-        
+
         let URL = URL(string: "https://electriccoin.co")!
 
         store.dependencies.databaseFiles = .noOp
@@ -26,11 +27,11 @@ final class PrivateDataConsentTests: XCTestCase {
         await store.send(.onAppear) { state in
             state.dataDbURL = [URL]
         }
-        
+
         await store.finish()
     }
-    
-    func testExportRequestSet() async throws {
+
+    @Test func exportRequestSet() async throws {
         let store = TestStore(
             initialState: PrivateDataConsent.State(
                 dataDbURL: [],
@@ -41,18 +42,18 @@ final class PrivateDataConsentTests: XCTestCase {
         ) {
             PrivateDataConsent()
         }
-        
+
         store.dependencies.logsHandler = .noOp
-        
+
         await store.send(.exportRequested) { state in
             state.exportOnlyLogs = false
             state.isExportingData = true
         }
-        
+
         await store.receive(.exportLogs(.start)) { state in
             state.exportLogsState.exportLogsDisabled = true
         }
-        
+
         await store.receive(.exportLogs(.finished(nil))) { state in
             state.exportLogsState.exportLogsDisabled = false
             state.exportLogsState.isSharingLogs = true
@@ -61,8 +62,8 @@ final class PrivateDataConsentTests: XCTestCase {
 
         await store.finish()
     }
-    
-    func testExportLogsRequestSet() async throws {
+
+    @Test func exportLogsRequestSet() async throws {
         let store = TestStore(
             initialState: PrivateDataConsent.State(
                 dataDbURL: [],
@@ -73,18 +74,18 @@ final class PrivateDataConsentTests: XCTestCase {
         ) {
             PrivateDataConsent()
         }
-        
+
         store.dependencies.logsHandler = .noOp
-        
+
         await store.send(.exportLogsRequested) { state in
             state.exportOnlyLogs = true
             state.isExportingLogs = true
         }
-        
+
         await store.receive(.exportLogs(.start)) { state in
             state.exportLogsState.exportLogsDisabled = true
         }
-        
+
         await store.receive(.exportLogs(.finished(nil))) { state in
             state.exportLogsState.exportLogsDisabled = false
             state.exportLogsState.isSharingLogs = true
@@ -92,8 +93,8 @@ final class PrivateDataConsentTests: XCTestCase {
         }
         await store.finish()
     }
-    
-    func testExportingDoneWhenFinished() async throws {
+
+    @Test func exportingDoneWhenFinished() async throws {
         let store = TestStore(
             initialState: PrivateDataConsent.State(
                 dataDbURL: [],
@@ -105,17 +106,17 @@ final class PrivateDataConsentTests: XCTestCase {
         ) {
             PrivateDataConsent()
         }
-        
+
         await store.send(.shareFinished) { state in
             state.exportBinding = false
             state.isExportingData = false
             state.isExportingLogs = false
         }
-        
+
         await store.finish()
     }
-    
-    func testExportURLs_logsOnly() async throws {
+
+    @Test func exportURLs_logsOnly() async throws {
         let URLdb = URL(string: "http://db.url")!
         let URLlogs = URL(string: "http://logs.url")!
 
@@ -125,11 +126,11 @@ final class PrivateDataConsentTests: XCTestCase {
             exportLogsState: .init(zippedLogsURLs: [URLlogs]),
             exportOnlyLogs: true
         )
-        
-        XCTAssertEqual(state.exportURLs, [URLlogs])
+
+        #expect(state.exportURLs == [URLlogs])
     }
-    
-    func testExportURLs_dbAndlogs() async throws {
+
+    @Test func exportURLs_dbAndlogs() async throws {
         let URLdb = URL(string: "http://db.url")!
         let URLlogs = URL(string: "http://logs.url")!
 
@@ -139,11 +140,11 @@ final class PrivateDataConsentTests: XCTestCase {
             exportLogsState: .init(zippedLogsURLs: [URLlogs]),
             exportOnlyLogs: false
         )
-        
-        XCTAssertEqual(state.exportURLs, [URLdb, URLlogs])
+
+        #expect(state.exportURLs == [URLdb, URLlogs])
     }
-    
-    func testIsExportPossible_NoBecauseNotAcknowledged() async throws {
+
+    @Test func isExportPossible_NoBecauseNotAcknowledged() async throws {
         let state = PrivateDataConsent.State(
             dataDbURL: [],
             exportBinding: true,
@@ -151,11 +152,11 @@ final class PrivateDataConsentTests: XCTestCase {
             exportOnlyLogs: true,
             isAcknowledged: false
         )
-        
-        XCTAssertFalse(state.isExportPossible)
+
+        #expect(!state.isExportPossible)
     }
-    
-    func testIsExportPossible_NoBecauseExportingLogs() async throws {
+
+    @Test func isExportPossible_NoBecauseExportingLogs() async throws {
         let state = PrivateDataConsent.State(
             dataDbURL: [],
             exportBinding: true,
@@ -164,11 +165,11 @@ final class PrivateDataConsentTests: XCTestCase {
             isAcknowledged: true,
             isExportingLogs: true
         )
-        
-        XCTAssertFalse(state.isExportPossible)
+
+        #expect(!state.isExportPossible)
     }
-    
-    func testIsExportPossible_NoBecauseExportingData() async throws {
+
+    @Test func isExportPossible_NoBecauseExportingData() async throws {
         let state = PrivateDataConsent.State(
             dataDbURL: [],
             exportBinding: true,
@@ -177,11 +178,11 @@ final class PrivateDataConsentTests: XCTestCase {
             isAcknowledged: true,
             isExportingData: true
         )
-        
-        XCTAssertFalse(state.isExportPossible)
+
+        #expect(!state.isExportPossible)
     }
-    
-    func testIsExportPossible() async throws {
+
+    @Test func isExportPossible() async throws {
         let state = PrivateDataConsent.State(
             dataDbURL: [],
             exportBinding: true,
@@ -189,7 +190,7 @@ final class PrivateDataConsentTests: XCTestCase {
             exportOnlyLogs: true,
             isAcknowledged: true
         )
-        
-        XCTAssertTrue(state.isExportPossible)
+
+        #expect(state.isExportPossible)
     }
 }

--- a/zodlTests/QRCodeGeneratorTests/QRCodeGeneratorTests.swift
+++ b/zodlTests/QRCodeGeneratorTests/QRCodeGeneratorTests.swift
@@ -5,37 +5,37 @@
 //  Created by Cosmos on 18.05.2026.
 //
 
-import XCTest
+import Testing
+import UIKit
 import CoreImage
 @testable import zodl_internal
 
-
-class QRCodeGeneratorTests: XCTestCase {
-    func testGenerateCodeValidString() {
+@Suite struct QRCodeGeneratorTests {
+    @Test func generateCodeValidString() {
         let image = QRCodeGenerator.generateCode(
             from: "zcash:t1testaddress123",
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeValidString` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateCodeEmptyString() {
+    @Test func generateCodeEmptyString() {
         let image = QRCodeGenerator.generateCode(
             from: "",
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeEmptyString` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateCodeLongString() {
+    @Test func generateCodeLongString() {
         // Unified addresses can be very long (~300+ chars)
         let longAddress = String(repeating: "a", count: 500)
         let image = QRCodeGenerator.generateCode(
@@ -43,308 +43,275 @@ class QRCodeGeneratorTests: XCTestCase {
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeLongString` is expected to produce a non-nil image for long unified addresses"
         )
     }
 
-    func testGenerateCodeUnicodeString() {
+    @Test func generateCodeUnicodeString() {
         let unicodeMemo = "zcash:t1addr?memo=Gracias%20por%20tu%20compra%20🎉"
         let image = QRCodeGenerator.generateCode(
             from: unicodeMemo,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeUnicodeString` is expected to produce a non-nil image for unicode content"
         )
     }
 
-    func testGenerateCodeProducesSquareImage() {
-        let image = QRCodeGenerator.generateCode(
-            from: "test-data",
-            overlayedWithZcashLogo: false
+    @Test func generateCodeProducesSquareImage() throws {
+        let image = try #require(
+            QRCodeGenerator.generateCode(from: "test-data", overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testGenerateCodeProducesSquareImage` image is expected to be non-nil"
         )
 
-        guard let image else {
-            XCTFail("QRCodeGenerator tests: `testGenerateCodeProducesSquareImage` image is expected to be non-nil")
-            return
-        }
-
-        XCTAssertEqual(
-            image.width,
-            image.height,
+        #expect(
+            image.width == image.height,
             "QRCodeGenerator tests: `testGenerateCodeProducesSquareImage` width is expected to equal height but got \(image.width) x \(image.height)"
         )
     }
 
-    func testGenerateCodeRespectsScaleParameter() {
-        let smallImage = QRCodeGenerator.generateCode(
-            from: "test",
-            scale: 5,
-            overlayedWithZcashLogo: false
+    @Test func generateCodeRespectsScaleParameter() throws {
+        let smallImage = try #require(
+            QRCodeGenerator.generateCode(from: "test", scale: 5, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testGenerateCodeRespectsScaleParameter` small image is expected to be non-nil"
         )
-        let largeImage = QRCodeGenerator.generateCode(
-            from: "test",
-            scale: 20,
-            overlayedWithZcashLogo: false
+        let largeImage = try #require(
+            QRCodeGenerator.generateCode(from: "test", scale: 20, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testGenerateCodeRespectsScaleParameter` large image is expected to be non-nil"
         )
 
-        guard let smallImage, let largeImage else {
-            XCTFail("QRCodeGenerator tests: `testGenerateCodeRespectsScaleParameter` both images are expected to be non-nil")
-            return
-        }
-
-        XCTAssertGreaterThan(
-            largeImage.width,
-            smallImage.width,
+        #expect(
+            largeImage.width > smallImage.width,
             "QRCodeGenerator tests: `testGenerateCodeRespectsScaleParameter` larger scale is expected to produce larger image but got \(largeImage.width) vs \(smallImage.width)"
         )
     }
 
-    func testGenerateCodeSameInputProducesSameDimensions() {
+    @Test func generateCodeSameInputProducesSameDimensions() throws {
         let input = "zcash:t1deterministic123"
-        let image1 = QRCodeGenerator.generateCode(from: input, overlayedWithZcashLogo: false)
-        let image2 = QRCodeGenerator.generateCode(from: input, overlayedWithZcashLogo: false)
+        let image1 = try #require(
+            QRCodeGenerator.generateCode(from: input, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testGenerateCodeSameInputProducesSameDimensions` first image is expected to be non-nil"
+        )
+        let image2 = try #require(
+            QRCodeGenerator.generateCode(from: input, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testGenerateCodeSameInputProducesSameDimensions` second image is expected to be non-nil"
+        )
 
-        guard let image1, let image2 else {
-            XCTFail("QRCodeGenerator tests: `testGenerateCodeSameInputProducesSameDimensions` both images are expected to be non-nil")
-            return
-        }
-
-        XCTAssertEqual(
-            image1.width,
-            image2.width,
+        #expect(
+            image1.width == image2.width,
             "QRCodeGenerator tests: `testGenerateCodeSameInputProducesSameDimensions` widths are expected to match but got \(image1.width) vs \(image2.width)"
         )
-        XCTAssertEqual(
-            image1.height,
-            image2.height,
+        #expect(
+            image1.height == image2.height,
             "QRCodeGenerator tests: `testGenerateCodeSameInputProducesSameDimensions` heights are expected to match but got \(image1.height) vs \(image2.height)"
         )
     }
 
-    func testGenerateCodeDifferentInputsBothSucceed() {
+    @Test func generateCodeDifferentInputsBothSucceed() {
         let image1 = QRCodeGenerator.generateCode(from: "zcash:t1address_one", overlayedWithZcashLogo: false)
         let image2 = QRCodeGenerator.generateCode(from: "zcash:t1address_two", overlayedWithZcashLogo: false)
 
-        XCTAssertNotNil(image1, "QRCodeGenerator tests: `testGenerateCodeDifferentInputsBothSucceed` first image is expected to be non-nil")
-        XCTAssertNotNil(image2, "QRCodeGenerator tests: `testGenerateCodeDifferentInputsBothSucceed` second image is expected to be non-nil")
+        #expect(image1 != nil, "QRCodeGenerator tests: `testGenerateCodeDifferentInputsBothSucceed` first image is expected to be non-nil")
+        #expect(image2 != nil, "QRCodeGenerator tests: `testGenerateCodeDifferentInputsBothSucceed` second image is expected to be non-nil")
     }
 
-    func testGenerateCodeKeystoneVendor() {
+    @Test func generateCodeKeystoneVendor() {
         let image = QRCodeGenerator.generateCode(
             from: "keystone-data",
             vendor: .keystone,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeKeystoneVendor` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateCodeZashiVendor() {
+    @Test func generateCodeZashiVendor() {
         let image = QRCodeGenerator.generateCode(
             from: "zashi-data",
             vendor: .zashi,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeZashiVendor` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateCodeMaxPrivacyTrue() {
+    @Test func generateCodeMaxPrivacyTrue() {
         let image = QRCodeGenerator.generateCode(
             from: "privacy-test",
             maxPrivacy: true,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeMaxPrivacyTrue` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateCodeMaxPrivacyFalse() {
+    @Test func generateCodeMaxPrivacyFalse() {
         let image = QRCodeGenerator.generateCode(
             from: "privacy-test",
             maxPrivacy: false,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeMaxPrivacyFalse` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateCodeWithBlackColor() {
+    @Test func generateCodeWithBlackColor() {
         let image = QRCodeGenerator.generateCode(
             from: "color-test",
             color: .black,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeWithBlackColor` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateCodeWithCustomColor() {
+    @Test func generateCodeWithCustomColor() {
         let image = QRCodeGenerator.generateCode(
             from: "color-test",
             color: .blue,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeWithCustomColor` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateAsyncFutureCompletesSuccessfully() async {
+    @Test func generateAsyncFutureCompletesSuccessfully() async {
         let image = await QRCodeGenerator.generate(
             from: "async-test",
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(image, "QRCodeGenerator tests: `testGenerateAsyncFutureCompletesSuccessfully` is expected to produce a non-nil image")
+        #expect(image != nil, "QRCodeGenerator tests: `testGenerateAsyncFutureCompletesSuccessfully` is expected to produce a non-nil image")
     }
 
-    func testGenerateCodeWithZIP321URI() {
+    @Test func generateCodeWithZIP321URI() {
         let zip321URI = "zcash:t1testaddr?amount=1.5&memo=Test%20memo"
         let image = QRCodeGenerator.generateCode(
             from: zip321URI,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeWithZIP321URI` is expected to produce a non-nil image"
         )
     }
 
-    func testGenerateCodeWithZIP321URIMultipleParams() {
+    @Test func generateCodeWithZIP321URIMultipleParams() {
         let zip321URI = "zcash:t1testaddr?amount=0.001&memo=Payment%20for%20coffee&message=Thanks"
         let image = QRCodeGenerator.generateCode(
             from: zip321URI,
             overlayedWithZcashLogo: false
         )
 
-        XCTAssertNotNil(
-            image,
+        #expect(
+            image != nil,
             "QRCodeGenerator tests: `testGenerateCodeWithZIP321URIMultipleParams` is expected to produce a non-nil image"
         )
     }
 
-    func testRoundTripSimpleAddress() {
+    @Test func roundTripSimpleAddress() throws {
         let input = "t1gXqfSSQt6WfpwyuCU3Wi7sSVZ66DYQ3Po"
-        let image = QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false)
-
-        guard let image else {
-            XCTFail("QRCodeGenerator tests: `testRoundTripSimpleAddress` image is expected to be non-nil")
-            return
-        }
+        let image = try #require(
+            QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testRoundTripSimpleAddress` image is expected to be non-nil"
+        )
 
         let decoded = decodeQRCode(image)
-        XCTAssertEqual(
-            decoded,
-            input,
+        #expect(
+            decoded == input,
             "QRCodeGenerator tests: `testRoundTripSimpleAddress` decoded QR is expected to be \(input) but it is \(decoded ?? "nil")"
         )
     }
 
-    func testRoundTripZIP321URI() {
+    @Test func roundTripZIP321URI() throws {
         let input = "zcash:t1testaddr?amount=1.5&memo=Test%20memo"
-        let image = QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false)
-
-        guard let image else {
-            XCTFail("QRCodeGenerator tests: `testRoundTripZIP321URI` image is expected to be non-nil")
-            return
-        }
+        let image = try #require(
+            QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testRoundTripZIP321URI` image is expected to be non-nil"
+        )
 
         let decoded = decodeQRCode(image)
-        XCTAssertEqual(
-            decoded,
-            input,
+        #expect(
+            decoded == input,
             "QRCodeGenerator tests: `testRoundTripZIP321URI` decoded QR is expected to match input but it is \(decoded ?? "nil")"
         )
     }
 
-    func testRoundTripZIP321URIWithMemo() {
+    @Test func roundTripZIP321URIWithMemo() throws {
         let input = "zcash:t1addr?amount=0.001&memo=Payment%20for%20coffee&message=Thanks"
-        let image = QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false)
-
-        guard let image else {
-            XCTFail("QRCodeGenerator tests: `testRoundTripZIP321URIWithMemo` image is expected to be non-nil")
-            return
-        }
+        let image = try #require(
+            QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testRoundTripZIP321URIWithMemo` image is expected to be non-nil"
+        )
 
         let decoded = decodeQRCode(image)
-        XCTAssertEqual(
-            decoded,
-            input,
+        #expect(
+            decoded == input,
             "QRCodeGenerator tests: `testRoundTripZIP321URIWithMemo` decoded QR is expected to preserve all params but it is \(decoded ?? "nil")"
         )
     }
 
-    func testRoundTripUnicodeContent() {
+    @Test func roundTripUnicodeContent() throws {
         let input = "zcash:t1addr?memo=Gracias%20🎉"
-        let image = QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false)
-
-        guard let image else {
-            XCTFail("QRCodeGenerator tests: `testRoundTripUnicodeContent` image is expected to be non-nil")
-            return
-        }
+        let image = try #require(
+            QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testRoundTripUnicodeContent` image is expected to be non-nil"
+        )
 
         let decoded = decodeQRCode(image)
-        XCTAssertEqual(
-            decoded,
-            input,
+        #expect(
+            decoded == input,
             "QRCodeGenerator tests: `testRoundTripUnicodeContent` decoded QR is expected to preserve unicode but it is \(decoded ?? "nil")"
         )
     }
 
-    func testRoundTripLongUnifiedAddress() {
+    @Test func roundTripLongUnifiedAddress() throws {
         let input = "u1" + String(repeating: "abcdef1234", count: 30)
-        let image = QRCodeGenerator.generateCode(from: input, scale: 20, color: .black, overlayedWithZcashLogo: false)
-
-        guard let image else {
-            XCTFail("QRCodeGenerator tests: `testRoundTripLongUnifiedAddress` image is expected to be non-nil")
-            return
-        }
+        let image = try #require(
+            QRCodeGenerator.generateCode(from: input, scale: 20, color: .black, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testRoundTripLongUnifiedAddress` image is expected to be non-nil"
+        )
 
         let decoded = decodeQRCode(image)
-        XCTAssertEqual(
-            decoded,
-            input,
+        #expect(
+            decoded == input,
             "QRCodeGenerator tests: `testRoundTripLongUnifiedAddress` decoded QR is expected to match long address but it is \(decoded ?? "nil")"
         )
     }
 
-    func testRoundTripEmptyString() {
+    @Test func roundTripEmptyString() throws {
         let input = ""
-        let image = QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false)
-
-        guard let image else {
-            XCTFail("QRCodeGenerator tests: `testRoundTripEmptyString` image is expected to be non-nil")
-            return
-        }
+        let image = try #require(
+            QRCodeGenerator.generateCode(from: input, color: .black, overlayedWithZcashLogo: false),
+            "QRCodeGenerator tests: `testRoundTripEmptyString` image is expected to be non-nil"
+        )
 
         let decoded = decodeQRCode(image)
-        XCTAssertEqual(
-            decoded,
-            input,
+        #expect(
+            decoded == input,
             "QRCodeGenerator tests: `testRoundTripEmptyString` decoded QR is expected to be empty but it is \(decoded ?? "nil")"
         )
     }

--- a/zodlTests/ReviewRequestTests/ReviewRequestTests.swift
+++ b/zodlTests/ReviewRequestTests/ReviewRequestTests.swift
@@ -5,28 +5,29 @@
 //  Created by Lukáš Korba on 04.04.2023.
 //
 
-import XCTest
+import Testing
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
 @MainActor
-final class ReviewRequestTests: XCTestCase {
-    func testSyncFinishedPersistency() async throws {
-        guard let userDefaults = UserDefaults.init(suiteName: "testSyncFinishedPersistency") else {
-            XCTFail("Review Request: UserDefaults failed to initialize")
-            return
-        }
-        
+@Suite struct ReviewRequestTests {
+    @Test func syncFinishedPersistency() async throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testSyncFinishedPersistency"),
+            "Review Request: UserDefaults failed to initialize"
+        )
+
         let store = TestStore(
             initialState: .initial
         ) {
             Home()
         }
-        
+
         let now = Date.now
         let userDefaultsClient: UserDefaultsClient = .live(userDefaults: userDefaults)
-        
+
         store.dependencies.reviewRequest =
             .live(
                 appVersion: .mock,
@@ -35,21 +36,21 @@ final class ReviewRequestTests: XCTestCase {
                 ),
                 userDefaults: userDefaultsClient
             )
-        
+
         var syncState: SynchronizerState = .zero
         syncState.syncStatus = .upToDate
-        
+
         await store.send(.synchronizerStateChanged(syncState.redacted))
-        
+
         let storedDate = userDefaultsClient.objectForKey(ReviewRequestClient.Constants.latestSyncKey) as? TimeInterval
-        XCTAssertEqual(now.timeIntervalSince1970, storedDate, "Review Request: stored date doesn't match the input.")
+        #expect(now.timeIntervalSince1970 == storedDate, "Review Request: stored date doesn't match the input.")
     }
-    
-    func testFoundTransactionsPersistency() async throws {
-        guard let userDefaults = UserDefaults.init(suiteName: "testFoundTransactionsPersistency") else {
-            XCTFail("Review Request: UserDefaults failed to initialize")
-            return
-        }
+
+    @Test func foundTransactionsPersistency() async throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testFoundTransactionsPersistency"),
+            "Review Request: UserDefaults failed to initialize"
+        )
 
         let store = TestStore(
             initialState: .initial
@@ -74,14 +75,14 @@ final class ReviewRequestTests: XCTestCase {
         await store.send(.foundTransactions)
 
         let storedDate = userDefaultsClient.objectForKey(ReviewRequestClient.Constants.foundTransactionsKey) as? TimeInterval
-        XCTAssertEqual(now.timeIntervalSince1970, storedDate, "Review Request: stored date doesn't match the input.")
+        #expect(now.timeIntervalSince1970 == storedDate, "Review Request: stored date doesn't match the input.")
     }
-    
-    func testCanRequestReview_FirstTime() throws {
-        guard let userDefaults = UserDefaults.init(suiteName: "testCanRequestReview_FirstTime") else {
-            XCTFail("Review Request: UserDefaults failed to initialize")
-            return
-        }
+
+    @Test func canRequestReview_FirstTime() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testCanRequestReview_FirstTime"),
+            "Review Request: UserDefaults failed to initialize"
+        )
 
         let now = Date.now
         let userDefaultsClient: UserDefaultsClient = .live(userDefaults: userDefaults)
@@ -96,15 +97,15 @@ final class ReviewRequestTests: XCTestCase {
             ),
             userDefaults: userDefaultsClient
         )
-        
-        XCTAssertTrue(reviewRequest.canRequestReview())
+
+        #expect(reviewRequest.canRequestReview())
     }
-    
-    func testCanRequestReview_NewerVersion() throws {
-        guard let userDefaults = UserDefaults.init(suiteName: "testCanRequestReview_NewerVersion") else {
-            XCTFail("Review Request: UserDefaults failed to initialize")
-            return
-        }
+
+    @Test func canRequestReview_NewerVersion() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testCanRequestReview_NewerVersion"),
+            "Review Request: UserDefaults failed to initialize"
+        )
 
         let now = Date.now
         let userDefaultsClient: UserDefaultsClient = .live(userDefaults: userDefaults)
@@ -123,15 +124,15 @@ final class ReviewRequestTests: XCTestCase {
             ),
             userDefaults: userDefaultsClient
         )
-        
-        XCTAssertTrue(reviewRequest.canRequestReview())
+
+        #expect(reviewRequest.canRequestReview())
     }
-    
-    func testCanRequestReview_OlderVersion() throws {
-        guard let userDefaults = UserDefaults.init(suiteName: "testCanRequestReview_OlderVersion") else {
-            XCTFail("Review Request: UserDefaults failed to initialize")
-            return
-        }
+
+    @Test func canRequestReview_OlderVersion() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testCanRequestReview_OlderVersion"),
+            "Review Request: UserDefaults failed to initialize"
+        )
 
         let now = Date.now
         let userDefaultsClient: UserDefaultsClient = .live(userDefaults: userDefaults)
@@ -150,15 +151,15 @@ final class ReviewRequestTests: XCTestCase {
             ),
             userDefaults: userDefaultsClient
         )
-        
-        XCTAssertFalse(reviewRequest.canRequestReview())
+
+        #expect(!reviewRequest.canRequestReview())
     }
-    
-    func testCanRequestReview_MissingSync() throws {
-        guard let userDefaults = UserDefaults.init(suiteName: "testCanRequestReview_MissingSync") else {
-            XCTFail("Review Request: UserDefaults failed to initialize")
-            return
-        }
+
+    @Test func canRequestReview_MissingSync() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testCanRequestReview_MissingSync"),
+            "Review Request: UserDefaults failed to initialize"
+        )
 
         let now = Date.now
         let userDefaultsClient: UserDefaultsClient = .live(userDefaults: userDefaults)
@@ -170,15 +171,15 @@ final class ReviewRequestTests: XCTestCase {
             ),
             userDefaults: userDefaultsClient
         )
-        
-        XCTAssertFalse(reviewRequest.canRequestReview())
+
+        #expect(!reviewRequest.canRequestReview())
     }
-    
-    func testCanRequestReview_MissingTransaction() throws {
-        guard let userDefaults = UserDefaults.init(suiteName: "testCanRequestReview_MissingTransaction") else {
-            XCTFail("Review Request: UserDefaults failed to initialize")
-            return
-        }
+
+    @Test func canRequestReview_MissingTransaction() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testCanRequestReview_MissingTransaction"),
+            "Review Request: UserDefaults failed to initialize"
+        )
 
         let now = Date.now
         let userDefaultsClient: UserDefaultsClient = .live(userDefaults: userDefaults)
@@ -196,7 +197,7 @@ final class ReviewRequestTests: XCTestCase {
             ),
             userDefaults: userDefaultsClient
         )
-        
-        XCTAssertFalse(reviewRequest.canRequestReview())
+
+        #expect(!reviewRequest.canRequestReview())
     }
 }

--- a/zodlTests/SensitiveDataTests/SensitiveDataTests.swift
+++ b/zodlTests/SensitiveDataTests/SensitiveDataTests.swift
@@ -5,49 +5,49 @@
 //  Created by Lukáš Korba on 06.02.2023.
 //
 
-import XCTest
+import Testing
 @preconcurrency import MnemonicSwift
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-class SensitiveDataTests: XCTestCase {
-    func testSeedPhraseConformsToUndescribable() throws {
+@Suite struct SensitiveDataTests {
+    @Test func seedPhraseConformsToUndescribable() throws {
         #if UNREDACTED
-        XCTAssertNil(SeedPhrase.self as? Undescribable)
+        #expect((SeedPhrase.self as? Undescribable) == nil)
         #else
-        XCTAssertNotNil(SeedPhrase.self as? Undescribable)
+        #expect((SeedPhrase.self as? Undescribable) != nil)
         #endif
     }
-    
-    func testBirthdayConformsToUndescribable() throws {
+
+    @Test func birthdayConformsToUndescribable() throws {
         #if UNREDACTED
-        XCTAssertNil(Birthday.self as? Undescribable)
+        #expect((Birthday.self as? Undescribable) == nil)
         #else
-        XCTAssertNotNil(Birthday.self as? Undescribable)
+        #expect((Birthday.self as? Undescribable) != nil)
         #endif
     }
-    
-    func testRedactableStringConformsToUndescribable() throws {
+
+    @Test func redactableStringConformsToUndescribable() throws {
         #if UNREDACTED
-        XCTAssertNil(RedactableString.self as? Undescribable)
+        #expect((RedactableString.self as? Undescribable) == nil)
         #else
-        XCTAssertNotNil(RedactableString.self as? Undescribable)
+        #expect((RedactableString.self as? Undescribable) != nil)
         #endif
     }
-    
-    func testRedactableBlockHeightConformsToUndescribable() throws {
+
+    @Test func redactableBlockHeightConformsToUndescribable() throws {
         #if UNREDACTED
-        XCTAssertNil(RedactableBlockHeight.self as? Undescribable)
+        #expect((RedactableBlockHeight.self as? Undescribable) == nil)
         #else
-        XCTAssertNotNil(RedactableBlockHeight.self as? Undescribable)
+        #expect((RedactableBlockHeight.self as? Undescribable) != nil)
         #endif
     }
-        
-    func testRedactableInt64ConformsToUndescribable() throws {
+
+    @Test func redactableInt64ConformsToUndescribable() throws {
         #if UNREDACTED
-        XCTAssertNil(RedactableInt64.self as? Undescribable)
+        #expect((RedactableInt64.self as? Undescribable) == nil)
         #else
-        XCTAssertNotNil(RedactableInt64.self as? Undescribable)
+        #expect((RedactableInt64.self as? Undescribable) != nil)
         #endif
     }
 }

--- a/zodlTests/UtilTests/AutoServerSelectionClientTests.swift
+++ b/zodlTests/UtilTests/AutoServerSelectionClientTests.swift
@@ -1,9 +1,9 @@
-import XCTest
+import Testing
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-final class AutoServerSelectionClientTests: XCTestCase {
+@Suite struct AutoServerSelectionClientTests {
     private final class Recorder: @unchecked Sendable {
         var switchedTo: LightWalletEndpoint?
         var persisted: UserPreferencesStorage.ServerConfig?
@@ -40,28 +40,28 @@ final class AutoServerSelectionClientTests: XCTestCase {
         return recorder
     }
 
-    func testNoOpWhenFlagOff() async {
+    @Test func noOpWhenFlagOff() async {
         let r = await run(flag: false, current: endpoint("zec.rocks"), best: endpoint("na.zec.rocks"))
-        XCTAssertNil(r.switchedTo)
-        XCTAssertNil(r.persisted)
+        #expect(r.switchedTo == nil)
+        #expect(r.persisted == nil)
     }
 
-    func testNoSwitchWhenBestEqualsCurrent() async {
+    @Test func noSwitchWhenBestEqualsCurrent() async {
         let r = await run(flag: true, current: endpoint("zec.rocks"), best: endpoint("zec.rocks"))
-        XCTAssertNil(r.switchedTo)
-        XCTAssertNil(r.persisted)
+        #expect(r.switchedTo == nil)
+        #expect(r.persisted == nil)
     }
 
-    func testSwitchesAndPersistsWhenIdle() async {
+    @Test func switchesAndPersistsWhenIdle() async {
         let r = await run(flag: true, current: endpoint("zec.rocks"), best: endpoint("na.zec.rocks"))
-        XCTAssertEqual(r.switchedTo?.host, "na.zec.rocks")
-        XCTAssertEqual(r.persisted?.host, "na.zec.rocks")
-        XCTAssertEqual(r.persisted?.isCustom, false)
+        #expect(r.switchedTo?.host == "na.zec.rocks")
+        #expect(r.persisted?.host == "na.zec.rocks")
+        #expect(r.persisted?.isCustom == false)
     }
 
-    func testSkipsWhenGuardBusy() async {
+    @Test func skipsWhenGuardBusy() async {
         let r = await run(flag: true, current: endpoint("zec.rocks"), best: endpoint("na.zec.rocks"), guardBusy: true)
-        XCTAssertNil(r.switchedTo)
-        XCTAssertNil(r.persisted)
+        #expect(r.switchedTo == nil)
+        #expect(r.persisted == nil)
     }
 }

--- a/zodlTests/UtilTests/AutomaticServerSelectionMigrationTests.swift
+++ b/zodlTests/UtilTests/AutomaticServerSelectionMigrationTests.swift
@@ -1,9 +1,9 @@
-import XCTest
+import Testing
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-final class AutomaticServerSelectionMigrationTests: XCTestCase {
+@Suite struct AutomaticServerSelectionMigrationTests {
     /// In-memory stand-in for the parts of `userStoredPreferences` the migration touches.
     private final class Box: @unchecked Sendable {
         var server: UserPreferencesStorage.ServerConfig?
@@ -23,27 +23,27 @@ final class AutomaticServerSelectionMigrationTests: XCTestCase {
         return box.flag
     }
 
-    func testNoStoredServerEnablesAutomatic() {
-        XCTAssertEqual(runMigration(network: .mainnet, server: nil), true)
+    @Test func noStoredServerEnablesAutomatic() {
+        #expect(runMigration(network: .mainnet, server: nil) == true)
     }
 
-    func testDefaultServerEnablesAutomatic() {
+    @Test func defaultServerEnablesAutomatic() {
         let def = ZcashSDKEnvironment.defaultEndpoint(for: .mainnet)
         let config = UserPreferencesStorage.ServerConfig(host: def.host, port: def.port, isCustom: false)
-        XCTAssertEqual(runMigration(network: .mainnet, server: config), true)
+        #expect(runMigration(network: .mainnet, server: config) == true)
     }
 
-    func testCustomServerSelectsManual() {
+    @Test func customServerSelectsManual() {
         let config = UserPreferencesStorage.ServerConfig(host: "my.server.example", port: 9067, isCustom: true)
-        XCTAssertEqual(runMigration(network: .mainnet, server: config), false)
+        #expect(runMigration(network: .mainnet, server: config) == false)
     }
 
-    func testNonDefaultKnownServerSelectsManual() {
+    @Test func nonDefaultKnownServerSelectsManual() {
         let config = UserPreferencesStorage.ServerConfig(host: "na.zec.rocks", port: 443, isCustom: false)
-        XCTAssertEqual(runMigration(network: .mainnet, server: config), false)
+        #expect(runMigration(network: .mainnet, server: config) == false)
     }
 
-    func testRunsOnlyOnce() {
+    @Test func runsOnlyOnce() {
         let box = Box(server: nil)
         box.flag = false // pretend the user already chose Manual
         withDependencies {
@@ -53,6 +53,6 @@ final class AutomaticServerSelectionMigrationTests: XCTestCase {
         } operation: {
             ZcashSDKEnvironment.initializeAutomaticServerSelectionIfNeeded(for: .mainnet)
         }
-        XCTAssertEqual(box.flag, false, "Migration must not overwrite an already-set flag")
+        #expect(box.flag == false, "Migration must not overwrite an already-set flag")
     }
 }

--- a/zodlTests/UtilTests/AutomaticServerSelectionStorageTests.swift
+++ b/zodlTests/UtilTests/AutomaticServerSelectionStorageTests.swift
@@ -1,23 +1,24 @@
-import XCTest
+import Testing
+import Foundation
 import ComposableArchitecture
 import os
 @testable import zodl_internal
 
-final class AutomaticServerSelectionStorageTests: XCTestCase {
-    func testFlagDefaultsToNilThenRoundTrips() {
+@Suite struct AutomaticServerSelectionStorageTests {
+    @Test func flagDefaultsToNilThenRoundTrips() {
         let storage = UserPreferencesStorage(
             defaultExchangeRate: Data(),
             defaultServer: Data(),
             userDefaults: .ephemeralForTests()
         )
 
-        XCTAssertNil(storage.automaticServerSelection, "Flag must be nil before it is ever set")
+        #expect(storage.automaticServerSelection == nil, "Flag must be nil before it is ever set")
 
         storage.setAutomaticServerSelection(true)
-        XCTAssertEqual(storage.automaticServerSelection, true)
+        #expect(storage.automaticServerSelection == true)
 
         storage.setAutomaticServerSelection(false)
-        XCTAssertEqual(storage.automaticServerSelection, false)
+        #expect(storage.automaticServerSelection == false)
     }
 }
 

--- a/zodlTests/UtilTests/DatabaseFilesTests.swift
+++ b/zodlTests/UtilTests/DatabaseFilesTests.swift
@@ -5,34 +5,34 @@
 //  Created by Lukáš Korba on 07.04.2022.
 //
 
-import XCTest
+import Testing
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-class DatabaseFilesTests: XCTestCase {
+@Suite struct DatabaseFilesTests {
     let network = ZcashNetworkBuilder.network(for: .testnet)
-    
-    func testDatabaseFilesPresent() throws {
+
+    @Test func databaseFilesPresent() throws {
         let mockedFileManager = FileManagerClient(
             url: { _, _, _, _ in .emptyURL },
             fileExists: { _ in return true },
             removeItem: { _ in }
         )
-        
+
         let dfInteractor = DatabaseFilesClient.live(databaseFiles: DatabaseFiles(fileManager: mockedFileManager))
         let areFilesPresent = dfInteractor.areDbFilesPresentFor(network)
-        XCTAssertTrue(areFilesPresent, "DatabaseFiles: `testDatabaseFilesPresent` is expected to be true but it's \(areFilesPresent)")
+        #expect(areFilesPresent, "DatabaseFiles: `testDatabaseFilesPresent` is expected to be true but it's \(areFilesPresent)")
     }
 
-    func testDatabaseFilesNotPresent() throws {
+    @Test func databaseFilesNotPresent() throws {
         let mockedFileManager = FileManagerClient(
             url: { _, _, _, _ in .emptyURL },
             fileExists: { _ in return false },
             removeItem: { _ in }
         )
-        
+
         let dfInteractor = DatabaseFilesClient.live(databaseFiles: DatabaseFiles(fileManager: mockedFileManager))
         let areFilesPresent = dfInteractor.areDbFilesPresentFor(network)
-        XCTAssertFalse(areFilesPresent, "DatabaseFiles: `testDatabaseFilesNotPresent` is expected to be false but it's \(areFilesPresent)")
+        #expect(!areFilesPresent, "DatabaseFiles: `testDatabaseFilesNotPresent` is expected to be false but it's \(areFilesPresent)")
     }
 }

--- a/zodlTests/UtilTests/DecommissionedServerMigrationTests.swift
+++ b/zodlTests/UtilTests/DecommissionedServerMigrationTests.swift
@@ -5,23 +5,26 @@
 //  Created on 2026-06-05.
 //
 
-import XCTest
+import Testing
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-final class DecommissionedServerMigrationTests: XCTestCase {
+// Uses a real, named UserDefaults suite shared across its test methods, so the suite is
+// serialized to keep each test's makeStorage()/removeAll() setup isolated.
+@Suite(.serialized) struct DecommissionedServerMigrationTests {
     // MARK: - Removal of decommissioned servers
 
-    func test_endpoints_doNotContainDecommissionedServers() {
+    @Test func endpoints_doNotContainDecommissionedServers() {
         let hosts = ZcashSDKEnvironment.endpoints(for: .mainnet).map { $0.host }
 
-        XCTAssertFalse(hosts.contains("eu2.zec.stardust.rest"), "eu2.zec.stardust.rest must be removed from endpoints()")
-        XCTAssertFalse(hosts.contains("jp.zec.stardust.rest"), "jp.zec.stardust.rest must be removed from endpoints()")
+        #expect(!hosts.contains("eu2.zec.stardust.rest"), "eu2.zec.stardust.rest must be removed from endpoints()")
+        #expect(!hosts.contains("jp.zec.stardust.rest"), "jp.zec.stardust.rest must be removed from endpoints()")
 
         let mainnetServers = ZcashSDKEnvironment.servers(for: .mainnet)
-        XCTAssertFalse(mainnetServers.contains(.hardcoded("eu2.zec.stardust.rest:443")), "eu2 must be removed from servers(for:)")
-        XCTAssertFalse(mainnetServers.contains(.hardcoded("jp.zec.stardust.rest:443")), "jp must be removed from servers(for:)")
+        #expect(!mainnetServers.contains(.hardcoded("eu2.zec.stardust.rest:443")), "eu2 must be removed from servers(for:)")
+        #expect(!mainnetServers.contains(.hardcoded("jp.zec.stardust.rest:443")), "jp must be removed from servers(for:)")
     }
 
     // MARK: - Helpers
@@ -30,7 +33,7 @@ final class DecommissionedServerMigrationTests: XCTestCase {
 
     /// A real `UserPreferencesStorage` backed by an isolated, cleared UserDefaults suite (stateful).
     private func makeStorage() throws -> UserPreferencesStorage {
-        let suite = try XCTUnwrap(UserDefaults(suiteName: Self.suiteName))
+        let suite = try #require(UserDefaults(suiteName: Self.suiteName))
         let storage = UserPreferencesStorage(
             defaultExchangeRate: Data(),
             defaultServer: Data(),
@@ -59,7 +62,7 @@ final class DecommissionedServerMigrationTests: XCTestCase {
 
     // MARK: - Rule 1: default server -> no migration
 
-    func test_noStoredServer_noMigration() throws {
+    @Test func noStoredServer_noMigration() throws {
         let storage = try makeStorage()
 
         withDependencies {
@@ -68,10 +71,10 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertNil(storage.server)
+        #expect(storage.server == nil)
     }
 
-    func test_storedDefaultServer_noMigration() throws {
+    @Test func storedDefaultServer_noMigration() throws {
         let storage = try makeStorage()
         try storage.setServer(mainnetDefault)
 
@@ -81,12 +84,12 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, mainnetDefault)
+        #expect(storage.server == mainnetDefault)
     }
 
     // MARK: - Rule 2: manual server, not removed -> no migration
 
-    func test_manualServerNotRemoved_noMigration() throws {
+    @Test func manualServerNotRemoved_noMigration() throws {
         let storage = try makeStorage()
         let original = UserPreferencesStorage.ServerConfig(host: "na.zec.rocks", port: 443, isCustom: false)
         try storage.setServer(original)
@@ -97,12 +100,12 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, original)
+        #expect(storage.server == original)
     }
 
     // MARK: - Rule 3: manual server, removed -> migrate to default
 
-    func test_manualServerRemoved_eu2_migratesToDefault() throws {
+    @Test func manualServerRemoved_eu2_migratesToDefault() throws {
         let storage = try makeStorage()
         try storage.setServer(UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 443, isCustom: false))
 
@@ -112,10 +115,10 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, mainnetDefault)
+        #expect(storage.server == mainnetDefault)
     }
 
-    func test_manualServerRemoved_jp_migratesToDefault() throws {
+    @Test func manualServerRemoved_jp_migratesToDefault() throws {
         let storage = try makeStorage()
         try storage.setServer(UserPreferencesStorage.ServerConfig(host: "jp.zec.stardust.rest", port: 443, isCustom: false))
 
@@ -125,12 +128,12 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, mainnetDefault)
+        #expect(storage.server == mainnetDefault)
     }
 
     // MARK: - Rule 4: custom server, other URL -> no migration
 
-    func test_customServerOther_noMigration() throws {
+    @Test func customServerOther_noMigration() throws {
         let storage = try makeStorage()
         let original = UserPreferencesStorage.ServerConfig(host: "my.custom.node", port: 443, isCustom: true)
         try storage.setServer(original)
@@ -141,12 +144,12 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, original)
+        #expect(storage.server == original)
     }
 
     // MARK: - Rule 5: custom server, exact decommissioned URL -> migrate to default
 
-    func test_customServerExact_eu2_migratesToDefault() throws {
+    @Test func customServerExact_eu2_migratesToDefault() throws {
         let storage = try makeStorage()
         try storage.setServer(UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 443, isCustom: true))
 
@@ -156,10 +159,10 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, mainnetDefault)
+        #expect(storage.server == mainnetDefault)
     }
 
-    func test_customServerExact_jp_migratesToDefault() throws {
+    @Test func customServerExact_jp_migratesToDefault() throws {
         let storage = try makeStorage()
         try storage.setServer(UserPreferencesStorage.ServerConfig(host: "jp.zec.stardust.rest", port: 443, isCustom: true))
 
@@ -169,12 +172,12 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, mainnetDefault)
+        #expect(storage.server == mainnetDefault)
     }
 
     // MARK: - Edge: decommissioned host on a non-443 port -> no migration ("exactly :443")
 
-    func test_customDecommissionedHost_nonDefaultPort_noMigration() throws {
+    @Test func customDecommissionedHost_nonDefaultPort_noMigration() throws {
         let storage = try makeStorage()
         let original = UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 9067, isCustom: true)
         try storage.setServer(original)
@@ -185,12 +188,12 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, original)
+        #expect(storage.server == original)
     }
 
     // MARK: - Edge: testnet user on a decommissioned custom URL -> migrate to testnet default
 
-    func test_testnetCustomDecommissioned_migratesToTestnetDefault() throws {
+    @Test func testnetCustomDecommissioned_migratesToTestnetDefault() throws {
         let storage = try makeStorage()
         try storage.setServer(UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 443, isCustom: true))
 
@@ -200,12 +203,12 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .testnet)
         }
 
-        XCTAssertEqual(storage.server, UserPreferencesStorage.ServerConfig(host: "testnet.zec.rocks", port: 443, isCustom: false))
+        #expect(storage.server == UserPreferencesStorage.ServerConfig(host: "testnet.zec.rocks", port: 443, isCustom: false))
     }
 
     // MARK: - Idempotency
 
-    func test_migrationIsIdempotent() throws {
+    @Test func migrationIsIdempotent() throws {
         let storage = try makeStorage()
         try storage.setServer(UserPreferencesStorage.ServerConfig(host: "jp.zec.stardust.rest", port: 443, isCustom: true))
 
@@ -217,12 +220,12 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.migrateDecommissionedServersIfNeeded(for: .mainnet)
         }
 
-        XCTAssertEqual(storage.server, mainnetDefault)
+        #expect(storage.server == mainnetDefault)
     }
 
     // MARK: - Integration: serverConfig(for:) returns the default after migrating
 
-    func test_serverConfig_returnsDefault_afterMigratingDecommissionedServer() throws {
+    @Test func serverConfig_returnsDefault_afterMigratingDecommissionedServer() throws {
         let storage = try makeStorage()
         try storage.setServer(UserPreferencesStorage.ServerConfig(host: "eu2.zec.stardust.rest", port: 443, isCustom: false))
 
@@ -233,7 +236,7 @@ final class DecommissionedServerMigrationTests: XCTestCase {
             ZcashSDKEnvironment.serverConfig(for: .mainnet)
         }
 
-        XCTAssertEqual(result, mainnetDefault, "serverConfig(for:) must return the default that the SDK Initializer will use")
-        XCTAssertEqual(storage.server, mainnetDefault, "the migration must be persisted")
+        #expect(result == mainnetDefault, "serverConfig(for:) must return the default that the SDK Initializer will use")
+        #expect(storage.server == mainnetDefault, "the migration must be persisted")
     }
 }

--- a/zodlTests/UtilTests/LoggerTests.swift
+++ b/zodlTests/UtilTests/LoggerTests.swift
@@ -5,14 +5,16 @@
 //  Created by Lukáš Korba on 24.01.2023.
 //
 
-import XCTest
+import Testing
 import OSLog
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-class LoggerTests: XCTestCase {
+// Logs are written to and read back from the process-global OSLog store, so the
+// suite is serialized to avoid concurrent writers/readers racing the shared store.
+@Suite(.serialized) struct LoggerTests {
     let timeToPast: TimeInterval = 0.1
-    
+
     // NOTE: Tests that exercise `.debug` log-level entries are intentionally
     // omitted. On a fresh CI simulator without an active OSLog subsystem
     // profile, `.debug` entries are not retained by `OSLogStore`, which makes
@@ -20,105 +22,105 @@ class LoggerTests: XCTestCase {
     // The remaining tests cover `.error / .warning / .event / .info`, which
     // are all persisted by default and run reliably in any environment.
 
-    func testOSLogger_ErrorLevel_ErrorLog() throws {
+    @Test func osLogger_ErrorLevel_ErrorLog() throws {
         let category = "testOSLogger_ErrorLevel_ErrorLog"
         let osLogger = OSLogger(logLevel: .debug, category: category)
         let testMessage = "error message"
-        
+
         osLogger.error(testMessage)
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
-        XCTAssertNotNil(logs)
-        
+
+        #expect(logs != nil)
+
         guard let logs else { return }
-        
-        XCTAssertEqual(logs.count, 1)
-        
+
+        #expect(logs.count == 1)
+
         let loggedMessage = logs[0].osLoggedMessage()
-        
-        XCTAssertEqual(testMessage, loggedMessage)
+
+        #expect(testMessage == loggedMessage)
     }
-    
-    func testOSLogger_WarningLevel_WarningLog() throws {
+
+    @Test func osLogger_WarningLevel_WarningLog() throws {
         let category = "testOSLogger_WarningLevel_WarningLog"
         let osLogger = OSLogger(logLevel: .warning, category: category)
         let testMessage = "warning message"
-        
+
         osLogger.warn(testMessage)
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
-        XCTAssertNotNil(logs)
-        
+
+        #expect(logs != nil)
+
         guard let logs else { return }
-        
-        XCTAssertEqual(logs.count, 1)
-        
+
+        #expect(logs.count == 1)
+
         let loggedMessage = logs[0].osLoggedMessage()
-        
-        XCTAssertEqual(testMessage, loggedMessage)
+
+        #expect(testMessage == loggedMessage)
     }
-    
-    func testOSLogger_EventLevel_EventLog() throws {
+
+    @Test func osLogger_EventLevel_EventLog() throws {
         let category = "testOSLogger_EventLevel_EventLog"
         let osLogger = OSLogger(logLevel: .event, category: category)
         let testMessage = "event message"
-        
+
         osLogger.event(testMessage)
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
-        XCTAssertNotNil(logs)
-        
+
+        #expect(logs != nil)
+
         guard let logs else { return }
-        
-        XCTAssertEqual(logs.count, 1)
-        
+
+        #expect(logs.count == 1)
+
         let loggedMessage = logs[0].osLoggedMessage()
-        
-        XCTAssertEqual(testMessage, loggedMessage)
+
+        #expect(testMessage == loggedMessage)
     }
-    
-    func testOSLogger_InfoLevel_InfoLog() throws {
+
+    @Test func osLogger_InfoLevel_InfoLog() throws {
         let category = "testOSLogger_InfoLevel_InfoLog"
         let osLogger = OSLogger(logLevel: .info, category: category)
         let testMessage = "info message"
-        
+
         osLogger.info(testMessage)
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
-        XCTAssertNotNil(logs)
-        
+
+        #expect(logs != nil)
+
         guard let logs else { return }
-        
-        XCTAssertEqual(logs.count, 1)
-        
+
+        #expect(logs.count == 1)
+
         let loggedMessage = logs[0].osLoggedMessage()
-        
-        XCTAssertEqual(testMessage, loggedMessage)
+
+        #expect(testMessage == loggedMessage)
     }
-    
-    func testOSLogger_ErrorLevel_OtherLogs() throws {
+
+    @Test func osLogger_ErrorLevel_OtherLogs() throws {
         let category = "testOSLogger_ErrorLevel_OtherLogs"
         let osLogger = OSLogger(logLevel: .error, category: category)
         let testMessage = "debug message"
-        
+
         osLogger.debug(testMessage)
         osLogger.error(testMessage)
         osLogger.warn(testMessage)
         osLogger.event(testMessage)
         osLogger.info(testMessage)
-        
+
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
+
         guard let logs else { return }
-        
-        XCTAssertEqual(logs.count, 1)
+
+        #expect(logs.count == 1)
     }
-    
-    func testOSLogger_WarningLevel_OtherLogs() throws {
+
+    @Test func osLogger_WarningLevel_OtherLogs() throws {
         let category = "testOSLogger_WarningLevel_OtherLogs"
         let osLogger = OSLogger(logLevel: .warning, category: category)
         let testMessage = "debug message"
-        
+
         osLogger.debug(testMessage)
         osLogger.error(testMessage)
         osLogger.warn(testMessage)
@@ -126,17 +128,17 @@ class LoggerTests: XCTestCase {
         osLogger.info(testMessage)
 
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
+
         guard let logs else { return }
 
-        XCTAssertEqual(logs.count, 2)
+        #expect(logs.count == 2)
     }
-    
-    func testOSLogger_EventLevel_OtherLogs() throws {
+
+    @Test func osLogger_EventLevel_OtherLogs() throws {
         let category = "testOSLogger_EventLevel_OtherLogs"
         let osLogger = OSLogger(logLevel: .event, category: category)
         let testMessage = "debug message"
-        
+
         osLogger.debug(testMessage)
         osLogger.error(testMessage)
         osLogger.warn(testMessage)
@@ -144,17 +146,17 @@ class LoggerTests: XCTestCase {
         osLogger.info(testMessage)
 
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
+
         guard let logs else { return }
 
-        XCTAssertEqual(logs.count, 3)
+        #expect(logs.count == 3)
     }
-    
-    func testOSLogger_InfoLevel_OtherLogs() throws {
+
+    @Test func osLogger_InfoLevel_OtherLogs() throws {
         let category = "testOSLogger_InfoLevel_OtherLogs"
         let osLogger = OSLogger(logLevel: .info, category: category)
         let testMessage = "debug message"
-        
+
         osLogger.debug(testMessage)
         osLogger.error(testMessage)
         osLogger.warn(testMessage)
@@ -162,29 +164,29 @@ class LoggerTests: XCTestCase {
         osLogger.info(testMessage)
 
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
+
         guard let logs else { return }
 
-        XCTAssertEqual(logs.count, 4)
+        #expect(logs.count == 4)
     }
-    
-    func testWalletLogger() throws {
+
+    @Test func walletLoggerLogsViaProxy() throws {
         let category = "testWalletLogger"
         walletLogger = OSLogger(logLevel: .info, category: category)
         let testMessage = "wallet test message"
-        
+
         LoggerProxy.info(testMessage)
         let logs = TestLogStore.exportCategory(category, hoursToThePast: timeToPast)
-        
-        XCTAssertNotNil(logs)
-        
+
+        #expect(logs != nil)
+
         guard let logs else { return }
-        
-        XCTAssertEqual(logs.count, 1)
-        
+
+        #expect(logs.count == 1)
+
         let loggedMessage = logs[0].osLoggedMessage()
-        
-        XCTAssertEqual(testMessage, loggedMessage)
+
+        #expect(testMessage == loggedMessage)
     }
 }
 
@@ -195,7 +197,7 @@ extension String {
         if split.count == 2 {
             return split[1]
         }
-        
+
         return nil
     }
 }
@@ -203,19 +205,19 @@ extension String {
 enum TestLogStore {
     static func exportCategory(_ category: String, hoursToThePast: TimeInterval = 24) -> [String]? {
         guard let bundle = Bundle.main.bundleIdentifier else { return nil }
-        
+
         do {
             let store = try OSLogStore(scope: .currentProcessIdentifier)
             let date = Date.now.addingTimeInterval(-hoursToThePast * 3600)
             let position = store.position(date: date)
             var entries: [String] = []
-            
+
             entries = try store
                 .getEntries(at: position)
                 .compactMap { $0 as? OSLogEntryLog }
                 .filter { $0.subsystem == bundle && $0.category == category }
                 .map { "[\($0.date.formatted())] \($0.composedMessage)" }
-            
+
             return entries
         } catch {
             return nil

--- a/zodlTests/UtilTests/SecItemClientTests.swift
+++ b/zodlTests/UtilTests/SecItemClientTests.swift
@@ -5,7 +5,9 @@
 //  Created by Lukáš Korba on 12.04.2022.
 //
 
-import XCTest
+import Testing
+import Foundation
+import Security
 @testable import zodl_internal
 
 extension WalletStorage.KeychainError {
@@ -20,124 +22,88 @@ extension WalletStorage.KeychainError {
     }
 }
 
-class SecItemClientTests: XCTestCase {
-    func test_secItemAdd_KeychainErrorDuplicate() throws {
+@Suite struct SecItemClientTests {
+    @Test func secItemAdd_KeychainErrorDuplicate() {
         let secItemDuplicate = SecItemClient(
             copyMatching: { _, _ in errSecSuccess },
             add: { _, _ in errSecDuplicateItem },
             update: { _, _ in errSecSuccess },
             delete: { _ in errSecSuccess }
         )
-        
-        let walletStorage = WalletStorage(secItem: secItemDuplicate)
-        
-        do {
-            try walletStorage.setData(Data(), forKey: "")
 
-            XCTFail("SecItemClient: test_secItemAdd_KeychainErrorDuplicate expected to fail but passed.")
-        } catch {
-            guard let error = error as? WalletStorage.KeychainError else {
-                XCTFail("SecItemClient: the error is expected to be WalletStorage.KeychainError but it's \(error).")
-                
-                return
-            }
-            
-            XCTAssertEqual(
-                error.debugValue,
-                WalletStorage.KeychainError.duplicate.debugValue,
-                "SecItemClient: error must be .duplicate but it's \(error)."
-            )
+        let walletStorage = WalletStorage(secItem: secItemDuplicate)
+
+        let error = #expect(throws: WalletStorage.KeychainError.self) {
+            try walletStorage.setData(Data(), forKey: "")
         }
+
+        #expect(
+            error?.debugValue == WalletStorage.KeychainError.duplicate.debugValue,
+            "SecItemClient: error must be .duplicate but it's \(String(describing: error))."
+        )
     }
-    
-    func test_secItemAdd_KeychainErrorUnknown() throws {
+
+    @Test func secItemAdd_KeychainErrorUnknown() {
         let secItemDuplicate = SecItemClient(
             copyMatching: { _, _ in errSecSuccess },
             add: { _, _ in errSecCoreFoundationUnknown },
             update: { _, _ in errSecSuccess },
             delete: { _ in errSecSuccess }
         )
-        
-        let walletStorage = WalletStorage(secItem: secItemDuplicate)
-        
-        do {
-            try walletStorage.setData(Data(), forKey: "")
 
-            XCTFail("SecItemClient: test_secItemAdd_KeychainErrorUnknown expected to fail but passed.")
-        } catch {
-            guard let error = error as? WalletStorage.KeychainError else {
-                XCTFail("SecItemClient: the error is expected to be WalletStorage.KeychainError but it's \(error).")
-                
-                return
-            }
-            
-            XCTAssertEqual(
-                error.debugValue,
-                WalletStorage.KeychainError.unknown(0).debugValue,
-                "SecItemClient: error must be .unknown but it's \(error)."
-            )
+        let walletStorage = WalletStorage(secItem: secItemDuplicate)
+
+        let error = #expect(throws: WalletStorage.KeychainError.self) {
+            try walletStorage.setData(Data(), forKey: "")
         }
+
+        #expect(
+            error?.debugValue == WalletStorage.KeychainError.unknown(0).debugValue,
+            "SecItemClient: error must be .unknown but it's \(String(describing: error))."
+        )
     }
-    
-    func test_secItemUpdate_KeychainErrorNoDataFound() throws {
+
+    @Test func secItemUpdate_KeychainErrorNoDataFound() {
         let secItemDuplicate = SecItemClient(
             copyMatching: { _, _ in errSecSuccess },
             add: { _, _ in errSecSuccess },
             update: { _, _ in errSecItemNotFound },
             delete: { _ in errSecSuccess }
         )
-        
-        let walletStorage = WalletStorage(secItem: secItemDuplicate)
-        
-        do {
-            try walletStorage.updateData(Data(), forKey: "")
 
-            XCTFail("SecItemClient: test_secItemUpdate_KeychainErrorNoDataFound expected to fail but passed.")
-        } catch {
-            guard let error = error as? WalletStorage.KeychainError else {
-                XCTFail("SecItemClient: the error is expected to be WalletStorage.KeychainError but it's \(error).")
-                
-                return
-            }
-            
-            XCTAssertEqual(
-                error.debugValue,
-                WalletStorage.KeychainError.noDataFound.debugValue,
-                "SecItemClient: error must be .noDataFound but it's \(error)."
-            )
+        let walletStorage = WalletStorage(secItem: secItemDuplicate)
+
+        let error = #expect(throws: WalletStorage.KeychainError.self) {
+            try walletStorage.updateData(Data(), forKey: "")
         }
+
+        #expect(
+            error?.debugValue == WalletStorage.KeychainError.noDataFound.debugValue,
+            "SecItemClient: error must be .noDataFound but it's \(String(describing: error))."
+        )
     }
-    
-    func test_secItemUpdate_KeychainErrorUnknown() throws {
+
+    @Test func secItemUpdate_KeychainErrorUnknown() {
         let secItemDuplicate = SecItemClient(
             copyMatching: { _, _ in errSecSuccess },
             add: { _, _ in errSecSuccess },
             update: { _, _ in errSecCoreFoundationUnknown },
             delete: { _ in errSecSuccess }
         )
-        
-        let walletStorage = WalletStorage(secItem: secItemDuplicate)
-        
-        do {
-            try walletStorage.updateData(Data(), forKey: "")
 
-            XCTFail("SecItemClient: test_secItemUpdate_KeychainErrorUnknown expected to fail but passed.")
-        } catch {
-            guard let error = error as? WalletStorage.KeychainError else {
-                XCTFail("SecItemClient: the error is expected to be WalletStorage.KeychainError but it's \(error).")
-                
-                return
-            }
-            
-            XCTAssertEqual(
-                error.debugValue,
-                WalletStorage.KeychainError.unknown(0).debugValue,
-                "SecItemClient: error must be .unknown but it's \(error)."
-            )
+        let walletStorage = WalletStorage(secItem: secItemDuplicate)
+
+        let error = #expect(throws: WalletStorage.KeychainError.self) {
+            try walletStorage.updateData(Data(), forKey: "")
         }
+
+        #expect(
+            error?.debugValue == WalletStorage.KeychainError.unknown(0).debugValue,
+            "SecItemClient: error must be .unknown but it's \(String(describing: error))."
+        )
     }
-    
-    func test_secItemDelete_Succeeded() throws {
+
+    @Test func secItemDelete_Succeeded() {
         let secItemDuplicate = SecItemClient(
             copyMatching: { _, _ in errSecSuccess },
             add: { _, _ in errSecSuccess },
@@ -147,10 +113,12 @@ class SecItemClientTests: XCTestCase {
 
         let walletStorage = WalletStorage(secItem: secItemDuplicate)
 
-        XCTAssertNoThrow(try walletStorage.deleteData(forKey: ""))
+        #expect(throws: Never.self) {
+            try walletStorage.deleteData(forKey: "")
+        }
     }
 
-    func test_secItemDelete_Failed() throws {
+    @Test func secItemDelete_Failed() {
         let secItemDuplicate = SecItemClient(
             copyMatching: { _, _ in errSecSuccess },
             add: { _, _ in errSecSuccess },
@@ -160,6 +128,8 @@ class SecItemClientTests: XCTestCase {
 
         let walletStorage = WalletStorage(secItem: secItemDuplicate)
 
-        XCTAssertThrowsError(try walletStorage.deleteData(forKey: ""))
+        #expect(throws: (any Error).self) {
+            try walletStorage.deleteData(forKey: "")
+        }
     }
 }

--- a/zodlTests/UtilTests/ServerEndpointsTests.swift
+++ b/zodlTests/UtilTests/ServerEndpointsTests.swift
@@ -1,30 +1,30 @@
-import XCTest
+import Testing
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-final class ServerEndpointsTests: XCTestCase {
-    func testTestnetReturnsOnlyDefault() {
+@Suite struct ServerEndpointsTests {
+    @Test func testnetReturnsOnlyDefault() {
         let endpoints = ZcashSDKEnvironment.endpoints(for: .testnet)
-        XCTAssertEqual(endpoints.count, 1)
-        XCTAssertEqual(endpoints.first?.host, ZcashSDKEnvironment.defaultEndpoint(for: .testnet).host)
+        #expect(endpoints.count == 1)
+        #expect(endpoints.first?.host == ZcashSDKEnvironment.defaultEndpoint(for: .testnet).host)
     }
 
-    func testTestnetSkipDefaultIsEmpty() {
-        XCTAssertTrue(ZcashSDKEnvironment.endpoints(for: .testnet, skipDefault: true).isEmpty)
+    @Test func testnetSkipDefaultIsEmpty() {
+        #expect(ZcashSDKEnvironment.endpoints(for: .testnet, skipDefault: true).isEmpty)
     }
 
-    func testMainnetContainsKnownServersWithSecureAndTimeout() {
+    @Test func mainnetContainsKnownServersWithSecureAndTimeout() {
         let endpoints = ZcashSDKEnvironment.endpoints(for: .mainnet)
-        XCTAssertTrue(endpoints.contains { $0.host == "zec.rocks" && $0.port == 443 })
-        XCTAssertTrue(endpoints.contains { $0.host == "eu.zec.stardust.rest" })
-        XCTAssertTrue(endpoints.allSatisfy { $0.secure })
-        XCTAssertTrue(endpoints.allSatisfy {
+        #expect(endpoints.contains { $0.host == "zec.rocks" && $0.port == 443 })
+        #expect(endpoints.contains { $0.host == "eu.zec.stardust.rest" })
+        #expect(endpoints.allSatisfy { $0.secure })
+        #expect(endpoints.allSatisfy {
             $0.streamingCallTimeoutInMillis == ZcashSDKEnvironment.ZcashSDKConstants.streamingCallTimeoutInMillis
         })
     }
 
-    func testMainnetSkipDefaultExcludesDefaultHost() {
+    @Test func mainnetSkipDefaultExcludesDefaultHost() {
         let endpoints = ZcashSDKEnvironment.endpoints(for: .mainnet, skipDefault: true)
-        XCTAssertFalse(endpoints.contains { $0.host == "zec.rocks" })
+        #expect(!(endpoints.contains { $0.host == "zec.rocks" }))
     }
 }

--- a/zodlTests/UtilTests/ServerSetupStoreTests.swift
+++ b/zodlTests/UtilTests/ServerSetupStoreTests.swift
@@ -1,16 +1,16 @@
-import XCTest
+import Testing
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
 @MainActor
-final class ServerSetupStoreTests: XCTestCase {
+@Suite struct ServerSetupStoreTests {
     private final class Prefs: @unchecked Sendable {
         var automatic: Bool?
         var server: UserPreferencesStorage.ServerConfig?
     }
 
-    func testManualSaveSwitchesPersistsAndFlagsManual() async {
+    @Test func manualSaveSwitchesPersistsAndFlagsManual() async {
         let prefs = Prefs()
         let switched = LockIsolated<LightWalletEndpoint?>(nil)
 
@@ -38,13 +38,13 @@ final class ServerSetupStoreTests: XCTestCase {
         await store.send(.setServerTapped)
         await store.receive(\.switchSucceeded)
 
-        XCTAssertEqual(switched.value?.host, "na.zec.rocks")
-        XCTAssertEqual(prefs.automatic, false)
-        XCTAssertEqual(prefs.server?.host, "na.zec.rocks")
-        XCTAssertEqual(prefs.server?.isCustom, false)
+        #expect(switched.value?.host == "na.zec.rocks")
+        #expect(prefs.automatic == false)
+        #expect(prefs.server?.host == "na.zec.rocks")
+        #expect(prefs.server?.isCustom == false)
     }
 
-    func testAutomaticSaveFlagsAutomatic() async {
+    @Test func automaticSaveFlagsAutomatic() async {
         let prefs = Prefs()
 
         var initial = ServerSetup.State()
@@ -72,11 +72,11 @@ final class ServerSetupStoreTests: XCTestCase {
         await store.send(.setServerTapped)
         await store.receive(\.switchSucceeded)
 
-        XCTAssertEqual(prefs.automatic, true)
-        XCTAssertEqual(prefs.server?.host, "na.zec.rocks")
+        #expect(prefs.automatic == true)
+        #expect(prefs.server?.host == "na.zec.rocks")
     }
 
-    func testNoChangesDoesNothing() async {
+    @Test func noChangesDoesNothing() async {
         let store = TestStore(initialState: ServerSetup.State()) {
             ServerSetup()
         } withDependencies: {
@@ -86,7 +86,7 @@ final class ServerSetupStoreTests: XCTestCase {
         await store.send(.setServerTapped)
     }
 
-    func testOnAppearClearsStuckUpdatingFlag() async {
+    @Test func onAppearClearsStuckUpdatingFlag() async {
         var initial = ServerSetup.State()
         initial.isUpdatingServer = true   // a previous switch that hung or was cancelled left this set
         initial.network = .mainnet
@@ -106,10 +106,10 @@ final class ServerSetupStoreTests: XCTestCase {
 
         await store.send(.onAppear)
 
-        XCTAssertFalse(store.state.isUpdatingServer, "onAppear must clear a stuck isUpdatingServer flag so the screen isn't wedged")
+        #expect(!store.state.isUpdatingServer, "onAppear must clear a stuck isUpdatingServer flag so the screen isn't wedged")
     }
 
-    func testSwitchingToAutomaticBenchmarksWhenNoFreshResultAndOffersFastest() async {
+    @Test func switchingToAutomaticBenchmarksWhenNoFreshResultAndOffersFastest() async {
         var initial = ServerSetup.State()
         initial.connectionMode = .manual
         initial.activeSyncServer = "na.zec.rocks:443" // current server, offered as a placeholder
@@ -127,18 +127,18 @@ final class ServerSetupStoreTests: XCTestCase {
         store.exhaustivity = .off
 
         // Before benchmarking, Automatic offers the current server as a placeholder.
-        XCTAssertEqual(store.state.automaticDisplayServer, "na.zec.rocks:443")
+        #expect(store.state.automaticDisplayServer == "na.zec.rocks:443")
 
         await store.send(.connectionModeChanged(.automatic))
         await store.receive(\.evaluateServers)
         await store.receive(\.evaluatedServers)
 
         // After benchmarking, Automatic offers the fastest server.
-        XCTAssertEqual(store.state.recommendedSyncServer, "eu.zec.rocks:443")
-        XCTAssertEqual(store.state.automaticDisplayServer, "eu.zec.rocks:443")
+        #expect(store.state.recommendedSyncServer == "eu.zec.rocks:443")
+        #expect(store.state.automaticDisplayServer == "eu.zec.rocks:443")
     }
 
-    func testSwitchingToAutomaticReusesFreshBenchmark() async {
+    @Test func switchingToAutomaticReusesFreshBenchmark() async {
         let benchmarked = LockIsolated(false)
 
         var initial = ServerSetup.State()
@@ -161,8 +161,8 @@ final class ServerSetupStoreTests: XCTestCase {
         await store.send(.connectionModeChanged(.automatic))
 
         // No benchmark runs; Automatic immediately offers the existing fastest server.
-        XCTAssertFalse(benchmarked.value, "must not re-benchmark when a fresh result already exists")
-        XCTAssertEqual(store.state.connectionMode, .automatic)
-        XCTAssertEqual(store.state.automaticDisplayServer, "eu.zec.rocks:443")
+        #expect(!benchmarked.value, "must not re-benchmark when a fresh result already exists")
+        #expect(store.state.connectionMode == .automatic)
+        #expect(store.state.automaticDisplayServer == "eu.zec.rocks:443")
     }
 }

--- a/zodlTests/UtilTests/TransactionGuardTests.swift
+++ b/zodlTests/UtilTests/TransactionGuardTests.swift
@@ -1,18 +1,21 @@
-import XCTest
+import Testing
 @testable import zodl_internal
 
-final class TransactionGuardTests: XCTestCase {
-    func testTryAcquireFailsWhileHeld() async {
+// Several tests drive the shared `TransactionGuardClient.liveValue`, which is backed by a single
+// process-global mutex actor. They must not run concurrently or they would contend on that guard,
+// so the suite is serialized (matching XCTest's previous serial execution).
+@Suite(.serialized) struct TransactionGuardTests {
+    @Test func tryAcquireFailsWhileHeld() async {
         let guardActor = TransactionGuard()
         try? await guardActor.acquire()
         let acquired = await guardActor.tryAcquire()
-        XCTAssertFalse(acquired, "tryAcquire must fail while the guard is held")
+        #expect(!acquired, "tryAcquire must fail while the guard is held")
         await guardActor.release()
         let acquiredAfter = await guardActor.tryAcquire()
-        XCTAssertTrue(acquiredAfter, "tryAcquire must succeed after release")
+        #expect(acquiredAfter, "tryAcquire must succeed after release")
     }
 
-    func testSwitchIsSkippedWhileSubmissionActive() async {
+    @Test func switchIsSkippedWhileSubmissionActive() async {
         let client = TransactionGuardClient.liveValue
         let submissionStarted = AsyncBox()
         let releaseSubmission = AsyncBox()
@@ -26,16 +29,16 @@ final class TransactionGuardTests: XCTestCase {
 
         await submissionStarted.wait()
         let didSwitch = try? await client.switchIfIdle { /* would switch here */ }
-        XCTAssertEqual(didSwitch, false, "Auto switch must skip while a submission is active")
+        #expect(didSwitch == false, "Auto switch must skip while a submission is active")
 
         await releaseSubmission.signal()
         _ = try? await submission.value
 
         let didSwitchAfter = try? await client.switchIfIdle { }
-        XCTAssertEqual(didSwitchAfter, true, "Auto switch must run once the submission finished")
+        #expect(didSwitchAfter == true, "Auto switch must run once the submission finished")
     }
 
-    func testManualSwitchWaitsForSubmission() async {
+    @Test func manualSwitchWaitsForSubmission() async {
         let client = TransactionGuardClient.liveValue
         let order = OrderRecorder()
         let submissionStarted = AsyncBox()
@@ -63,10 +66,10 @@ final class TransactionGuardTests: XCTestCase {
         _ = try? await manual.value
 
         let recorded = await order.values
-        XCTAssertEqual(recorded, ["submission-end", "switch"], "Manual switch must wait for the submission")
+        #expect(recorded == ["submission-end", "switch"], "Manual switch must wait for the submission")
     }
 
-    func testParkedSubmissionCancelledDoesNotRunBody() async {
+    @Test func parkedSubmissionCancelledDoesNotRunBody() async {
         let client = TransactionGuardClient.liveValue
         let holderAcquired = AsyncBox()
         let releaseHolder = AsyncBox()
@@ -97,10 +100,10 @@ final class TransactionGuardTests: XCTestCase {
         _ = try? await holder.value
         _ = try? await parked.value
 
-        XCTAssertFalse(bodyRan.value, "A cancelled, parked submission must not run its body")
+        #expect(!bodyRan.value, "A cancelled, parked submission must not run its body")
     }
 
-    func testParkedAcquireUnblocksOnCancellationEvenIfHolderNeverReleases() async {
+    @Test func parkedAcquireUnblocksOnCancellationEvenIfHolderNeverReleases() async {
         let guardActor = TransactionGuard()
         // Holder takes the guard and never releases — simulates a hung switch.
         try? await guardActor.acquire()
@@ -123,36 +126,36 @@ final class TransactionGuardTests: XCTestCase {
         parked.cancel()
 
         let unblockedByCancellation = await parked.value
-        XCTAssertTrue(
+        #expect(
             unblockedByCancellation,
             "A parked acquire() must throw CancellationError when cancelled, even if the holder never releases"
         )
         // Cancelling the waiter must not have released the holder's guard.
         let stillHeld = await guardActor.tryAcquire()
-        XCTAssertFalse(stillHeld, "Cancelling a waiter must not release the guard held by another task")
+        #expect(!stillHeld, "Cancelling a waiter must not release the guard held by another task")
     }
 
-    func testWithTimeoutThrowsWhenOperationExceedsDeadline() async {
+    @Test func withTimeoutThrowsWhenOperationExceedsDeadline() async {
         // Cooperative case only: Task.sleep honors cancellation, so withTimeout can return and throw.
         // A non-cancellable operation would not surface the timeout (see withTimeout / serverSwitchTimeout).
         do {
             try await withTimeout(.milliseconds(50)) {
                 try await Task.sleep(for: .seconds(10))
             }
-            XCTFail("withTimeout should have thrown TransactionTimeoutError")
+            Issue.record("withTimeout should have thrown TransactionTimeoutError")
         } catch is TransactionTimeoutError {
             // expected
         } catch {
-            XCTFail("Unexpected error: \(error)")
+            Issue.record("Unexpected error: \(error)")
         }
     }
 
-    func testWithTimeoutReturnsValueWhenOperationFinishesInTime() async throws {
+    @Test func withTimeoutReturnsValueWhenOperationFinishesInTime() async throws {
         let value = try await withTimeout(.seconds(5)) { 42 }
-        XCTAssertEqual(value, 42)
+        #expect(value == 42)
     }
 
-    func testSwitchWaitingReleasesGuardWhenSwitchTimesOut() async {
+    @Test func switchWaitingReleasesGuardWhenSwitchTimesOut() async {
         let client = TransactionGuardClient.liveValue
         // A *cancellation-aware* switch body (Task.sleep) that overruns its timeout must release the
         // guard, not wedge it. This holds only because Task.sleep honors cancellation; a body that
@@ -163,10 +166,10 @@ final class TransactionGuardTests: XCTestCase {
                 try await Task.sleep(for: .seconds(10))
             }
         }
-        XCTAssertNil(timedOut, "switchWaiting must rethrow the timeout")
+        #expect(timedOut == nil, "switchWaiting must rethrow the timeout")
 
         let didSwitch = try? await client.switchIfIdle { }
-        XCTAssertEqual(didSwitch, true, "Guard must be free after a timed-out switch")
+        #expect(didSwitch == true, "Guard must be free after a timed-out switch")
     }
 }
 

--- a/zodlTests/UtilTests/UserPreferencesStorageTests.swift
+++ b/zodlTests/UtilTests/UserPreferencesStorageTests.swift
@@ -5,21 +5,22 @@
 //  Created by Lukáš Korba on 22.03.2022.
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import zodl_internal
 
-class UserPreferencesStorageTests: XCTestCase {
+// Uses a real, named UserDefaults suite ("test") shared across its test methods,
+// so the suite is serialized to keep each test's setup/teardown isolated.
+@Suite(.serialized)
+final class UserPreferencesStorageTests {
     // swiftlint:disable:next implicitly_unwrapped_optional
     var storage: UserPreferencesStorage!
 
-    override func setUp() {
-        super.setUp()
-        
-        guard let userDefaults = UserDefaults.init(suiteName: "test") else {
-            XCTFail("UserPreferencesStorageTests: UserDefaults.init(suiteName: \"test\") failed to initialize")
-            return
-        }
-        
+    init() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "test"),
+            "UserPreferencesStorageTests: UserDefaults(suiteName: \"test\") failed to initialize"
+        )
         storage = UserPreferencesStorage(
             defaultExchangeRate: Data(),
             defaultServer: Data(),
@@ -27,53 +28,51 @@ class UserPreferencesStorageTests: XCTestCase {
         )
         storage.removeAll()
     }
-    
-    override func tearDown() {
-        super.tearDown()
+
+    deinit {
         storage.removeAll()
-        storage = nil
     }
-    
+
     // MARK: - Default values in the live UserDefaults environment
-    
-    func testDefaultServer_defaultValue() throws {
-        XCTAssertEqual(nil, storage.server, "User Preferences: `defaultServer` default doesn't match.")
+
+    @Test func defaultServer_defaultValue() throws {
+        #expect(storage.server == nil, "User Preferences: `defaultServer` default doesn't match.")
     }
 
     // MARK: - Set new values in the live UserDefaults environment
 
-    func testDefaultServer_setNewValue() throws {
+    @Test func defaultServer_setNewValue() throws {
         let serverConfig = UserPreferencesStorage.ServerConfig(host: "host", port: 13, isCustom: true)
         try storage.setServer(serverConfig)
 
-        XCTAssertEqual(serverConfig, storage.server, "User Preferences: `server` default doesn't match.")
+        #expect(storage.server == serverConfig, "User Preferences: `server` default doesn't match.")
     }
 
     // MARK: - Mocked user defaults vs. default values
 
-    func testDefaultServer_mocked() throws {
+    @Test func defaultServer_mocked() throws {
         let mockedUD = UserDefaultsClient(
             objectForKey: { _ in Data() },
             remove: { _ in },
             setValue: { _, _ in }
         )
-        
+
         let mockedStorage = UserPreferencesStorage(
             defaultExchangeRate: Data(),
             defaultServer: Data(),
             userDefaults: mockedUD
         )
 
-        XCTAssertEqual(nil, mockedStorage.server, "User Preferences: `server` default doesn't match.")
+        #expect(mockedStorage.server == nil, "User Preferences: `server` default doesn't match.")
     }
 
     // MARK: - Remove all keys from the live UD environment
-    
-    func testRemoveAll() throws {
-        guard let userDefaults = UserDefaults.init(suiteName: "test") else {
-            XCTFail("User Preferences: UserDefaults.init(suiteName: \"test\") failed to initialize")
-            return
-        }
+
+    @Test func removeAll() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "test"),
+            "User Preferences: UserDefaults(suiteName: \"test\") failed to initialize"
+        )
 
         // fill in the data
         UserPreferencesStorage.Constants.allCases.forEach {
@@ -85,8 +84,8 @@ class UserPreferencesStorageTests: XCTestCase {
 
         // check the presence
         UserPreferencesStorage.Constants.allCases.forEach {
-            XCTAssertNil(
-                userDefaults.object(forKey: $0.rawValue),
+            #expect(
+                userDefaults.object(forKey: $0.rawValue) == nil,
                 "User Preferences: key \($0.rawValue) should be removed but it's still present in User Defaults"
             )
         }

--- a/zodlTests/UtilTests/ZatoshiTests.swift
+++ b/zodlTests/UtilTests/ZatoshiTests.swift
@@ -5,15 +5,26 @@
 //  Created by Lukáš Korba on 26.05.2022.
 //
 
-import XCTest
+import Testing
+import Foundation
+import os
 @testable import zodl_internal
 @preconcurrency import ZcashLightClientKit
 
-class ZatoshiTests: XCTestCase {
+/// Serializes access to the process-global `NumberFormatter` singletons
+/// (`NumberFormatter.zashiBalanceFormatter`, `.zcashNumberFormatter8FractionDigits`) across the
+/// formatter-sensitive suites (`ZatoshiTests`, `ZatoshiStringRepresentationTests`,
+/// `ZatoshiStringRepresentationCommaTests`), which Swift Testing runs in parallel by default. Any
+/// test that sets a formatter's `locale` and then reads it must do so inside `shared.withLockUnchecked`
+/// so an `en_US` regime never overlaps a `cs_CZ` regime on the same singleton.
+enum FormatterTestGate {
+    static let shared = OSAllocatedUnfairLock()
+}
+
+@Suite struct ZatoshiTests {
     let usNumberFormatter = NumberFormatter()
-    
-    override func setUp() {
-        super.setUp()
+
+    init() {
         usNumberFormatter.maximumFractionDigits = 8
         usNumberFormatter.maximumIntegerDigits = 8
         usNumberFormatter.numberStyle = .decimal
@@ -21,204 +32,186 @@ class ZatoshiTests: XCTestCase {
         usNumberFormatter.locale = Locale(identifier: "en_US")
     }
 
-    func testLowerBound() throws {
+    @Test func lowerBound() throws {
         let number = Zatoshi(-Zatoshi.Constants.maxZatoshi - 1)
-        
-        XCTAssertEqual(
-            -Zatoshi.Constants.maxZatoshi,
-            number.amount,
+
+        #expect(
+            -Zatoshi.Constants.maxZatoshi == number.amount,
             "Zatoshi tests: `testLowerBound` the value is expected to be clamped to lower bound but it's \(number.amount)"
         )
     }
 
-    func testUpperBound() throws {
+    @Test func upperBound() throws {
         let number = Zatoshi(Zatoshi.Constants.maxZatoshi + 1)
 
-        XCTAssertEqual(
-            Zatoshi.Constants.maxZatoshi,
-            number.amount,
+        #expect(
+            Zatoshi.Constants.maxZatoshi == number.amount,
             "Zatoshi tests: `testUpperBound` the value is expected to be clamped to upper bound but it's \(number.amount)"
         )
     }
-    
-    func testAddingZatoshi() throws {
+
+    @Test func addingZatoshi() throws {
         let numberA1 = Zatoshi(100_000)
         let numberB1 = Zatoshi(200_000)
         let result1 = numberA1 + numberB1
-        
-        XCTAssertEqual(
-            result1.amount,
-            Zatoshi(300_000).amount,
+
+        #expect(
+            result1.amount == Zatoshi(300_000).amount,
             "Zatoshi tests: `testAddingZatoshi` the value is expected to be 300_000 but it's \(result1.amount)"
         )
 
         let numberA2 = Zatoshi(-100_000)
         let numberB2 = Zatoshi(200_000)
         let result2 = numberA2 + numberB2
-        
-        XCTAssertEqual(
-            result2.amount,
-            Zatoshi(100_000).amount,
+
+        #expect(
+            result2.amount == Zatoshi(100_000).amount,
             "Zatoshi tests: `testAddingZatoshi` the value is expected to be 100_000 but it's \(result2.amount)"
         )
-        
+
         let numberA3 = Zatoshi(100_000)
         let numberB3 = Zatoshi(-200_000)
         let result3 = numberA3 + numberB3
-        
-        XCTAssertEqual(
-            result3.amount,
-            Zatoshi(-100_000).amount,
+
+        #expect(
+            result3.amount == Zatoshi(-100_000).amount,
             "Zatoshi tests: `testAddingZatoshi` the value is expected to be -100_000 but it's \(result3.amount)"
         )
 
         let number = Zatoshi(Zatoshi.Constants.maxZatoshi)
         let result4 = number + number
-        
-        XCTAssertEqual(
-            result4.amount,
-            Zatoshi.Constants.maxZatoshi,
+
+        #expect(
+            result4.amount == Zatoshi.Constants.maxZatoshi,
             "Zatoshi tests: `testAddingZatoshi` the value is expected to be clamped to upper bound but it's \(result4.amount)"
         )
     }
-    
-    func testSubtractingZatoshi() throws {
+
+    @Test func subtractingZatoshi() throws {
         let numberA1 = Zatoshi(100_000)
         let numberB1 = Zatoshi(200_000)
         let result1 = numberA1 - numberB1
-        
-        XCTAssertEqual(
-            result1.amount,
-            Zatoshi(-100_000).amount,
+
+        #expect(
+            result1.amount == Zatoshi(-100_000).amount,
             "Zatoshi tests: `testSubtractingZatoshi` the value is expected to be -100_000 but it's \(result1.amount)"
         )
 
         let numberA2 = Zatoshi(-100_000)
         let numberB2 = Zatoshi(200_000)
         let result2 = numberA2 - numberB2
-        
-        XCTAssertEqual(
-            result2.amount,
-            Zatoshi(-300_000).amount,
+
+        #expect(
+            result2.amount == Zatoshi(-300_000).amount,
             "Zatoshi tests: `testSubtractingZatoshi` the value is expected to be -300_000 but it's \(result2.amount)"
         )
-        
+
         let numberA3 = Zatoshi(100_000)
         let numberB3 = Zatoshi(-200_000)
         let result3 = numberA3 - numberB3
-        
-        XCTAssertEqual(
-            result3.amount,
-            Zatoshi(300_000).amount,
+
+        #expect(
+            result3.amount == Zatoshi(300_000).amount,
             "Zatoshi tests: `testSubtractingZatoshi` the value is expected to be 300_000 but it's \(result3.amount)"
         )
 
         let number = Zatoshi(-Zatoshi.Constants.maxZatoshi)
         let result4 = number + number
-        
-        XCTAssertEqual(
-            result4.amount,
-            -Zatoshi.Constants.maxZatoshi,
+
+        #expect(
+            result4.amount == -Zatoshi.Constants.maxZatoshi,
             "Zatoshi tests: `testSubtractingZatoshi` the value is expected to be clamped to lower bound but it's \(result4.amount)"
         )
     }
-    
-    func testHumanReadable() throws {
+
+    @Test func humanReadable() throws {
         // result of this division is 1.4285714285714285714285714285714285714
         let number = Zatoshi.from(decimal: Decimal(200.0 / 140.0))
-        
+
         // IMPORTANT: the INTERNAL value of number is still 1.4285714285714285714285714285714285714!!!
         // but decimalString is rounding it to maximumFractionDigits set to be 8
-        
+
         // We can't compare it to double value 1.42857143 (or even Decimal(1.42857143))
         // so we convert it to string, in that case we are proving it to be rendered
         //    to the user exactly the way we want
-        XCTAssertEqual(
-            number.decimalString(formatter: usNumberFormatter),
-            "1.42857143",
+        #expect(
+            number.decimalString(formatter: usNumberFormatter) == "1.42857143",
             "Zatoshi tests: the value is expected to be 1.42857143 but it's \(number.decimalString())"
         )
     }
 
-    func testUSDtoZecToUSD() throws {
+    @Test func usdToZecToUSD() throws {
         // The price of zec is $140, we want to send $200
         let usd2zec = NSDecimalNumber(decimal: 200.0 / 140.0)
 
-        XCTAssertEqual(
-            usd2zec.decimalString,
-            "1.42857143",
+        #expect(
+            usd2zec.decimalString == "1.42857143",
             "Zatoshi tests: `testUSDtoZatoshiToUSD` the value is expected to be 1.42857143 but it's \(usd2zec.decimalString)"
         )
-        
+
         // convert it back
         let zec2usd = NSDecimalNumber(decimal: usd2zec.decimalValue * 140.0)
 
-        XCTAssertEqual(
-            zec2usd.decimalString,
-            "200",
+        #expect(
+            zec2usd.decimalString == "200",
             "Zatoshi tests: `testUSDtoZatoshiToUSD` the value is expected to be 200 but it's \(zec2usd.decimalString)"
         )
     }
-    
-    func testStringToZatoshi() throws {
+
+    @Test func stringToZatoshi() throws {
         if let number = Zatoshi.from(decimalString: "200.0", formatter: usNumberFormatter) {
-            XCTAssertEqual(
-                number.decimalString(formatter: usNumberFormatter),
-                "200",
+            #expect(
+                number.decimalString(formatter: usNumberFormatter) == "200",
                 "Zatoshi tests: `testStringToZec` the value is expected to be 200 but it's \(number.decimalString())"
             )
         } else {
-            XCTFail("Zatoshi tests: `testStringToZatoshi` failed to convert number.")
+            Issue.record("Zatoshi tests: `testStringToZatoshi` failed to convert number.")
         }
 
         if let number = Zatoshi.from(decimalString: "0.02836478949923", formatter: usNumberFormatter) {
-            XCTAssertEqual(
-                number.amount,
-                2_836_479,
+            #expect(
+                number.amount == 2_836_479,
                 "Zatoshi tests: the value is expected to be 2_836_478 but it's \(number.amount)"
             )
         } else {
-            XCTFail("Zatoshi tests: `testStringToZatoshi` failed to convert number.")
+            Issue.record("Zatoshi tests: `testStringToZatoshi` failed to convert number.")
         }
     }
-    
-    func testZashiRounding() throws {
-        let zashiBalanceFormatter = NumberFormatter.zashiBalanceFormatter
-        zashiBalanceFormatter.locale = Locale(identifier: "en_US")
-        
-        var balance = zashiBalanceFormatter.string(from: Zatoshi(11_440_000).decimalValue) ?? ""
-        XCTAssertEqual(
-            balance,
-            "0.114",
-            "Zatoshi tests: `testZashiRounding` the value is expected to be 0.114 but it's \(balance)"
-        )
 
-        balance = zashiBalanceFormatter.string(from: Zatoshi(11_410_000).decimalValue) ?? ""
-        XCTAssertEqual(
-            balance,
-            "0.114",
-            "Zatoshi tests: `testZashiRounding` the value is expected to be 0.114 but it's \(balance)"
-        )
+    @Test func zashiRounding() throws {
+        FormatterTestGate.shared.withLockUnchecked {
+            let zashiBalanceFormatter = NumberFormatter.zashiBalanceFormatter
+            zashiBalanceFormatter.locale = Locale(identifier: "en_US")
 
-        balance = zashiBalanceFormatter.string(from: Zatoshi(11_440_000).decimalValue) ?? ""
-        XCTAssertEqual(
-            balance,
-            "0.114",
-            "Zatoshi tests: `testZashiRounding` the value is expected to be 0.114 but it's \(balance)"
-        )
+            var balance = zashiBalanceFormatter.string(from: Zatoshi(11_440_000).decimalValue) ?? ""
+            #expect(
+                balance == "0.114",
+                "Zatoshi tests: `testZashiRounding` the value is expected to be 0.114 but it's \(balance)"
+            )
 
-        balance = zashiBalanceFormatter.string(from: Zatoshi(11_450_000).decimalValue) ?? ""
-        XCTAssertEqual(
-            balance,
-            "0.115",
-            "Zatoshi tests: `testZashiRounding` the value is expected to be 0.115 but it's \(balance)"
-        )
+            balance = zashiBalanceFormatter.string(from: Zatoshi(11_410_000).decimalValue) ?? ""
+            #expect(
+                balance == "0.114",
+                "Zatoshi tests: `testZashiRounding` the value is expected to be 0.114 but it's \(balance)"
+            )
 
-        balance = zashiBalanceFormatter.string(from: Zatoshi(11_490_000).decimalValue) ?? ""
-        XCTAssertEqual(
-            balance,
-            "0.115",
-            "Zatoshi tests: `testZashiRounding` the value is expected to be 0.115 but it's \(balance)"
-        )
+            balance = zashiBalanceFormatter.string(from: Zatoshi(11_440_000).decimalValue) ?? ""
+            #expect(
+                balance == "0.114",
+                "Zatoshi tests: `testZashiRounding` the value is expected to be 0.114 but it's \(balance)"
+            )
+
+            balance = zashiBalanceFormatter.string(from: Zatoshi(11_450_000).decimalValue) ?? ""
+            #expect(
+                balance == "0.115",
+                "Zatoshi tests: `testZashiRounding` the value is expected to be 0.115 but it's \(balance)"
+            )
+
+            balance = zashiBalanceFormatter.string(from: Zatoshi(11_490_000).decimalValue) ?? ""
+            #expect(
+                balance == "0.115",
+                "Zatoshi tests: `testZashiRounding` the value is expected to be 0.115 but it's \(balance)"
+            )
+        }
     }
 }

--- a/zodlTests/VotingTests/VotingAPIResponseParserTests.swift
+++ b/zodlTests/VotingTests/VotingAPIResponseParserTests.swift
@@ -1,9 +1,9 @@
 import Foundation
-import XCTest
+import Testing
 @testable import zodl_internal
 
-final class VotingAPIResponseParserTests: XCTestCase {
-    func testParseJSONObjectAcceptsRegularJSONObject() throws {
+@Suite struct VotingAPIResponseParserTests {
+    @Test func parseJSONObjectAcceptsRegularJSONObject() throws {
         let response = try makeResponse()
         let data = Data(#"{"tx_hash":"ABC123","code":0,"log":""}"#.utf8)
 
@@ -13,11 +13,11 @@ final class VotingAPIResponseParserTests: XCTestCase {
             context: "POST /shielded-vote/v1/delegate-vote"
         )
 
-        XCTAssertEqual(json["tx_hash"] as? String, "ABC123")
-        XCTAssertEqual((json["code"] as? NSNumber)?.uint32Value, 0)
+        #expect(json["tx_hash"] as? String == "ABC123")
+        #expect((json["code"] as? NSNumber)?.uint32Value == 0)
     }
 
-    func testParseJSONObjectAcceptsDoubleEncodedJSONObject() throws {
+    @Test func parseJSONObjectAcceptsDoubleEncodedJSONObject() throws {
         let response = try makeResponse()
         let data = Data(#""{\"tx_hash\":\"ABC123\",\"code\":0,\"log\":\"\"}""#.utf8)
 
@@ -27,39 +27,38 @@ final class VotingAPIResponseParserTests: XCTestCase {
             context: "POST /shielded-vote/v1/delegate-vote"
         )
 
-        XCTAssertEqual(json["tx_hash"] as? String, "ABC123")
-        XCTAssertEqual((json["code"] as? NSNumber)?.uint32Value, 0)
+        #expect(json["tx_hash"] as? String == "ABC123")
+        #expect((json["code"] as? NSNumber)?.uint32Value == 0)
     }
 
-    func testParseJSONObjectIncludesContextOnMalformedJSON() throws {
+    @Test func parseJSONObjectIncludesContextOnMalformedJSON() throws {
         let response = try makeResponse()
         let data = Data("<html>ok</html>".utf8)
 
-        do {
+        let error = #expect(throws: (any Error).self) {
             _ = try SvAPIResponseParser.parseJSONObject(
                 data,
                 response: response,
                 context: "POST /shielded-vote/v1/delegate-vote"
             )
-            XCTFail("Expected invalid response error")
-        } catch {
-            XCTAssertTrue(error.localizedDescription.contains("POST /shielded-vote/v1/delegate-vote"))
-            XCTAssertTrue(error.localizedDescription.contains("Content-Type: application/json"))
-            XCTAssertTrue(error.localizedDescription.contains("<html>ok</html>"))
         }
+
+        #expect(error?.localizedDescription.contains("POST /shielded-vote/v1/delegate-vote") == true)
+        #expect(error?.localizedDescription.contains("Content-Type: application/json") == true)
+        #expect(error?.localizedDescription.contains("<html>ok</html>") == true)
     }
 
-    func testParseTxResultAcceptsFlatVoteAPIEnvelope() throws {
+    @Test func parseTxResultAcceptsFlatVoteAPIEnvelope() throws {
         let result = try SvAPIResponseParser.parseTxResult([
             "tx_hash": "ABC123",
             "code": 0,
             "log": ""
         ])
 
-        XCTAssertEqual(result, TxResult(txHash: "ABC123", code: 0, log: ""))
+        #expect(result == TxResult(txHash: "ABC123", code: 0, log: ""))
     }
 
-    func testParseTxResultAcceptsCosmosRestEnvelope() throws {
+    @Test func parseTxResultAcceptsCosmosRestEnvelope() throws {
         let result = try SvAPIResponseParser.parseTxResult([
             "tx_response": [
                 "txhash": "ABC123",
@@ -68,10 +67,10 @@ final class VotingAPIResponseParserTests: XCTestCase {
             ]
         ])
 
-        XCTAssertEqual(result, TxResult(txHash: "ABC123", code: 0, log: ""))
+        #expect(result == TxResult(txHash: "ABC123", code: 0, log: ""))
     }
 
-    func testParseTxResultAcceptsCometEnvelope() throws {
+    @Test func parseTxResultAcceptsCometEnvelope() throws {
         let result = try SvAPIResponseParser.parseTxResult([
             "result": [
                 "hash": "ABC123",
@@ -80,20 +79,19 @@ final class VotingAPIResponseParserTests: XCTestCase {
             ]
         ])
 
-        XCTAssertEqual(result, TxResult(txHash: "ABC123", code: 0, log: ""))
+        #expect(result == TxResult(txHash: "ABC123", code: 0, log: ""))
     }
 
     private func makeResponse() throws -> HTTPURLResponse {
-        guard let url = URL(string: "https://vote-chain-primary.valargroup.org/shielded-vote/v1/delegate-vote"),
-              let response = HTTPURLResponse(
+        let url = try #require(URL(string: "https://vote-chain-primary.valargroup.org/shielded-vote/v1/delegate-vote"))
+        let response = try #require(
+            HTTPURLResponse(
                 url: url,
                 statusCode: 200,
                 httpVersion: nil,
                 headerFields: ["Content-Type": "application/json"]
-              )
-        else {
-            throw XCTSkip("Failed to build HTTPURLResponse fixture")
-        }
+            )
+        )
         return response
     }
 }

--- a/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -1,11 +1,14 @@
 import ComposableArchitecture
 import Foundation
-import XCTest
+import Testing
 @testable import zodl_internal
 @testable @preconcurrency import ZcashLightClientKit
 
-final class VotingCoordFlowCoordinatorTests: XCTestCase {
-    func testBatchVoteSubmittedMovesDraftIntoSubmittedVotes() {
+// Drives a TCA coordinator that touches process-global `@Shared` state (e.g. `selectedWalletAccount`)
+// and uses plain `Store`s for the async cases, so the suite is serialized to match XCTest's previous
+// serial execution and avoid cross-test races on that shared state.
+@Suite(.serialized) struct VotingCoordFlowCoordinatorTests {
+    @Test func batchVoteSubmittedMovesDraftIntoSubmittedVotes() {
         let metadata = VotingMetadataBox()
         var state = VotingCoordFlow.State()
         state.roundCache[roundId] = roundSession(
@@ -27,13 +30,13 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         }
 
         let session = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(session.draftVotes, [2: .option(1)])
-        XCTAssertEqual(session.votes, [1: .option(0)])
-        XCTAssertEqual(metadata.drafts[roundId], ["2": 1])
-        XCTAssertEqual(metadata.submittedVotes[roundId], ["1": 0])
+        #expect(session.draftVotes == [2: .option(1)])
+        #expect(session.votes == [1: .option(0)])
+        #expect(metadata.drafts[roundId] == ["2": 1])
+        #expect(metadata.submittedVotes[roundId] == ["1": 0])
     }
 
-    func testBatchSubmissionCompletedAcceptsPartialBallotWhenDraftsAreDrained() {
+    @Test func batchSubmissionCompletedAcceptsPartialBallotWhenDraftsAreDrained() {
         let metadata = VotingMetadataBox()
         var state = VotingCoordFlow.State()
         state.roundCache[roundId] = roundSession(
@@ -56,14 +59,14 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         }
 
         let session = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(session.batchSubmissionStatus, .completed(successCount: 2))
-        XCTAssertEqual(session.voteRecord?.votingWeight, 50_000_000)
-        XCTAssertEqual(session.voteRecord?.proposalCount, 2)
-        XCTAssertEqual(state.voteRecords[roundId]?.proposalCount, 2)
-        XCTAssertEqual(metadata.records[roundId]?.proposalCount, 2)
+        #expect(session.batchSubmissionStatus == .completed(successCount: 2))
+        #expect(session.voteRecord?.votingWeight == 50_000_000)
+        #expect(session.voteRecord?.proposalCount == 2)
+        #expect(state.voteRecords[roundId]?.proposalCount == 2)
+        #expect(metadata.records[roundId]?.proposalCount == 2)
     }
 
-    func testBatchSubmissionCompletedFailsWhenDraftsRemain() {
+    @Test func batchSubmissionCompletedFailsWhenDraftsRemain() {
         var state = VotingCoordFlow.State()
         state.roundCache[roundId] = roundSession(
             drafts: [2: .option(1)],
@@ -78,18 +81,17 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let session = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(
-            session.batchSubmissionStatus,
-            .submissionFailed(
+        #expect(
+            session.batchSubmissionStatus == .submissionFailed(
                 error: String(localizable: .coinVoteSubmissionGenericBatchFailure),
                 submittedCount: 1,
                 totalCount: 2
             )
         )
-        XCTAssertNil(session.voteRecord)
+        #expect(session.voteRecord == nil)
     }
 
-    func testBatchSubmissionCompletedFailsWhenVoteErrorsExist() {
+    @Test func batchSubmissionCompletedFailsWhenVoteErrorsExist() {
         var session = roundSession(votes: [1: .option(0)])
         session.batchVoteErrors = [2: "server unavailable"]
         var state = VotingCoordFlow.State()
@@ -103,18 +105,17 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(
-            updated.batchSubmissionStatus,
-            .submissionFailed(
+        #expect(
+            updated.batchSubmissionStatus == .submissionFailed(
                 error: "server unavailable",
                 submittedCount: 1,
                 totalCount: 1
             )
         )
-        XCTAssertNil(updated.voteRecord)
+        #expect(updated.voteRecord == nil)
     }
 
-    func testBatchSubmissionProgressClearsPreviousSubmissionStep() {
+    @Test func batchSubmissionProgressClearsPreviousSubmissionStep() {
         var session = roundSession()
         session.voteSubmissionStep = .sendingShares
         session.currentVoteBundleIndex = 0
@@ -130,14 +131,14 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.batchSubmissionStatus, .submitting(currentIndex: 0, totalCount: 1, currentProposalId: 1))
-        XCTAssertEqual(updated.submittingProposalId, 1)
-        XCTAssertTrue(updated.isSubmittingVote)
-        XCTAssertNil(updated.voteSubmissionStep)
-        XCTAssertNil(updated.currentVoteBundleIndex)
+        #expect(updated.batchSubmissionStatus == .submitting(currentIndex: 0, totalCount: 1, currentProposalId: 1))
+        #expect(updated.submittingProposalId == 1)
+        #expect(updated.isSubmittingVote)
+        #expect(updated.voteSubmissionStep == nil)
+        #expect(updated.currentVoteBundleIndex == nil)
     }
 
-    func testAuthenticationSucceededStartsSoftwareDelegationAtSubmitTime() {
+    @Test func authenticationSucceededStartsSoftwareDelegationAtSubmitTime() {
         var session = RoundSession(roundId: activeRoundId)
         session.bundleCount = 1
         session.draftVotes = [1: .option(0)]
@@ -148,13 +149,13 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         _ = VotingCoordFlow().reduceAuthenticationSucceeded(&state, roundId: activeRoundId)
 
         let updated = tryUnwrap(state.roundCache[activeRoundId])
-        XCTAssertFalse(state.pendingBatchSubmission)
-        XCTAssertEqual(updated.batchSubmissionStatus, .authorizing)
-        XCTAssertEqual(updated.voteSubmissionStep, .authorizingVote)
-        XCTAssertEqual(updated.delegationProofStatus, .generating(progress: 0))
+        #expect(!state.pendingBatchSubmission)
+        #expect(updated.batchSubmissionStatus == .authorizing)
+        #expect(updated.voteSubmissionStep == .authorizingVote)
+        #expect(updated.delegationProofStatus == .generating(progress: 0))
     }
 
-    func testDelegationFailureDuringBatchAuthorizationShowsAuthorizationFailure() {
+    @Test func delegationFailureDuringBatchAuthorizationShowsAuthorizationFailure() {
         var session = roundSession()
         session.bundleCount = 2
         session.currentKeystoneBundleIndex = 1
@@ -178,18 +179,18 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.delegationProofStatus, .failed("nullifier already spent"))
-        XCTAssertFalse(updated.isDelegationProofInFlight)
-        XCTAssertFalse(state.pendingBatchSubmission)
-        XCTAssertEqual(updated.batchSubmissionStatus, .authorizationFailed(error: "nullifier already spent"))
-        XCTAssertNil(updated.voteSubmissionStep)
-        XCTAssertNil(updated.currentVoteBundleIndex)
-        XCTAssertEqual(updated.currentKeystoneBundleIndex, 0)
-        XCTAssertTrue(updated.keystoneBundleSignatures.isEmpty)
-        XCTAssertEqual(updated.keystoneSigningStatus, .failed("nullifier already spent"))
+        #expect(updated.delegationProofStatus == .failed("nullifier already spent"))
+        #expect(!updated.isDelegationProofInFlight)
+        #expect(!state.pendingBatchSubmission)
+        #expect(updated.batchSubmissionStatus == .authorizationFailed(error: "nullifier already spent"))
+        #expect(updated.voteSubmissionStep == nil)
+        #expect(updated.currentVoteBundleIndex == nil)
+        #expect(updated.currentKeystoneBundleIndex == 0)
+        #expect(updated.keystoneBundleSignatures.isEmpty)
+        #expect(updated.keystoneSigningStatus == .failed("nullifier already spent"))
     }
 
-    func testIntermediateKeystoneSignatureAdvancesToNextBundle() {
+    @Test func intermediateKeystoneSignatureAdvancesToNextBundle() {
         var session = roundSession()
         session.bundleCount = 2
         session.currentKeystoneBundleIndex = 0
@@ -206,15 +207,15 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.currentKeystoneBundleIndex, 1)
-        XCTAssertEqual(updated.keystoneBundleSignatures, [signature(byte: 1)])
-        XCTAssertEqual(updated.keystoneSigningStatus, .idle)
-        XCTAssertFalse(updated.isDelegationProofInFlight)
-        XCTAssertNil(updated.pendingVotingPczt)
-        XCTAssertNil(updated.pendingUnsignedDelegationPczt)
+        #expect(updated.currentKeystoneBundleIndex == 1)
+        #expect(updated.keystoneBundleSignatures == [signature(byte: 1)])
+        #expect(updated.keystoneSigningStatus == .idle)
+        #expect(!updated.isDelegationProofInFlight)
+        #expect(updated.pendingVotingPczt == nil)
+        #expect(updated.pendingUnsignedDelegationPczt == nil)
     }
 
-    func testFinalKeystoneSignatureMovesToFinalizingAuthorization() {
+    @Test func finalKeystoneSignatureMovesToFinalizingAuthorization() {
         var session = roundSession()
         session.bundleCount = 2
         session.currentKeystoneBundleIndex = 1
@@ -233,19 +234,19 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.keystoneBundleSignatures, [
+        #expect(updated.keystoneBundleSignatures == [
             signature(byte: 1, bundleIndex: 0),
             signature(byte: 2, bundleIndex: 1)
         ])
-        XCTAssertEqual(updated.keystoneSigningStatus, .finalizingAuthorization)
-        XCTAssertEqual(updated.delegationProofStatus, .generating(progress: 0))
-        XCTAssertTrue(updated.isDelegationProofInFlight)
-        XCTAssertEqual(updated.batchSubmissionStatus, .authorizing)
-        XCTAssertEqual(updated.voteSubmissionStep, .authorizingVote)
-        XCTAssertFalse(isDelegationSigningTop(state))
+        #expect(updated.keystoneSigningStatus == .finalizingAuthorization)
+        #expect(updated.delegationProofStatus == .generating(progress: 0))
+        #expect(updated.isDelegationProofInFlight)
+        #expect(updated.batchSubmissionStatus == .authorizing)
+        #expect(updated.voteSubmissionStep == .authorizingVote)
+        #expect(!isDelegationSigningTop(state))
     }
 
-    func testSkippingRemainingKeystoneBundlesKeepsOnlySignedWeight() {
+    @Test func skippingRemainingKeystoneBundlesKeepsOnlySignedWeight() {
         var session = roundSession(
             votingWeight: 100_000_000,
             notes: [
@@ -270,17 +271,17 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         _ = VotingCoordFlow().reduceSkipRemainingKeystoneBundles(&state, roundId: roundId)
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.bundleCount, 1)
-        XCTAssertEqual(updated.votingWeight, 87_500_000)
-        XCTAssertEqual(updated.eligibleBundleCount, 2)
-        XCTAssertEqual(updated.eligibleVotingWeight, 100_000_000)
-        XCTAssertEqual(updated.keystoneSigningStatus, .finalizingAuthorization)
-        XCTAssertEqual(updated.batchSubmissionStatus, .authorizing)
-        XCTAssertEqual(updated.voteSubmissionStep, .authorizingVote)
-        XCTAssertFalse(isDelegationSigningTop(state))
+        #expect(updated.bundleCount == 1)
+        #expect(updated.votingWeight == 87_500_000)
+        #expect(updated.eligibleBundleCount == 2)
+        #expect(updated.eligibleVotingWeight == 100_000_000)
+        #expect(updated.keystoneSigningStatus == .finalizingAuthorization)
+        #expect(updated.batchSubmissionStatus == .authorizing)
+        #expect(updated.voteSubmissionStep == .authorizingVote)
+        #expect(!isDelegationSigningTop(state))
     }
 
-    func testSkippingRemainingKeystoneBundlesDropsSparseRecoveredState() {
+    @Test func skippingRemainingKeystoneBundlesDropsSparseRecoveredState() {
         var session = roundSession(
             votingWeight: 150_000_000,
             notes: notes(count: 15, value: 10_000_000)
@@ -295,12 +296,12 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         _ = VotingCoordFlow().reduceSkipRemainingKeystoneBundles(&state, roundId: roundId)
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.bundleCount, 1)
-        XCTAssertEqual(updated.completedKeystoneDelegationBundleIndices, Set([0]))
-        XCTAssertTrue(updated.keystoneBundleSignatures.isEmpty)
+        #expect(updated.bundleCount == 1)
+        #expect(updated.completedKeystoneDelegationBundleIndices == Set([0]))
+        #expect(updated.keystoneBundleSignatures.isEmpty)
     }
 
-    func testRecoveredKeystoneBundleResumesAtFirstIncompleteBundle() {
+    @Test func recoveredKeystoneBundleResumesAtFirstIncompleteBundle() {
         var session = roundSession()
         session.bundleCount = 2
         var state = VotingCoordFlow.State()
@@ -312,11 +313,11 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.completedKeystoneDelegationBundleIndices, Set([0]))
-        XCTAssertEqual(updated.currentKeystoneBundleIndex, 1)
+        #expect(updated.completedKeystoneDelegationBundleIndices == Set([0]))
+        #expect(updated.currentKeystoneBundleIndex == 1)
     }
 
-    func testFinalSignatureAfterRecoveredBundleMovesToFinalizingAuthorization() {
+    @Test func finalSignatureAfterRecoveredBundleMovesToFinalizingAuthorization() {
         var session = roundSession()
         session.bundleCount = 2
         session.currentKeystoneBundleIndex = 1
@@ -335,17 +336,17 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.completedKeystoneDelegationBundleIndices, Set([0]))
-        XCTAssertEqual(updated.keystoneBundleSignatures, [signature(byte: 2, bundleIndex: 1)])
-        XCTAssertEqual(updated.keystoneSigningStatus, .finalizingAuthorization)
-        XCTAssertEqual(updated.delegationProofStatus, .generating(progress: 0))
-        XCTAssertTrue(updated.isDelegationProofInFlight)
-        XCTAssertEqual(updated.batchSubmissionStatus, .authorizing)
-        XCTAssertEqual(updated.voteSubmissionStep, .authorizingVote)
-        XCTAssertFalse(isDelegationSigningTop(state))
+        #expect(updated.completedKeystoneDelegationBundleIndices == Set([0]))
+        #expect(updated.keystoneBundleSignatures == [signature(byte: 2, bundleIndex: 1)])
+        #expect(updated.keystoneSigningStatus == .finalizingAuthorization)
+        #expect(updated.delegationProofStatus == .generating(progress: 0))
+        #expect(updated.isDelegationProofInFlight)
+        #expect(updated.batchSubmissionStatus == .authorizing)
+        #expect(updated.voteSubmissionStep == .authorizingVote)
+        #expect(!isDelegationSigningTop(state))
     }
 
-    func testDuplicateKeystoneScanIsRejectedBeforeSignatureExtraction() {
+    @Test func duplicateKeystoneScanIsRejectedBeforeSignatureExtraction() {
         let duplicateSighash = Data(repeating: 0x02, count: 32)
         let message = VotingCoordFlow.keystoneScanRejectionMessage(
             scannedSighash: duplicateSighash,
@@ -357,13 +358,10 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             bundleCount: 2
         )
 
-        XCTAssertEqual(
-            message,
-            String(localizable: .coinVoteDelegationSigningDuplicateSignature("1", "2"))
-        )
+        #expect(message == String(localizable: .coinVoteDelegationSigningDuplicateSignature("1", "2")))
     }
 
-    func testWrongKeystoneScanIsRejectedBeforeSignatureExtraction() {
+    @Test func wrongKeystoneScanIsRejectedBeforeSignatureExtraction() {
         let pendingSighash = Data(repeating: 0x05, count: 32)
         let scannedSighash = Data(repeating: 0x06, count: 32)
         let message = VotingCoordFlow.keystoneScanRejectionMessage(
@@ -374,28 +372,25 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             bundleCount: 2
         )
 
-        XCTAssertEqual(
-            message,
-            String(localizable: .coinVoteDelegationSigningWrongSignature("2", "2"))
-        )
+        #expect(message == String(localizable: .coinVoteDelegationSigningWrongSignature("2", "2")))
     }
 
-    func testMatchingKeystoneScanIsAcceptedForCurrentBundle() {
+    @Test func matchingKeystoneScanIsAcceptedForCurrentBundle() {
         let pendingSighash = Data(repeating: 0x05, count: 32)
 
-        XCTAssertNil(
+        #expect(
             VotingCoordFlow.keystoneScanRejectionMessage(
                 scannedSighash: pendingSighash,
                 expectedSighash: pendingSighash,
                 existingSignatures: [signature(byte: 1, bundleIndex: 0)],
                 currentBundleIndex: 1,
                 bundleCount: 2
-            )
+            ) == nil
         )
     }
 
     @MainActor
-    func testDuplicateKeystoneScanReducerRejectsWithoutExtractingSignature() async {
+    @Test func duplicateKeystoneScanReducerRejectsWithoutExtractingSignature() async {
         let duplicateSighash = Data(repeating: 0x02, count: 32)
         let expectedMessage = String(localizable: .coinVoteDelegationSigningDuplicateSignature("1", "2"))
         let recorder = EventRecorder()
@@ -422,18 +417,18 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         }
 
         let session = tryUnwrap(store.state.roundCache[roundId])
-        XCTAssertNil(store.state.keystoneScan)
-        XCTAssertEqual(store.state.keystoneSignatureRejectionSheet?.message, expectedMessage)
-        XCTAssertEqual(session.keystoneSigningStatus, .awaitingSignature)
-        XCTAssertEqual(session.currentKeystoneBundleIndex, 1)
-        XCTAssertNotNil(session.pendingVotingPczt)
-        XCTAssertEqual(session.batchSubmissionStatus, .idle)
+        #expect(store.state.keystoneScan == nil)
+        #expect(store.state.keystoneSignatureRejectionSheet?.message == expectedMessage)
+        #expect(session.keystoneSigningStatus == .awaitingSignature)
+        #expect(session.currentKeystoneBundleIndex == 1)
+        #expect(session.pendingVotingPczt != nil)
+        #expect(session.batchSubmissionStatus == .idle)
         try? await Task.sleep(nanoseconds: 50_000_000)
-        XCTAssertTrue(recorder.events().isEmpty)
+        #expect(recorder.events().isEmpty)
     }
 
     @MainActor
-    func testWrongKeystoneScanReducerRejectsWithoutExtractingSignature() async {
+    @Test func wrongKeystoneScanReducerRejectsWithoutExtractingSignature() async {
         let pendingSighash = Data(repeating: 0x05, count: 32)
         let scannedSighash = Data(repeating: 0x06, count: 32)
         let expectedMessage = String(localizable: .coinVoteDelegationSigningWrongSignature("2", "2"))
@@ -454,18 +449,18 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         }
 
         let session = tryUnwrap(store.state.roundCache[roundId])
-        XCTAssertNil(store.state.keystoneScan)
-        XCTAssertEqual(store.state.keystoneSignatureRejectionSheet?.message, expectedMessage)
-        XCTAssertEqual(session.keystoneSigningStatus, .awaitingSignature)
-        XCTAssertEqual(session.currentKeystoneBundleIndex, 1)
-        XCTAssertNotNil(session.pendingVotingPczt)
-        XCTAssertEqual(session.batchSubmissionStatus, .idle)
+        #expect(store.state.keystoneScan == nil)
+        #expect(store.state.keystoneSignatureRejectionSheet?.message == expectedMessage)
+        #expect(session.keystoneSigningStatus == .awaitingSignature)
+        #expect(session.currentKeystoneBundleIndex == 1)
+        #expect(session.pendingVotingPczt != nil)
+        #expect(session.batchSubmissionStatus == .idle)
         try? await Task.sleep(nanoseconds: 50_000_000)
-        XCTAssertTrue(recorder.events().isEmpty)
+        #expect(recorder.events().isEmpty)
     }
 
     @MainActor
-    func testKeystoneAuthorizationSkipsRecoveredBundleAndSubmitsOnlyMissingBundle() async {
+    @Test func keystoneAuthorizationSkipsRecoveredBundleAndSubmitsOnlyMissingBundle() async {
         let recorder = EventRecorder()
         let sig = signature(byte: 2, bundleIndex: 1)
         let store = Store(initialState: authorizationState(signatures: [sig], completedBundles: [0])) {
@@ -479,7 +474,7 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             store.state.roundCache[self.activeRoundId]?.delegationProofStatus == .complete
         }
 
-        XCTAssertEqual(recorder.events(), [
+        #expect(recorder.events() == [
             "recover:0",
             "recover:1",
             "prove:1",
@@ -490,12 +485,12 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             "van:1:43"
         ])
         let session = tryUnwrap(store.state.roundCache[activeRoundId])
-        XCTAssertEqual(session.delegationProofStatus, .complete)
-        XCTAssertTrue(session.completedKeystoneDelegationBundleIndices.isEmpty)
+        #expect(session.delegationProofStatus == .complete)
+        #expect(session.completedKeystoneDelegationBundleIndices.isEmpty)
     }
 
     @MainActor
-    func testKeystoneAuthorizationRecoversPersistedBundleAndSubmitsOnlyMissingBundle() async {
+    @Test func keystoneAuthorizationRecoversPersistedBundleAndSubmitsOnlyMissingBundle() async {
         let recorder = EventRecorder()
         let sig = signature(byte: 2, bundleIndex: 1)
         let store = Store(initialState: authorizationState(signatures: [sig], completedBundles: [])) {
@@ -513,7 +508,7 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             store.state.roundCache[self.activeRoundId]?.delegationProofStatus == .complete
         }
 
-        XCTAssertEqual(recorder.events(), [
+        #expect(recorder.events() == [
             "recover:0",
             "fetch:cached-bundle-0-tx",
             "van:0:43",
@@ -526,12 +521,12 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             "van:1:43"
         ])
         let session = tryUnwrap(store.state.roundCache[activeRoundId])
-        XCTAssertEqual(session.delegationProofStatus, .complete)
-        XCTAssertTrue(session.completedKeystoneDelegationBundleIndices.isEmpty)
+        #expect(session.delegationProofStatus == .complete)
+        #expect(session.completedKeystoneDelegationBundleIndices.isEmpty)
     }
 
     @MainActor
-    func testRecoveredPersistedKeystoneBundleIsRetainedIfLaterBundleFails() async {
+    @Test func recoveredPersistedKeystoneBundleIsRetainedIfLaterBundleFails() async {
         let recorder = EventRecorder()
         let expectedError = TestError.proofFailed.localizedDescription
         let sig = signature(byte: 2, bundleIndex: 1)
@@ -551,7 +546,7 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             store.state.roundCache[self.activeRoundId]?.batchSubmissionStatus == .authorizationFailed(error: expectedError)
         }
 
-        XCTAssertEqual(recorder.events(), [
+        #expect(recorder.events() == [
             "recover:0",
             "fetch:cached-bundle-0-tx",
             "van:0:43",
@@ -559,13 +554,13 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             "prove:1"
         ])
         let session = tryUnwrap(store.state.roundCache[activeRoundId])
-        XCTAssertEqual(session.completedKeystoneDelegationBundleIndices, Set([0]))
-        XCTAssertEqual(session.currentKeystoneBundleIndex, 1)
-        XCTAssertEqual(session.batchSubmissionStatus, .authorizationFailed(error: expectedError))
+        #expect(session.completedKeystoneDelegationBundleIndices == Set([0]))
+        #expect(session.currentKeystoneBundleIndex == 1)
+        #expect(session.batchSubmissionStatus == .authorizationFailed(error: expectedError))
     }
 
     @MainActor
-    func testSuccessfulKeystoneBundleIsRetainedIfLaterBundleFails() async {
+    @Test func successfulKeystoneBundleIsRetainedIfLaterBundleFails() async {
         let recorder = EventRecorder()
         let expectedError = TestError.proofFailed.localizedDescription
         let store = Store(
@@ -591,7 +586,7 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             store.state.roundCache[self.activeRoundId]?.batchSubmissionStatus == .authorizationFailed(error: expectedError)
         }
 
-        XCTAssertEqual(recorder.events(), [
+        #expect(recorder.events() == [
             "recover:0",
             "recover:1",
             "prove:0",
@@ -603,14 +598,14 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             "prove:1"
         ])
         let session = tryUnwrap(store.state.roundCache[activeRoundId])
-        XCTAssertEqual(session.completedKeystoneDelegationBundleIndices, Set([0]))
-        XCTAssertTrue(session.keystoneBundleSignatures.isEmpty)
-        XCTAssertEqual(session.currentKeystoneBundleIndex, 1)
-        XCTAssertEqual(session.batchSubmissionStatus, .authorizationFailed(error: expectedError))
+        #expect(session.completedKeystoneDelegationBundleIndices == Set([0]))
+        #expect(session.keystoneBundleSignatures.isEmpty)
+        #expect(session.currentKeystoneBundleIndex == 1)
+        #expect(session.batchSubmissionStatus == .authorizationFailed(error: expectedError))
     }
 
     @MainActor
-    func testRetryBatchSubmissionResumesKeystoneAtFirstIncompleteBundle() async {
+    @Test func retryBatchSubmissionResumesKeystoneAtFirstIncompleteBundle() async {
         let recorder = EventRecorder()
         var state = authorizationState(signatures: [], completedBundles: [0])
         state.roundCache[activeRoundId]?.draftVotes = [1: .option(0)]
@@ -637,15 +632,15 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
             store.state.roundCache[self.activeRoundId]?.keystoneSigningStatus == .awaitingSignature
         }
 
-        XCTAssertEqual(recorder.events(), ["pczt:1"])
+        #expect(recorder.events() == ["pczt:1"])
         let session = tryUnwrap(store.state.roundCache[activeRoundId])
-        XCTAssertEqual(session.completedKeystoneDelegationBundleIndices, Set([0]))
-        XCTAssertEqual(session.currentKeystoneBundleIndex, 1)
-        XCTAssertNotNil(session.pendingVotingPczt)
-        XCTAssertEqual(session.batchSubmissionStatus, .authorizing)
+        #expect(session.completedKeystoneDelegationBundleIndices == Set([0]))
+        #expect(session.currentKeystoneBundleIndex == 1)
+        #expect(session.pendingVotingPczt != nil)
+        #expect(session.batchSubmissionStatus == .authorizing)
     }
 
-    func testDelegationRejectedResetsKeystoneLoopButPreservesVotes() {
+    @Test func delegationRejectedResetsKeystoneLoopButPreservesVotes() {
         var session = roundSession(
             drafts: [2: .option(1)],
             votes: [1: .option(0)]
@@ -666,17 +661,17 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let updated = tryUnwrap(state.roundCache[roundId])
-        XCTAssertEqual(updated.currentKeystoneBundleIndex, 0)
-        XCTAssertTrue(updated.keystoneBundleSignatures.isEmpty)
-        XCTAssertEqual(updated.keystoneSigningStatus, .idle)
-        XCTAssertEqual(updated.batchSubmissionStatus, .idle)
-        XCTAssertEqual(updated.draftVotes, [2: .option(1)])
-        XCTAssertEqual(updated.votes, [1: .option(0)])
-        XCTAssertFalse(state.pendingBatchSubmission)
-        XCTAssertFalse(isDelegationSigningTop(state))
+        #expect(updated.currentKeystoneBundleIndex == 0)
+        #expect(updated.keystoneBundleSignatures.isEmpty)
+        #expect(updated.keystoneSigningStatus == .idle)
+        #expect(updated.batchSubmissionStatus == .idle)
+        #expect(updated.draftVotes == [2: .option(1)])
+        #expect(updated.votes == [1: .option(0)])
+        #expect(!state.pendingBatchSubmission)
+        #expect(!isDelegationSigningTop(state))
     }
 
-    func testDelegationPipelineRecoversConfirmedCachedTxBeforeSkippingBundle() async throws {
+    @Test func delegationPipelineRecoversConfirmedCachedTxBeforeSkippingBundle() async throws {
         let recorder = RecoveryOrderRecorder()
         var votingCrypto = VotingCryptoClient()
         votingCrypto.getDelegationTxHash = { _, _ in .present("cached-tx") }
@@ -712,10 +707,10 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let events = await recorder.events()
-        XCTAssertEqual(events, ["fetch:cached-tx", "van:0:42"])
+        #expect(events == ["fetch:cached-tx", "van:0:42"])
     }
 
-    func testDelegationPipelineDoesNotSkipCachedTxWithoutConfirmedVanPosition() async throws {
+    @Test func delegationPipelineDoesNotSkipCachedTxWithoutConfirmedVanPosition() async throws {
         let recorder = RecoveryOrderRecorder()
         var votingCrypto = VotingCryptoClient()
         votingCrypto.getDelegationTxHash = { _, _ in .present("cached-tx") }
@@ -764,7 +759,7 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
         )
 
         let events = await recorder.events()
-        XCTAssertEqual(events, [
+        #expect(events == [
             "fetch:cached-tx",
             "registration",
             "submit",
@@ -970,27 +965,21 @@ final class VotingCoordFlowCoordinatorTests: XCTestCase {
     @MainActor
     private func waitForStore(
         timeoutNanoseconds: UInt64 = 2_000_000_000,
-        file: StaticString = #filePath,
-        line: UInt = #line,
+        sourceLocation: SourceLocation = #_sourceLocation,
         condition: @escaping @MainActor () -> Bool
     ) async {
         let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
         while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
-        XCTAssertTrue(condition(), "Timed out waiting for store state", file: file, line: line)
+        #expect(condition(), "Timed out waiting for store state", sourceLocation: sourceLocation)
     }
 
-    private func tryUnwrap<T>(
-        _ value: T?,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> T {
-        do {
-            return try XCTUnwrap(value, file: file, line: line)
-        } catch {
-            fatalError("XCTUnwrap failed")
+    private func tryUnwrap<T>(_ value: T?) -> T {
+        guard let value else {
+            fatalError("tryUnwrap: required value was unexpectedly nil")
         }
+        return value
     }
 
     private func keystoneWalletAccount() -> WalletAccount {

--- a/zodlTests/VotingTests/VotingHelpersTests.swift
+++ b/zodlTests/VotingTests/VotingHelpersTests.swift
@@ -1,26 +1,26 @@
 import ComposableArchitecture
 import Foundation
-import XCTest
+import Testing
 @testable import zodl_internal
 
-final class VotingHelpersTests: XCTestCase {
-    func testVotingErrorMapperMapsPirProofRootMismatchToSnapshotMismatch() {
+@Suite struct VotingHelpersTests {
+    @Test func votingErrorMapperMapsPirProofRootMismatchToSnapshotMismatch() {
         let message = VotingErrorMapper.userFriendlyMessage(
             from: "Internal error: PIR proof root mismatch: expected aa, got bb"
         )
 
-        XCTAssertEqual(message, String(localizable: .coinVoteStoreUserErrorPirSnapshotMismatch))
+        #expect(message == String(localizable: .coinVoteStoreUserErrorPirSnapshotMismatch))
     }
 
-    func testVotingErrorMapperMapsPirProofVerificationFailureBeforeFetchFailure() {
+    @Test func votingErrorMapperMapsPirProofVerificationFailureBeforeFetchFailure() {
         let message = VotingErrorMapper.userFriendlyMessage(
             from: "PIR parallel fetch failed: PIR proof verification failed: bad path"
         )
 
-        XCTAssertEqual(message, String(localizable: .coinVoteStoreUserErrorPirInvalidProofData))
+        #expect(message == String(localizable: .coinVoteStoreUserErrorPirInvalidProofData))
     }
 
-    func testSmartBundlesUsesRustOrderingAndPerBundleQuantization() {
+    @Test func smartBundlesUsesRustOrderingAndPerBundleQuantization() {
         let notes = [
             note(value: 31_568_000, position: 0),
             note(value: 26_000_000, position: 1),
@@ -36,23 +36,25 @@ final class VotingHelpersTests: XCTestCase {
 
         let result = notes.smartBundles()
 
-        XCTAssertEqual(result.bundles.map { $0.map(\.position) }, [
+        let positions = result.bundles.map { $0.map(\.position) }
+        #expect(positions == [
             [0, 1, 2, 3, 4],
             [5, 6, 7, 8, 9]
         ])
-        XCTAssertEqual(result.bundles.map(Self.total), [
+        #expect(result.bundles.map(Self.total) == [
             88_068_000,
             13_000_000
         ])
-        XCTAssertEqual(result.bundles.map { quantizeWeight(Self.total($0)) }, [
+        let quantized = result.bundles.map { quantizeWeight(Self.total($0)) }
+        #expect(quantized == [
             87_500_000,
             12_500_000
         ])
-        XCTAssertEqual(result.eligibleWeight, 100_000_000)
-        XCTAssertEqual(result.droppedCount, 0)
+        #expect(result.eligibleWeight == 100_000_000)
+        #expect(result.droppedCount == 0)
     }
 
-    func testSmartBundlesDropsTrailingDustBundle() {
+    @Test func smartBundlesDropsTrailingDustBundle() {
         let notes = [
             note(value: 30_000_000, position: 0),
             note(value: 20_000_000, position: 1),
@@ -64,20 +66,21 @@ final class VotingHelpersTests: XCTestCase {
 
         let result = notes.smartBundles()
 
-        XCTAssertEqual(result.bundles.map { $0.map(\.position) }, [[0, 1, 2, 3, 4]])
-        XCTAssertEqual(result.eligibleWeight, 75_000_000)
-        XCTAssertEqual(result.droppedCount, 1)
+        let positions = result.bundles.map { $0.map(\.position) }
+        #expect(positions == [[0, 1, 2, 3, 4]])
+        #expect(result.eligibleWeight == 75_000_000)
+        #expect(result.droppedCount == 1)
     }
 
-    func testVotingAuthorizationMemoUsesRawEightDecimalBundleTotal() {
-        XCTAssertEqual(votingRawZecString(31_568_000), "0.31568000")
-        XCTAssertEqual(
-            votingAuthorizationMemo(pollTitle: "Shielded Poll", rawWeight: 31_568_000),
-            "I am authorizing this hotkey managed by my wallet to vote on Shielded Poll with 0.31568000 ZEC."
+    @Test func votingAuthorizationMemoUsesRawEightDecimalBundleTotal() {
+        #expect(votingRawZecString(31_568_000) == "0.31568000")
+        #expect(
+            votingAuthorizationMemo(pollTitle: "Shielded Poll", rawWeight: 31_568_000)
+                == "I am authorizing this hotkey managed by my wallet to vote on Shielded Poll with 0.31568000 ZEC."
         )
     }
 
-    func testSubmittedVotesByProposalRequiresEveryExpectedBundle() {
+    @Test func submittedVotesByProposalRequiresEveryExpectedBundle() {
         let records = [
             VoteRecord(proposalId: 1, bundleIndex: 0, choice: .option(0), submitted: true),
             VoteRecord(proposalId: 1, bundleIndex: 1, choice: .option(0), submitted: true),
@@ -86,25 +89,19 @@ final class VotingHelpersTests: XCTestCase {
             VoteRecord(proposalId: 3, bundleIndex: 1, choice: .option(1), submitted: true)
         ]
 
-        XCTAssertEqual(
-            submittedVotesByProposal(records, bundleCount: 2),
-            [1: .option(0)]
-        )
+        #expect(submittedVotesByProposal(records, bundleCount: 2) == [1: .option(0)])
     }
 
-    func testSubmittedVotesByProposalAllowsLegacyUnknownBundleCount() {
+    @Test func submittedVotesByProposalAllowsLegacyUnknownBundleCount() {
         let records = [
             VoteRecord(proposalId: 1, bundleIndex: 0, choice: .option(0), submitted: true),
             VoteRecord(proposalId: 2, bundleIndex: 0, choice: .option(1), submitted: false)
         ]
 
-        XCTAssertEqual(
-            submittedVotesByProposal(records, bundleCount: 0),
-            [1: .option(0)]
-        )
+        #expect(submittedVotesByProposal(records, bundleCount: 0) == [1: .option(0)])
     }
 
-    func testSyntheticAbstainOnlyMatchesUiGeneratedChoice() {
+    @Test func syntheticAbstainOnlyMatchesUiGeneratedChoice() {
         let proposal = VotingProposal(
             id: 1,
             title: "ZIP Poll",
@@ -125,13 +122,13 @@ final class VotingHelpersTests: XCTestCase {
             ]
         )
 
-        XCTAssertTrue(Voting.isSyntheticAbstain(choice: .option(2), proposal: proposal))
-        XCTAssertFalse(Voting.isSyntheticAbstain(choice: .option(1), proposal: proposal))
-        XCTAssertFalse(Voting.isSyntheticAbstain(choice: .option(3), proposal: proposalWithNativeAbstain))
-        XCTAssertFalse(Voting.isSyntheticAbstain(choice: .option(2), proposal: nil))
+        #expect(Voting.isSyntheticAbstain(choice: .option(2), proposal: proposal))
+        #expect(!Voting.isSyntheticAbstain(choice: .option(1), proposal: proposal))
+        #expect(!Voting.isSyntheticAbstain(choice: .option(3), proposal: proposalWithNativeAbstain))
+        #expect(!Voting.isSyntheticAbstain(choice: .option(2), proposal: nil))
     }
 
-    func testLoadCompletedVoteRecordClearsStaleRecordWhenDraftsRemain() {
+    @Test func loadCompletedVoteRecordClearsStaleRecordWhenDraftsRemain() {
         let roundId = "round-1"
         let metadata = VotingHelpersMetadataBox()
         metadata.records[roundId] = PersistedVotingRecord(
@@ -147,14 +144,14 @@ final class VotingHelpersTests: XCTestCase {
         withDependencies {
             $0.votingMetadata = votingMetadataClient(metadata)
         } operation: {
-            XCTAssertNil(Voting.loadCompletedVoteRecord(roundId: roundId, account: nil))
+            #expect(Voting.loadCompletedVoteRecord(roundId: roundId, account: nil) == nil)
         }
 
-        XCTAssertNil(metadata.records[roundId])
-        XCTAssertEqual(metadata.drafts[roundId], ["1": 0])
+        #expect(metadata.records[roundId] == nil)
+        #expect(metadata.drafts[roundId] == ["1": 0])
     }
 
-    func testVoteRecordReportsSkippedKeystoneBundles() {
+    @Test func voteRecordReportsSkippedKeystoneBundles() {
         let skippedRecord = Voting.VoteRecord(
             votedAt: Date(timeIntervalSince1970: 1_000),
             votingWeight: 25_000_000,
@@ -172,10 +169,10 @@ final class VotingHelpersTests: XCTestCase {
             totalBundleCount: 4
         )
 
-        XCTAssertEqual(skippedRecord.skippedKeystoneBundleCount, 3)
-        XCTAssertTrue(skippedRecord.hasSkippedKeystoneBundles)
-        XCTAssertNil(completeRecord.skippedKeystoneBundleCount)
-        XCTAssertFalse(completeRecord.hasSkippedKeystoneBundles)
+        #expect(skippedRecord.skippedKeystoneBundleCount == 3)
+        #expect(skippedRecord.hasSkippedKeystoneBundles)
+        #expect(completeRecord.skippedKeystoneBundleCount == nil)
+        #expect(!completeRecord.hasSkippedKeystoneBundles)
     }
 
     private static func total(_ notes: [NoteInfo]) -> UInt64 {

--- a/zodlTests/VotingTests/VotingServiceConfigTests.swift
+++ b/zodlTests/VotingTests/VotingServiceConfigTests.swift
@@ -1,11 +1,11 @@
 import CryptoKit
 import Foundation
+import Testing
 @preconcurrency import ZcashLightClientKit
-import XCTest
 @testable import zodl_internal
 
-final class VotingServiceConfigTests: XCTestCase {
-    func testDecodeFromFullZIP1244CompliantJSON() throws {
+@Suite struct VotingServiceConfigTests {
+    @Test func decodeFromFullZIP1244CompliantJSON() throws {
         let json = """
         {
           "config_version": 1,
@@ -26,14 +26,14 @@ final class VotingServiceConfigTests: XCTestCase {
         """
         let config = try JSONDecoder().decode(VotingServiceConfig.self, from: Data(json.utf8))
 
-        XCTAssertEqual(config.configVersion, 1)
-        XCTAssertEqual(config.voteServers.count, 1)
-        XCTAssertEqual(config.pirEndpoints.first?.label, "pir-1")
-        XCTAssertEqual(config.supportedVersions.voteServer, "v1")
-        XCTAssertEqual(config.supportedVersions.pir, ["v0", "v1"])
+        #expect(config.configVersion == 1)
+        #expect(config.voteServers.count == 1)
+        #expect(config.pirEndpoints.first?.label == "pir-1")
+        #expect(config.supportedVersions.voteServer == "v1")
+        #expect(config.supportedVersions.pir == ["v0", "v1"])
     }
 
-    func testDecodeAcceptsConfigWithoutProposalsSnapshotOrDeadline() {
+    @Test func decodeAcceptsConfigWithoutProposalsSnapshotOrDeadline() {
         let json = """
         {
           "config_version": 1,
@@ -44,10 +44,12 @@ final class VotingServiceConfigTests: XCTestCase {
         }
         """
 
-        XCTAssertNoThrow(try JSONDecoder().decode(VotingServiceConfig.self, from: Data(json.utf8)))
+        #expect(throws: Never.self) {
+            try JSONDecoder().decode(VotingServiceConfig.self, from: Data(json.utf8))
+        }
     }
 
-    func testDecodeAcceptsEmptyRoundsRegistry() throws {
+    @Test func decodeAcceptsEmptyRoundsRegistry() throws {
         let config = try JSONDecoder().decode(VotingServiceConfig.self, from: Data("""
         {
           "config_version": 1,
@@ -58,11 +60,13 @@ final class VotingServiceConfigTests: XCTestCase {
         }
         """.utf8))
 
-        XCTAssertTrue(config.rounds.isEmpty)
-        XCTAssertNoThrow(try config.validate())
+        #expect(config.rounds.isEmpty)
+        #expect(throws: Never.self) {
+            try config.validate()
+        }
     }
 
-    func testValidateRejectsNonHexRoundId() {
+    @Test func validateRejectsNonHexRoundId() {
         let config = VotingServiceConfig(
             configVersion: 1,
             voteServers: [.init(url: "https://x", label: "a")],
@@ -77,34 +81,38 @@ final class VotingServiceConfigTests: XCTestCase {
             ]
         )
 
-        XCTAssertThrowsError(try config.validate())
+        #expect(throws: (any Error).self) {
+            try config.validate()
+        }
     }
 
-    func testStaticConfigValidationRejectsShortTrustedKey() {
+    @Test func staticConfigValidationRejectsShortTrustedKey() {
         let config = makeStaticConfig(trustedKeyBytes: Data(repeating: 0x01, count: 31))
 
-        XCTAssertThrowsError(try config.validate())
+        #expect(throws: (any Error).self) {
+            try config.validate()
+        }
     }
 
-    func testPinnedConfigSourceParseAcceptsCosmovisorChecksumAndStripsIt() throws {
+    @Test func pinnedConfigSourceParseAcceptsCosmovisorChecksumAndStripsIt() throws {
         let hex = String(repeating: "0a", count: 32)
         let source = try PinnedConfigSource.parse(
             "https://example.com/static-voting-config.json?foo=bar&checksum=sha256:\(hex)&baz=qux"
         )
 
-        XCTAssertEqual(source.url.absoluteString, "https://example.com/static-voting-config.json?foo=bar&baz=qux")
-        XCTAssertEqual(source.sha256?.count, 32)
-        XCTAssertEqual(source.sha256?.first, 0x0a)
+        #expect(source.url.absoluteString == "https://example.com/static-voting-config.json?foo=bar&baz=qux")
+        #expect(source.sha256?.count == 32)
+        #expect(source.sha256?.first == 0x0a)
     }
 
-    func testPinnedConfigSourceParseAcceptsMissingChecksum() throws {
+    @Test func pinnedConfigSourceParseAcceptsMissingChecksum() throws {
         let source = try PinnedConfigSource.parse("https://example.com/static-voting-config.json")
 
-        XCTAssertEqual(source.url.absoluteString, "https://example.com/static-voting-config.json")
-        XCTAssertNil(source.sha256)
+        #expect(source.url.absoluteString == "https://example.com/static-voting-config.json")
+        #expect(source.sha256 == nil)
     }
 
-    func testPinnedConfigSourceParseRejectsMalformedSources() {
+    @Test func pinnedConfigSourceParseRejectsMalformedSources() {
         let validHex = String(repeating: "0a", count: 32)
         let cases = [
             "https://example.com/static-voting-config.json?checksum=sha512:\(validHex)",
@@ -115,111 +123,127 @@ final class VotingServiceConfigTests: XCTestCase {
         ]
 
         for raw in cases {
-            XCTAssertThrowsError(try PinnedConfigSource.parse(raw), raw) { error in
-                guard case VotingConfigError.staticConfigSourceMalformed = error else {
-                    return XCTFail("expected malformed source, got \(error)")
-                }
+            let error = #expect(throws: VotingConfigError.self, "raw=\(raw)") {
+                try PinnedConfigSource.parse(raw)
+            }
+            guard case .staticConfigSourceMalformed? = error else {
+                Issue.record("expected malformed source for \(raw), got \(String(describing: error))")
+                continue
             }
         }
     }
 
-    func testStaticConfigDecodeAndVerifyAcceptsMatchingSHA256() throws {
+    @Test func staticConfigDecodeAndVerifyAcceptsMatchingSHA256() throws {
         let config = makeStaticConfig()
         let data = try JSONEncoder().encode(config)
         let sha256 = Data(SHA256.hash(data: data))
 
         let decoded = try StaticVotingConfig.decodeAndVerify(data: data, expectedSHA256: sha256)
 
-        XCTAssertEqual(decoded, config)
+        #expect(decoded == config)
     }
 
-    func testStaticConfigDecodeAndVerifyRejectsHashMismatch() throws {
+    @Test func staticConfigDecodeAndVerifyRejectsHashMismatch() throws {
         let data = try JSONEncoder().encode(makeStaticConfig())
 
-        XCTAssertThrowsError(
+        let error = #expect(throws: VotingConfigError.self) {
             try StaticVotingConfig.decodeAndVerify(data: data, expectedSHA256: Data(repeating: 0, count: 32))
-        ) { error in
-            guard case VotingConfigError.staticConfigHashMismatch = error else {
-                return XCTFail("expected hash mismatch, got \(error)")
-            }
+        }
+        guard case .staticConfigHashMismatch? = error else {
+            Issue.record("expected hash mismatch, got \(String(describing: error))")
+            return
         }
     }
 
-    func testStaticConfigDecodeAndVerifyStillValidatesDecodedConfig() throws {
+    @Test func staticConfigDecodeAndVerifyStillValidatesDecodedConfig() throws {
         let config = makeStaticConfig(trustedKeyBytes: Data(repeating: 0x01, count: 31))
         let data = try JSONEncoder().encode(config)
         let sha256 = Data(SHA256.hash(data: data))
 
-        XCTAssertThrowsError(try StaticVotingConfig.decodeAndVerify(data: data, expectedSHA256: sha256))
+        #expect(throws: (any Error).self) {
+            try StaticVotingConfig.decodeAndVerify(data: data, expectedSHA256: sha256)
+        }
     }
 
-    func testValidateAcceptsCurrentWalletCapabilities() {
+    @Test func validateAcceptsCurrentWalletCapabilities() {
         let config = makeConfig(
             supportedVersions: .init(pir: ["v0"], voteProtocol: "v0", tally: "v0", voteServer: "v1")
         )
 
-        XCTAssertNoThrow(try config.validate())
+        #expect(throws: Never.self) {
+            try config.validate()
+        }
     }
 
-    func testValidateRejectsUnknownVoteServer() {
+    @Test func validateRejectsUnknownVoteServer() {
         let config = makeConfig(
             supportedVersions: .init(pir: ["v0"], voteProtocol: "v0", tally: "v0", voteServer: "v99")
         )
 
-        XCTAssertThrowsError(try config.validate()) { error in
-            guard case VotingConfigError.unsupportedVersion(let component, let advertised) = error else {
-                return XCTFail("expected unsupportedVersion, got \(error)")
-            }
-            XCTAssertEqual(component, "vote_server")
-            XCTAssertEqual(advertised, "v99")
+        let error = #expect(throws: VotingConfigError.self) {
+            try config.validate()
         }
+        guard case .unsupportedVersion(let component, let advertised)? = error else {
+            Issue.record("expected unsupportedVersion, got \(String(describing: error))")
+            return
+        }
+        #expect(component == "vote_server")
+        #expect(advertised == "v99")
     }
 
-    func testValidateRejectsWhenPIRIntersectionIsEmpty() {
+    @Test func validateRejectsWhenPIRIntersectionIsEmpty() {
         let config = makeConfig(
             supportedVersions: .init(pir: ["v42"], voteProtocol: "v0", tally: "v0", voteServer: "v1")
         )
 
-        XCTAssertThrowsError(try config.validate()) { error in
-            guard case VotingConfigError.unsupportedVersion(let component, _) = error else {
-                return XCTFail("expected unsupportedVersion, got \(error)")
-            }
-            XCTAssertEqual(component, "pir")
+        let error = #expect(throws: VotingConfigError.self) {
+            try config.validate()
         }
+        guard case .unsupportedVersion(let component, _)? = error else {
+            Issue.record("expected unsupportedVersion, got \(String(describing: error))")
+            return
+        }
+        #expect(component == "pir")
     }
 
-    func testValidateAcceptsWhenPIRIntersectionIsNonEmpty() {
+    @Test func validateAcceptsWhenPIRIntersectionIsNonEmpty() {
         let config = makeConfig(
             supportedVersions: .init(pir: ["v42", "v0"], voteProtocol: "v0", tally: "v0", voteServer: "v1")
         )
 
-        XCTAssertNoThrow(try config.validate())
+        #expect(throws: Never.self) {
+            try config.validate()
+        }
     }
 
-    func testValidateRejectsUnknownVoteProtocol() {
+    @Test func validateRejectsUnknownVoteProtocol() {
         let config = makeConfig(
             supportedVersions: .init(pir: ["v0"], voteProtocol: "v99", tally: "v0", voteServer: "v1")
         )
 
-        XCTAssertThrowsError(try config.validate()) { error in
-            guard case VotingConfigError.unsupportedVersion(let component, _) = error else {
-                return XCTFail("expected unsupportedVersion, got \(error)")
-            }
-            XCTAssertEqual(component, "vote_protocol")
+        let error = #expect(throws: VotingConfigError.self) {
+            try config.validate()
         }
+        guard case .unsupportedVersion(let component, _)? = error else {
+            Issue.record("expected unsupportedVersion, got \(String(describing: error))")
+            return
+        }
+        #expect(component == "vote_protocol")
     }
 
-    func testValidateRejectsUnknownTally() {
+    @Test func validateRejectsUnknownTally() {
         let config = makeConfig(
             supportedVersions: .init(pir: ["v0"], voteProtocol: "v0", tally: "v99", voteServer: "v1")
         )
 
-        XCTAssertThrowsError(try config.validate()) { error in
-            guard case VotingConfigError.unsupportedVersion(let component, _) = error else {
-                return XCTFail("expected unsupportedVersion, got \(error)")
-            }
-            XCTAssertEqual(component, "tally")
+        let error = #expect(throws: VotingConfigError.self) {
+            try config.validate()
         }
+        guard case .unsupportedVersion(let component, _)? = error else {
+            Issue.record("expected unsupportedVersion, got \(String(describing: error))")
+            return
+        }
+        #expect(component == "tally")
     }
 
     private func makeConfig(supportedVersions: VotingServiceConfig.SupportedVersions) -> VotingServiceConfig {
@@ -245,7 +269,7 @@ final class VotingServiceConfigTests: XCTestCase {
     }
 }
 
-final class RoundAuthenticatorTests: XCTestCase {
+@Suite struct RoundAuthenticatorTests {
     private let roundId = "58d9319ac86933b81769a7c0972444fa39212ad3790646398de6ce6534de2225"
     private let eaPK = Data(base64Encoded: "N72oXeIF96QwWBtChaCwde3tjTt75ZfAs455V4usYwM=")!
     private let adminPubkey = Data(base64Encoded: "rKDbmhkoW9ja7dMiCV+1uTao7wXWV6xN/57erkrOuiQ=")!
@@ -253,97 +277,91 @@ final class RoundAuthenticatorTests: XCTestCase {
         base64Encoded: "rnll+KsHIFt73GpyNoWrX57dlcX8hTi8GU5X/xpwg3vcE+jCARUXpD7LsK+OLw6R5q1kU/zccwNgzsmclt4WAg=="
     )!
 
-    func testAuthenticateAcceptsFixtureFromDynamicConfig() {
-        XCTAssertEqual(
+    @Test func authenticateAcceptsFixtureFromDynamicConfig() {
+        #expect(
             RoundAuthenticator.authenticate(
                 chainEaPK: eaPK,
                 roundIdHex: roundId,
                 rounds: [roundId: makeEntry()],
                 trustedKeys: [makeTrustedKey()]
-            ),
-            .authenticated
+            ) == .authenticated
         )
     }
 
-    func testAuthenticateReportsMissingRound() {
-        XCTAssertEqual(
+    @Test func authenticateReportsMissingRound() {
+        #expect(
             RoundAuthenticator.authenticate(
                 chainEaPK: eaPK,
                 roundIdHex: roundId,
                 rounds: [:],
                 trustedKeys: [makeTrustedKey()]
-            ),
-            .missingRound
+            ) == .missingRound
         )
     }
 
-    func testAuthenticateReportsUnknownAuthVersion() {
-        XCTAssertEqual(
+    @Test func authenticateReportsUnknownAuthVersion() {
+        #expect(
             RoundAuthenticator.authenticate(
                 chainEaPK: eaPK,
                 roundIdHex: roundId,
                 rounds: [roundId: makeEntry(authVersion: 2)],
                 trustedKeys: [makeTrustedKey()]
-            ),
-            .unknownAuthVersion
+            ) == .unknownAuthVersion
         )
     }
 
-    func testAuthenticateReportsInvalidSignatures() {
+    @Test func authenticateReportsInvalidSignatures() {
         var badSig = adminSignature
         badSig[0] ^= 0xFF
 
-        XCTAssertEqual(
+        #expect(
             RoundAuthenticator.authenticate(
                 chainEaPK: eaPK,
                 roundIdHex: roundId,
                 rounds: [roundId: makeEntry(signature: badSig)],
                 trustedKeys: [makeTrustedKey()]
-            ),
-            .invalidSignatures
+            ) == .invalidSignatures
         )
     }
 
-    func testAuthenticateReportsEaPKMismatch() {
+    @Test func authenticateReportsEaPKMismatch() {
         var chainEaPK = eaPK
         chainEaPK[0] ^= 0xFF
 
-        XCTAssertEqual(
+        #expect(
             RoundAuthenticator.authenticate(
                 chainEaPK: chainEaPK,
                 roundIdHex: roundId,
                 rounds: [roundId: makeEntry()],
                 trustedKeys: [makeTrustedKey()]
-            ),
-            .eaPKMismatch
+            ) == .eaPKMismatch
         )
     }
 
-    func testAuthenticateReportsInvalidSignaturesWhenEntryEaPKIsShort() {
-        XCTAssertEqual(
+    @Test func authenticateReportsInvalidSignaturesWhenEntryEaPKIsShort() {
+        #expect(
             RoundAuthenticator.authenticate(
                 chainEaPK: eaPK,
                 roundIdHex: roundId,
                 rounds: [roundId: makeEntry(eaPK: Data(repeating: 0x01, count: 31))],
                 trustedKeys: [makeTrustedKey()]
-            ),
-            .invalidSignatures
+            ) == .invalidSignatures
         )
     }
 
-    func testVerifyEntrySignaturesRejectsUnknownKeyId() {
+    @Test func verifyEntrySignaturesRejectsUnknownKeyId() {
         let entry = makeEntry(keyId: "unknown-key")
 
-        XCTAssertFalse(RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
+        #expect(!RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
     }
 
-    func testVerifyEntrySignaturesRejectsSignatureAlgMismatch() {
+    @Test func verifyEntrySignaturesRejectsSignatureAlgMismatch() {
         let entry = makeEntry(signatureAlg: "ed448")
 
-        XCTAssertFalse(RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
+        #expect(!RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
     }
 
-    func testVerifyEntrySignaturesRejectsTrustedKeyAlgMismatch() {
+    @Test func verifyEntrySignaturesRejectsTrustedKeyAlgMismatch() {
         let trustedKey = StaticVotingConfig.TrustedKey(
             keyId: "valar-test",
             alg: "ed448",
@@ -351,16 +369,16 @@ final class RoundAuthenticatorTests: XCTestCase {
             notes: nil
         )
 
-        XCTAssertFalse(RoundAuthenticator.verifyEntrySignatures(entry: makeEntry(), trustedKeys: [trustedKey]))
+        #expect(!RoundAuthenticator.verifyEntrySignatures(entry: makeEntry(), trustedKeys: [trustedKey]))
     }
 
-    func testVerifyEntrySignaturesRejectsShortSignature() {
+    @Test func verifyEntrySignaturesRejectsShortSignature() {
         let entry = makeEntry(signature: Data(repeating: 0x01, count: 63))
 
-        XCTAssertFalse(RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
+        #expect(!RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
     }
 
-    func testVerifyEntrySignaturesAcceptsWhenAnySignatureIsValid() {
+    @Test func verifyEntrySignaturesAcceptsWhenAnySignatureIsValid() {
         let entry = VotingServiceConfig.RoundEntry(
             authVersion: 1,
             eaPk: eaPK,
@@ -370,10 +388,10 @@ final class RoundAuthenticatorTests: XCTestCase {
             ]
         )
 
-        XCTAssertTrue(RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
+        #expect(RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
     }
 
-    func testServiceConfigDropsOnlyRoundsWithoutValidSignatures() {
+    @Test func serviceConfigDropsOnlyRoundsWithoutValidSignatures() {
         var badSignature = adminSignature
         badSignature[0] ^= 0xFF
         let invalidRoundId = String(repeating: "b", count: 64)
@@ -390,7 +408,7 @@ final class RoundAuthenticatorTests: XCTestCase {
 
         let filtered = serviceConfigRetainingRoundsWithValidSignatures(config, trustedKeys: [makeTrustedKey()])
 
-        XCTAssertEqual(Set(filtered.rounds.keys), [roundId])
+        #expect(Set(filtered.rounds.keys) == [roundId])
     }
 
     private func makeEntry(
@@ -414,49 +432,67 @@ final class RoundAuthenticatorTests: XCTestCase {
     }
 }
 
-final class VotingSessionParsingTests: XCTestCase {
-    func testParseVotingSessionAcceptsValidProposalBounds() {
-        XCTAssertNoThrow(try parseVotingSession(from: makeRound()))
+@Suite struct VotingSessionParsingTests {
+    @Test func parseVotingSessionAcceptsValidProposalBounds() {
+        #expect(throws: Never.self) {
+            try parseVotingSession(from: makeRound())
+        }
     }
 
-    func testParseVotingSessionRejectsEmptyProposals() {
-        XCTAssertThrowsError(try parseVotingSession(from: makeRound(proposals: [])))
+    @Test func parseVotingSessionRejectsEmptyProposals() {
+        #expect(throws: (any Error).self) {
+            try parseVotingSession(from: makeRound(proposals: []))
+        }
     }
 
-    func testParseVotingSessionRejectsTooManyProposals() {
-        XCTAssertThrowsError(try parseVotingSession(from: makeRound(proposals: (1...16).map { makeProposal(id: $0) })))
+    @Test func parseVotingSessionRejectsTooManyProposals() {
+        #expect(throws: (any Error).self) {
+            try parseVotingSession(from: makeRound(proposals: (1...16).map { makeProposal(id: $0) }))
+        }
     }
 
-    func testParseVotingSessionRejectsProposalIdOutsideRange() {
-        XCTAssertThrowsError(try parseVotingSession(from: makeRound(proposals: [makeProposal(id: 16)])))
+    @Test func parseVotingSessionRejectsProposalIdOutsideRange() {
+        #expect(throws: (any Error).self) {
+            try parseVotingSession(from: makeRound(proposals: [makeProposal(id: 16)]))
+        }
     }
 
-    func testParseVotingSessionRejectsDuplicateProposalIds() {
-        XCTAssertThrowsError(try parseVotingSession(from: makeRound(proposals: [makeProposal(id: 1), makeProposal(id: 1)])))
+    @Test func parseVotingSessionRejectsDuplicateProposalIds() {
+        #expect(throws: (any Error).self) {
+            try parseVotingSession(from: makeRound(proposals: [makeProposal(id: 1), makeProposal(id: 1)]))
+        }
     }
 
-    func testParseVotingSessionRejectsTooFewOptions() {
-        XCTAssertThrowsError(try parseVotingSession(from: makeRound(proposals: [
-            makeProposal(id: 1, options: [makeOption(index: 0)])
-        ])))
+    @Test func parseVotingSessionRejectsTooFewOptions() {
+        #expect(throws: (any Error).self) {
+            try parseVotingSession(from: makeRound(proposals: [
+                makeProposal(id: 1, options: [makeOption(index: 0)])
+            ]))
+        }
     }
 
-    func testParseVotingSessionRejectsTooManyOptions() {
-        XCTAssertThrowsError(try parseVotingSession(from: makeRound(proposals: [
-            makeProposal(id: 1, options: (0...8).map { makeOption(index: $0) })
-        ])))
+    @Test func parseVotingSessionRejectsTooManyOptions() {
+        #expect(throws: (any Error).self) {
+            try parseVotingSession(from: makeRound(proposals: [
+                makeProposal(id: 1, options: (0...8).map { makeOption(index: $0) })
+            ]))
+        }
     }
 
-    func testParseVotingSessionRejectsDuplicateOptionIndices() {
-        XCTAssertThrowsError(try parseVotingSession(from: makeRound(proposals: [
-            makeProposal(id: 1, options: [makeOption(index: 0), makeOption(index: 0)])
-        ])))
+    @Test func parseVotingSessionRejectsDuplicateOptionIndices() {
+        #expect(throws: (any Error).self) {
+            try parseVotingSession(from: makeRound(proposals: [
+                makeProposal(id: 1, options: [makeOption(index: 0), makeOption(index: 0)])
+            ]))
+        }
     }
 
-    func testParseVotingSessionRejectsNonContiguousOptionIndices() {
-        XCTAssertThrowsError(try parseVotingSession(from: makeRound(proposals: [
-            makeProposal(id: 1, options: [makeOption(index: 0), makeOption(index: 2)])
-        ])))
+    @Test func parseVotingSessionRejectsNonContiguousOptionIndices() {
+        #expect(throws: (any Error).self) {
+            try parseVotingSession(from: makeRound(proposals: [
+                makeProposal(id: 1, options: [makeOption(index: 0), makeOption(index: 2)])
+            ]))
+        }
     }
 
     private func makeRound(proposals: [[String: Any]]? = nil) -> [String: Any] {
@@ -496,8 +532,8 @@ final class VotingSessionParsingTests: XCTestCase {
     }
 }
 
-final class ShareRecoveryPollingTests: XCTestCase {
-    func testPollingConfirmsFromRecordedHelperInsteadOfFirstConfiguredHelper() async throws {
+@Suite struct ShareRecoveryPollingTests {
+    @Test func pollingConfirmsFromRecordedHelperInsteadOfFirstConfiguredHelper() async throws {
         let recorder = SharePostRecorder()
         let share = try makeShareDelegation(
             sentToURLs: [
@@ -521,15 +557,15 @@ final class ShareRecoveryPollingTests: XCTestCase {
         )
 
         let queriedServers = await recorder.servers()
-        XCTAssertEqual(queriedServers, ["https://helper-3.example.com"])
-        XCTAssertEqual(result.confirmedShares, [
+        #expect(queriedServers == ["https://helper-3.example.com"])
+        #expect(result.confirmedShares == [
             ShareDelegationKey(bundleIndex: 0, proposalId: 1, shareIndex: 0)
         ])
-        XCTAssertTrue(result.resubmissionShares.isEmpty)
-        XCTAssertEqual(result.queriedCount, 1)
+        #expect(result.resubmissionShares.isEmpty)
+        #expect(result.queriedCount == 1)
     }
 
-    func testPollingContinuesAfterOneRecordedHelperErrors() async throws {
+    @Test func pollingContinuesAfterOneRecordedHelperErrors() async throws {
         let recorder = SharePostRecorder()
         let share = try makeShareDelegation(
             sentToURLs: [
@@ -555,46 +591,46 @@ final class ShareRecoveryPollingTests: XCTestCase {
         )
 
         let queriedServers = await recorder.servers()
-        XCTAssertEqual(queriedServers, [
+        #expect(queriedServers == [
             "https://helper-3.example.com",
             "https://helper-4.example.com"
         ])
-        XCTAssertEqual(result.confirmedShares, [
+        #expect(result.confirmedShares == [
             ShareDelegationKey(bundleIndex: 0, proposalId: 1, shareIndex: 0)
         ])
-        XCTAssertTrue(result.resubmissionShares.isEmpty)
-        XCTAssertEqual(result.queriedCount, 2)
+        #expect(result.resubmissionShares.isEmpty)
+        #expect(result.queriedCount == 2)
     }
 
-    func testImmediateSharesUseCreatedAtForReadinessAndResubmission() throws {
+    @Test func immediateSharesUseCreatedAtForReadinessAndResubmission() throws {
         let share = try makeShareDelegation(
             sentToURLs: ["https://helper.example.com"],
             submitAt: 0,
             createdAt: 100
         )
 
-        XCTAssertFalse(VotingCoordFlow.isShareReadyForStatusCheck(share, now: 109))
-        XCTAssertTrue(VotingCoordFlow.isShareReadyForStatusCheck(share, now: 110))
-        XCTAssertFalse(VotingCoordFlow.shouldResubmitShare(share, now: 129, voteEndTime: 200))
-        XCTAssertTrue(VotingCoordFlow.shouldResubmitShare(share, now: 130, voteEndTime: 200))
+        #expect(!VotingCoordFlow.isShareReadyForStatusCheck(share, now: 109))
+        #expect(VotingCoordFlow.isShareReadyForStatusCheck(share, now: 110))
+        #expect(!VotingCoordFlow.shouldResubmitShare(share, now: 129, voteEndTime: 200))
+        #expect(VotingCoordFlow.shouldResubmitShare(share, now: 130, voteEndTime: 200))
     }
 
-    func testDelayedSharesUseSubmitAtForReadinessAndResubmission() throws {
+    @Test func delayedSharesUseSubmitAtForReadinessAndResubmission() throws {
         let share = try makeShareDelegation(
             sentToURLs: ["https://helper.example.com"],
             submitAt: 200,
             createdAt: 100
         )
 
-        XCTAssertFalse(VotingCoordFlow.isShareReadyForStatusCheck(share, now: 209))
-        XCTAssertTrue(VotingCoordFlow.isShareReadyForStatusCheck(share, now: 210))
-        XCTAssertFalse(VotingCoordFlow.shouldResubmitShare(share, now: 229, voteEndTime: 320))
-        XCTAssertTrue(VotingCoordFlow.shouldResubmitShare(share, now: 230, voteEndTime: 320))
+        #expect(!VotingCoordFlow.isShareReadyForStatusCheck(share, now: 209))
+        #expect(VotingCoordFlow.isShareReadyForStatusCheck(share, now: 210))
+        #expect(!VotingCoordFlow.shouldResubmitShare(share, now: 229, voteEndTime: 320))
+        #expect(VotingCoordFlow.shouldResubmitShare(share, now: 230, voteEndTime: 320))
     }
 }
 
-final class ShareResubmissionFallbackTests: XCTestCase {
-    func testResubmissionTriesUntriedHelpersFirst() async {
+@Suite struct ShareResubmissionFallbackTests {
+    @Test func resubmissionTriesUntriedHelpersFirst() async {
         let recorder = SharePostRecorder()
 
         let acceptedServers = await resubmitSharePayload(
@@ -611,12 +647,12 @@ final class ShareResubmissionFallbackTests: XCTestCase {
             orderServers: { $0 }
         )
 
-        XCTAssertEqual(acceptedServers, ["https://untried.example.com"])
+        #expect(acceptedServers == ["https://untried.example.com"])
         let recordedServers = await recorder.servers()
-        XCTAssertEqual(recordedServers, ["https://untried.example.com"])
+        #expect(recordedServers == ["https://untried.example.com"])
     }
 
-    func testResubmissionFallsBackToAlreadySentHelperWhenUntriedFails() async {
+    @Test func resubmissionFallsBackToAlreadySentHelperWhenUntriedFails() async {
         let recorder = SharePostRecorder()
 
         let acceptedServers = await resubmitSharePayload(
@@ -636,15 +672,15 @@ final class ShareResubmissionFallbackTests: XCTestCase {
             orderServers: { $0 }
         )
 
-        XCTAssertEqual(acceptedServers, ["https://already-sent.example.com"])
+        #expect(acceptedServers == ["https://already-sent.example.com"])
         let recordedServers = await recorder.servers()
-        XCTAssertEqual(recordedServers, [
+        #expect(recordedServers == [
             "https://untried.example.com",
             "https://already-sent.example.com"
         ])
     }
 
-    func testResubmissionReturnsEmptyWhenAllHelpersFail() async {
+    @Test func resubmissionReturnsEmptyWhenAllHelpersFail() async {
         let recorder = SharePostRecorder()
 
         let acceptedServers = await resubmitSharePayload(
@@ -662,17 +698,17 @@ final class ShareResubmissionFallbackTests: XCTestCase {
             orderServers: { $0 }
         )
 
-        XCTAssertTrue(acceptedServers.isEmpty)
+        #expect(acceptedServers.isEmpty)
         let recordedServers = await recorder.servers()
-        XCTAssertEqual(recordedServers, [
+        #expect(recordedServers == [
             "https://untried.example.com",
             "https://already-sent.example.com"
         ])
     }
 }
 
-final class ShareDelegationPostFallbackTests: XCTestCase {
-    func testSelectedHelperFailureBackfillsSameShareAndPrunesFailedHelper() async throws {
+@Suite struct ShareDelegationPostFallbackTests {
+    @Test func selectedHelperFailureBackfillsSameShareAndPrunesFailedHelper() async throws {
         let recorder = SharePostRecorder()
         let payload = makeRecoverySharePayload()
 
@@ -694,23 +730,23 @@ final class ShareDelegationPostFallbackTests: XCTestCase {
         )
 
         let recordedServers = await recorder.servers()
-        XCTAssertEqual(recordedServers.count, 3)
-        XCTAssertEqual(Set(recordedServers), Set([
+        #expect(recordedServers.count == 3)
+        #expect(Set(recordedServers) == Set([
             "https://online-one.example.com",
             "https://offline.example.com",
             "https://online-two.example.com"
         ]))
-        XCTAssertEqual(result.delegatedShares.first?.acceptedByServers, [
+        #expect(result.delegatedShares.first?.acceptedByServers == [
             "https://online-one.example.com",
             "https://online-two.example.com"
         ])
-        XCTAssertEqual(result.remainingServerURLs, [
+        #expect(result.remainingServerURLs == [
             "https://online-one.example.com",
             "https://online-two.example.com"
         ])
     }
 
-    func testOfflineHelperIsAttemptedAtMostOnceThenLaterSharesUseOnlineHelper() async throws {
+    @Test func offlineHelperIsAttemptedAtMostOnceThenLaterSharesUseOnlineHelper() async throws {
         let recorder = SharePostRecorder()
         let payloads = (0..<2).map { makeRecoverySharePayload(index: UInt32($0)) }
 
@@ -731,19 +767,19 @@ final class ShareDelegationPostFallbackTests: XCTestCase {
         )
 
         let recordedServers = await recorder.servers()
-        XCTAssertEqual(recordedServers, [
+        #expect(recordedServers == [
             "https://offline.example.com",
             "https://online.example.com",
             "https://online.example.com"
         ])
-        XCTAssertEqual(result.delegatedShares.map(\.acceptedByServers), [
+        #expect(result.delegatedShares.map(\.acceptedByServers) == [
             ["https://online.example.com"],
             ["https://online.example.com"]
         ])
-        XCTAssertEqual(result.remainingServerURLs, ["https://online.example.com"])
+        #expect(result.remainingServerURLs == ["https://online.example.com"])
     }
 
-    func testAllSelectedHelpersFailButBackfillHelperSucceeds() async throws {
+    @Test func allSelectedHelpersFailButBackfillHelperSucceeds() async throws {
         let recorder = SharePostRecorder()
         let payload = makeRecoverySharePayload()
 
@@ -765,18 +801,18 @@ final class ShareDelegationPostFallbackTests: XCTestCase {
         )
 
         let recordedServers = await recorder.servers()
-        XCTAssertEqual(recordedServers.count, 3)
-        XCTAssertEqual(Set(recordedServers), Set([
+        #expect(recordedServers.count == 3)
+        #expect(Set(recordedServers) == Set([
             "https://offline-one.example.com",
             "https://offline-two.example.com",
             "https://online.example.com"
         ]))
-        XCTAssertEqual(result.delegatedShares.first?.acceptedByServers, ["https://online.example.com"])
-        XCTAssertEqual(result.remainingServerURLs, ["https://online.example.com"])
+        #expect(result.delegatedShares.first?.acceptedByServers == ["https://online.example.com"])
+        #expect(result.remainingServerURLs == ["https://online.example.com"])
     }
 
-    func testAllConfiguredHelpersFailThrowsNoReachableVoteServers() async throws {
-        do {
+    @Test func allConfiguredHelpersFailThrowsNoReachableVoteServers() async {
+        await #expect(throws: ShareDelegationError.noReachableVoteServers) {
             _ = try await delegateSharePayloads(
                 [makeRecoverySharePayload()],
                 roundIdHex: "aabb",
@@ -787,15 +823,12 @@ final class ShareDelegationPostFallbackTests: XCTestCase {
                 postShare: { _, _ in throw SharePostFailure() },
                 selectTargets: { servers, targetCount in Array(servers.prefix(targetCount)) }
             )
-            XCTFail("Expected share delegation to fail")
-        } catch {
-            XCTAssertEqual(error as? ShareDelegationError, .noReachableVoteServers)
         }
     }
 }
 
-final class DelegateSharesWithFallbackTests: XCTestCase {
-    func testDelegateSharesWithFallbackRetriesReachabilityExhaustion() async throws {
+@Suite struct DelegateSharesWithFallbackTests {
+    @Test func delegateSharesWithFallbackRetriesReachabilityExhaustion() async throws {
         let attempts = AttemptCounter()
         var votingAPI = VotingAPIClient()
         votingAPI.delegateShares = { _, _, serverURLs in
@@ -815,11 +848,11 @@ final class DelegateSharesWithFallbackTests: XCTestCase {
         )
 
         let attemptCount = await attempts.value()
-        XCTAssertEqual(attemptCount, 3)
-        XCTAssertEqual(result.remainingServerURLs, ["https://vote.example.com"])
+        #expect(attemptCount == 3)
+        #expect(result.remainingServerURLs == ["https://vote.example.com"])
     }
 
-    func testDelegateSharesWithFallbackRethrowsUnexpectedErrorWithoutRetry() async {
+    @Test func delegateSharesWithFallbackRethrowsUnexpectedErrorWithoutRetry() async {
         let attempts = AttemptCounter()
         var votingAPI = VotingAPIClient()
         votingAPI.delegateShares = { _, _, _ in
@@ -827,7 +860,7 @@ final class DelegateSharesWithFallbackTests: XCTestCase {
             throw SharePostFailure()
         }
 
-        do {
+        await #expect(throws: SharePostFailure.self) {
             _ = try await Voting.delegateSharesWithFallback(
                 [],
                 roundId: "aabb",
@@ -835,12 +868,9 @@ final class DelegateSharesWithFallbackTests: XCTestCase {
                 serverURLs: ["https://vote.example.com"],
                 retryDelay: .zero
             )
-            XCTFail("Expected unexpected share delegation error")
-        } catch {
-            XCTAssertTrue(error is SharePostFailure)
         }
         let attemptCount = await attempts.value()
-        XCTAssertEqual(attemptCount, 1)
+        #expect(attemptCount == 1)
     }
 }
 

--- a/zodlTests/VotingTests/VotingSessionTests.swift
+++ b/zodlTests/VotingTests/VotingSessionTests.swift
@@ -1,48 +1,50 @@
-import XCTest
+import Testing
 import Foundation
 @testable import zodl_internal
 
-final class VotingSessionTests: XCTestCase {
-    func testLastMomentBufferUsesFortyPercentForShortRounds() throws {
+@Suite struct VotingSessionTests {
+    @Test func lastMomentBufferUsesFortyPercentForShortRounds() throws {
         let ceremonyStart = Date(timeIntervalSince1970: 1_000)
         let voteEndTime = ceremonyStart.addingTimeInterval(10 * 60)
         let session = makeSession(ceremonyStart: ceremonyStart, voteEndTime: voteEndTime)
 
-        XCTAssertEqual(try XCTUnwrap(session.lastMomentBuffer), 4 * 60, accuracy: 0.001)
+        let buffer = try #require(session.lastMomentBuffer)
+        #expect(abs(buffer - 4 * 60) <= 0.001)
     }
 
-    func testLastMomentBufferCapsAtSixHoursForLongRounds() throws {
+    @Test func lastMomentBufferCapsAtSixHoursForLongRounds() throws {
         let ceremonyStart = Date(timeIntervalSince1970: 1_000)
         let voteEndTime = ceremonyStart.addingTimeInterval(24 * 60 * 60)
         let session = makeSession(ceremonyStart: ceremonyStart, voteEndTime: voteEndTime)
 
-        XCTAssertEqual(try XCTUnwrap(session.lastMomentBuffer), 6 * 60 * 60, accuracy: 0.001)
+        let buffer = try #require(session.lastMomentBuffer)
+        #expect(abs(buffer - 6 * 60 * 60) <= 0.001)
     }
 
-    func testLastMomentBufferIsNilForInvalidRoundTimes() {
+    @Test func lastMomentBufferIsNilForInvalidRoundTimes() {
         let ceremonyStart = Date(timeIntervalSince1970: 1_000)
         let voteEndTime = ceremonyStart
         let session = makeSession(ceremonyStart: ceremonyStart, voteEndTime: voteEndTime)
 
-        XCTAssertNil(session.lastMomentBuffer)
+        #expect(session.lastMomentBuffer == nil)
     }
 
-    func testIsLastMomentForShortRoundWithinBuffer() {
+    @Test func isLastMomentForShortRoundWithinBuffer() {
         let now = Date()
         let voteEndTime = now.addingTimeInterval(3 * 60)
         let ceremonyStart = voteEndTime.addingTimeInterval(-10 * 60)
         let session = makeSession(ceremonyStart: ceremonyStart, voteEndTime: voteEndTime)
 
-        XCTAssertTrue(session.isLastMoment)
+        #expect(session.isLastMoment)
     }
 
-    func testIsLastMomentForShortRoundBeforeBuffer() {
+    @Test func isLastMomentForShortRoundBeforeBuffer() {
         let now = Date()
         let voteEndTime = now.addingTimeInterval(5 * 60)
         let ceremonyStart = voteEndTime.addingTimeInterval(-10 * 60)
         let session = makeSession(ceremonyStart: ceremonyStart, voteEndTime: voteEndTime)
 
-        XCTAssertFalse(session.isLastMoment)
+        #expect(!session.isLastMoment)
     }
 
     private func makeSession(ceremonyStart: Date, voteEndTime: Date) -> VotingSession {

--- a/zodlTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationCommaTests.swift
+++ b/zodlTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationCommaTests.swift
@@ -5,200 +5,74 @@
 //  Created by Lukáš Korba on 2024-02-12.
 //
 
-import XCTest
+import Testing
+import Foundation
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-final class ZatoshiStringRepresentationCommaTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        
-        let zashiBalanceFormatter = NumberFormatter.zashiBalanceFormatter
-        zashiBalanceFormatter.locale = Locale(identifier: "cs_CZ")
-        
-        let zashiNumberFormatter = NumberFormatter.zcashNumberFormatter8FractionDigits
-        zashiNumberFormatter.locale = Locale(identifier: "cs_CZ")
+@Suite struct ZatoshiStringRepresentationCommaTests {
+    // Only value types (Int64 / simple app enums / String), so it is safe to treat as Sendable.
+    struct Sample: @unchecked Sendable {
+        let zatoshi: Int64
+        let prefix: ZatoshiStringRepresentation.PrefixSymbol
+        let format: ZatoshiStringRepresentation.Format
+        let most: String
+        let least: String
     }
 
-    // MARK: - Fee Format
-    
-    func testFeeFormat() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.feeFormat, "Typical Fee < 0,001")
+    @Test(arguments: csCZZatoshiSamples)
+    func significantDigits(_ sample: Sample) {
+        let repr = FormatterTestGate.shared.withLockUnchecked {
+            NumberFormatter.zashiBalanceFormatter.locale = Locale(identifier: "cs_CZ")
+            NumberFormatter.zcashNumberFormatter8FractionDigits.locale = Locale(identifier: "cs_CZ")
+            return ZatoshiStringRepresentation(Zatoshi(sample.zatoshi), prefixSymbol: sample.prefix, format: sample.format)
+        }
+
+        #expect(repr.mostSignificantDigits == sample.most)
+        #expect(repr.leastSignificantDigits == sample.least)
     }
 
-    // MARK: - Prefix None
-    
-    func testPrefixNone_Abbreviated_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
+    @Test func feeFormat() {
+        let repr = FormatterTestGate.shared.withLockUnchecked { () -> ZatoshiStringRepresentation in
+            NumberFormatter.zashiBalanceFormatter.locale = Locale(identifier: "cs_CZ")
+            NumberFormatter.zcashNumberFormatter8FractionDigits.locale = Locale(identifier: "cs_CZ")
+            return ZatoshiStringRepresentation(Zatoshi(0))
+        }
 
-    func testPrefixNone_Abbreviated_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0,000...")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixNone_Abbreviated_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0,001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixNone_Abbreviated_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0,258")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-    
-    func testPrefixNone_Expanded_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixNone_Expanded_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "99")
-    }
-
-    func testPrefixNone_Expanded_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0,001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixNone_Expanded_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0,257")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "93456")
-    }
-    
-    // MARK: - Prefix Plus
-    
-    func testPrefixPlus_Abbreviated_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), prefixSymbol: .plus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Abbreviated_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), prefixSymbol: .plus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0,000...")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Abbreviated_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), prefixSymbol: .plus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0,001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Abbreviated_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), prefixSymbol: .plus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0,258")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-    
-    func testPrefixPlus_Expanded_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), prefixSymbol: .plus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Expanded_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), prefixSymbol: .plus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "99")
-    }
-
-    func testPrefixPlus_Expanded_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), prefixSymbol: .plus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0,001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Expanded_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), prefixSymbol: .plus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0,257")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "93456")
-    }
-    
-    // MARK: - Prefix Minus
-    
-    func testPrefixMinus_Abbreviated_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), prefixSymbol: .minus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Abbreviated_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), prefixSymbol: .minus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0,000...")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Abbreviated_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), prefixSymbol: .minus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0,001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Abbreviated_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), prefixSymbol: .minus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0,258")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-    
-    func testPrefixMinus_Expanded_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), prefixSymbol: .minus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Expanded_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), prefixSymbol: .minus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0,000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "99")
-    }
-
-    func testPrefixMinus_Expanded_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), prefixSymbol: .minus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0,001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Expanded_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), prefixSymbol: .minus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0,257")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "93456")
+        #expect(repr.feeFormat == "Typical Fee < 0,001")
     }
 }
+
+// cs_CZ locale: comma decimal separator. One row per original `testPrefix*` method.
+private let csCZZatoshiSamples: [ZatoshiStringRepresentationCommaTests.Sample] = [
+    // Prefix None — Abbreviated
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 0, prefix: .none, format: .abbreviated, most: "0,000", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 99_000, prefix: .none, format: .abbreviated, most: "0,000...", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 100_000, prefix: .none, format: .abbreviated, most: "0,001", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 25_793_456, prefix: .none, format: .abbreviated, most: "0,258", least: ""),
+    // Prefix None — Expanded
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 0, prefix: .none, format: .expanded, most: "0,000", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 99_000, prefix: .none, format: .expanded, most: "0,000", least: "99"),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 100_000, prefix: .none, format: .expanded, most: "0,001", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 25_793_456, prefix: .none, format: .expanded, most: "0,257", least: "93456"),
+    // Prefix Plus — Abbreviated
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 0, prefix: .plus, format: .abbreviated, most: "+0,000", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 99_000, prefix: .plus, format: .abbreviated, most: "+0,000...", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 100_000, prefix: .plus, format: .abbreviated, most: "+0,001", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 25_793_456, prefix: .plus, format: .abbreviated, most: "+0,258", least: ""),
+    // Prefix Plus — Expanded
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 0, prefix: .plus, format: .expanded, most: "+0,000", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 99_000, prefix: .plus, format: .expanded, most: "+0,000", least: "99"),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 100_000, prefix: .plus, format: .expanded, most: "+0,001", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 25_793_456, prefix: .plus, format: .expanded, most: "+0,257", least: "93456"),
+    // Prefix Minus — Abbreviated
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 0, prefix: .minus, format: .abbreviated, most: "-0,000", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 99_000, prefix: .minus, format: .abbreviated, most: "-0,000...", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 100_000, prefix: .minus, format: .abbreviated, most: "-0,001", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 25_793_456, prefix: .minus, format: .abbreviated, most: "-0,258", least: ""),
+    // Prefix Minus — Expanded
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 0, prefix: .minus, format: .expanded, most: "-0,000", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 99_000, prefix: .minus, format: .expanded, most: "-0,000", least: "99"),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 100_000, prefix: .minus, format: .expanded, most: "-0,001", least: ""),
+    ZatoshiStringRepresentationCommaTests.Sample(zatoshi: 25_793_456, prefix: .minus, format: .expanded, most: "-0,257", least: "93456")
+]

--- a/zodlTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationTests.swift
+++ b/zodlTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationTests.swift
@@ -5,200 +5,74 @@
 //  Created by Lukáš Korba on 17.11.2023.
 //
 
-import XCTest
+import Testing
+import Foundation
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-final class ZatoshiStringRepresentationTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        
-        let zashiBalanceFormatter = NumberFormatter.zashiBalanceFormatter
-        zashiBalanceFormatter.locale = Locale(identifier: "en_US")
-        
-        let zashiNumberFormatter = NumberFormatter.zcashNumberFormatter8FractionDigits
-        zashiNumberFormatter.locale = Locale(identifier: "en_US")
-    }
-    
-    // MARK: - Fee Format
-    
-    func testFeeFormat() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.feeFormat, "Typical Fee < 0.001")
+@Suite struct ZatoshiStringRepresentationTests {
+    // Only value types (Int64 / simple app enums / String), so it is safe to treat as Sendable.
+    struct Sample: @unchecked Sendable {
+        let zatoshi: Int64
+        let prefix: ZatoshiStringRepresentation.PrefixSymbol
+        let format: ZatoshiStringRepresentation.Format
+        let most: String
+        let least: String
     }
 
-    // MARK: - Prefix None
-    
-    func testPrefixNone_Abbreviated_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
+    @Test(arguments: enUSZatoshiSamples)
+    func significantDigits(_ sample: Sample) {
+        let repr = FormatterTestGate.shared.withLockUnchecked {
+            NumberFormatter.zashiBalanceFormatter.locale = Locale(identifier: "en_US")
+            NumberFormatter.zcashNumberFormatter8FractionDigits.locale = Locale(identifier: "en_US")
+            return ZatoshiStringRepresentation(Zatoshi(sample.zatoshi), prefixSymbol: sample.prefix, format: sample.format)
+        }
+
+        #expect(repr.mostSignificantDigits == sample.most)
+        #expect(repr.leastSignificantDigits == sample.least)
     }
 
-    func testPrefixNone_Abbreviated_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0.000...")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
+    @Test func feeFormat() {
+        let repr = FormatterTestGate.shared.withLockUnchecked { () -> ZatoshiStringRepresentation in
+            NumberFormatter.zashiBalanceFormatter.locale = Locale(identifier: "en_US")
+            NumberFormatter.zcashNumberFormatter8FractionDigits.locale = Locale(identifier: "en_US")
+            return ZatoshiStringRepresentation(Zatoshi(0))
+        }
 
-    func testPrefixNone_Abbreviated_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0.001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixNone_Abbreviated_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456))
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0.258")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-    
-    func testPrefixNone_Expanded_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixNone_Expanded_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "99")
-    }
-
-    func testPrefixNone_Expanded_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0.001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixNone_Expanded_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "0.257")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "93456")
-    }
-    
-    // MARK: - Prefix Plus
-    
-    func testPrefixPlus_Abbreviated_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), prefixSymbol: .plus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Abbreviated_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), prefixSymbol: .plus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0.000...")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Abbreviated_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), prefixSymbol: .plus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0.001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Abbreviated_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), prefixSymbol: .plus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0.258")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-    
-    func testPrefixPlus_Expanded_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), prefixSymbol: .plus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Expanded_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), prefixSymbol: .plus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "99")
-    }
-
-    func testPrefixPlus_Expanded_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), prefixSymbol: .plus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0.001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixPlus_Expanded_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), prefixSymbol: .plus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "+0.257")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "93456")
-    }
-    
-    // MARK: - Prefix Minus
-    
-    func testPrefixMinus_Abbreviated_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), prefixSymbol: .minus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Abbreviated_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), prefixSymbol: .minus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0.000...")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Abbreviated_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), prefixSymbol: .minus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0.001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Abbreviated_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), prefixSymbol: .minus)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0.258")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-    
-    func testPrefixMinus_Expanded_ZeroZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(0), prefixSymbol: .minus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Expanded_LessThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(99_000), prefixSymbol: .minus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0.000")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "99")
-    }
-
-    func testPrefixMinus_Expanded_100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(100_000), prefixSymbol: .minus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0.001")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "")
-    }
-
-    func testPrefixMinus_Expanded_MoreThan100kZatoshi() throws {
-        let zatoshiStringRepresentation = ZatoshiStringRepresentation(Zatoshi(25_793_456), prefixSymbol: .minus, format: .expanded)
-        
-        XCTAssertEqual(zatoshiStringRepresentation.mostSignificantDigits, "-0.257")
-        XCTAssertEqual(zatoshiStringRepresentation.leastSignificantDigits, "93456")
+        #expect(repr.feeFormat == "Typical Fee < 0.001")
     }
 }
+
+// en_US locale: the original 24 `testPrefix*` methods, one row each.
+private let enUSZatoshiSamples: [ZatoshiStringRepresentationTests.Sample] = [
+    // Prefix None — Abbreviated
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 0, prefix: .none, format: .abbreviated, most: "0.000", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 99_000, prefix: .none, format: .abbreviated, most: "0.000...", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 100_000, prefix: .none, format: .abbreviated, most: "0.001", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 25_793_456, prefix: .none, format: .abbreviated, most: "0.258", least: ""),
+    // Prefix None — Expanded
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 0, prefix: .none, format: .expanded, most: "0.000", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 99_000, prefix: .none, format: .expanded, most: "0.000", least: "99"),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 100_000, prefix: .none, format: .expanded, most: "0.001", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 25_793_456, prefix: .none, format: .expanded, most: "0.257", least: "93456"),
+    // Prefix Plus — Abbreviated
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 0, prefix: .plus, format: .abbreviated, most: "+0.000", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 99_000, prefix: .plus, format: .abbreviated, most: "+0.000...", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 100_000, prefix: .plus, format: .abbreviated, most: "+0.001", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 25_793_456, prefix: .plus, format: .abbreviated, most: "+0.258", least: ""),
+    // Prefix Plus — Expanded
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 0, prefix: .plus, format: .expanded, most: "+0.000", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 99_000, prefix: .plus, format: .expanded, most: "+0.000", least: "99"),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 100_000, prefix: .plus, format: .expanded, most: "+0.001", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 25_793_456, prefix: .plus, format: .expanded, most: "+0.257", least: "93456"),
+    // Prefix Minus — Abbreviated
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 0, prefix: .minus, format: .abbreviated, most: "-0.000", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 99_000, prefix: .minus, format: .abbreviated, most: "-0.000...", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 100_000, prefix: .minus, format: .abbreviated, most: "-0.001", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 25_793_456, prefix: .minus, format: .abbreviated, most: "-0.258", least: ""),
+    // Prefix Minus — Expanded
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 0, prefix: .minus, format: .expanded, most: "-0.000", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 99_000, prefix: .minus, format: .expanded, most: "-0.000", least: "99"),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 100_000, prefix: .minus, format: .expanded, most: "-0.001", least: ""),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 25_793_456, prefix: .minus, format: .expanded, most: "-0.257", least: "93456")
+]


### PR DESCRIPTION
Rewrites all 28 test files in `zodlTests/` from XCTest to Apple's **Swift Testing** framework (`@Suite` / `@Test` / `#expect` / `#require`), and documents the new convention in `CLAUDE.md`.

## What changed
- **All 28 files** converted to Swift Testing — `0` files still import `XCTest`. The 34 former `XCTestCase` classes are now `@Suite` structs.
- **Mechanical mapping:** `XCTAssertEqual`→`#expect(==)`, `XCTUnwrap`→`#require`, `XCTFail`→`Issue.record`, `XCTAssertThrowsError`→`#expect(throws:)` (capturing the error where associated values are asserted), accuracy asserts → `abs(diff) <= tolerance`, the one `XCTSkip` fixture → `#require`. `setUp`→`init`; the lone `tearDown` suite (`UserPreferencesStorage`) becomes a `final class` with `deinit`.
- **Hybrid parametrization:** the table-style suites become `@Test(arguments:)` — `ZatoshiStringRepresentation` (en_US + cs_CZ) and the `CurrencyConversion` convert groups. Test-case coverage is unchanged.
- **CLAUDE.md:** the Tests section now requires Swift Testing for every new test, fixes the stale `secantTests`→`zodlTests` target name, and notes the parallel-execution gotcha.

## Parallelism isolation
Swift Testing runs suites (and parametrized cases) **in parallel by default**, unlike XCTest's serial execution. Suites touching process-global state are serialized:
- `@Suite(.serialized)`: `UserPreferencesStorage` & `DecommissionedServerMigration` (named `UserDefaults` suites), `Logger` (OSLog store), `TransactionGuard` (shared `TransactionGuardClient.liveValue`), `VotingCoordFlowCoordinator` (TCA `@Shared` state).
- A shared `OSAllocatedUnfairLock` (`FormatterTestGate`, in `ZatoshiTests`) serializes the global `NumberFormatter` locale so the en_US/cs_CZ Zatoshi suites never overlap.
- Added explicit `import Foundation` where `import XCTest` previously provided it transitively.

## Verification
`RunAllTests` on scheme `zodl-internal` (Xcode 26.5 / Swift 6.3): **312 tests, 0 failures** — matching the pre-migration baseline, confirmed across multiple consecutive runs (no parallelism flakiness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)