### PR TITLE
[MOB-1324] Add Tor enabled flag to support data

### DIFF
--- a/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGenerator.swift
+++ b/secant/Sources/Dependencies/SupportDataGenerator/SupportDataGenerator.swift
@@ -6,6 +6,7 @@
 //
 
 @preconcurrency import AVFoundation
+import ComposableArchitecture
 import Foundation
 import LocalAuthentication
 import UIKit
@@ -31,6 +32,7 @@ enum SupportDataGenerator {
             DeviceModelItem(),
             LocaleItem(),
             FreeDiskSpaceItem(),
+            TorItem(),
             PermissionsItems()
         ]
 
@@ -182,6 +184,22 @@ private struct FreeDiskSpaceItem: SupportDataGeneratorItem {
         }
 
         return [(Constants.freeDiskSpaceKey, freeDiskSpace)]
+    }
+}
+
+private struct TorItem: SupportDataGeneratorItem {
+    private enum Constants {
+        static let torKey = "Tor enabled"
+        static let yesText = "Yes"
+        static let noText = "No"
+    }
+
+    func generate() -> [(String, String)] {
+        @Dependency(\.walletStorage) var walletStorage
+
+        let torEnabled = walletStorage.exportTorSetupFlag() ?? false
+
+        return [(Constants.torKey, torEnabled ? Constants.yesText : Constants.noText)]
     }
 }
 


### PR DESCRIPTION
## Summary

Adds whether **Tor Protection** is enabled to the auto-generated support data that gets attached to feedback / bug-report emails.

A new `TorItem` is added to `SupportDataGenerator.generate()`, reading the persisted setting via `@Dependency(\.walletStorage).exportTorSetupFlag()` — the same source of truth that `TorSetup` writes to. It emits a single line:

```
Tor enabled: Yes
```

(or `No` when disabled / unset).

Because the item lives inside `SupportDataGenerator.generate()`, it automatically flows into every consumer of the support data — `SendFeedback`, plus `TransactionDetails`, `ResyncWallet`, `DisconnectHWWallet`, `OSStatusError`, `SmartBanner`, etc.

The text is intentionally **not localized** — support data is a payload the team reads, so it stays in plain English (label `Tor enabled`, value `Yes`/`No`).

## Notes

- Uses the user-facing **setting** (`exportTorSetupFlag`) rather than the SDK's live runtime Tor status, which reflects what the user chose in Advanced Settings — usually what's wanted in a bug report.

## Testing

- Built `secant.xcodeproj` successfully via Xcode (no errors).
- No existing tests cover `SupportDataGenerator`, so none needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)