### PR TITLE
[MOB-1364] Update swapAPIAccess routing flag on every runtime Tor toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - Opening the Recovery Phrase from Advanced Settings now always requires Face ID / Touch ID, and the seed words are only loaded and rendered after a successful authentication.
 - The tax CSV export is now written to a protected location and deleted as soon as the share sheet closes, instead of remaining in temporary storage.
 - Exported support logs no longer leave plaintext files behind: staging files are removed right after the ZIP is built and the ZIP is deleted when the share sheet closes.
+- Turning Tor on or off now applies to exchange-rate, swap and voting requests immediately instead of after the next app launch.
 
 ### Removed
 - A hidden legacy debug menu (reachable via a gesture on the splash screen) that could copy the seed phrase to the clipboard without Face ID / Touch ID.

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -1434,6 +1434,7 @@
 		54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E83225E24EEF486F002B79 /* RecoveryPhraseBackupTests.swift */; };
 		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
 		349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */; };
+		349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */; };
 		63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D430BF2CF73CFB82A13F1CB /* SecItemClientTests.swift */; };
 		7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */; };
 		8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1983F0BB6D025B08BBD186B /* QRCodeGeneratorTests.swift */; };
@@ -1629,6 +1630,7 @@
 		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
 		349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTransactionHistoryTests.swift; sourceTree = "<group>"; };
 		349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportLogsTests.swift; sourceTree = "<group>"; };
+		349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorSetupTests.swift; sourceTree = "<group>"; };
 		34AA6BA42F85774F00D244E2 /* ABv1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABv1.swift; sourceTree = "<group>"; };
 		34AA6BA62F85774F00D244E2 /* AddressBookContacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookContacts.swift; sourceTree = "<group>"; };
 		34AA6BA72F85774F00D244E2 /* AddressBookEncryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEncryption.swift; sourceTree = "<group>"; };
@@ -2344,6 +2346,7 @@
 				349CE6582FDC358500E2B9CF /* SettingsTests */,
 				349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */,
 				349CE6182FDC1B1500E2B9CF /* ExportLogsTests */,
+				349CE6262FDC1CEA00E2B9CF /* TorSetupTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2448,6 +2451,14 @@
 				349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */,
 			);
 			path = ExportLogsTests;
