### PR TITLE
[MOB-1367] Remove support-log export staging files and ZIP from temp storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
 - Opening the Recovery Phrase from Advanced Settings now always requires Face ID / Touch ID, and the seed words are only loaded and rendered after a successful authentication.
 - The tax CSV export is now written to a protected location and deleted as soon as the share sheet closes, instead of remaining in temporary storage.
+- Exported support logs no longer leave plaintext files behind: staging files are removed right after the ZIP is built and the ZIP is deleted when the share sheet closes.
 
 ### Removed
 - A hidden legacy debug menu (reachable via a gesture on the splash screen) that could copy the seed phrase to the clipboard without Face ID / Touch ID.

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -1433,6 +1433,7 @@
 		38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E83225E24EEF486F002B79 /* RecoveryPhraseBackupTests.swift */; };
 		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
+		349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */; };
 		63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D430BF2CF73CFB82A13F1CB /* SecItemClientTests.swift */; };
 		7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */; };
 		8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1983F0BB6D025B08BBD186B /* QRCodeGeneratorTests.swift */; };
@@ -1627,6 +1628,7 @@
 		349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseDisplayTests.swift; sourceTree = "<group>"; };
 		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
 		349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTransactionHistoryTests.swift; sourceTree = "<group>"; };
+		349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportLogsTests.swift; sourceTree = "<group>"; };
 		34AA6BA42F85774F00D244E2 /* ABv1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABv1.swift; sourceTree = "<group>"; };
 		34AA6BA62F85774F00D244E2 /* AddressBookContacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookContacts.swift; sourceTree = "<group>"; };
 		34AA6BA72F85774F00D244E2 /* AddressBookEncryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEncryption.swift; sourceTree = "<group>"; };
@@ -2341,6 +2343,7 @@
 				349CE5D42FDC0EDF00E2B9CF /* SendTests */,
 				349CE6582FDC358500E2B9CF /* SettingsTests */,
 				349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */,
+				349CE6182FDC1B1500E2B9CF /* ExportLogsTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2437,6 +2440,14 @@
 				349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */,
 			);
 			path = ExportTransactionHistoryTests;
