### PR TITLE
[MOB-1388] Cross-chain swap quote-binding security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,9 @@ directly impact users rather than highlighting other crucial architectural updat
 - The Confirm button on a migration transfer plan now keeps its loading indicator up until your transfers are prepared and presigned (the first delivery kicked off), then opens the Migration Scheduled screen — one tap, no dead first tap, and the Home banner reflects the committed run when you return. The Confirm button still can no longer be tapped again after a successful commit.
 - [Ironwood] Accepting a migration plan on a large wallet no longer stalls for tens of minutes — plan commit completes promptly.
 
+### Security
+- Cross-chain swap quotes are now verified against your request before the transaction is signed: the ZEC amount, payout and refund addresses, assets, and slippage tolerance must match what you requested, and the swap is refused on any mismatch. This protects against a malicious or tampered swap-provider response redirecting your funds.
+
 ## 3.7.3 build 1 (20026-07-12)
 
 ### Changed

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuote.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuote.swift
@@ -23,7 +23,13 @@ struct SwapQuote: Codable, Equatable, Hashable {
     let amountOutUsd: String
     /// Number of seconds it takes to process this quote
     let timeEstimate: TimeInterval
-    
+    /// Echoed off-chain payout recipient (the address the user typed); validated == request at parse time.
+    let recipient: String
+    /// Echoed origin assetId; validated == request at parse time.
+    let originAssetId: String
+    /// Echoed destination assetId; validated == request at parse time.
+    let destinationAssetId: String
+
     init(
         depositAddress: String,
         amountIn: Decimal,
@@ -31,7 +37,10 @@ struct SwapQuote: Codable, Equatable, Hashable {
         minAmountIn: Decimal,
         amountOut: Decimal,
         amountOutUsd: String,
-        timeEstimate: TimeInterval
+        timeEstimate: TimeInterval,
+        recipient: String,
+        originAssetId: String,
+        destinationAssetId: String
     ) {
         self.depositAddress = depositAddress
         self.amountIn = amountIn
@@ -40,5 +49,18 @@ struct SwapQuote: Codable, Equatable, Hashable {
         self.amountOut = amountOut
         self.amountOutUsd = amountOutUsd
         self.timeEstimate = timeEstimate
+        self.recipient = recipient
+        self.originAssetId = originAssetId
+        self.destinationAssetId = destinationAssetId
+    }
+}
+
+extension SwapQuote {
+    /// Re-binds the quote to current user intent immediately before signing (TOCTOU guard): the echoed
+    /// payout recipient and both asset ids must still match what the user is looking at.
+    func matchesSigningIntent(address: String, originAssetId: String, destinationAssetId: String) -> Bool {
+        recipient == address
+            && self.originAssetId == originAssetId
+            && self.destinationAssetId == destinationAssetId
     }
 }

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -19,7 +19,64 @@ enum SwapQuoteValidationError: Error, Equatable {
     case refundMismatch
 }
 
+/// The subset of the swap-quote response the validator inspects: the echoed `quoteRequest` fields plus
+/// the `quote` amounts, all already parsed into typed values.
+struct SwapQuoteResponseFields: Equatable {
+    let depositAddress: String
+    let echoedOriginAsset: String
+    let echoedDestinationAsset: String
+    let echoedSwapType: String
+    let echoedSlippageTolerance: Int
+    let echoedRecipient: String
+    let echoedRefundTo: String
+    let amountIn: Decimal
+    let amountInFormatted: Decimal
+    let minAmountIn: Decimal
+    let amountOut: Decimal
+    let amountOutFormatted: Decimal
+    let minAmountOut: Decimal
+}
+
 enum SwapQuoteValidator {
+    /// Validates a freshly-received quote against the request we sent. Throws the first failure; the caller
+    /// fails closed (maps to the "quote unavailable" path) on any throw.
+    static func validate(
+        request: SwapQuoteRequest,
+        response: SwapQuoteResponseFields,
+        originDecimals: Int,
+        destinationDecimals: Int
+    ) throws {
+        try requireMatchingAssetId(field: "originAsset", expected: request.originAsset, actual: response.echoedOriginAsset)
+        try requireMatchingAssetId(field: "destinationAsset", expected: request.destinationAsset, actual: response.echoedDestinationAsset)
+
+        if request.swapType != response.echoedSwapType {
+            throw SwapQuoteValidationError.swapTypeMismatch
+        }
+        if request.slippageTolerance != response.echoedSlippageTolerance {
+            throw SwapQuoteValidationError.slippageToleranceMismatch
+        }
+        if request.recipient != response.echoedRecipient {
+            throw SwapQuoteValidationError.recipientMismatch
+        }
+        if request.refundTo != response.echoedRefundTo {
+            throw SwapQuoteValidationError.refundMismatch
+        }
+        // amountInFormatted must be strictly positive (also fail closed on NaN — defends zecExchangeRate-style
+        // divisions downstream). It comes from Decimal(string:) which never yields NaN, but guard anyway.
+        guard !response.amountInFormatted.isNaN,
+              NSDecimalNumber(decimal: response.amountInFormatted).compare(NSDecimalNumber.zero) == ComparisonResult.orderedDescending else {
+            throw SwapQuoteValidationError.nonPositiveAmount(field: "amountInFormatted")
+        }
+
+        try requireConsistent(name: "amountIn", raw: response.amountIn, formatted: response.amountInFormatted, decimals: originDecimals)
+        try requireConsistent(name: "amountOut", raw: response.amountOut, formatted: response.amountOutFormatted, decimals: destinationDecimals)
+        try requireWithinSlippage(
+            swapType: request.swapType, amountIn: response.amountIn, amountOut: response.amountOut,
+            minAmountIn: response.minAmountIn, minAmountOut: response.minAmountOut, slippageToleranceBps: request.slippageTolerance
+        )
+        try requireMatchesRequestedAmount(swapType: request.swapType, requestedAmount: request.amount, rawAmountIn: response.amountIn, rawAmountOut: response.amountOut)
+    }
+
     /// The signed raw base-unit amount must equal the exact decimal expansion of the displayed
     /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
     /// must not be relaxed to a tolerance.

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -1,0 +1,32 @@
+//
+//  SwapQuoteValidation.swift
+//  Zashi
+//
+
+import Foundation
+
+/// Typed failures from validating a swap quote against the request we sent and the user's intent.
+/// Each is fail-closed: the caller maps any of these to the existing "quote unavailable" path.
+enum SwapQuoteValidationError: Error, Equatable {
+    case assetMismatch(field: String)
+    case swapTypeMismatch
+    case slippageToleranceMismatch
+    case amountInconsistency(field: String)
+    case nonPositiveAmount(field: String)
+    case slippageExceeded
+    case requestedAmountMismatch
+    case recipientMismatch
+    case refundMismatch
+}
+
+enum SwapQuoteValidator {
+    /// The signed raw base-unit amount must equal the exact decimal expansion of the displayed
+    /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
+    /// must not be relaxed to a tolerance.
+    static func requireConsistent(name: String, raw: Decimal, formatted: Decimal, decimals: Int) throws {
+        let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
+        if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
+    }
+}

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -84,7 +84,14 @@ enum SwapQuoteValidator {
         guard !raw.isNaN, !formatted.isNaN, (0...32).contains(decimals) else {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
-        let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
+        // A server-controlled `formatted` can be huge (e.g. "1e120"); the default NSDecimalNumber behavior
+        // raises an uncatchable NSDecimalNumberOverflowException on overflow, so use the non-raising handler
+        // and fail closed on the resulting NaN rather than crash.
+        let expected = NSDecimalNumber(decimal: formatted)
+            .multiplying(byPowerOf10: Int16(decimals), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
+        guard !expected.doubleValue.isNaN else {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
         if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
@@ -113,8 +120,11 @@ enum SwapQuoteValidator {
         case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
             // Output floats: minAmountOut must be >= amountOut * (1 - slippage), rounded DOWN.
             let floor = NSDecimalNumber(decimal: amountOut)
-                .multiplying(by: denominator.subtracting(bps))
+                .multiplying(by: denominator.subtracting(bps), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
                 .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundDownZeroScale)
+            guard !floor.doubleValue.isNaN else {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
             if NSDecimalNumber(decimal: minAmountOut).compare(floor) == ComparisonResult.orderedAscending {
                 throw SwapQuoteValidationError.slippageExceeded
             }
@@ -122,8 +132,11 @@ enum SwapQuoteValidator {
         case Near1Click.Constants.exactOutput:
             // Input floats: minAmountIn (worst-case max input) must be <= amountIn * (1 + slippage), rounded UP.
             let ceiling = NSDecimalNumber(decimal: amountIn)
-                .multiplying(by: denominator.adding(bps))
+                .multiplying(by: denominator.adding(bps), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
                 .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundUpZeroScale)
+            guard !ceiling.doubleValue.isNaN else {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
             if NSDecimalNumber(decimal: minAmountIn).compare(ceiling) == ComparisonResult.orderedDescending {
                 throw SwapQuoteValidationError.slippageExceeded
             }
@@ -166,6 +179,14 @@ enum SwapQuoteValidator {
             throw SwapQuoteValidationError.requestedAmountMismatch
         }
     }
+
+    /// Full-precision, non-raising behavior for the consistency/slippage multiplications. A server-controlled
+    /// amount can overflow `Decimal`; the default behavior raises an uncatchable NSDecimalNumberOverflowException,
+    /// so this returns NaN on overflow and the callers fail closed instead of crashing.
+    static let nonRaisingNoScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.plain, scale: Int16(NSDecimalNoScale),
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
 
     static let roundDownZeroScale = NSDecimalNumberHandler(
         roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -44,7 +44,8 @@ enum SwapQuoteValidator {
         minAmountOut: Decimal,
         slippageToleranceBps: Int
     ) throws {
-        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN, slippageToleranceBps >= 0 else {
+        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN,
+              slippageToleranceBps >= 0, slippageToleranceBps <= 10_000 else {
             throw SwapQuoteValidationError.slippageExceeded
         }
 
@@ -71,6 +72,8 @@ enum SwapQuoteValidator {
             }
 
         default:
+            // Unknown swap type has no floating side to validate. swapType is pinned to the request by the
+            // validate() orchestrator, so this is unreachable in the integrated path; no-op here is safe.
             break
         }
     }

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -24,6 +24,9 @@ enum SwapQuoteValidator {
     /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
     /// must not be relaxed to a tolerance.
     static func requireConsistent(name: String, raw: Decimal, formatted: Decimal, decimals: Int) throws {
+        guard !raw.isNaN, !formatted.isNaN, (0...32).contains(decimals) else {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
         let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
         if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
             throw SwapQuoteValidationError.amountInconsistency(field: name)

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -78,6 +78,38 @@ enum SwapQuoteValidator {
         }
     }
 
+    /// The returned asset id must exactly equal the asset id we requested (an opaque identifier from the
+    /// same token list, so exact-match is correct).
+    static func requireMatchingAssetId(field: String, expected: String, actual: String) throws {
+        if expected != actual {
+            throw SwapQuoteValidationError.assetMismatch(field: field)
+        }
+    }
+
+    /// The user-fixed side of the swap must equal the amount the user requested (exact, in base units).
+    /// EXACT_INPUT / FLEX_INPUT fix the input; EXACT_OUTPUT fixes the output. Fails closed on an
+    /// unparseable/NaN requested amount, a NaN quoted amount, or an unknown swap type.
+    static func requireMatchesRequestedAmount(swapType: String, requestedAmount: String, rawAmountIn: Decimal, rawAmountOut: Decimal) throws {
+        guard let requested = Decimal(string: requestedAmount, locale: Locale(identifier: "en_US_POSIX")), !requested.isNaN else {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        let userFixed: Decimal
+        switch swapType {
+        case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
+            userFixed = rawAmountIn
+        case Near1Click.Constants.exactOutput:
+            userFixed = rawAmountOut
+        default:
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        guard !userFixed.isNaN else {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        if NSDecimalNumber(decimal: userFixed).compare(NSDecimalNumber(decimal: requested)) != ComparisonResult.orderedSame {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+    }
+
     static let roundDownZeroScale = NSDecimalNumberHandler(
         roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
         raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -22,7 +22,6 @@ enum SwapQuoteValidationError: Error, Equatable {
 /// The subset of the swap-quote response the validator inspects: the echoed `quoteRequest` fields plus
 /// the `quote` amounts, all already parsed into typed values.
 struct SwapQuoteResponseFields: Equatable {
-    let depositAddress: String
     let echoedOriginAsset: String
     let echoedDestinationAsset: String
     let echoedSwapType: String

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -32,4 +32,56 @@ enum SwapQuoteValidator {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
     }
+
+    /// Fail-closed slippage check on the server-determined (floating) side of the quote. Integer base-unit
+    /// math with the server's own DOWN/UP truncation so legitimate boundary quotes are accepted. Fails
+    /// closed on NaN bounds (server-controlled strings can parse to NaN) and negative slippage.
+    static func requireWithinSlippage(
+        swapType: String,
+        amountIn: Decimal,
+        amountOut: Decimal,
+        minAmountIn: Decimal,
+        minAmountOut: Decimal,
+        slippageToleranceBps: Int
+    ) throws {
+        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN, slippageToleranceBps >= 0 else {
+            throw SwapQuoteValidationError.slippageExceeded
+        }
+
+        let denominator = NSDecimalNumber(value: 10_000)
+        let bps = NSDecimalNumber(value: slippageToleranceBps)
+
+        switch swapType {
+        case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
+            // Output floats: minAmountOut must be >= amountOut * (1 - slippage), rounded DOWN.
+            let floor = NSDecimalNumber(decimal: amountOut)
+                .multiplying(by: denominator.subtracting(bps))
+                .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundDownZeroScale)
+            if NSDecimalNumber(decimal: minAmountOut).compare(floor) == ComparisonResult.orderedAscending {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
+
+        case Near1Click.Constants.exactOutput:
+            // Input floats: minAmountIn (worst-case max input) must be <= amountIn * (1 + slippage), rounded UP.
+            let ceiling = NSDecimalNumber(decimal: amountIn)
+                .multiplying(by: denominator.adding(bps))
+                .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundUpZeroScale)
+            if NSDecimalNumber(decimal: minAmountIn).compare(ceiling) == ComparisonResult.orderedDescending {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
+
+        default:
+            break
+        }
+    }
+
+    static let roundDownZeroScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
+
+    static let roundUpZeroScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.up, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
 }

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -46,6 +46,7 @@ struct Near1Click {
         static let refundedAmountFormatted = "refundedAmountFormatted"
         static let amountInFormatted = "amountInFormatted"
         static let amountOutFormatted = "amountOutFormatted"
+        static let minAmountOut = "minAmountOut"
         static let recipient = "recipient"
         static let deadline = "deadline"
         static let timestamp = "timestamp"
@@ -273,6 +274,103 @@ struct Near1Click {
 
         return chainAssets.removingDuplicates()
     }
+
+    /// Parses a NEAR 1Click quote response and validates it against the request we sent, returning a
+    /// trusted `SwapQuote` or throwing. Throws `SwapQuoteValidationError` on a field/amount/slippage
+    /// mismatch and `SwapAndPayClient.EndpointError.message` on malformed JSON. Pure and unit-testable.
+    static func makeValidatedQuote(
+        jsonObject: [String: Any],
+        request: SwapQuoteRequest,
+        zecAsset: SwapAsset,
+        toAsset: SwapAsset,
+        isSwapToZec: Bool
+    ) throws -> SwapQuote {
+        guard let quote = jsonObject[Constants.quote] as? [String: Any],
+              let depositAddress = quote[Constants.depositAddress] as? String,
+              let amountInString = quote[Constants.amountIn] as? String,
+              let amountInUsdString = quote[Constants.amountInUsd] as? String,
+              let amountInFormattedString = quote[Constants.amountInFormatted] as? String,
+              let minAmountInString = quote[Constants.minAmountIn] as? String,
+              let minAmountOutString = quote[Constants.minAmountOut] as? String,
+              let amountOutString = quote[Constants.amountOut] as? String,
+              let amountOutUsdString = quote[Constants.amountOutUsd] as? String,
+              let amountOutFormattedString = quote[Constants.amountOutFormatted] as? String,
+              let timeEstimate = quote[Constants.timeEstimate] as? Int else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
+        }
+
+        guard let quoteRequestDict = jsonObject[Constants.quoteRequest] as? [String: Any],
+              let echoedOriginAsset = quoteRequestDict[Constants.originAsset] as? String,
+              let echoedDestinationAsset = quoteRequestDict[Constants.destinationAsset] as? String,
+              let echoedSwapType = quoteRequestDict[Constants.swapType] as? String,
+              let echoedSlippage = quoteRequestDict[Constants.slippageTolerance] as? Int,
+              let echoedRecipient = quoteRequestDict[Constants.recipient] as? String,
+              let echoedRefundTo = quoteRequestDict[Constants.refundTo] as? String else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote request echo failed.")
+        }
+
+        let posix = Locale(identifier: "en_US_POSIX")
+        let amountIn = NSDecimalNumber(string: amountInString).decimalValue
+        let minAmountIn = NSDecimalNumber(string: minAmountInString).decimalValue
+        let minAmountOut = NSDecimalNumber(string: minAmountOutString).decimalValue
+        let amountOut = NSDecimalNumber(string: amountOutString).decimalValue
+
+        guard let amountInFormatted = Decimal(string: amountInFormattedString, locale: posix),
+              let amountOutFormatted = Decimal(string: amountOutFormattedString, locale: posix) else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
+        }
+
+        let response = SwapQuoteResponseFields(
+            depositAddress: depositAddress,
+            echoedOriginAsset: echoedOriginAsset,
+            echoedDestinationAsset: echoedDestinationAsset,
+            echoedSwapType: echoedSwapType,
+            echoedSlippageTolerance: echoedSlippage,
+            echoedRecipient: echoedRecipient,
+            echoedRefundTo: echoedRefundTo,
+            amountIn: amountIn,
+            amountInFormatted: amountInFormatted,
+            minAmountIn: minAmountIn,
+            amountOut: amountOut,
+            amountOutFormatted: amountOutFormatted,
+            minAmountOut: minAmountOut
+        )
+
+        try SwapQuoteValidator.validate(
+            request: request,
+            response: response,
+            originDecimals: isSwapToZec ? toAsset.decimals : zecAsset.decimals,
+            destinationDecimals: isSwapToZec ? zecAsset.decimals : toAsset.decimals
+        )
+
+        if isSwapToZec {
+            return SwapQuote(
+                depositAddress: depositAddress,
+                amountIn: amountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
+                amountInUsd: amountInUsdString,
+                minAmountIn: minAmountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
+                amountOut: amountOut / Decimal(pow(10.0, Double(zecAsset.decimals))),
+                amountOutUsd: amountOutUsdString,
+                timeEstimate: TimeInterval(timeEstimate),
+                recipient: echoedRecipient,
+                originAssetId: echoedOriginAsset,
+                destinationAssetId: echoedDestinationAsset
+            )
+        }
+
+        return SwapQuote(
+            depositAddress: depositAddress,
+            amountIn: amountIn,
+            amountInUsd: amountInUsdString,
+            minAmountIn: minAmountIn,
+            amountOut: amountOut / Decimal(pow(10.0, Double(toAsset.decimals))),
+            amountOutUsd: amountOutUsdString,
+            timeEstimate: TimeInterval(timeEstimate),
+            recipient: echoedRecipient,
+            originAssetId: echoedOriginAsset,
+            destinationAssetId: echoedDestinationAsset
+        )
+    }
 }
 
 extension Near1Click {
@@ -366,42 +464,19 @@ extension Near1Click {
                 )
             }
             
-            guard let quote = jsonObject[Constants.quote] as? [String: Any],
-                  let depositAddress = quote[Constants.depositAddress] as? String,
-                  let amountInString = quote[Constants.amountIn] as? String,
-                  let amountInUsdString = quote[Constants.amountInUsd] as? String,
-                  let minAmountInString = quote[Constants.minAmountIn] as? String,
-                  let amountOutString = quote[Constants.amountOut] as? String,
-                  let amountOutUsdString = quote[Constants.amountOutUsd] as? String,
-                  let timeEstimate = quote[Constants.timeEstimate] as? Int else {
-                throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
-            }
-            
-            let amountIn = NSDecimalNumber(string: amountInString).decimalValue
-            let minAmountIn = NSDecimalNumber(string: minAmountInString).decimalValue
-            let amountOut = NSDecimalNumber(string: amountOutString).decimalValue
-            
-            if isSwapToZec {
-                return SwapQuote(
-                    depositAddress: depositAddress,
-                    amountIn: amountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
-                    amountInUsd: amountInUsdString,
-                    minAmountIn: minAmountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
-                    amountOut: amountOut / Decimal(pow(10.0, Double(zecAsset.decimals))),
-                    amountOutUsd: amountOutUsdString,
-                    timeEstimate: TimeInterval(timeEstimate)
+            do {
+                return try Near1Click.makeValidatedQuote(
+                    jsonObject: jsonObject,
+                    request: requestData,
+                    zecAsset: zecAsset,
+                    toAsset: toAsset,
+                    isSwapToZec: isSwapToZec
+                )
+            } catch is SwapQuoteValidationError {
+                throw SwapAndPayClient.EndpointError.message(
+                    String(localizable: exactInput ? .swapQuoteUnavailableSwap : .swapQuoteUnavailable)
                 )
             }
-            
-            return SwapQuote(
-                depositAddress: depositAddress,
-                amountIn: amountIn,
-                amountInUsd: amountInUsdString,
-                minAmountIn: minAmountIn,
-                amountOut: amountOut / Decimal(pow(10.0, Double(toAsset.decimals))),
-                amountOutUsd: amountOutUsdString,
-                timeEstimate: TimeInterval(timeEstimate)
-            )
         },
         status: { depositAddress, isSwapToZec in
             let (data, response) = try await Near1Click.getCall(urlString: "\(Constants.statusUrl)\(depositAddress)", includeJwtKey: true)

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -321,7 +321,6 @@ struct Near1Click {
         }
 
         let response = SwapQuoteResponseFields(
-            depositAddress: depositAddress,
             echoedOriginAsset: echoedOriginAsset,
             echoedDestinationAsset: echoedDestinationAsset,
             echoedSwapType: echoedSwapType,

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -738,13 +738,27 @@ struct SwapAndPay {
                     state.isQuoteRequestInFlight = false
                     return .none
                 }
-                let zecAmount = Zatoshi(NSDecimalNumber(decimal: quote.amountIn).int64Value)
+                // Defensive re-bind to current user intent before signing (TOCTOU guard). The quote was
+                // already validated against the request at parse time; this re-checks it against the state
+                // the user is looking at now and fails closed without building a proposal.
+                guard let selectedAsset = state.selectedAsset,
+                      let zecAsset = state.zecAsset,
+                      quote.matchesSigningIntent(
+                        address: state.address,
+                        originAssetId: zecAsset.assetId,
+                        destinationAssetId: selectedAsset.assetId
+                      ) else {
+                    return .send(.sendFailed("swap quote does not match request".toZcashError()))
+                }
+                guard let zecAmount = Zatoshi(safeZatoshiDecimal: quote.amountIn) else {
+                    return .send(.sendFailed("swap amount out of range".toZcashError()))
+                }
                 return .run { send in
                     do {
                         let recipient = try Recipient(quote.depositAddress, network: zcashSDKEnvironment.network().networkType)
 
                         let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, zecAmount, nil)
-                        
+
                         await send(.proposal(proposal))
                     } catch {
                         await send(.sendFailed(error.toZcashError()))

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -1411,7 +1411,7 @@ extension SwapAndPay.State {
         
         let zashiFeeCoeff = (Decimal(SwapAndPayClient.Constants.zashiFeeBps) / Decimal(10_000))
         let zashiFee = quote.amountIn * zashiFeeCoeff
-        let zatoshi = Zatoshi(Int64(truncating: NSDecimalNumber(decimal: zashiFee)))
+        let zatoshi = Zatoshi(NSDecimalNumber(decimal: zashiFee).clampedInt64Value)
         
         return zatoshi.decimalString()
     }
@@ -1454,7 +1454,7 @@ extension SwapAndPay.State {
         let swapCoeff: Decimal = isSwapExperienceEnabled ? 0.0 : 1.0
         let slippageDecimal = amountInUsdDecimal * slippage * 0.01 * swapCoeff
         let zatoshiDecimal = NSDecimalNumber(decimal: (slippageDecimal / zecAsset.usdPrice) * Decimal(Zatoshi.Constants.oneZecInZatoshi))
-        let zatoshi = Zatoshi(Int64(zatoshiDecimal.doubleValue))
+        let zatoshi = Zatoshi(zatoshiDecimal.clampedInt64Value)
         
         return zatoshi.decimalString()
     }
@@ -1512,7 +1512,7 @@ extension SwapAndPay.State {
         
         // zashi fee
         let zashiFee = quote.amountIn * 0.005
-        let zatoshiZashiFee = Int64(truncating: NSDecimalNumber(decimal: zashiFee))
+        let zatoshiZashiFee = NSDecimalNumber(decimal: zashiFee).clampedInt64Value
         
         return transactionFee + zatoshiZashiFee
     }

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -1,0 +1,41 @@
+//
+//  SafeNumericConversions.swift
+//  Zashi
+//
+
+import Foundation
+@preconcurrency import ZcashLightClientKit
+
+extension NSDecimalNumber {
+    /// `int64Value` clamped to the representable range. Never traps — unlike `Int64(self.doubleValue)`,
+    /// which traps when the value exceeds `Int64`'s range or is non-finite.
+    var clampedInt64Value: Int64 {
+        if self.compare(NSDecimalNumber(value: Int64.max)) != ComparisonResult.orderedAscending {
+            return Int64.max
+        }
+        if self.compare(NSDecimalNumber(value: Int64.min)) != ComparisonResult.orderedDescending {
+            return Int64.min
+        }
+        return self.int64Value
+    }
+}
+
+extension Zatoshi {
+    /// Builds a `Zatoshi` from a zatoshi-denominated `Decimal`, returning nil (instead of trapping or
+    /// wrapping) when the value is NaN, negative, or above the max ZEC supply. The fractional part is
+    /// truncated DOWN.
+    init?(safeZatoshiDecimal decimal: Decimal) {
+        guard !decimal.isNaN, decimal >= Decimal(0) else {
+            return nil
+        }
+        var rounded = Decimal()
+        var value = decimal
+        NSDecimalRound(&rounded, &value, 0, NSDecimalNumber.RoundingMode.down)
+
+        let maxZatoshi = Decimal(21_000_000) * Decimal(Zatoshi.Constants.oneZecInZatoshi)
+        guard rounded <= maxZatoshi else {
+            return nil
+        }
+        self = Zatoshi(NSDecimalNumber(decimal: rounded).clampedInt64Value)
+    }
+}

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -7,16 +7,30 @@ import Foundation
 @preconcurrency import ZcashLightClientKit
 
 extension NSDecimalNumber {
-    /// `int64Value` clamped to the representable range. Never traps — unlike `Int64(self.doubleValue)`,
-    /// which traps when the value exceeds `Int64`'s range or is non-finite.
+    private static let int64MaxValue = NSDecimalNumber(value: Int64.max)
+    private static let int64MinValue = NSDecimalNumber(value: Int64.min)
+    /// Truncates the fractional part DOWN before the `Int64` conversion. `NSDecimalNumber.int64Value`
+    /// returns 0 for any value with a fractional part, so it must be rounded to integer scale first.
+    private static let truncatingBehavior = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
+
+    /// `Int64` value clamped to the representable range, with any fractional part truncated DOWN. Never
+    /// traps — unlike `Int64(self.doubleValue)`, which traps when the value exceeds `Int64`'s range or is
+    /// non-finite. A NaN maps to `0`. `NSDecimalNumber.int64Value` returns `0` for any non-integer value,
+    /// so the value is rounded to integer scale before that conversion.
     var clampedInt64Value: Int64 {
-        if self.compare(NSDecimalNumber(value: Int64.max)) != ComparisonResult.orderedAscending {
+        if self.doubleValue.isNaN {
+            return 0
+        }
+        if self.compare(NSDecimalNumber.int64MaxValue) != ComparisonResult.orderedAscending {
             return Int64.max
         }
-        if self.compare(NSDecimalNumber(value: Int64.min)) != ComparisonResult.orderedDescending {
+        if self.compare(NSDecimalNumber.int64MinValue) != ComparisonResult.orderedDescending {
             return Int64.min
         }
-        return self.int64Value
+        return self.rounding(accordingToBehavior: NSDecimalNumber.truncatingBehavior).int64Value
     }
 }
 

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -46,7 +46,7 @@ extension Zatoshi {
         var value = decimal
         NSDecimalRound(&rounded, &value, 0, NSDecimalNumber.RoundingMode.down)
 
-        let maxZatoshi = Decimal(21_000_000) * Decimal(Zatoshi.Constants.oneZecInZatoshi)
+        let maxZatoshi = Decimal(Zatoshi.Constants.maxZatoshi)
         guard rounded <= maxZatoshi else {
             return nil
         }

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -83,10 +83,51 @@ import Testing
         }
     }
 
-    @Test func rejectsMissingMinAmountOut() {
-        #expect(throws: (any Error).self) {
+    @Test func rejectsMissingMinAmountOutAsEndpointError() {
+        // A malformed/missing field surfaces as EndpointError (NOT a validation error), so it propagates
+        // out of the closure's `catch is SwapQuoteValidationError` and still fails closed downstream.
+        #expect(throws: SwapAndPayClient.EndpointError.self) {
             _ = try Near1Click.makeValidatedQuote(
                 jsonObject: self.json(includeMinAmountOut: false),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func acceptsValidSwapToZecQuote() throws {
+        // Swap-to-ZEC (token -> ZEC, FLEX_INPUT): user fixes the token input; amountIn is divided by the
+        // token's decimals and amountOut by ZEC's decimals when built.
+        let swapToZecRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.flexInput, slippageTolerance: 100,
+            originAsset: "btc.id", depositType: Near1Click.Constants.originChain, destinationAsset: "zec.id",
+            amount: "200000", refundTo: "user-btc-addr", refundType: Near1Click.Constants.originChain,
+            recipient: "wallet-ua", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let swapToZecJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "200000", "amountInUsd": "10",
+                "amountInFormatted": "0.002", "minAmountIn": "200000",
+                "amountOut": "100000000", "amountOutUsd": "10", "amountOutFormatted": "1", "minAmountOut": "99000000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "btc.id", "destinationAsset": "zec.id", "swapType": Near1Click.Constants.flexInput,
+                "slippageTolerance": 100, "recipient": "wallet-ua", "refundTo": "user-btc-addr"
+            ]
+        ]
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: swapToZecJson, request: swapToZecRequest, zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: true)
+        let expectedAmountIn = try #require(Decimal(string: "0.002", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(quote.amountIn == expectedAmountIn)
+        #expect(quote.amountOut == Decimal(1))
+        #expect(quote.originAssetId == "btc.id")
+        #expect(quote.destinationAssetId == "zec.id")
+    }
+
+    @Test func rejectsSwapTypeSubstitution() {
+        #expect(throws: SwapQuoteValidationError.swapTypeMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(swapType: Near1Click.Constants.exactOutput),
                 request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
             )
         }

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -1,0 +1,104 @@
+//
+//  Near1ClickQuoteMapperTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct Near1ClickQuoteMapperTests {
+    private let zecAsset = SwapAsset(provider: "near", chain: "zec", token: "ZEC", assetId: "zec.id", usdPrice: Decimal(30), decimals: 8)
+    private let btcAsset = SwapAsset(provider: "near", chain: "btc", token: "BTC", assetId: "btc.id", usdPrice: Decimal(60_000), decimals: 8)
+
+    private func request(amount: String = "100000000", recipient: String = "recipient", refundTo: String = "refund") -> SwapQuoteRequest {
+        SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactInput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: amount, refundTo: refundTo, refundType: Near1Click.Constants.originChain,
+            recipient: recipient, recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+    }
+
+    private func json(
+        depositAddress: String = "deposit", originAsset: String = "zec.id", destinationAsset: String = "btc.id",
+        swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100,
+        recipient: String = "recipient", refundTo: String = "refund",
+        amountIn: String = "100000000", amountInFormatted: String = "1", minAmountIn: String = "100000000",
+        amountOut: String = "200000", amountOutFormatted: String = "0.002", minAmountOut: String = "198000",
+        includeMinAmountOut: Bool = true
+    ) -> [String: Any] {
+        var quote: [String: Any] = [
+            "depositAddress": depositAddress, "amountIn": amountIn, "amountInUsd": "10",
+            "amountInFormatted": amountInFormatted, "minAmountIn": minAmountIn,
+            "amountOut": amountOut, "amountOutUsd": "10", "amountOutFormatted": amountOutFormatted,
+            "timeEstimate": 60
+        ]
+        if includeMinAmountOut {
+            quote["minAmountOut"] = minAmountOut
+        }
+        return [
+            "quote": quote,
+            "quoteRequest": [
+                "originAsset": originAsset, "destinationAsset": destinationAsset, "swapType": swapType,
+                "slippageTolerance": slippage, "recipient": recipient, "refundTo": refundTo
+            ]
+        ]
+    }
+
+    @Test func acceptsValidQuote() throws {
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: json(), request: request(), zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false)
+        #expect(quote.depositAddress == "deposit")
+        #expect(quote.amountIn == Decimal(100_000_000))
+        #expect(quote.recipient == "recipient")
+        #expect(quote.originAssetId == "zec.id")
+        #expect(quote.destinationAssetId == "btc.id")
+    }
+
+    @Test func rejectsInflatedAmountIn() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(amountIn: "200000000", amountInFormatted: "2", minAmountIn: "200000000"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsRecipientSubstitution() {
+        #expect(throws: SwapQuoteValidationError.recipientMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(recipient: "attacker"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsOriginAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(originAsset: "zec.tampered"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsMissingMinAmountOut() {
+        #expect(throws: (any Error).self) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(includeMinAmountOut: false),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func depositAddressSubstitutionAloneIsNotCaught() throws {
+        // Documented residual: binding cannot detect a swapped deposit address (server-generated, unverifiable).
+        // Only transport security (user-opt-in Tor) closes this; the quote still builds with the attacker address.
+        let quote = try Near1Click.makeValidatedQuote(
+            jsonObject: json(depositAddress: "attacker-deposit"),
+            request: request(), zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false
+        )
+        #expect(quote.depositAddress == "attacker-deposit")
+    }
+}

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -142,4 +142,60 @@ import Testing
         )
         #expect(quote.depositAddress == "attacker-deposit")
     }
+
+    @Test func acceptsValidCrosspayQuote() throws {
+        // Crosspay (ZEC -> token, EXACT_OUTPUT): user fixes the token OUTPUT; the ZEC input floats within the
+        // slippage ceiling. amountIn (ZEC) is kept raw for signing; amountOut is divided by the token decimals.
+        let crosspayRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactOutput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: "200000", refundTo: "refund", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let crosspayJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "300000000", "amountInUsd": "10",
+                "amountInFormatted": "3", "minAmountIn": "303000000",
+                "amountOut": "200000", "amountOutUsd": "10", "amountOutFormatted": "0.002", "minAmountOut": "200000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "zec.id", "destinationAsset": "btc.id", "swapType": Near1Click.Constants.exactOutput,
+                "slippageTolerance": 100, "recipient": "recipient", "refundTo": "refund"
+            ]
+        ]
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: crosspayJson, request: crosspayRequest, zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false)
+        #expect(quote.amountIn == Decimal(300_000_000))
+        let expectedAmountOut = try #require(Decimal(string: "0.002", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(quote.amountOut == expectedAmountOut)
+        #expect(quote.recipient == "recipient")
+    }
+
+    @Test func rejectsCrosspayInputAboveSlippageCeiling() {
+        // EXACT_OUTPUT input floats: ceiling = amountIn 300000000 × 1.01 = 303000000. A guaranteed worst-case
+        // input above that exceeds the user's slippage tolerance and must fail closed.
+        let crosspayRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactOutput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: "200000", refundTo: "refund", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let crosspayJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "300000000", "amountInUsd": "10",
+                "amountInFormatted": "3", "minAmountIn": "400000000",
+                "amountOut": "200000", "amountOutUsd": "10", "amountOutFormatted": "0.002", "minAmountOut": "200000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "zec.id", "destinationAsset": "btc.id", "swapType": Near1Click.Constants.exactOutput,
+                "slippageTolerance": 100, "recipient": "recipient", "refundTo": "refund"
+            ]
+        ]
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            _ = try Near1Click.makeValidatedQuote(jsonObject: crosspayJson, request: crosspayRequest, zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false)
+        }
+    }
 }

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -74,6 +74,17 @@ import Testing
         }
     }
 
+    @Test func rejectsOverflowingAmountFormatted() {
+        // A huge server amountInFormatted overflows the consistency multiply; it must fail closed as a
+        // validation error, not crash the validator with an uncatchable NSDecimalNumberOverflowException.
+        #expect(throws: SwapQuoteValidationError.self) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(amountInFormatted: "1e120"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
     @Test func rejectsOriginAssetSubstitution() {
         #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
             _ = try Near1Click.makeValidatedQuote(

--- a/zodlTests/SwapTests/SafeNumericConversionsTests.swift
+++ b/zodlTests/SwapTests/SafeNumericConversionsTests.swift
@@ -1,0 +1,44 @@
+//
+//  SafeNumericConversionsTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct SafeNumericConversionsTests {
+    @Test func clampedInt64ReturnsValueInRange() {
+        #expect(NSDecimalNumber(value: 100).clampedInt64Value == 100)
+    }
+
+    @Test func clampedInt64ClampsAboveMax() {
+        let huge = NSDecimalNumber(string: "99999999999999999999")
+        #expect(huge.clampedInt64Value == Int64.max)
+    }
+
+    @Test func clampedInt64ClampsBelowMin() {
+        let veryNegative = NSDecimalNumber(string: "-99999999999999999999")
+        #expect(veryNegative.clampedInt64Value == Int64.min)
+    }
+
+    @Test func safeZatoshiAcceptsNormalValue() {
+        let zatoshi = Zatoshi(safeZatoshiDecimal: Decimal(100_000_000))
+        #expect(zatoshi == Zatoshi(100_000_000))
+    }
+
+    @Test func safeZatoshiTruncatesFraction() throws {
+        let value = try #require(Decimal(string: "100000000.9", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(Zatoshi(safeZatoshiDecimal: value) == Zatoshi(100_000_000))
+    }
+
+    @Test func safeZatoshiRejectsNegative() {
+        #expect(Zatoshi(safeZatoshiDecimal: Decimal(-1)) == nil)
+    }
+
+    @Test func safeZatoshiRejectsOverMaxSupply() throws {
+        let overMax = try #require(Decimal(string: "99999999999999999999", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(Zatoshi(safeZatoshiDecimal: overMax) == nil)
+    }
+}

--- a/zodlTests/SwapTests/SafeNumericConversionsTests.swift
+++ b/zodlTests/SwapTests/SafeNumericConversionsTests.swift
@@ -23,6 +23,19 @@ import Testing
         #expect(veryNegative.clampedInt64Value == Int64.min)
     }
 
+    @Test func clampedInt64TruncatesNonInteger() {
+        // Regression: NSDecimalNumber.int64Value returns 0 for any value with a fractional part, so an
+        // in-range non-integer (e.g. the slippage buffer in swapSlippageStr) must be truncated, not zeroed.
+        #expect(NSDecimalNumber(string: "333333.3333").clampedInt64Value == 333_333)
+        #expect(NSDecimalNumber(string: "0.9").clampedInt64Value == 0)
+        #expect(NSDecimalNumber(string: "100.5").clampedInt64Value == 100)
+    }
+
+    @Test func clampedInt64MapsNaNToZero() {
+        // A NaN (e.g. a Decimal division by a server usdPrice of 0) must fall back to 0, not Int64.min.
+        #expect(NSDecimalNumber.notANumber.clampedInt64Value == 0)
+    }
+
     @Test func safeZatoshiAcceptsNormalValue() {
         let zatoshi = Zatoshi(safeZatoshiDecimal: Decimal(100_000_000))
         #expect(zatoshi == Zatoshi(100_000_000))

--- a/zodlTests/SwapTests/SwapQuoteIntentTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteIntentTests.swift
@@ -1,0 +1,30 @@
+//
+//  SwapQuoteIntentTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct SwapQuoteIntentTests {
+    private func quote(recipient: String = "addr", origin: String = "zec.id", destination: String = "btc.id") -> SwapQuote {
+        SwapQuote(
+            depositAddress: "deposit", amountIn: Decimal(100_000_000), amountInUsd: "10",
+            minAmountIn: Decimal(100_000_000), amountOut: Decimal(2_000_000), amountOutUsd: "10",
+            timeEstimate: 60, recipient: recipient, originAssetId: origin, destinationAssetId: destination
+        )
+    }
+
+    @Test func matchesWhenAllFieldsAgree() {
+        #expect(quote().matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "btc.id"))
+    }
+
+    @Test func failsWhenRecipientDiffers() {
+        #expect(!quote(recipient: "other").matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "btc.id"))
+    }
+
+    @Test func failsWhenDestinationAssetDiffers() {
+        #expect(!quote().matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "eth.id"))
+    }
+}

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -1,3 +1,8 @@
+//
+//  SwapQuoteValidationTests.swift
+//  Zashi
+//
+
 import Foundation
 import Testing
 @testable import zodl_internal
@@ -18,5 +23,22 @@ import Testing
         #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
             try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(2), decimals: 8)
         }
+    }
+
+    @Test func requireConsistentThrowsOnNaNRaw() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal.nan, formatted: Decimal(1), decimals: 8)
+        }
+    }
+
+    @Test func requireConsistentThrowsOnOutOfRangeDecimals() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(1), decimals: 1000)
+        }
+    }
+
+    @Test func requireConsistentPassesForFractionalFormatted() throws {
+        let formatted = try #require(Decimal(string: "0.00000001", locale: Locale(identifier: "en_US_POSIX")))
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -205,7 +205,7 @@ import Testing
         minAmountOut: Decimal = Decimal(1_980_000)
     ) -> SwapQuoteResponseFields {
         SwapQuoteResponseFields(
-            depositAddress: "deposit-addr", echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
+            echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
             echoedSwapType: swapType, echoedSlippageTolerance: slippage, echoedRecipient: recipient, echoedRefundTo: refundTo,
             amountIn: amountIn, amountInFormatted: amountInFormatted, minAmountIn: minAmountIn,
             amountOut: amountOut, amountOutFormatted: amountOutFormatted, minAmountOut: minAmountOut

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -42,6 +42,16 @@ import Testing
         try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
 
+    @Test func requireConsistentFailsClosedOnOverflowingFormatted() throws {
+        // A server-controlled `formatted` can overflow when multiplied by 10^decimals; the default
+        // NSDecimalNumber behavior would raise an uncatchable NSDecimalNumberOverflowException (crash).
+        // It must instead fail closed.
+        let huge = try #require(Decimal(string: "1e120", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: huge, decimals: 8)
+        }
+    }
+
     // MARK: requireWithinSlippage — server's worst-case guarantee must respect requested slippage
 
     @Test func slippageOutputFloatingPassesAtAndAboveFloor() throws {
@@ -108,6 +118,24 @@ import Testing
         // minAmountOut passes (bypass). The bound must make this fail closed.
         #expect(throws: SwapQuoteValidationError.slippageExceeded) {
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
+        }
+    }
+
+    @Test func slippageFailsClosedOnOverflowingOutput() throws {
+        // amountOut * (10000 - bps) overflows Decimal; the multiply must not trap, and the NaN result
+        // must fail closed (output-floating side).
+        let huge = try #require(Decimal(string: "1e125", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: huge, minAmountIn: Decimal(1000), minAmountOut: Decimal(1), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnOverflowingInput() throws {
+        // amountIn * (10000 + bps) overflows Decimal on the EXACT_OUTPUT ceiling. compare(NaN) is
+        // orderedAscending, so without the explicit NaN guard this would bypass — it must fail closed.
+        let huge = try #require(Decimal(string: "1e125", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: huge, amountOut: Decimal(1000), minAmountIn: Decimal(1), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
         }
     }
 

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -110,4 +110,48 @@ import Testing
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
         }
     }
