### PR TITLE
[PRO-334] Fail pending sent tx when chain tip is past its expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Added
 - Server selection now offers an Automatic mode that benchmarks known servers and keeps your wallet on the fastest one; Manual mode still lets you pin a specific server. Automatic switching is paused while sending, swapping, shielding, or voting.
 
+### Fixed
+- A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
+
+### Fixed
+- A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
+
 ## 3.5.2 build 1 (20026-06-08)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Fixed
 - A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
 
-### Fixed
-- A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
-
 ## 3.5.2 build 1 (20026-06-08)
 
 ### Changed

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -352,8 +352,14 @@ extension SDKSynchronizerClient {
         let clearedTransactions = zcashTransactions.compactMap { rawTransaction in
             rawTransaction.accountUUID == accountUUID ? rawTransaction : nil
         }
-        
+
         var clearedTxs: [TransactionState] = []
+        // Snapshot the chain tip once so TransactionState can fall back to an expiry-vs-tip
+        // check when the SDK's `expired_unmined` column hasn't caught up (post-hardfork case
+        // tracked in PRO-334). `latestBlockHeight == 0` means we haven't synced yet, so
+        // hand nil to the init in that case to disable the fallback.
+        let tipNow = synchronizer.latestState.latestBlockHeight
+        let currentChainTip: BlockHeight? = tipNow > 0 ? tipNow : nil
 
         for clearedTransaction in clearedTransactions {
             var hasTransparentOutputs = false
@@ -368,7 +374,8 @@ extension SDKSynchronizerClient {
             var transaction = TransactionState.init(
                 transaction: clearedTransaction,
                 memos: nil,
-                hasTransparentOutputs: hasTransparentOutputs
+                hasTransparentOutputs: hasTransparentOutputs,
+                currentChainTip: currentChainTip
             )
 
             let recipients = await synchronizer.getRecipients(for: clearedTransaction)

--- a/secant/Sources/Models/TransactionState.swift
+++ b/secant/Sources/Models/TransactionState.swift
@@ -382,7 +382,8 @@ extension TransactionState {
     init(
         transaction: ZcashTransaction.Overview,
         memos: [Memo]? = nil,
-        hasTransparentOutputs: Bool = false
+        hasTransparentOutputs: Bool = false,
+        currentChainTip: BlockHeight? = nil
     ) {
         expiryHeight = transaction.expiryHeight
         minedHeight = transaction.minedHeight
@@ -397,9 +398,22 @@ extension TransactionState {
         memoCount = transaction.memoCount
         totalSpent = transaction.totalSpent
         totalReceived = transaction.totalReceived
-        
+
         let isPending = isSentTransaction ? minedHeight == nil : transaction.state == .pending
-        let isExpired = transaction.state == .expired
+        // The SDK marks `transaction.state == .expired` only when its Rust-side `expired_unmined`
+        // column has been flipped to true. Across a hardfork that column doesn't reliably update
+        // for txs that were pending at the time of the fork: the user sees their stuck send as
+        // "Sending" indefinitely. Cross-check expiry against the current chain tip so we mark
+        // such a tx failed even when the SDK column hasn't caught up.
+        let chainTipPastExpiry: Bool = {
+            guard isSentTransaction,
+                  minedHeight == nil,
+                  let expiry = transaction.expiryHeight, expiry > 0,
+                  let tip = currentChainTip
+            else { return false }
+            return tip >= expiry
+        }()
+        let isExpired = transaction.state == .expired || chainTipPastExpiry
         
         // failed check
         if isExpired {

--- a/secant/Sources/Models/TransactionState.swift
+++ b/secant/Sources/Models/TransactionState.swift
@@ -400,19 +400,18 @@ extension TransactionState {
         totalReceived = transaction.totalReceived
 
         let isPending = isSentTransaction ? minedHeight == nil : transaction.state == .pending
-        // The SDK marks `transaction.state == .expired` only when its Rust-side `expired_unmined`
-        // column has been flipped to true. Across a hardfork that column doesn't reliably update
-        // for txs that were pending at the time of the fork: the user sees their stuck send as
-        // "Sending" indefinitely. Cross-check expiry against the current chain tip so we mark
-        // such a tx failed even when the SDK column hasn't caught up.
-        let chainTipPastExpiry: Bool = {
-            guard isSentTransaction,
-                  minedHeight == nil,
-                  let expiry = transaction.expiryHeight, expiry > 0,
-                  let tip = currentChainTip
-            else { return false }
-            return tip >= expiry
-        }()
+        // Fallback for when the SDK's `expired_unmined` column lags (e.g. an unmined sent tx
+        // that was pending across a consensus-rule change keeps reporting `.pending` indefinitely).
+        let chainTipPastExpiry: Bool
+        if isSentTransaction,
+           minedHeight == nil,
+           let expiry = transaction.expiryHeight, expiry > 0,
+           let tip = currentChainTip,
+           tip >= expiry {
+            chainTipPastExpiry = true
+        } else {
+            chainTipPastExpiry = false
+        }
         let isExpired = transaction.state == .expired || chainTipPastExpiry
         
         // failed check


### PR DESCRIPTION
## What

Stops the wallet from rendering an unminable sent tx as "Sending"
indefinitely once the chain tip has passed its `expiry_height`.

Adds a `currentChainTip` parameter to `TransactionState.init` and, when
both that parameter and the tx's `expiry_height` are known, treats an
unmined sent tx as failed when `chainTip >= expiry`. The single call
site in `SDKSynchronizerLive` is updated to pass
`synchronizer.latestState.latestBlockHeight` (or `nil` when the wallet
hasn't synced yet, preserving the original behaviour during fresh
launch).

## Why

Reported in [PRO-334]. Repro:

1. User sends a tx on a pre-HF version of the app (e.g. v3.4.1)
2. Tx broadcasts but is never mined — the upcoming consensus rule
   change makes it permanently unminable
3. User updates the app to a post-HF version (e.g. v3.5.3)
4. The Activity list keeps showing the tx as "Sending" forever

Root cause is upstream in the SDK: `Overview.State.init` only returns
`.expired` when its `expired_unmined` column has been flipped, and that
column doesn't reliably catch up for txs that were unmined when the
wallet migrated across a consensus-rule change. The SDK fix is filed in
[zcash/zcash-swift-wallet-sdk#1756]; this PR is the immediate user-
facing fix, scoped so it can ship before the SDK release cycle.

## Safety

- Funds are not at risk either way: the signed tx bytes are bound to
  the old consensus branch, no validator post-HF will accept them, and
  the SDK's `TxResubmissionAction` already refuses to resubmit
  (`expiry > tip` filter)
- The fallback only fires for sent txs with `minedHeight == nil` AND a
  known `currentChainTip` AND a known `expiry > 0` AND `tip >= expiry`.
  Each condition matches reality before we flip the status
- `currentChainTip` is `nil` during pre-sync, so a freshly-launched
  wallet keeps the current "render as Sending until we know better"
  behaviour

## Once the SDK fix lands

The SDK PR makes `Overview.State` itself return `.expired` in this case,
which means `transaction.state == .expired` will be true on its own and
this fallback becomes redundant (but harmless). We can revert it then
or leave the defence-in-depth.