### PR TITLE
[MOB-1365] Verify voting proposal metadata against on-chain proposals_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - The tax CSV export is now written to a protected location and deleted as soon as the share sheet closes, instead of remaining in temporary storage.
 - Exported support logs no longer leave plaintext files behind: staging files are removed right after the ZIP is built and the ZIP is deleted when the share sheet closes.
 - Turning Tor on or off now applies to exchange-rate, swap and voting requests immediately instead of after the next app launch.
+- Coinholder Polling now verifies the proposal titles, descriptions and option labels it displays against the round's on-chain `proposals_hash` before showing the ballot or accepting a vote, and refuses tampered rounds.
 
 ### Removed
 - A hidden legacy debug menu (reachable via a gesture on the splash screen) that could copy the seed phrase to the clipboard without Face ID / Touch ID.

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -49,6 +49,10 @@
 		349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5E92FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift */; };
 		349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */; };
 		349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */; };
+		349CE63A2FDC259F00E2B9CF /* ProposalsHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6392FDC259F00E2B9CF /* ProposalsHasher.swift */; };
+		349CE63B2FDC259F00E2B9CF /* ProposalsHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6392FDC259F00E2B9CF /* ProposalsHasher.swift */; };
+		349CE63C2FDC259F00E2B9CF /* ProposalsHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6392FDC259F00E2B9CF /* ProposalsHasher.swift */; };
+		349CE6412FDC263900E2B9CF /* ProposalsHasherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6402FDC263900E2B9CF /* ProposalsHasherTests.swift */; };
 		34AA6DD82F85774F00D244E2 /* SwapAndPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CF82F85774F00D244E2 /* SwapAndPayStore.swift */; };
 		34AA6DD92F85774F00D244E2 /* RemoteStorageInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C102F85774F00D244E2 /* RemoteStorageInterface.swift */; };
 		34AA6DDA2F85774F00D244E2 /* WalletConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C4B2F85774F00D244E2 /* WalletConfigProvider.swift */; };
@@ -1631,6 +1635,8 @@
 		349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTransactionHistoryTests.swift; sourceTree = "<group>"; };
 		349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportLogsTests.swift; sourceTree = "<group>"; };
 		349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorSetupTests.swift; sourceTree = "<group>"; };
+		349CE6392FDC259F00E2B9CF /* ProposalsHasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposalsHasher.swift; sourceTree = "<group>"; };
+		349CE6402FDC263900E2B9CF /* ProposalsHasherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposalsHasherTests.swift; sourceTree = "<group>"; };
 		34AA6BA42F85774F00D244E2 /* ABv1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABv1.swift; sourceTree = "<group>"; };
 		34AA6BA62F85774F00D244E2 /* AddressBookContacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookContacts.swift; sourceTree = "<group>"; };
 		34AA6BA72F85774F00D244E2 /* AddressBookEncryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEncryption.swift; sourceTree = "<group>"; };
@@ -3971,6 +3977,7 @@
 				37CEBE932F8E939D002DA90E /* VotingAPIClientLiveKey.swift */,
 				37D0F0000000000000000002 /* RoundAuthenticator.swift */,
 				37CEBE942F8E939D002DA90E /* VotingAPIClientTestKey.swift */,
+				349CE6392FDC259F00E2B9CF /* ProposalsHasher.swift */,
 			);
 			path = VotingAPIClient;
 			sourceTree = "<group>";
@@ -4423,6 +4430,7 @@
 				AD0D00232D00000100000002 /* VotingServiceConfigTests.swift */,
 				AD0D00222D00000100000002 /* VotingCoordFlowCoordinatorTests.swift */,
 				AD0D00212D00000100000002 /* VotingHelpersTests.swift */,
+				349CE6402FDC263900E2B9CF /* ProposalsHasherTests.swift */,
 			);
 			path = VotingTests;
 			sourceTree = "<group>";
@@ -5134,6 +5142,7 @@
 				348EC4CD2FD7FD96008495FB /* ServerEndpointsTests.swift in Sources */,
 				348EC4CE2FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift in Sources */,
 				348EC4CF2FD7FD96008495FB /* ServerSetupStoreTests.swift in Sources */,