+			sourceTree = "<group>";
+		};
+		349CE6262FDC1CEA00E2B9CF /* TorSetupTests */ = {
+			isa = PBXGroup;
+			children = (
+				349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */,
+			);
+			path = TorSetupTests;
 			sourceTree = "<group>";
 		};
 		34AA6BA52F85774F00D244E2 /* Migration */ = {
@@ -5109,6 +5120,7 @@
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
 				349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */,
 				349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */,
+				349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */,
 				7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */,
 				DB87FBCDB6C1FC4EA9311A26 /* DeeplinkURLParsingTests.swift in Sources */,
 				051F035A06D6092E00704BAB /* HomeTests.swift in Sources */,

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -239,7 +239,13 @@ extension SDKSynchronizerClient: DependencyKey {
             getCustomUnifiedAddress: { accountUUID, receivers in
                 try await synchronizer.getCustomUnifiedAddress(accountUUID: accountUUID, receivers: receivers)
             },
-            torEnabled: { enabled in
+            torEnabled: { [sharedSwapAPIAccess = $swapAPIAccess] enabled in
+                // Keep the app-level HTTP routing flag in sync with every runtime Tor
+                // toggle, not only with the stored value read at synchronizer
+                // construction. Updated before the SDK call so a failed Tor init
+                // fails closed (requests keep using the protected path) instead of
+                // silently egressing directly.
+                sharedSwapAPIAccess.withLock { $0 = enabled ? .protected : .direct }
                 try await synchronizer.tor(enabled: enabled)
             },
             exchangeRateEnabled: { enabled in

--- a/secant/Sources/Features/Root/RootTorInitCheck.swift
+++ b/secant/Sources/Features/Root/RootTorInitCheck.swift
@@ -45,6 +45,7 @@ extension Root {
                 try? walletStorage.importTorSetupFlag(false)
                 try? userStoredPreferences.setExchangeRate(.init(manual: false, automatic: false))
                 state.$currencyConversion.withLock { $0 = nil }
+                state.$swapAPIAccess.withLock { $0 = .direct }
                 state.homeState.walletBalancesState.isExchangeRateFeatureOn = false
                 return .run { [state] send in
                     await send(.home(.smartBanner(.closeAndCleanupBanner)))

--- a/secant/Sources/Features/TorSetup/TorSetupStore.swift
+++ b/secant/Sources/Features/TorSetup/TorSetupStore.swift
@@ -71,6 +71,7 @@ struct TorSetup {
         var activeSettingsOption: SettingsOptions?
         var currentSettingsOption = SettingsOptions.optOut
         var isSettingsView: Bool = false
+        @Shared(.inMemory(.swapAPIAccess)) var swapAPIAccess: WalletStorage.SwapAPIAccess = .direct
 
         var isSaveButtonDisabled: Bool {
             currentSettingsOption == activeSettingsOption
@@ -130,6 +131,9 @@ struct TorSetup {
                 
             case .enableTapped:
                 try? walletStorage.importTorSetupFlag(true)
+                // Route exchange-rate, swap and voting requests through the
+                // protected path immediately, not only after the next app start.
+                state.$swapAPIAccess.withLock { $0 = .protected }
                 return .run { send in
                     do {
                         try await sdkSynchronizer.torEnabled(true)
@@ -148,6 +152,7 @@ struct TorSetup {
             case .saveChangesTapped:
                 let newFlag = state.currentSettingsOption == .optIn
                 try? walletStorage.importTorSetupFlag(newFlag)
+                state.$swapAPIAccess.withLock { $0 = newFlag ? .protected : .direct }
                 state.activeSettingsOption = state.currentSettingsOption
                 let currentSettingsOption = state.currentSettingsOption
                 if state.currentSettingsOption == .optOut {
@@ -171,6 +176,7 @@ struct TorSetup {
 
             case .disableTapped:
                 try? walletStorage.importTorSetupFlag(false)
+                state.$swapAPIAccess.withLock { $0 = .direct }
                 return .run { _ in
                     try? await sdkSynchronizer.torEnabled(false)
                 }

--- a/zodlTests/TorSetupTests/TorSetupTests.swift
+++ b/zodlTests/TorSetupTests/TorSetupTests.swift
@@ -1,0 +1,123 @@
+//
+//  TorSetupTests.swift
+//  zodlTests
+//
+//  Created by Michal Fousek on 12.06.2026.
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+
+/// Covers MOB-1364: every runtime Tor toggle must update the shared `swapAPIAccess`
+/// routing flag immediately, so the exchange-rate, swap-and-pay and voting clients
+/// (which read the flag per request) switch between `URLSession` and the protected
+/// Tor path without an app restart.
+@Suite struct TorSetupTests {
+    private struct TorInitFailure: Error { }
+
+    @MainActor @Test func enableRoutesProtectedImmediately() async {
+        let store = TestStore(
+            initialState: TorSetup.State()
+        ) {
+            TorSetup()
+        } withDependencies: {
+            $0.walletStorage.importTorSetupFlag = { _ in }
+            $0.sdkSynchronizer.torEnabled = { _ in }
+        }
+
+        await store.send(.enableTapped) {
+            $0.$swapAPIAccess.withLock { $0 = .protected }
+        }
+
+        await store.finish()
+    }
+
+    @MainActor @Test func enableKeepsProtectedRoutingWhenTorInitFails() async {
+        let store = TestStore(
+            initialState: TorSetup.State()
+        ) {
+            TorSetup()
+        } withDependencies: {
+            $0.walletStorage.importTorSetupFlag = { _ in }
+            $0.sdkSynchronizer.torEnabled = { _ in throw TorInitFailure() }
+        }
+
+        await store.send(.enableTapped) {
+            // Fail closed: the user opted into Tor, so requests must not silently
+            // fall back to direct networking just because the Tor init failed.
+            $0.$swapAPIAccess.withLock { $0 = .protected }
+        }
+
+        await store.receive(.torInitFailed)
+
+        await store.finish()
+    }
+
+    @MainActor @Test func disableRoutesDirectImmediately() async {
+        var initialState = TorSetup.State()
+        initialState.$swapAPIAccess.withLock { $0 = .protected }
+
+        let store = TestStore(
+            initialState: initialState
+        ) {
+            TorSetup()
+        } withDependencies: {
+            $0.walletStorage.importTorSetupFlag = { _ in }
+            $0.sdkSynchronizer.torEnabled = { _ in }
+        }
+
+        await store.send(.disableTapped) {
+            $0.$swapAPIAccess.withLock { $0 = .direct }
+        }
+
+        await store.finish()
+    }
+
+    @MainActor @Test func saveChangesOptInRoutesProtectedImmediately() async {
+        let store = TestStore(
+            initialState: TorSetup.State(currentSettingsOption: .optIn)
+        ) {
+            TorSetup()
+        } withDependencies: {
+            $0.walletStorage.importTorSetupFlag = { _ in }
+            $0.sdkSynchronizer.torEnabled = { _ in }
+        }
+
+        await store.send(.saveChangesTapped) {
+            $0.activeSettingsOption = .optIn
+            $0.$swapAPIAccess.withLock { $0 = .protected }
+        }
+
+        await store.receive(.settingsOptionChanged(.optIn))
+        await store.receive(.torInitSucceeded)
+        await store.receive(.backToHomeTapped)
+
+        await store.finish()
+    }
+
+    @MainActor @Test func saveChangesOptOutRoutesDirectImmediately() async {
+        var initialState = TorSetup.State(currentSettingsOption: .optOut)
+        initialState.$swapAPIAccess.withLock { $0 = .protected }
+
+        let store = TestStore(
+            initialState: initialState
+        ) {
+            TorSetup()
+        } withDependencies: {
+            $0.walletStorage.importTorSetupFlag = { _ in }
+            $0.userStoredPreferences.setExchangeRate = { _ in }
+            $0.sdkSynchronizer.torEnabled = { _ in }
+        }
+
+        await store.send(.saveChangesTapped) {
+            $0.activeSettingsOption = .optOut
+            $0.$swapAPIAccess.withLock { $0 = .direct }
+        }
+
+        await store.receive(.settingsOptionChanged(.optOut))
+        await store.receive(.backToHomeTapped)
+
+        await store.finish()
+    }
+}


### PR DESCRIPTION
## Linear

[MOB-1364 — [Security] Tor enablement does not update the shared network flag until restart](https://linear.app/zodl/issue/MOB-1364/security-tor-enablement-does-not-update-the-shared-network-flag-until) (sub-issue of MOB-1276, finding ZODL-IOS-03)

## Problem

The shared `swapAPIAccess` flag decides per request whether the **exchange-rate** (`ExchangeRateLiveKey`), **swap-and-pay** (`Near1Click`) and **voting** (`VotingAPIClientLiveKey`) clients use `URLSession.shared` or the SDK's `httpRequestOverTor` path. The only write was in `SDKSynchronizerClient.live()` — once, at construction, from the stored Tor setting. Runtime Tor toggles called only `sdkSynchronizer.torEnabled(_)`, so:

- enabling Tor mid-session → those requests **kept egressing directly** (IP/network metadata exposure) until the next launch, while the user believed protected networking was active;
- disabling Tor mid-session → requests kept trying the Tor path.

## Fix

`swapAPIAccess` is now updated at every runtime toggle point:

1. **`SDKSynchronizerLive.torEnabled` (choke point):** any caller of `sdkSynchronizer.torEnabled` updates the flag automatically. The flag is set **before** the SDK call, so if Tor init throws, routing **fails closed** (stays on the protected path, requests error out) rather than silently leaking via direct networking.
2. **`TorSetup` reducer:** `.enableTapped`, `.saveChangesTapped` (both directions), `.disableTapped` update the shared flag synchronously — the next request after the tap already routes correctly.
3. **`Root.torDisableTapped`** (the "Tor init failed → disable" alert path): this path never calls `torEnabled` (call commented out), so it now sets the flag to `.direct` explicitly.

All three consumers read `@Shared(.inMemory(.swapAPIAccess))` at request time, so the change takes effect immediately, no restart needed.

## Verification

- ✅ Build succeeds (zodl-internal scheme)
- ✅ Full suite passes (317 tests), incl. 5 new `TorSetupTests`: protected immediately on enable, **fail-closed when Tor init fails**, direct immediately on disable, and both save-changes directions

## Manual testing steps

> Observing routing: easiest with a local HTTP proxy (Proxyman/Charles/mitmproxy) configured on the Simulator, or Console.app filtering the app's network logs. Direct requests to `api.coinmarketcap`-backed rate endpoint / `1click.chaindefuser.com` (swap) are visible to the proxy; Tor-routed requests are not (they go through the SDK's Tor client).

1. **Enable Tor mid-session routes immediately:** Start the app with Tor OFF and currency conversion ON — observe the exchange-rate request hitting the proxy directly. Then Settings → Advanced Settings → Private (Tor) → Enable (or select opt-in + Save). Pull-to-refresh the rate (or open the swap flow to fetch assets). **Expected:** no new direct requests appear in the proxy from this moment — without restarting the app. (Pre-fix: requests kept appearing until relaunch.)
2. **Disable Tor mid-session routes immediately:** With Tor ON, disable it in the same screen. Refresh the rate. **Expected:** the request now appears in the proxy (direct) immediately.
3. **Fail-closed on Tor init failure:** Enable Tor in airplane mode-ish conditions (or otherwise make Tor bootstrap fail — e.g. block the network right after tapping Enable) so the "Tor failed" alert appears. Choose "Don't disable". Refresh the exchange rate. **Expected:** the request does NOT egress directly (it fails) — privacy is preserved while the user's Tor preference is ON.
4. **Failure alert → Disable:** Repeat step 3 but choose "Disable Tor" in the alert. **Expected:** requests route directly again immediately, and the Tor setting shows disabled.
5. **Restart consistency:** After each of the above, kill and relaunch the app. **Expected:** routing matches the persisted setting (same behavior as before this PR).
6. **Voting + swap surfaces:** With Tor ON, open the swap flow (asset list fetch) and the voting screen (round fetch). **Expected:** no direct hits in the proxy for these either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)