### PR TITLE
[MOB-1368] Delete tax CSV export from temp storage after sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Fixed
 - A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
 - Opening the Recovery Phrase from Advanced Settings now always requires Face ID / Touch ID, and the seed words are only loaded and rendered after a successful authentication.
+- The tax CSV export is now written to a protected location and deleted as soon as the share sheet closes, instead of remaining in temporary storage.
 
 ### Removed
 - A hidden legacy debug menu (reachable via a gesture on the splash screen) that could copy the seed phrase to the clipboard without Face ID / Touch ID.

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -1432,6 +1432,7 @@
 		37D0F0000000000000000024 /* RoundAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0F0000000000000000002 /* RoundAuthenticator.swift */; };
 		38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E83225E24EEF486F002B79 /* RecoveryPhraseBackupTests.swift */; };
+		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
 		63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D430BF2CF73CFB82A13F1CB /* SecItemClientTests.swift */; };
 		7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */; };
 		8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1983F0BB6D025B08BBD186B /* QRCodeGeneratorTests.swift */; };
@@ -1625,6 +1626,7 @@
 		349CE5E92FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiServerSubmitRoutingTests.swift; sourceTree = "<group>"; };
 		349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseDisplayTests.swift; sourceTree = "<group>"; };
 		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
+		349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTransactionHistoryTests.swift; sourceTree = "<group>"; };
 		34AA6BA42F85774F00D244E2 /* ABv1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABv1.swift; sourceTree = "<group>"; };
 		34AA6BA62F85774F00D244E2 /* AddressBookContacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookContacts.swift; sourceTree = "<group>"; };
 		34AA6BA72F85774F00D244E2 /* AddressBookEncryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEncryption.swift; sourceTree = "<group>"; };
@@ -2338,6 +2340,7 @@
 				9E139AAD2B07B39700D104B8 /* ZatoshiStringRepresentation */,
 				349CE5D42FDC0EDF00E2B9CF /* SendTests */,
 				349CE6582FDC358500E2B9CF /* SettingsTests */,
+				349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2426,6 +2429,14 @@
 				349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */,
 			);
 			path = SettingsTests;
+			sourceTree = "<group>";
+		};
+		349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */ = {
+			isa = PBXGroup;
+			children = (
+				349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */,
+			);
+			path = ExportTransactionHistoryTests;
 			sourceTree = "<group>";
 		};
 		34AA6BA52F85774F00D244E2 /* Migration */ = {
@@ -5085,6 +5096,7 @@
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
 				54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */,
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
+				349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */,
 				7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */,
 				DB87FBCDB6C1FC4EA9311A26 /* DeeplinkURLParsingTests.swift in Sources */,
 				051F035A06D6092E00704BAB /* HomeTests.swift in Sources */,

--- a/secant/Sources/Dependencies/TaxExporter/TaxExporterInterface.swift
+++ b/secant/Sources/Dependencies/TaxExporter/TaxExporterInterface.swift
@@ -18,4 +18,7 @@ extension DependencyValues {
 @DependencyClient
 struct TaxExporterClient {
     var cointrackerCSVfor: @Sendable ([TransactionState], String) throws -> URL
+    /// Removes all CSV exports from the temporary directory. Call it once the share
+    /// sheet is closed so transaction history never outlives the share flow on disk.
+    var cleanupExports: @Sendable () throws -> Void
 }

--- a/secant/Sources/Dependencies/TaxExporter/TaxExporterLiveKey.swift
+++ b/secant/Sources/Dependencies/TaxExporter/TaxExporterLiveKey.swift
@@ -89,17 +89,43 @@ extension TaxExporterClient: DependencyKey {
 
                 let csvData = csvString.data(using: .utf8) ?? Data()
 
-                // Create a temporary file URL
+                // Purge exports left behind by previous runs (e.g. when the app was
+                // killed while the share sheet was open), then write the new CSV into
+                // a unique, file-protected directory.
+                try? FileManager.default.removeItem(at: exportsRootURL())
+
+                let exportDirectory = exportsRootURL().appendingPathComponent(UUID().uuidString, isDirectory: true)
+                try FileManager.default.createDirectory(
+                    at: exportDirectory,
+                    withIntermediateDirectories: true,
+                    attributes: [.protectionKey: FileProtectionType.complete]
+                )
+
                 let component = String(localizable: .taxExportFileName($1, String(prevYear)))
-                let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(component)
+                let tempURL = exportDirectory.appendingPathComponent(component)
 
                 do {
-                    try csvData.write(to: tempURL)
+                    try csvData.write(to: tempURL, options: [.completeFileProtection])
                     return tempURL
                 } catch {
+                    try? FileManager.default.removeItem(at: exportDirectory)
                     throw error
                 }
+            },
+            cleanupExports: {
+                let rootURL = exportsRootURL()
+
+                guard FileManager.default.fileExists(atPath: rootURL.path) else {
+                    return
+                }
+
+                try FileManager.default.removeItem(at: rootURL)
             }
         )
+    }
+
+    /// All tax CSV exports live under this directory so they can be removed wholesale.
+    private static func exportsRootURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("tax-exports", isDirectory: true)
     }
 }