+				349CE6412FDC263900E2B9CF /* ProposalsHasherTests.swift in Sources */,
 				348EC4D02FD7FD96008495FB /* TransactionGuardTests.swift in Sources */,
 				348EC4D12FD7FD96008495FB /* AutoServerSelectionClientTests.swift in Sources */,
 				921B3D95249329CD65C36E1B /* LoggerTests.swift in Sources */,
@@ -5250,6 +5259,7 @@
 				9EEBF83A2FBC64D700DD38DB /* ProposalDetailStore.swift in Sources */,
 				34AA74EC2F85774F00D244E2 /* VisualEffectBlur.swift in Sources */,
 				34AA74ED2F85774F00D244E2 /* RootAddressBook.swift in Sources */,
+				349CE63A2FDC259F00E2B9CF /* ProposalsHasher.swift in Sources */,
 				34AA74EE2F85774F00D244E2 /* PasteboardInterface.swift in Sources */,
 				34AA74EF2F85774F00D244E2 /* AddressBookEncryptionKeys.swift in Sources */,
 				34AA74F02F85774F00D244E2 /* ScanCoordFlowView.swift in Sources */,
@@ -5720,6 +5730,7 @@
 				9EEBF8392FBC64D700DD38DB /* ProposalDetailStore.swift in Sources */,
 				34AA71882F85774F00D244E2 /* VisualEffectBlur.swift in Sources */,
 				34AA71892F85774F00D244E2 /* RootAddressBook.swift in Sources */,
+				349CE63C2FDC259F00E2B9CF /* ProposalsHasher.swift in Sources */,
 				34AA718A2F85774F00D244E2 /* PasteboardInterface.swift in Sources */,
 				34AA718B2F85774F00D244E2 /* AddressBookEncryptionKeys.swift in Sources */,
 				34AA718C2F85774F00D244E2 /* ScanCoordFlowView.swift in Sources */,
@@ -6190,6 +6201,7 @@
 				9EEBF83C2FBC64D700DD38DB /* ProposalDetailStore.swift in Sources */,
 				34AA6E242F85774F00D244E2 /* VisualEffectBlur.swift in Sources */,
 				34AA6E252F85774F00D244E2 /* RootAddressBook.swift in Sources */,
+				349CE63B2FDC259F00E2B9CF /* ProposalsHasher.swift in Sources */,
 				34AA6E262F85774F00D244E2 /* PasteboardInterface.swift in Sources */,
 				34AA6E272F85774F00D244E2 /* AddressBookEncryptionKeys.swift in Sources */,
 				34AA6E282F85774F00D244E2 /* ScanCoordFlowView.swift in Sources */,