+
+    // MARK: requireMatchingAssetId
+
+    @Test func requireMatchingAssetIdPassesOnEqual() throws {
+        try SwapQuoteValidator.requireMatchingAssetId(field: "originAsset", expected: "nep141:zec.omft.near", actual: "nep141:zec.omft.near")
+    }
+
+    @Test func requireMatchingAssetIdThrowsOnDifferent() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            try SwapQuoteValidator.requireMatchingAssetId(field: "originAsset", expected: "a", actual: "b")
+        }
+    }
+
+    // MARK: requireMatchesRequestedAmount — user-fixed side must equal requested base units
+
+    @Test func requestedAmountExactInputBindsAmountIn() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+    }
+
+    @Test func requestedAmountExactOutputBindsAmountOut() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactOutput, requestedAmount: "2000000", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+    }
+
+    @Test func requestedAmountFlexInputBindsAmountIn() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.flexInput, requestedAmount: "2000000", rawAmountIn: Decimal(2_000_000), rawAmountOut: Decimal(100_000_000))
+    }
+
+    @Test func requestedAmountThrowsOnInflatedAmountIn() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal(200_000_000), rawAmountOut: Decimal(2_000_000))
+        }
+    }
+
+    @Test func requestedAmountFailsClosedOnNaNAmount() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal.nan, rawAmountOut: Decimal(2_000_000))
+        }
+    }
+
+    @Test func requestedAmountFailsClosedOnUnparseableRequest() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "not-a-number", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -154,4 +154,106 @@ import Testing
             try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "not-a-number", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
         }
     }