--- a/secant/Sources/Features/ExportTransactionHistory/ExportTransactionHistoryStore.swift
+++ b/secant/Sources/Features/ExportTransactionHistory/ExportTransactionHistoryStore.swift
@@ -35,6 +35,7 @@ struct ExportTransactionHistory {
         case exportRequested
         case preparationOfUrlsFailed
         case shareFinished
+        case shareSheetClosed
         case urlsPrepared(URL)
     }
 
@@ -70,6 +71,13 @@ struct ExportTransactionHistory {
             case .shareFinished:
                 state.isExportingData = false
                 state.exportBinding = false
+                return .none
+
+            case .shareSheetClosed:
+                // The share sheet is gone (shared or cancelled), the CSV with the
+                // transaction history must not stay behind in the temp directory.
+                state.dataURL = .emptyURL
+                try? taxExporter.cleanupExports()
                 return .none
             }
         }

--- a/secant/Sources/Features/ExportTransactionHistory/ExportTransactionHistoryView.swift
+++ b/secant/Sources/Features/ExportTransactionHistory/ExportTransactionHistoryView.swift
@@ -59,15 +59,21 @@ struct ExportTransactionHistoryView: View {
 private extension ExportTransactionHistoryView {
     @ViewBuilder func shareLogsView() -> some View {
         if store.exportBinding {
-            UIShareDialogView(activityItems:
-                [ShareableURL(
-                    url: store.dataURL,
-                    title: String(localizable: .taxExportTaxFile),
-                    desc: String(localizable: .taxExportShareDesc(store.accountName))
-                )]
-            ) {
-                store.send(.shareFinished)
-            }
+            UIShareDialogView(
+                activityItems: [
+                    ShareableURL(
+                        url: store.dataURL,
+                        title: String(localizable: .taxExportTaxFile),
+                        desc: String(localizable: .taxExportShareDesc(store.accountName))
+                    )
+                ],
+                completion: {
+                    store.send(.shareFinished)
+                },
+                onDismiss: {
+                    store.send(.shareSheetClosed)
+                }
+            )
             // UIShareDialogView only wraps UIActivityViewController presentation
             // so frame is set to 0 to not break SwiftUI's layout
             .frame(width: 0, height: 0)

--- a/secant/Sources/UIComponents/UIKitBridge/UIShareDialog.swift
+++ b/secant/Sources/UIComponents/UIKitBridge/UIShareDialog.swift
@@ -139,10 +139,16 @@ class UIShareDialog: UIView {
 }
 
 extension UIShareDialog {
-    func doInitialSetup(activityItems: [Any], completion: @escaping () -> Void) {
+    func doInitialSetup(activityItems: [Any], completion: @escaping () -> Void, onDismiss: (() -> Void)? = nil) {
         DispatchQueue.main.async {
             let activityVC = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-            
+
+            if let onDismiss {
+                activityVC.completionWithItemsHandler = { _, _, _, _ in
+                    onDismiss()
+                }
+            }
+
             UIApplication.shared.connectedScenes.map({ $0 as? UIWindowScene })
             .compactMap({ $0 })
             .first?.windows.first?.rootViewController?.present(
@@ -156,16 +162,22 @@ extension UIShareDialog {
 
 struct UIShareDialogView: UIViewRepresentable {
     let activityItems: [Any]
+    /// Called when the share sheet finished presenting. Use it to reset the binding
+    /// that triggered the presentation.
     let completion: () -> Void
+    /// Called when the share sheet is closed, both on completed share and on cancel.
+    /// Use it to clean up shared artifacts (e.g. temporary files).
+    let onDismiss: (() -> Void)?
 
-    init(activityItems: [Any], completion: @escaping () -> Void) {
+    init(activityItems: [Any], completion: @escaping () -> Void, onDismiss: (() -> Void)? = nil) {
         self.activityItems = activityItems
         self.completion = completion
+        self.onDismiss = onDismiss
     }
-    
+
     func makeUIView(context: UIViewRepresentableContext<UIShareDialogView>) -> UIShareDialog {
         let view = UIShareDialog()
-        view.doInitialSetup(activityItems: activityItems, completion: completion)
+        view.doInitialSetup(activityItems: activityItems, completion: completion, onDismiss: onDismiss)
         return view
     }
     

--- a/zodlTests/ExportTransactionHistoryTests/ExportTransactionHistoryTests.swift
+++ b/zodlTests/ExportTransactionHistoryTests/ExportTransactionHistoryTests.swift
@@ -1,0 +1,74 @@
+//
+//  ExportTransactionHistoryTests.swift
+//  zodlTests
+//
+//  Created by Michal Fousek on 12.06.2026.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+
+/// Covers MOB-1368: the tax CSV export is written into a unique, file-protected
+/// temporary directory and removed again once the share sheet is closed.
+///
+/// Serialized because the live exporter tests share the same on-disk
+/// `tmp/tax-exports` directory.
+@Suite(.serialized) struct ExportTransactionHistoryTests {
+    @MainActor @Test func shareSheetClosedRemovesExportAndResetsURL() async throws {
+        let cleanupCalled = LockIsolated(false)
+
+        var initialState = ExportTransactionHistory.State()
+        initialState.dataURL = URL(fileURLWithPath: "/tmp/tax-exports/some/export.csv")
+
+        let store = TestStore(
+            initialState: initialState
+        ) {
+            ExportTransactionHistory()
+        } withDependencies: {
+            $0.taxExporter.cleanupExports = { cleanupCalled.setValue(true) }
+        }
+
+        await store.send(.shareSheetClosed) {
+            $0.dataURL = .emptyURL
+        }
+
+        await store.finish()
+
+        #expect(cleanupCalled.value)
+    }
+
+    @Test func liveExporterWritesEachExportIntoUniqueDirectory() throws {
+        let exporter = TaxExporterClient.liveValue
+
+        let firstURL = try exporter.cointrackerCSVfor([], "Zashi")
+        #expect(FileManager.default.fileExists(atPath: firstURL.path))
+
+        let secondURL = try exporter.cointrackerCSVfor([], "Zashi")
+        #expect(FileManager.default.fileExists(atPath: secondURL.path))
+
+        // Unique directory per export and stale exports purged by the next one.
+        #expect(firstURL != secondURL)
+        #expect(firstURL.deletingLastPathComponent() != secondURL.deletingLastPathComponent())
+        #expect(!FileManager.default.fileExists(atPath: firstURL.path))
+
+        try exporter.cleanupExports()
+    }
+
+    @Test func liveExporterCleanupRemovesAllExports() throws {
+        let exporter = TaxExporterClient.liveValue
+
+        let exportURL = try exporter.cointrackerCSVfor([], "Zashi")
+        #expect(FileManager.default.fileExists(atPath: exportURL.path))
+
+        try exporter.cleanupExports()
+
+        #expect(!FileManager.default.fileExists(atPath: exportURL.path))
+        let exportsRoot = FileManager.default.temporaryDirectory.appendingPathComponent("tax-exports", isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: exportsRoot.path))
+
+        // Cleanup with nothing to remove must not throw.
+        try exporter.cleanupExports()
+    }
+}


### PR DESCRIPTION
## Linear

[MOB-1368 — [Security] Tax CSV export remains in the app temp directory after sharing](https://linear.app/zodl/issue/MOB-1368/security-tax-csv-export-remains-in-the-app-temp-directory-after) (sub-issue of MOB-1276, finding ZODL-IOS-08)

## Problem

`TaxExporterClient` serialized the transaction history CSV to a **fixed, predictable path** directly in the app temporary directory, with no file-protection class. The export reducer kept the URL in state and never deleted the file — the share sheet closing only reset UI flags. Transaction-history CSVs (dates, amounts, fees, account context) persisted in temp storage indefinitely.

A second subtlety: `UIShareDialogView`'s `completion` fires when the sheet finishes *presenting* (it's the `present(animated:completion:)` callback), so there was no hook at all for "user finished/cancelled sharing".

## Fix

- Each export is written to a unique `tmp/tax-exports/<UUID>/` directory created with `FileProtectionType.complete`; the CSV itself is written with `.completeFileProtection`.
- `UIShareDialogView` gained an optional `onDismiss` callback wired to `UIActivityViewController.completionWithItemsHandler`, which fires on **both** completed share and cancel. All other call sites are untouched (parameter defaults to `nil`).
- The export screen sends a new `.shareSheetClosed` action from that hook; the reducer clears `dataURL` and calls the new `taxExporter.cleanupExports()`, which removes the whole `tax-exports` directory.
- Each new export first purges stale exports from previous runs, covering the app-killed-while-sheet-open case.

## Verification

- ✅ Build succeeds (zodl-internal scheme)
- ✅ Full suite passes (315 tests), incl. 3 new `ExportTransactionHistoryTests`: cleanup on share-sheet close, unique per-export directory + stale purge, idempotent `cleanupExports`

## Manual testing steps

> Tip: to inspect the app's tmp directory on Simulator, run the app, then `xcrun simctl get_app_container booted co.electriccoin.zcash data` (adjust bundle id for the installed variant) and look into `tmp/`.

1. **Export + complete share:** Settings → Advanced Settings → Export tax file (pass Face ID) → Download → share sheet opens → pick *Save to Files* and save. **Expected:** the saved CSV opens fine from Files; afterwards the app's `tmp/tax-exports` directory does **not** exist.
2. **Export + cancel:** Same flow, but dismiss the share sheet (swipe down / Cancel). **Expected:** `tmp/tax-exports` is removed right after the sheet closes.
3. **Share still works while sheet open:** With the sheet open, wait a few seconds, then choose AirDrop or Save to Files. **Expected:** sharing succeeds (file is only deleted when the sheet closes, not when it appears).
4. **Stale cleanup:** Start an export, and while the share sheet is open force-kill the app (the CSV stays behind — pre-existing behavior on kill). Relaunch, run another export. **Expected:** after the new export, only the new `<UUID>` directory exists under `tmp/tax-exports`, the stale one is gone; and after closing the sheet, everything is gone.
5. **Repeat exports:** Run Download twice in a row in the same session. **Expected:** second export works, share sheet shows the CSV, no accumulation of old files.
6. **Regression — other share dialogs:** Test a couple of other share flows (e.g. Receive → share address, Transaction details → share, Send feedback → share). **Expected:** they behave exactly as before (the `onDismiss` hook is opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)