--- a/secant/Sources/Dependencies/VotingAPIClient/ProposalsHasher.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/ProposalsHasher.swift
@@ -1,0 +1,64 @@
+//
+//  ProposalsHasher.swift
+//  Zashi
+//
+//  Created by Michal Fousek on 12.06.2026.
+//
+
+import CryptoKit
+import Foundation
+
+/// Recomputes the ZIP 1244 §"Proposals Hash" over chain-sourced proposal metadata.
+///
+/// The round's `proposals_hash` is authoritative chain state, while the proposal
+/// array itself arrives from a vote server that is only an endpoint-discovery
+/// target, not a trust anchor. Recomputing the hash from the parsed proposals and
+/// comparing it to `proposals_hash` ensures the wallet displays - and the voter
+/// signs a `proposalId`/`choice` derived from - exactly the proposal set the
+/// chain committed to.
+///
+/// Only `id`, `title`, `description` and `options` (`index`, `label`) are part of
+/// the canonical form; option descriptions, ZIP numbers and forum links are
+/// UI-only metadata outside the hash.
+enum ProposalsHasher {
+    /// SHA-256 of the canonical JSON serialization of the proposals array.
+    static func computeProposalsHash(_ proposals: [VotingProposal]) -> Data {
+        Data(SHA256.hash(data: Data(canonicalProposalsJSON(proposals).utf8)))
+    }
+
+    /// Canonical JSON form per ZIP 1244: proposals sorted by `id` ascending, options by `index` ascending,
+    /// no whitespace, keys in order `id`, `title`, `description`, `options` (and `index`, `label` for each option).
+    static func canonicalProposalsJSON(_ proposals: [VotingProposal]) -> String {
+        let sortedProposals = proposals.sorted { $0.id < $1.id }
+        let parts = sortedProposals.map { proposal -> String in
+            let sortedOptions = proposal.options.sorted { $0.index < $1.index }
+            let optionParts = sortedOptions.map { option -> String in
+                "{\"index\":\(option.index),\"label\":\(jsonEncodedString(option.label))}"
+            }
+            let fields = [
+                "\"id\":\(proposal.id)",
+                "\"title\":\(jsonEncodedString(proposal.title))",
+                "\"description\":\(jsonEncodedString(proposal.description))",
+                "\"options\":[\(optionParts.joined(separator: ","))]"
+            ]
+            return "{\(fields.joined(separator: ","))}"
+        }
+        return "[\(parts.joined(separator: ","))]"
+    }
+
+    /// JSON-encode a Swift string to match the Rust `serde_json::to_string` byte output.
+    /// `JSONEncoder` with `.withoutEscapingSlashes` leaves `/` un-escaped (Swift default: `\/`);
+    /// otherwise defaults match serde_json (UTF-8 for non-ASCII, `\uXXXX` for control chars).
+    /// The chain computes `proposals_hash` using `serde_json`, so divergence here would
+    /// cause a hard-fail hash mismatch any time a proposal title or label contained `/`.
+    private static func jsonEncodedString(_ string: String) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        guard let data = try? encoder.encode(string) else {
+            // Encoding a String to JSON cannot fail in practice; an empty string
+            // keeps the canonical form valid and simply fails the hash comparison.
+            return "\"\""
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
@@ -695,6 +695,20 @@ private func authenticateVotingSession(_ session: VotingSession) async throws ->
         // surface as "no active round" rather than shown as a separate warning.
         throw SvAPIError.noActiveVotingSession
     }
+
+    // The EA key authenticates the round, but the proposal metadata (ids, titles,
+    // descriptions, option labels) arrives from the vote server unverified. Bind
+    // it to the chain-committed `proposals_hash` before it is displayed or a vote
+    // commitment is derived from it; fail closed on any mismatch.
+    let computedProposalsHash = ProposalsHasher.computeProposalsHash(session.proposals)
+    guard !session.proposalsHash.isEmpty, computedProposalsHash == session.proposalsHash else {
+        LoggerProxy.error(
+            // swiftlint:disable:next line_length
+            "Round auth failed: proposals_hash mismatch round=\(roundIdHex) chain=\(hexString(from: session.proposalsHash)) computed=\(hexString(from: computedProposalsHash))"
+        )
+        throw SvAPIError.noActiveVotingSession
+    }
+
     return session
 }
 