+
+    // MARK: validate — full orchestration over a baseline valid EXACT_INPUT quote
+
+    private func baselineRequest(swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100, amount: String = "100000000") -> SwapQuoteRequest {
+        SwapQuoteRequest(
+            dry: false, swapType: swapType, slippageTolerance: slippage,
+            originAsset: "origin.id", depositType: Near1Click.Constants.originChain, destinationAsset: "dest.id",
+            amount: amount, refundTo: "refund-addr", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient-addr", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+    }
+
+    private func baselineResponse(
+        originAsset: String = "origin.id", destinationAsset: String = "dest.id",
+        swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100,
+        recipient: String = "recipient-addr", refundTo: String = "refund-addr",
+        amountIn: Decimal = Decimal(100_000_000), amountInFormatted: Decimal = Decimal(1),
+        minAmountIn: Decimal = Decimal(100_000_000),
+        amountOut: Decimal = Decimal(2_000_000), amountOutFormatted: Decimal = Decimal(2),
+        minAmountOut: Decimal = Decimal(1_980_000)
+    ) -> SwapQuoteResponseFields {
+        SwapQuoteResponseFields(
+            depositAddress: "deposit-addr", echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
+            echoedSwapType: swapType, echoedSlippageTolerance: slippage, echoedRecipient: recipient, echoedRefundTo: refundTo,
+            amountIn: amountIn, amountInFormatted: amountInFormatted, minAmountIn: minAmountIn,
+            amountOut: amountOut, amountOutFormatted: amountOutFormatted, minAmountOut: minAmountOut
+        )
+    }
+
+    private func validateBaseline(request: SwapQuoteRequest? = nil, response: SwapQuoteResponseFields? = nil) throws {
+        try SwapQuoteValidator.validate(
+            request: request ?? baselineRequest(),
+            response: response ?? baselineResponse(),
+            originDecimals: 8, destinationDecimals: 6
+        )
+    }
+
+    @Test func validateAcceptsConsistentQuote() throws {
+        try validateBaseline()
+    }
+
+    @Test func validateRejectsOriginAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            try self.validateBaseline(response: self.baselineResponse(originAsset: "origin.tampered"))
+        }
+    }
+
+    @Test func validateRejectsDestinationAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "destinationAsset")) {
+            try self.validateBaseline(response: self.baselineResponse(destinationAsset: "dest.tampered"))
+        }
+    }
+
+    @Test func validateRejectsSwapTypeSubstitution() {
+        #expect(throws: SwapQuoteValidationError.swapTypeMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(swapType: Near1Click.Constants.exactOutput))
+        }
+    }
+
+    @Test func validateRejectsWidenedSlippageTolerance() {
+        #expect(throws: SwapQuoteValidationError.slippageToleranceMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(slippage: 10_000))
+        }
+    }
+
+    @Test func validateRejectsRecipientSubstitution() {
+        #expect(throws: SwapQuoteValidationError.recipientMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(recipient: "attacker-addr"))
+        }
+    }
+
+    @Test func validateRejectsRefundSubstitution() {
+        #expect(throws: SwapQuoteValidationError.refundMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(refundTo: "attacker-addr"))
+        }
+    }
+
+    @Test func validateRejectsNonPositiveAmountIn() {
+        #expect(throws: SwapQuoteValidationError.nonPositiveAmount(field: "amountInFormatted")) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(0), amountInFormatted: Decimal(0), minAmountIn: Decimal(0)))
+        }
+    }
+
+    @Test func validateRejectsRawFormattedInconsistency() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(999)))
+        }
+    }
+
+    @Test func validateRejectsInflatedAmountIn() {
+        // Consistent at 8 decimals (2 × 1e8 == 200_000_000) but not what the user requested (1 ZEC).
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(200_000_000), amountInFormatted: Decimal(2), minAmountIn: Decimal(200_000_000)))
+        }
+    }
+
+    @Test func validateRejectsSlippageBelowFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try self.validateBaseline(response: self.baselineResponse(minAmountOut: Decimal(1_900_000)))
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -41,4 +41,59 @@ import Testing
         let formatted = try #require(Decimal(string: "0.00000001", locale: Locale(identifier: "en_US_POSIX")))
         try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
