### PR TITLE
[MOB-1339] Treat "already in mempool" submit rejections as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Fixed
 - A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
+- We fixed a bug where a successful TEX send could show a misleading "transaction failed" screen.
 
 ## 3.5.2 build 1 (20026-06-08)
 

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -11,6 +11,12 @@ import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @preconcurrency import KeystoneSDK
 
+private func isAlreadyKnownToNetwork(_ description: String) -> Bool {
+    let lower = description.lowercased()
+    return lower.contains("already exists in mempool")
+        || lower.contains("already queued for download")
+}
+
 extension SDKSynchronizerClient: DependencyKey {
     static let liveValue: SDKSynchronizerClient = Self.live()
     
@@ -161,16 +167,21 @@ extension SDKSynchronizerClient: DependencyKey {
                             resubmitableFailure = true
                         case let .submitFailure(txId: id, code: code, description: description):
                             txIds.append(id.toHexStringTxId())
-                            statuses.append("code: \(code) desc: \(description)")
-                            errCode = code
-                            errDesc = description
+                            if isAlreadyKnownToNetwork(description) {
+                                successCount += 1
+                                statuses.append("success (already known to network): \(description)")
+                            } else {
+                                statuses.append("code: \(code) desc: \(description)")
+                                errCode = code
+                                errDesc = description
+                            }
                         case .notAttempted(txId: let id):
                             txIds.append(id.toHexStringTxId())
                             statuses.append("notAttempted")
                         }
                     }
                 }
-                
+
                 if successCount == 0 {
                     if resubmitableFailure {
                         return .grpcFailure(txIds: txIds)
@@ -265,15 +276,20 @@ extension SDKSynchronizerClient: DependencyKey {
                         resubmitableFailure = true
                     case let .submitFailure(txId: id, code: code, description: description):
                         txIds.append(id.toHexStringTxId())
-                        statuses.append("code: \(code) desc: \(description)")
-                        errCode = code
-                        errDesc = description
+                        if isAlreadyKnownToNetwork(description) {
+                            successCount += 1
+                            statuses.append("success (already known to network): \(description)")
+                        } else {
+                            statuses.append("code: \(code) desc: \(description)")
+                            errCode = code
+                            errDesc = description
+                        }
                     case .notAttempted(txId: let id):
                         txIds.append(id.toHexStringTxId())
                         statuses.append("notAttempted")
                     }
                 }
-                
+
                 if successCount == 0 {
                     if resubmitableFailure {
                         return .grpcFailure(txIds: txIds)


### PR DESCRIPTION
## Summary
- A TEX send (or any send that's rebroadcast after the original submit already landed in the network) currently surfaces a misleading "transaction failed" screen.
- Root cause: lightwalletd / zcashd returns `transaction already exists in mempool` or `transaction dropped because it is already queued for download` as a non-zero submit error, which the SDK reports as `.submitFailure`. Those descriptions actually mean the tx is already on the network — i.e. the broadcast succeeded.
- Fix: `SDKSynchronizerLive` now classifies `.submitFailure` with one of those two descriptions as effective success — counts toward `successCount`, status string rewritten so debug logs still surface the underlying description.
- This is the app-layer guard. The matching SDK-level fix lives at [Cosmos-Harry/zcash-swift-wallet-sdk → harry/treat-already-in-mempool-as-success](https://github.com/Cosmos-Harry/zcash-swift-wallet-sdk/pull/new/harry/treat-already-in-mempool-as-success) and becomes redundant (harmless) once that lands in our dependency pin.

Linear: MOB-1339

## Test plan
- [ ] Send to a TEX address from a v3.5.1+ wallet where the previous attempt is known to have broadcast successfully (e.g. retried after a confirmation timeout).
- [ ] Confirm the success screen renders instead of the failure screen.
- [ ] Confirm transaction list still shows the tx in the expected state.
- [ ] No regression for genuine failures: send with insufficient funds → failure screen still appears with the real error.