--- a/zodlTests/VotingTests/ProposalsHasherTests.swift
+++ b/zodlTests/VotingTests/ProposalsHasherTests.swift
@@ -1,0 +1,204 @@
+//
+//  ProposalsHasherTests.swift
+//  zodlTests
+//
+//  Created by Michal Fousek on 12.06.2026.
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+
+// Test fixtures contain pinned canonical JSON strings that intentionally exceed
+// the project's line-length limit — keeping them single-line makes the expected
+// byte output obvious and prevents accidental line-ending differences from
+// changing the pinned hash.
+// swiftlint:disable line_length
+
+/// Covers MOB-1365: the proposal metadata shown to the voter (and from which the
+/// signed `proposalId`/`choice` is derived) must recompute to the chain-committed
+/// `proposals_hash`; any tampering with titles, option labels or numeric IDs while
+/// the round EA key stays valid must change the computed hash.
+@Suite struct ProposalsHasherTests {
+    /// ZIP 1244 worked example.
+    private static let zipExampleProposal = VotingProposal(
+        id: 1,
+        title: "Approve protocol upgrade",
+        description: "Approve or oppose the proposed protocol upgrade.",
+        options: [
+            VoteOption(index: 0, label: "Support"),
+            VoteOption(index: 1, label: "Oppose")
+        ]
+    )
+    private static let zipExampleCanonical =
+        #"[{"id":1,"title":"Approve protocol upgrade","description":"Approve or oppose the proposed protocol upgrade.","options":[{"index":0,"label":"Support"},{"index":1,"label":"Oppose"}]}]"#
+    /// SHA-256 of the canonical string above, computed with `shasum -a 256` for reference.
+    private static let zipExampleHashHex = "3f9a361d43c4ddb77ad138a091374e2e2958718e64937f33df99a09bd567e63d"
+
+    private static func hexString(from data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @Test func canonicalJSONMatchesZIPExample() {
+        let canonical = ProposalsHasher.canonicalProposalsJSON([Self.zipExampleProposal])
+
+        #expect(canonical == Self.zipExampleCanonical)
+    }
+
+    @Test func computeProposalsHashMatchesZIPExample() {
+        let hash = ProposalsHasher.computeProposalsHash([Self.zipExampleProposal])
+
+        #expect(Self.hexString(from: hash) == Self.zipExampleHashHex)
+    }
+
+    @Test func canonicalJSONSortsProposalsByIdAndOptionsByIndex() {
+        let unsorted = [
+            VotingProposal(
+                id: 2,
+                title: "B",
+                description: "second",
+                options: [VoteOption(index: 1, label: "No"), VoteOption(index: 0, label: "Yes")]
+            ),
+            VotingProposal(
+                id: 1,
+                title: "A",
+                description: "first",
+                options: [VoteOption(index: 0, label: "X"), VoteOption(index: 1, label: "Y")]
+            )
+        ]
+
+        let canonical = ProposalsHasher.canonicalProposalsJSON(unsorted)
+
+        #expect(
+            canonical ==
+            #"[{"id":1,"title":"A","description":"first","options":[{"index":0,"label":"X"},{"index":1,"label":"Y"}]},{"id":2,"title":"B","description":"second","options":[{"index":0,"label":"Yes"},{"index":1,"label":"No"}]}]"#
+        )
+    }
+
+    /// Pins the canonicalization to Rust `serde_json::to_string` byte output for a
+    /// title containing `/`. Swift's default JSON encoding would emit `\/`; Rust
+    /// emits `/`. A mismatch here would make every wallet fail closed against the
+    /// chain's `proposals_hash` for any round with a slash in a title or label.
+    @Test func canonicalJSONDoesNotEscapeForwardSlashInTitles() {
+        let proposal = VotingProposal(
+            id: 1,
+            title: "NU5/NU6 activation",
+            description: "Should we activate NU5/NU6?",
+            options: [
+                VoteOption(index: 0, label: "Yes"),
+                VoteOption(index: 1, label: "No")
+            ]
+        )
+
+        let canonical = ProposalsHasher.canonicalProposalsJSON([proposal])
+
+        #expect(
+            canonical ==
+            #"[{"id":1,"title":"NU5/NU6 activation","description":"Should we activate NU5/NU6?","options":[{"index":0,"label":"Yes"},{"index":1,"label":"No"}]}]"#
+        )
+        #expect(
+            Self.hexString(from: ProposalsHasher.computeProposalsHash([proposal])) == "d4a105be1f44c96ca4abc6c952d7a6deb3f7cf4df2059a2afe4bb828b96078a1"
+        )
+    }
+
+    @Test func canonicalJSONEscapesSpecialCharactersInStrings() {
+        let proposal = VotingProposal(
+            id: 1,
+            title: "Quote \" and backslash \\",
+            description: "tab\there",
+            options: [VoteOption(index: 0, label: "tab\there")]
+        )
+
+        let canonical = ProposalsHasher.canonicalProposalsJSON([proposal])
+
+        #expect(canonical.contains(#"\""#), "should escape double quotes")
+        #expect(canonical.contains(#"\\"#), "should escape backslashes")
+        #expect(canonical.contains(#"\t"#), "should escape tabs")
+    }
+
+    /// UI-only metadata (option descriptions, ZIP numbers, forum links) is outside
+    /// the ZIP 1244 canonical form and must not change the hash.
+    @Test func uiOnlyMetadataDoesNotAffectHash() {
+        let withMetadata = VotingProposal(
+            id: 1,
+            title: "Approve protocol upgrade",
+            description: "Approve or oppose the proposed protocol upgrade.",
+            options: [
+                VoteOption(index: 0, label: "Support", description: "richer copy"),
+                VoteOption(index: 1, label: "Oppose", description: "more copy")
+            ],
+            zipNumber: "1244",
+            forumURL: URL(string: "https://forum.example.com/t/1")
+        )
+
+        let hash = ProposalsHasher.computeProposalsHash([withMetadata])
+
+        #expect(Self.hexString(from: hash) == Self.zipExampleHashHex)
+    }
+
+    // MARK: - Tamper detection (acceptance criteria: title, option order, numeric ids)
+
+    @Test func tamperedTitleChangesHash() {
+        var proposals = [Self.zipExampleProposal]
+        let chainHash = ProposalsHasher.computeProposalsHash(proposals)
+
+        proposals = [
+            VotingProposal(
+                id: 1,
+                title: "Reject protocol upgrade",
+                description: Self.zipExampleProposal.description,
+                options: Self.zipExampleProposal.options
+            )
+        ]
+
+        #expect(ProposalsHasher.computeProposalsHash(proposals) != chainHash)
+    }
+
+    @Test func swappedOptionLabelsChangeHash() {
+        let chainHash = ProposalsHasher.computeProposalsHash([Self.zipExampleProposal])
+
+        // The attacker swaps which numeric choice maps to which label.
+        let swapped = VotingProposal(
+            id: 1,
+            title: Self.zipExampleProposal.title,
+            description: Self.zipExampleProposal.description,
+            options: [
+                VoteOption(index: 0, label: "Oppose"),
+                VoteOption(index: 1, label: "Support")
+            ]
+        )
+
+        #expect(ProposalsHasher.computeProposalsHash([swapped]) != chainHash)
+    }
+
+    @Test func reorderedOptionArrayKeepsHash() {
+        let chainHash = ProposalsHasher.computeProposalsHash([Self.zipExampleProposal])
+
+        // Pure array reordering with index→label mapping intact is not a tamper;
+        // the canonical form sorts by index.
+        let reordered = VotingProposal(
+            id: 1,
+            title: Self.zipExampleProposal.title,
+            description: Self.zipExampleProposal.description,
+            options: [
+                VoteOption(index: 1, label: "Oppose"),
+                VoteOption(index: 0, label: "Support")
+            ]
+        )
+
+        #expect(ProposalsHasher.computeProposalsHash([reordered]) == chainHash)
+    }
+
+    @Test func tamperedNumericIdChangesHash() {
+        let chainHash = ProposalsHasher.computeProposalsHash([Self.zipExampleProposal])
+
+        let renumbered = VotingProposal(
+            id: 2,
+            title: Self.zipExampleProposal.title,
+            description: Self.zipExampleProposal.description,
+            options: Self.zipExampleProposal.options
+        )
+
+        #expect(ProposalsHasher.computeProposalsHash([renumbered]) != chainHash)
+    }
+}