+
+    // MARK: requireWithinSlippage — server's worst-case guarantee must respect requested slippage
+
+    @Test func slippageOutputFloatingPassesAtAndAboveFloor() throws {
+        // 10% slippage, amountOut=100 -> floor=90. minAmountIn is the fixed side (== amountIn) and ignored.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(90), slippageToleranceBps: 1000)
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.flexInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(95), slippageToleranceBps: 1000)
+    }
+
+    @Test func slippageOutputFloatingThrowsBelowFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(89), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageInputFloatingPassesAtAndBelowCeiling() throws {
+        // 10% slippage, amountIn=100 -> ceiling=110. minAmountOut is the fixed side and ignored.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(110), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(105), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+    }
+
+    @Test func slippageInputFloatingThrowsAboveCeiling() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(111), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageOutputAcceptsServerIntegerTruncatedFloor() throws {
+        // Real NEAR 1Click $10 ZEC -> USDC @ 30%: amountOut=9897372 × 0.70 = 6928160.4, server truncates DOWN to 6928160.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(2_245_828), amountOut: Decimal(9_897_372), minAmountIn: Decimal(2_245_828), minAmountOut: Decimal(6_928_160), slippageToleranceBps: 3000)
+    }
+
+    @Test func slippageOutputRejectsOneBelowIntegerFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(2_245_828), amountOut: Decimal(9_897_372), minAmountIn: Decimal(2_245_828), minAmountOut: Decimal(6_928_159), slippageToleranceBps: 3000)
+        }
+    }
+
+    @Test func slippageInputAcceptsServerIntegerRoundedCeiling() throws {
+        // amountIn=9897372 × 1.30 = 12866583.6, server rounds UP to 12866584.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(9_897_372), amountOut: Decimal(2_245_828), minAmountIn: Decimal(12_866_584), minAmountOut: Decimal(2_245_828), slippageToleranceBps: 3000)
+    }
+
+    @Test func slippageInputRejectsOneAboveIntegerCeiling() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(9_897_372), amountOut: Decimal(2_245_828), minAmountIn: Decimal(12_866_585), minAmountOut: Decimal(2_245_828), slippageToleranceBps: 3000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnNaNBound() {
+        // Server-controlled min bounds parse to Decimal.nan on garbage; must fail closed, never bypass.
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal.nan, slippageToleranceBps: 1000)
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -96,4 +96,18 @@ import Testing
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal.nan, slippageToleranceBps: 1000)
         }
     }