+			sourceTree = "<group>";
+		};
+		349CE6182FDC1B1500E2B9CF /* ExportLogsTests */ = {
+			isa = PBXGroup;
+			children = (
+				349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */,
+			);
+			path = ExportLogsTests;
 			sourceTree = "<group>";
 		};
 		34AA6BA52F85774F00D244E2 /* Migration */ = {
@@ -5097,6 +5108,7 @@
 				54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */,
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
 				349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */,
+				349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */,
 				7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */,
 				DB87FBCDB6C1FC4EA9311A26 /* DeeplinkURLParsingTests.swift in Sources */,
 				051F035A06D6092E00704BAB /* HomeTests.swift in Sources */,

--- a/secant/Sources/Dependencies/LogsHandler/LogsHandlerInterface.swift
+++ b/secant/Sources/Dependencies/LogsHandler/LogsHandlerInterface.swift
@@ -18,4 +18,8 @@ extension DependencyValues {
 @DependencyClient
 struct LogsHandlerClient {
     var exportAndStoreLogs: @Sendable (String, String, String) async throws -> URL?
+    /// Removes all log-export artifacts (ZIPs and any staging files) from the
+    /// temporary directory. Call it once the share sheet is closed so exported
+    /// logs never outlive the share flow on disk.
+    var cleanupExports: @Sendable () throws -> Void
 }

--- a/secant/Sources/Dependencies/LogsHandler/LogsHandlerLive.swift
+++ b/secant/Sources/Dependencies/LogsHandler/LogsHandlerLive.swift
@@ -15,9 +15,25 @@ extension LogsHandlerClient: DependencyKey {
     static func live() -> Self {
         Self(
             exportAndStoreLogs: { sdkLogs, tcaLogs, walletLogs in
-                // create a directory
-                let logsURL = FileManager.default.temporaryDirectory.appendingPathComponent("zashiPrivateData")
-                try FileManager.default.createDirectory(atPath: logsURL.path, withIntermediateDirectories: true)
+                // Purge artifacts left behind by previous exports (e.g. when the app
+                // was killed while the share sheet was open), then stage this export
+                // in a unique, file-protected directory.
+                try? FileManager.default.removeItem(at: exportsRootURL())
+                try? FileManager.default.removeItem(at: legacyStagingURL())
+
+                let exportDirectory = exportsRootURL().appendingPathComponent(UUID().uuidString, isDirectory: true)
+                // The staging directory name defines the folder name inside the produced ZIP.
+                let logsURL = exportDirectory.appendingPathComponent("zashiPrivateData", isDirectory: true)
+                try FileManager.default.createDirectory(
+                    at: logsURL,
+                    withIntermediateDirectories: true,
+                    attributes: [.protectionKey: FileProtectionType.complete]
+                )
+
+                // The plaintext staging files are only needed to build the ZIP.
+                defer {
+                    try? FileManager.default.removeItem(at: logsURL)
+                }
 
                 // export the logs
                 async let sdkLogsVerbose = LogsHandlerClient.exportAndStoreLogsFor(
@@ -42,7 +58,7 @@ extension LogsHandlerClient: DependencyKey {
 
                 // store the log files into the logs folder
                 try logs.forEach { logsHandler in
-                    try logsHandler.result.write(to: logsHandler.dir, atomically: true, encoding: String.Encoding.utf8)
+                    try Data(logsHandler.result.utf8).write(to: logsHandler.dir, options: [.completeFileProtection])
                 }
 
                 // zip the logs folder
@@ -53,14 +69,12 @@ extension LogsHandlerClient: DependencyKey {
                 archiveURL = await withCheckedContinuation { continuation in
                     coordinator.coordinate(readingItemAt: logsURL, options: [.forUploading], error: &zipError) { zipURL in
                         do {
-                            let tmpURL = try FileManager.default.url(
-                                for: .itemReplacementDirectory,
-                                in: .userDomainMask,
-                                appropriateFor: zipURL,
-                                create: true
-                            )
-                            .appendingPathComponent("zashiPrivateData.zip")
+                            let tmpURL = exportDirectory.appendingPathComponent("zashiPrivateData.zip")
                             try FileManager.default.moveItem(at: zipURL, to: tmpURL)
+                            try FileManager.default.setAttributes(
+                                [.protectionKey: FileProtectionType.complete],
+                                ofItemAtPath: tmpURL.path
+                            )
                             continuation.resume(returning: tmpURL)
                         } catch {
                             continuation.resume(returning: nil)
@@ -69,8 +83,33 @@ extension LogsHandlerClient: DependencyKey {
                 }
 
                 return archiveURL
+            },
+            cleanupExports: {
+                let rootURL = exportsRootURL()
+
+                if FileManager.default.fileExists(atPath: rootURL.path) {
+                    try FileManager.default.removeItem(at: rootURL)
+                }
+
+                // Staging directory used by previous app versions, purged here so an
+                // update cleans leftovers from before this fix.
+                let legacyURL = legacyStagingURL()
+
+                if FileManager.default.fileExists(atPath: legacyURL.path) {
+                    try FileManager.default.removeItem(at: legacyURL)
+                }
             }
         )
+    }
+
+    /// All log exports live under this directory so they can be removed wholesale.
+    private static func exportsRootURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("logs-exports", isDirectory: true)
+    }
+
+    /// Staging directory used before exports moved under `logs-exports`.
+    private static func legacyStagingURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("zashiPrivateData", isDirectory: true)
     }
 }
 

--- a/secant/Sources/Dependencies/LogsHandler/LogsHandlerTest.swift
+++ b/secant/Sources/Dependencies/LogsHandler/LogsHandlerTest.swift
@@ -10,6 +10,7 @@ import XCTestDynamicOverlay
 
 extension LogsHandlerClient {
     static let noOp = Self(
-        exportAndStoreLogs: { _, _, _ in nil }
+        exportAndStoreLogs: { _, _, _ in nil },
+        cleanupExports: { }
     )
 }

--- a/secant/Sources/Features/ExportLogs/ExportLogsStore.swift
+++ b/secant/Sources/Features/ExportLogs/ExportLogsStore.swift
@@ -36,6 +36,7 @@ struct ExportLogs {
         case finished(URL?)
         case failed(ZcashError)
         case shareFinished
+        case shareSheetClosed
     }
 
     @Dependency(\.logsHandler) var logsHandler
@@ -86,6 +87,13 @@ struct ExportLogs {
 
             case .shareFinished:
                 state.isSharingLogs = false
+                return .none
+
+            case .shareSheetClosed:
+                // The share sheet is gone (shared or cancelled), the exported logs
+                // must not stay behind in the temp directory.
+                state.zippedLogsURLs = []
+                try? logsHandler.cleanupExports()
                 return .none
             }
         }

--- a/secant/Sources/Features/PrivateDataConsent/PrivateDataConsentView.swift
+++ b/secant/Sources/Features/PrivateDataConsent/PrivateDataConsentView.swift
@@ -104,9 +104,15 @@ struct PrivateDataConsentView: View {
 private extension PrivateDataConsentView {
     @ViewBuilder func shareLogsView() -> some View {
         if store.exportBinding {
-            UIShareDialogView(activityItems: store.exportURLs) {
-                store.send(.shareFinished)
-            }
+            UIShareDialogView(
+                activityItems: store.exportURLs,
+                completion: {
+                    store.send(.shareFinished)
+                },
+                onDismiss: {
+                    store.send(.exportLogs(.shareSheetClosed))
+                }
+            )
             // UIShareDialogView only wraps UIActivityViewController presentation
             // so frame is set to 0 to not break SwiftUI's layout
             .frame(width: 0, height: 0)

--- a/secant/Sources/Features/Root/RootView.swift
+++ b/secant/Sources/Features/Root/RootView.swift
@@ -341,10 +341,14 @@ private extension RootView {
     @ViewBuilder func shareLogsView(_ store: StoreOf<Root>) -> some View {
         if store.exportLogsState.isSharingLogs {
             UIShareDialogView(
-                activityItems: store.exportLogsState.zippedLogsURLs
-            ) {
-                store.send(.exportLogs(.shareFinished))
-            }
+                activityItems: store.exportLogsState.zippedLogsURLs,
+                completion: {
+                    store.send(.exportLogs(.shareFinished))
+                },
+                onDismiss: {
+                    store.send(.exportLogs(.shareSheetClosed))
+                }
+            )
             // UIShareDialogView only wraps UIActivityViewController presentation
             // so frame is set to 0 to not break SwiftUI's layout
             .frame(width: 0, height: 0)

--- a/zodlTests/ExportLogsTests/ExportLogsTests.swift
+++ b/zodlTests/ExportLogsTests/ExportLogsTests.swift
@@ -1,0 +1,84 @@
+//
+//  ExportLogsTests.swift
+//  zodlTests
+//
+//  Created by Michal Fousek on 12.06.2026.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+
+/// Covers MOB-1367: the support-log export keeps no plaintext staging files behind,
+/// and the produced ZIP is removed once the share sheet is closed.
+///
+/// Serialized because the live exporter tests share the same on-disk
+/// `tmp/logs-exports` directory and read the process-global OSLog store.
+@Suite(.serialized) struct ExportLogsTests {
+    @MainActor @Test func shareSheetClosedRemovesExportsAndResetsURLs() async throws {
+        let cleanupCalled = LockIsolated(false)
+
+        let initialState = ExportLogs.State(
+            zippedLogsURLs: [URL(fileURLWithPath: "/tmp/logs-exports/some/zashiPrivateData.zip")]
+        )
+
+        let store = TestStore(
+            initialState: initialState
+        ) {
+            ExportLogs()
+        } withDependencies: {
+            $0.logsHandler.cleanupExports = { cleanupCalled.setValue(true) }
+        }
+
+        await store.send(.shareSheetClosed) {
+            $0.zippedLogsURLs = []
+        }
+
+        await store.finish()
+
+        #expect(cleanupCalled.value)
+    }
+
+    @Test func liveExportLeavesOnlyTheZipBehind() async throws {
+        let handler = LogsHandlerClient.liveValue
+
+        let zipURL = try await handler.exportAndStoreLogs(
+            LoggerConstants.sdkLogs,
+            LoggerConstants.tcaLogs,
+            LoggerConstants.walletLogs
+        )
+
+        let unwrappedZipURL = try #require(zipURL)
+        #expect(FileManager.default.fileExists(atPath: unwrappedZipURL.path))
+        #expect(unwrappedZipURL.lastPathComponent == "zashiPrivateData.zip")
+
+        // The plaintext staging directory is removed as soon as the ZIP exists.
+        let stagingURL = unwrappedZipURL.deletingLastPathComponent().appendingPathComponent("zashiPrivateData", isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: stagingURL.path))
+
+        try handler.cleanupExports()
+
+        #expect(!FileManager.default.fileExists(atPath: unwrappedZipURL.path))
+        let exportsRoot = FileManager.default.temporaryDirectory.appendingPathComponent("logs-exports", isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: exportsRoot.path))
+    }
+
+    @Test func liveCleanupRemovesLegacyStagingDirectory() throws {
+        let handler = LogsHandlerClient.liveValue
+
+        // Simulate a staging directory left behind by a previous app version.
+        let legacyURL = FileManager.default.temporaryDirectory.appendingPathComponent("zashiPrivateData", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyURL, withIntermediateDirectories: true)
+        let legacyLogURL = legacyURL.appendingPathComponent("walletLogs.txt")
+        try Data("legacy".utf8).write(to: legacyLogURL)
+        #expect(FileManager.default.fileExists(atPath: legacyLogURL.path))
+
+        try handler.cleanupExports()
+
+        #expect(!FileManager.default.fileExists(atPath: legacyURL.path))
+
+        // Cleanup with nothing to remove must not throw.
+        try handler.cleanupExports()
+    }
+}


### PR DESCRIPTION
## Linear

[MOB-1367 — [Security] Support log export leaves plaintext staging files and a ZIP in temp storage](https://linear.app/zodl/issue/MOB-1367/security-support-log-export-leaves-plaintext-staging-files-and-a-zip) (sub-issue of MOB-1276, finding ZODL-IOS-07)

## Problem

`LogsHandlerClient.exportAndStoreLogs` created `tmp/zashiPrivateData/` with plaintext SDK/TCA/wallet logs, zipped it into an item-replacement directory as `zashiPrivateData.zip`, and **neither artifact was ever removed** — `ExportLogs.shareFinished` only cleared UI flags. Log contents (addresses, txids, endpoints, operational context, depending on runtime) persisted in temp storage indefinitely, without an explicit protection class.

## Fix

- Exports are staged in a unique `tmp/logs-exports/<UUID>/` directory created with `FileProtectionType.complete`; the log files are written with `.completeFileProtection`.
- The **plaintext staging directory is deleted as soon as the ZIP is built** (`defer`) — from that moment only the ZIP exists on disk, with the complete protection class set explicitly.
- `UIShareDialogView` gained an optional `onDismiss` hook wired to `UIActivityViewController.completionWithItemsHandler`, which fires on **both** completed share and cancel (the pre-existing `completion` fires when the sheet finishes *presenting*, so it was unusable for cleanup). Identical change to the one in the MOB-1368 PR — whichever merges first, the other merges cleanly.
- `ExportLogs` gets a `.shareSheetClosed` action (wired from both consumers: the Root share overlay and Private Data Consent) that clears `zippedLogsURLs` and calls the new `logsHandler.cleanupExports()`.
- `cleanupExports` also purges the **legacy** `tmp/zashiPrivateData` location, so updating the app cleans leftovers created before this fix.
- Each new export purges stale artifacts first (covers app-killed-while-sheet-open).

On the "redact sensitive values" criterion: log *content* redaction is governed by the existing `Redactable`/`UNREDACTED` logging discipline upstream (what goes into OSLog), so this PR scopes to protection + retention; no change to what is logged.

## Verification

- ✅ Build succeeds (zodl-internal scheme)
- ✅ Full suite passes (315 tests), incl. 3 new `ExportLogsTests`: cleanup on share-sheet close, ZIP-only-on-disk after live export, legacy staging purge

## Manual testing steps

> Tip: to inspect the app's tmp directory on Simulator: `xcrun simctl get_app_container booted <bundle-id> data`, then look into `tmp/`.

1. **Staging never persists:** Settings → About → Export logs (or Settings → Advanced → Export private data, Face ID, then Export). While the share sheet is up, inspect `tmp/`: **Expected:** `tmp/logs-exports/<UUID>/` contains only `zashiPrivateData.zip` — no `zashiPrivateData/` folder with plaintext `.txt` files anywhere (pre-fix: `tmp/zashiPrivateData/` with 4 plaintext logs).
2. **Share + complete:** Pick *Save to Files*; save. **Expected:** the ZIP saves correctly and opens (contains `zashiPrivateData/` folder with the 4 log files); afterwards `tmp/logs-exports` is gone.
3. **Share + cancel:** Run export again, dismiss the sheet. **Expected:** `tmp/logs-exports` removed right after dismissal.
4. **Share works while sheet open:** With the sheet open, wait, then AirDrop or save. **Expected:** the share succeeds (ZIP is only removed on dismissal).
5. **Legacy cleanup:** Before updating to this build (or by manually creating `tmp/zashiPrivateData/` via a debugger/older build), have the legacy folder present. Run an export and close the sheet on the new build. **Expected:** legacy `tmp/zashiPrivateData` is also removed.
6. **Private data consent variant:** Settings → Advanced → Export private data (includes the wallet DB file alongside the ZIP). **Expected:** sharing works; after the sheet closes the logs ZIP is gone; the wallet **database file itself is untouched** (it lives in Documents, not tmp — only log artifacts are cleaned).
7. **Mail flow regression:** Send us feedback → if Mail composer flow attaches logs, verify it still attaches and sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)