### PR DESCRIPTION
## Linear

[MOB-1365 — [Security] Voting proposal metadata is not authenticated against proposals_hash before vote signing](https://linear.app/zodl/issue/MOB-1365/security-voting-proposal-metadata-is-not-authenticated-against) (sub-issue of MOB-1276, finding ZODL-IOS-05)

## Problem

`authenticateVotingSession` verified the round's signed **EA admin key**, but the proposal metadata (IDs, titles, descriptions, option labels) and the `proposals_hash` itself were parsed from the vote-server response and carried **unverified**. The vote commitment later signs a `proposalId`/`choice` derived from that metadata. A malicious or compromised vote server holding valid EA-key material could therefore display altered proposal text or swapped option labels while the wallet signs a vote for the attacker-selected numeric proposal/choice.

## Fix

- New `ProposalsHasher` recomputes the **ZIP 1244 §"Proposals Hash"** canonical form: proposals sorted by `id`, options by `index`, no whitespace, fixed key order (`id`, `title`, `description`, `options[{index,label}]`), string bytes matching Rust `serde_json::to_string` (no `\/` escaping) — then SHA-256.
- `authenticateVotingSession` (the single gate all round fetches go through: `/rounds`, `/rounds/active`, `/round/{id}`) now requires `computedHash == round.proposals_hash` **after** the EA-key check, and **fails closed** — a mismatching (or missing) hash hides the round behind the same "no active round" surface as failed EA auth, before anything is displayed or signable.
- Option descriptions, ZIP numbers and forum links are UI-only metadata outside the ZIP canonical form (verified below) — they don't affect the hash.

> **Note on the "ZIP 1244" naming.** "ZIP 1244" throughout this PR (and in the code comments) is **not a ratified/assigned ZIP number** — it is the number of the GitHub pull request [`zcash/zips#1244`](https://github.com/zcash/zips/pull/1244), which holds the *open draft* spec "Shielded Voting Wallet API" proposed by Valar Group (the vote-chain operator). The PR is literally titled **"[ZIP TBD]"**: a ZIP number has not been assigned yet, and `1244` is just the pull-request number in the `zcash/zips` repo. The `§"Proposals Hash"` canonical form implemented here is defined in that draft, and the example vector pinned in the tests (`3f9a361d…`) is the draft's own worked example. Because the draft is unmerged and still evolving, a later change to its canonical form would require a matching wallet update — the verification fails closed until then.

### Why this canonicalization is correct

1. It is the **same scheme this codebase used** to verify CDN-config proposals against the chain hash before proposals moved to chain rounds (removed only because the CDN stopped publishing proposal JSON — see `docs/voting-service-discovery.md`), including its pinned ZIP 1244 test vectors.
2. **Validated against production**: all **7 rounds** currently served by `vote-chain-primary.valargroup.org` recompute exactly to their `proposals_hash` with this scheme (including proto3 zero-index omission and a 15-proposal round).

## Verification

- ✅ Build succeeds (zodl-internal scheme)
- ✅ Full suite passes (322 tests), incl. 10 new `ProposalsHasherTests`: ZIP 1244 example vector, serde_json slash vector, sorting/escaping, and the acceptance-criteria tamper cases — modified title, swapped option labels, changed numeric id (hash changes) vs. benign array reorder and UI-only metadata (hash unchanged)

## Manual testing steps

1. **Happy path (production data):** Open the Coinholder Polling flow with a wallet on mainnet. **Expected:** rounds list and ballots load exactly as before (all current production rounds recompute correctly — verified against the live API during development).
2. **Tampered metadata fails closed (MITM harness):** Using a local HTTPS proxy (mitmproxy/Charles with the proxy CA trusted on a dev device/Simulator and Tor disabled), intercept the response of `/shielded-vote/v1/rounds` (or `/round/{id}`) and change one proposal's `title` (or swap two option `label`s, or change a proposal `id`) **without touching `proposals_hash`**. **Expected:** the affected round disappears from the list (treated as unauthenticated; log line `Round auth failed: proposals_hash mismatch round=…` in Console). No ballot with tampered text is ever rendered.
3. **Tampered hash also fails:** Same setup, but change `proposals_hash` instead. **Expected:** same fail-closed behavior.
4. **Missing hash fails:** Remove the `proposals_hash` field from the round JSON. **Expected:** round hidden (fail closed).
5. **Vote submission regression:** On an active testnet/staging round, complete a full vote (delegate → ballot → sign → submit). **Expected:** unchanged behavior; the tally/results screens still render.
6. **Tally-phase rounds:** Confirm finished rounds with results still display (they go through the same authentication gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