+
+    @Test func slippageFailsClosedOnNaNAmountInput() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal.nan, amountOut: Decimal(1000), minAmountIn: Decimal(110), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnAbsurdBps() {
+        // Without the <= 10_000 bound, bps=10_001 makes (10000 - bps) negative -> floor negative -> any
+        // minAmountOut passes (bypass). The bound must make this fail closed.
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct SwapQuoteValidationTests {
+    // MARK: requireConsistent — raw base-unit amount must equal formatted × 10^decimals
+
+    @Test func requireConsistentPassesWhenRawMatchesFormatted() throws {
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(1), decimals: 8)
+    }
+
+    @Test func requireConsistentPassesRegardlessOfFormattedScale() throws {
+        let formatted = try #require(Decimal(string: "1.00", locale: Locale(identifier: "en_US_POSIX")))
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: formatted, decimals: 8)
+    }
+
+    @Test func requireConsistentThrowsWhenRawDoesNotMatchFormatted() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(2), decimals: 8)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Hardens cross-chain swaps so a malicious swap provider (NEAR 1Click) — or a TLS MITM on the non-Tor path — can no longer redirect funds by returning a quote whose on-chain ZEC amount/recipient/asset/slippage differ from what the user requested while the UI shows benign values. This ports the Android fix ([zodl-android#2299](https://github.com/zodl-inc/zodl-android/pull/2299), [#2317](https://github.com/zodl-inc/zodl-android/pull/2317)) to iOS and addresses Mythos reports `0KXQ4VWX` (recipient/amount integrity) and `N32VTTCB` (amount-integrity / Int64 facet).

**Approach (matches Android):** bind every server-controlled field back to the request/user intent and **fail closed** before signing — stronger than merely displaying the (user-unverifiable) deposit address, so there is no confirmation-UI change.

### What changed
- **Pure validator** (`SwapQuoteValidation.swift`): asset-id / swapType / slippage-tolerance echo checks, raw↔formatted amount consistency, fail-closed slippage bounds (integer base-unit math), user-fixed-amount binding, positivity — all fail closed on NaN / out-of-range / garbage server input.
- **Parse-time gate** (`Near1Click.makeValidatedQuote`): the single quote-construction chokepoint validates against the request we sent; on any mismatch the live closure routes to the existing "quote unavailable" path (no proposal built).
- **Reducer re-bind** (`SwapAndPayStore.swapQuoteLoaded`): immediately before `proposeTransfer`, re-checks the quote against *current* on-screen intent (`matchesSigningIntent`) and converts the signed amount via an overflow-safe initializer (TOCTOU guard).
- **Overflow-safe conversions** (`SafeNumericConversions.swift`): replaces trapping `Int64(Double)` casts on the swap fee/slippage display path so a hostile `amountInUsd` can't crash the confirmation sheet.

### Protected vs. residual
- **Bound & fail-closed:** signed ZEC amount, off-chain payout recipient, refund address, origin/destination assets, slippage tolerance.
- **Residual (by design):** substituting *only* the on-chain `depositAddress` under a TLS MITM is not closable by binding (it's server-generated and unverifiable). Mitigation is **user-opt-in Tor only** — no cert pinning and no Tor enforcement were added (forcing Tor is a hard product no-go; it's illegal in some jurisdictions). This limitation is documented and asserted in a test.

### Automated tests (56, all green)
`SwapQuoteValidationTests` (36), `Near1ClickQuoteMapperTests` (10, incl. swap / crosspay / swap-to-ZEC and the deposit-address-residual case), `SafeNumericConversionsTests` (7), `SwapQuoteIntentTests` (3).

Design: `docs/superpowers/specs/2026-06-15-ios-swap-quote-binding-security-design.md` · Plan: `docs/superpowers/plans/2026-06-15-ios-swap-quote-binding-security.md`

## Manual test plan

**Prerequisites**
- Run `secant-mainnet` (or `secant-testnet`) on a wallet with spendable ZEC.
- For the tamper tests: an HTTPS debugging proxy (Proxyman/Charles) with its CA trusted on the device, and **Tor Protection disabled** in the app so swap calls use the direct `URLSession` path the proxy can rewrite. Target: `POST https://1click.chaindefuser.com/v0/quote`.

**A. Happy path / regression (no proxy)**
1. Swap **ZEC → BTC**: enter amount, get quote, review sheet shows expected ZEC/fees, confirm (biometrics), tx broadcasts (sending → success).
2. **CrossPay** (pay a non-ZEC address, exact-output): enter token amount + address, get quote, confirm, broadcast.
3. **Swap-to-ZEC** (token → ZEC): get quote; deposit address + QR are shown (no wallet ZEC spend).
   - *Expected:* all flows behave exactly as before — validation is transparent for honest quotes.

**B. Fail-closed — tamper the `/v0/quote` response body; app must show "Swap quote unavailable" and never reach confirmation/sign**
4. Inflate `quote.amountIn` (e.g. ×2) → unavailable.
5. Change `quoteRequest.recipient` (payout address) → unavailable.
6. Change `quoteRequest.originAsset` or `destinationAsset` → unavailable.
7. Widen `quoteRequest.slippageTolerance` (e.g. to `10000`) → unavailable.
8. Lower `quote.minAmountOut` below the floor `amountOut × (1 − slippage)` → unavailable.
9. Make `quote.amountIn` inconsistent with `quote.amountInFormatted` (off by 1) → unavailable.

**C. Documented residual (with proxy)**
10. Change **only** `quote.depositAddress` (leave amounts/recipient/assets/slippage intact) → the swap **still proceeds**. This is the known, by-design limitation (mitigated only by user-opt-in Tor). Not a bug.

**D. Transport (Tor)**
11. Enable Tor Protection and repeat A.1 → still works (validation runs identically on the Tor path). Note: tamper tests (B/C) require the direct path because a proxy can't inspect Tor traffic.

*(The Int64/exchange-rate crash facet is hard to trigger manually — it needs a pathological server `amountInUsd` — and is covered by `SafeNumericConversionsTests`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)