### PR TITLE
[MOB-1366] Document why wallet database files are kept eligible for backup

### DIFF
--- a/secant/Sources/Dependencies/DatabaseFiles/DatabaseFiles.swift
+++ b/secant/Sources/Dependencies/DatabaseFiles/DatabaseFiles.swift
@@ -8,6 +8,20 @@
 import Foundation
 @preconcurrency import ZcashLightClientKit
 
+/// Resolves the on-disk locations of the SDK wallet database files — `data.db` (with its
+/// SQLite sidecars), `cache.db`, `pending.db`, the sapling params and `to-dir` — all kept
+/// in the app's Documents directory.
+///
+/// These files are intentionally left eligible for system backups: we deliberately do
+/// **not** set `isExcludedFromBackup` on them, even though a security report flagged that
+/// wallet data then flows into iCloud/iTunes backups and device-migration transfers.
+///
+/// This is a conscious trade-off between security and UX. Some of this data lives *only*
+/// in these local files; it is not stored on any server or backend. Excluding the files
+/// from backups would therefore make the user permanently lose that information when
+/// migrating to a new device, so keeping them in backups is exactly what lets that data
+/// survive a device change. Do not add `isExcludedFromBackup` here without revisiting this
+/// decision.
 struct DatabaseFiles {
     enum DatabaseFilesError: Error {
         case getFsBlockDbRoot


### PR DESCRIPTION
## Linear

[MOB-1366 — [Security] Wallet database files sit in Documents without backup exclusion or file protection](https://linear.app/zodl/issue/MOB-1366/security-wallet-database-files-sit-in-documents-without-backup) (sub-issue of MOB-1276, finding ZODL-IOS-06)

## Outcome: intentional and documented — no functional change

The finding flagged that the SDK wallet artifacts in **Documents** carry neither `isExcludedFromBackup` nor an explicit file-protection class: `data.db` (+ SQLite `-wal`/`-shm`/`-journal` sidecars), `cache.db`, `pending.db`, the `fsBlockDb` cache directory, `to-dir` and the sapling params — so wallet data flows into iCloud/iTunes backups and device-migration transfers.

After review, **this is by design, not a defect.** Some of the data in these files exists *only* on the device — it is not held by any server or backend. Excluding the files from backups would make the user **permanently lose that information when migrating to a new device**. Keeping them eligible for backup is a deliberate trade-off between security and UX, so the backup-exclusion flag is intentionally *not* set.

## Change

The previously proposed in-place hardening (`DatabaseFiles.applyFileProtection(for:)` setting `isExcludedFromBackup = true` + a protection class, wired into `SDKSynchronizerLive`, plus its tests) has been **dropped**. In its place, this PR records the decision in code: a doc comment on `DatabaseFiles` explaining why `isExcludedFromBackup` is deliberately omitted, so the flag isn't re-introduced by a future "fix".

Comment only — no behavioral change.

## Verification

- N/A — documentation-only change, nothing to build or test beyond the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
