### PR TITLE
[MOB-1125] Implement multi currency conversion support

### DIFF
--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -6268,6 +6268,23 @@
         }
       }
     },
+    "currencyConversion.currencyLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currency"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moneda"
+          }
+        }
+      }
+    },
     "currencyConversion.enable" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6451,6 +6468,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Guardar cambios"
+          }
+        }
+      }
+    },
+    "currencyConversion.selectCurrencyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Currency"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar Moneda"
           }
         }
       }
@@ -12962,6 +12996,23 @@
         }
       }
     },
+    "serverSetup.allServers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browse all servers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar todos los servidores"
+          }
+        }
+      }
+    },
     "serverSetup.automatic" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -12992,57 +13043,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modo de conexión"
-          }
-        }
-      }
-    },
-    "serverSetup.manual" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manual"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manual"
-          }
-        }
-      }
-    },
-    "serverSetup.testing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testing"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Probando"
-          }
-        }
-      }
-    },
-    "serverSetup.allServers" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browse all servers"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Explorar todos los servidores"
           }
         }
       }
@@ -13111,6 +13111,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Servidores más rápidos"
+          }
+        }
+      }
+    },
+    "serverSetup.manual" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manual"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manual"
           }
         }
       }
@@ -13196,6 +13213,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Guardar selección"
+          }
+        }
+      }
+    },
+    "serverSetup.testing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Testing"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Probando"
           }
         }
       }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -12143,6 +12143,74 @@
         }
       }
     },
+    "send.currencyUnavailable.continueInZEC" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue in ZEC"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar en ZEC"
+          }
+        }
+      }
+    },
+    "send.currencyUnavailable.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live rates for %@ can't be fetched right now. You can use USD as a fallback, or keep entering amounts in ZEC only."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede obtener la tasa en tiempo real para %@ ahora mismo. Puedes usar USD como alternativa, o seguir introduciendo cantidades solo en ZEC."
+          }
+        }
+      }
+    },
+    "send.currencyUnavailable.switchToUSD" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch to USD"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar a USD"
+          }
+        }
+      }
+    },
+    "send.currencyUnavailable.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ conversion unavailable"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conversión a %@ no disponible"
+          }
+        }
+      }
+    },
     "send.error.insufficientFunds" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
@@ -32,4 +32,5 @@ struct ExchangeRateClient: Sendable {
 
     var exchangeRateEventStream: @Sendable () -> AnyPublisher<EchangeRateEvent, Never> = { Empty().eraseToAnyPublisher() }
     var refreshExchangeRateUSD: @Sendable () -> Void = { }
+    var selectedCurrency: @Sendable () -> CurrencyISO4217 = { .usd }
 }

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
@@ -20,9 +20,11 @@ extension DependencyValues {
 @DependencyClient
 struct ExchangeRateClient: Sendable {
     enum EchangeRateEvent: Equatable, Sendable {
-        case value(FiatCurrencyResult?)
-        case refreshEnable(FiatCurrencyResult?)
-        case stale(FiatCurrencyResult?)
+        // Each event carries the currency the rate was fetched for, so consumers never have to
+        // re-derive it (which would mislabel a rate when the selection changes mid-flight).
+        case value(FiatCurrencyResult?, CurrencyISO4217)
+        case refreshEnable(FiatCurrencyResult?, CurrencyISO4217)
+        case stale(FiatCurrencyResult?, CurrencyISO4217)
     }
     
     enum RateSource: Equatable, Sendable {

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
@@ -29,7 +29,7 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
     private var refreshTimer: Timer? = nil
     private var staleTimer: Timer? = nil
     private var isStale = false
-    private var nilValuesCounter = 0
+    private var isAwaitingSDKFallback = false
     private var isSetUp = false
     private var cachedCurrency: CurrencyISO4217 = .usd
 
@@ -123,6 +123,8 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
                             state: .success
                         )
 
+                        self.latestRate = fiat
+                        self.isAwaitingSDKFallback = false
                         eventStream.send(.value(fiat))
                     } catch {
                         coinMarketCapRateFailed(currency: currency)
@@ -142,6 +144,7 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
 
     func coinMarketCapRateFailed(currency: CurrencyISO4217 = .usd) {
         if currency == .usd {
+            isAwaitingSDKFallback = true
             refreshExchangeRateUSD(.sdk)
         } else {
             eventStream.send(.stale(latestRate))
@@ -154,32 +157,42 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
             return
         }
 
-        // retry logic for nil value
         guard let result else {
-            nilValuesCounter += 1
-
-            if nilValuesCounter == 2 {
-                refreshExchangeRateUSD(.coinMarketCap)
-            } else if nilValuesCounter > 2 {
+            // The SDK pushes nil here only when a fetch we triggered failed without a cached value.
+            // Initial CurrentValueSubject nils and unrelated transients are ignored.
+            if isAwaitingSDKFallback {
+                isAwaitingSDKFallback = false
                 eventStream.send(.stale(latestRate))
             }
-
             return
         }
 
-        latestRate = result
-
         @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
 
-        if isStale
-            && result.state != .fetching
-            && Date().timeIntervalSince1970 - result.date.timeIntervalSince1970 > zcashSDKEnvironment.exchangeRateStaleLimit() {
-            eventStream.send(.stale(latestRate))
-        } else {
-            eventStream.send(.value(latestRate))
-        }
+        switch result.state {
+        case .success:
+            isAwaitingSDKFallback = false
+            latestRate = result
 
-        rescheduleTimer()
+            if isStale
+                && Date().timeIntervalSince1970 - result.date.timeIntervalSince1970 > zcashSDKEnvironment.exchangeRateStaleLimit() {
+                eventStream.send(.stale(latestRate))
+            } else {
+                eventStream.send(.value(latestRate))
+            }
+
+            rescheduleTimer()
+
+        case .fetching:
+            // In-flight — propagate so the UI can show a progress indicator. Keep the fallback flag set
+            // until SDK delivers a terminal result.
+            latestRate = result
+            eventStream.send(.value(latestRate))
+
+        case .error:
+            isAwaitingSDKFallback = false
+            eventStream.send(.stale(latestRate))
+        }
     }
 
     func rescheduleTimer() {

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
@@ -19,7 +19,7 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
 
 @MainActor final class ExchangeRateProvider {
     enum Constants {
-        static let cmcRateURL = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=ZEC&convert=USD"
+        static let cmcRateBaseURL = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=ZEC&convert="
         static let zecKey = "ZEC"
     }
 
@@ -31,6 +31,7 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
     private var isStale = false
     private var nilValuesCounter = 0
     private var isSetUp = false
+    private var cachedCurrency: CurrencyISO4217 = .usd
 
     // nonisolated init() — empty, so live() can create it without main actor context
     nonisolated init() {}
@@ -49,7 +50,14 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
         }
     }
 
-    nonisolated func getCMCRate() async throws -> Double {
+    func selectedCurrency() -> CurrencyISO4217 {
+        @Dependency(\.userStoredPreferences) var userStoredPreferences
+        let currency = userStoredPreferences.exchangeRate()?.currency ?? .usd
+        cachedCurrency = currency
+        return currency
+    }
+
+    nonisolated func getCMCRate(for currency: CurrencyISO4217 = .usd) async throws -> Double {
         guard let cmcKey = PartnerKeys.cmcKey else {
             throw "CMC API Key missing"
         }
@@ -57,7 +65,7 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
         @Dependency(\.sdkSynchronizer) var sdkSynchronizer
         @Shared(.inMemory(.swapAPIAccess)) var swapAPIAccess: WalletStorage.SwapAPIAccess = .direct
 
-        guard let url = URL(string: Constants.cmcRateURL) else {
+        guard let url = URL(string: Constants.cmcRateBaseURL + currency.code) else {
             throw URLError(.badURL)
         }
 
@@ -77,8 +85,9 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
         }
 
         if let result = try? JSONDecoder().decode(CMCPrice.self, from: data) {
-            if let zec = result.data[Constants.zecKey] {
-                return zec.quote.USD.price
+            if let zec = result.data[Constants.zecKey],
+               let quote = zec.quote[currency.code] {
+                return quote.price
             }
         }
 
@@ -99,11 +108,14 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
                 return
             }
 
+            let currency = exchangeRate.currency
+            cachedCurrency = currency
+
             if rateSource == .coinMarketCap {
                 Task(priority: .low) { [weak self] in
                     guard let self else { return }
                     do {
-                        let price = try await getCMCRate()
+                        let price = try await getCMCRate(for: currency)
 
                         let fiat = FiatCurrencyResult(
                             date: Date(),
@@ -113,22 +125,35 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
 
                         eventStream.send(.value(fiat))
                     } catch {
-                        coinMarketCapRateFailed()
+                        coinMarketCapRateFailed(currency: currency)
                     }
                 }
             } else if rateSource == .sdk {
-                @Dependency(\.sdkSynchronizer) var sdkSynchronizer
-
-                sdkSynchronizer.refreshExchangeRateUSD()
+                // SDK fallback only provides USD rates
+                if currency == .usd {
+                    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+                    sdkSynchronizer.refreshExchangeRateUSD()
+                } else {
+                    eventStream.send(.stale(latestRate))
+                }
             }
         }
     }
 
-    func coinMarketCapRateFailed() {
-        refreshExchangeRateUSD(.sdk)
+    func coinMarketCapRateFailed(currency: CurrencyISO4217 = .usd) {
+        if currency == .usd {
+            refreshExchangeRateUSD(.sdk)
+        } else {
+            eventStream.send(.stale(latestRate))
+        }
     }
 
     func resolveResult(_ result: FiatCurrencyResult?) {
+        // SDK stream only provides USD — ignore when a different currency is selected
+        if cachedCurrency != .usd {
+            return
+        }
+
         // retry logic for nil value
         guard let result else {
             nilValuesCounter += 1
@@ -214,6 +239,10 @@ extension ExchangeRateClient: DependencyKey {
                 Task { @MainActor in
                     exchangeRateProvider.refreshExchangeRateUSD()
                 }
+            },
+            selectedCurrency: {
+                @Dependency(\.userStoredPreferences) var userStoredPreferences
+                return userStoredPreferences.exchangeRate()?.currency ?? .usd
             }
         )
     }

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
@@ -143,12 +143,11 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
     }
 
     func coinMarketCapRateFailed(currency: CurrencyISO4217 = .usd) {
-        if currency == .usd {
-            isAwaitingSDKFallback = true
-            refreshExchangeRateUSD(.sdk)
-        } else {
-            eventStream.send(.stale(latestRate))
-        }
+        // SDK USD fallback is temporarily disabled: TorClient.getExchangeRateUSD() traps on
+        // first use after isolatedClient() bootstrap (filed against zcash-swift-wallet-sdk).
+        // Until the SDK is fixed, surface every CMC failure as the unavailable state and let
+        // the user retry, instead of crashing the app via the Tor path.
+        eventStream.send(.stale(latestRate))
     }
 
     func resolveResult(_ result: FiatCurrencyResult?) {

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
@@ -24,8 +24,9 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
     }
 
     private var cancellable: AnyCancellable? = nil
-    nonisolated let eventStream = CurrentValueSubject<ExchangeRateClient.EchangeRateEvent, Never>(.value(nil))
+    nonisolated let eventStream = CurrentValueSubject<ExchangeRateClient.EchangeRateEvent, Never>(.value(nil, .usd))
     private var latestRate: FiatCurrencyResult? = nil
+    private var latestRateCurrency: CurrencyISO4217 = .usd
     private var refreshTimer: Timer? = nil
     private var staleTimer: Timer? = nil
     private var isStale = false
@@ -124,8 +125,9 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
                         )
 
                         self.latestRate = fiat
+                        self.latestRateCurrency = currency
                         self.isAwaitingSDKFallback = false
-                        eventStream.send(.value(fiat))
+                        eventStream.send(.value(fiat, currency))
                     } catch {
                         coinMarketCapRateFailed(currency: currency)
                     }
@@ -136,7 +138,7 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
                     @Dependency(\.sdkSynchronizer) var sdkSynchronizer
                     sdkSynchronizer.refreshExchangeRateUSD()
                 } else {
-                    eventStream.send(.stale(latestRate))
+                    eventStream.send(.stale(latestRate, currency))
                 }
             }
         }
@@ -147,21 +149,23 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
         // first use after isolatedClient() bootstrap (filed against zcash-swift-wallet-sdk).
         // Until the SDK is fixed, surface every CMC failure as the unavailable state and let
         // the user retry, instead of crashing the app via the Tor path.
-        eventStream.send(.stale(latestRate))
+        //
+        // Only offer the cached rate as a stale fallback when it was fetched for `currency`;
+        // a rate priced in a different currency must never be surfaced under this one.
+        let staleRate = latestRateCurrency == currency ? latestRate : nil
+        eventStream.send(.stale(staleRate, currency))
     }
 
     func resolveResult(_ result: FiatCurrencyResult?) {
         // SDK stream only provides USD — ignore when a different currency is selected
-        if cachedCurrency != .usd {
-            return
-        }
+        guard cachedCurrency == .usd else { return }
 
         guard let result else {
             // The SDK pushes nil here only when a fetch we triggered failed without a cached value.
             // Initial CurrentValueSubject nils and unrelated transients are ignored.
             if isAwaitingSDKFallback {
                 isAwaitingSDKFallback = false
-                eventStream.send(.stale(latestRate))
+                eventStream.send(.stale(latestRate, .usd))
             }
             return
         }
@@ -172,12 +176,13 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
         case .success:
             isAwaitingSDKFallback = false
             latestRate = result
+            latestRateCurrency = .usd
 
             if isStale
                 && Date().timeIntervalSince1970 - result.date.timeIntervalSince1970 > zcashSDKEnvironment.exchangeRateStaleLimit() {
-                eventStream.send(.stale(latestRate))
+                eventStream.send(.stale(latestRate, .usd))
             } else {
-                eventStream.send(.value(latestRate))
+                eventStream.send(.value(latestRate, .usd))
             }
 
             rescheduleTimer()
@@ -186,11 +191,12 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
             // In-flight — propagate so the UI can show a progress indicator. Keep the fallback flag set
             // until SDK delivers a terminal result.
             latestRate = result
-            eventStream.send(.value(latestRate))
+            latestRateCurrency = .usd
+            eventStream.send(.value(latestRate, .usd))
 
         case .error:
             isAwaitingSDKFallback = false
-            eventStream.send(.stale(latestRate))
+            eventStream.send(.stale(latestRate, .usd))
         }
     }
 
@@ -208,7 +214,7 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
             let timeToSchedule = zcashSDKEnvironment.exchangeRateIPRateLimit() - diff
 
             if timeToSchedule < 0 {
-                eventStream.send(.refreshEnable(latestRate))
+                eventStream.send(.refreshEnable(latestRate, .usd))
             } else {
                 refreshTimer?.invalidate()
                 refreshTimer = Timer.scheduledTimer(withTimeInterval: timeToSchedule, repeats: false) { [weak self] _ in
@@ -216,7 +222,7 @@ extension FiatCurrencyResult: @retroactive @unchecked Sendable {}
                         self?.refreshTimer?.invalidate()
                         self?.refreshTimer = nil
 
-                        self?.eventStream.send(.refreshEnable(self?.latestRate))
+                        self?.eventStream.send(.refreshEnable(self?.latestRate, .usd))
                     }
                 }
 

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateTestKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateTestKey.swift
@@ -10,6 +10,7 @@
 extension ExchangeRateClient {
     static let noOp = Self(
         exchangeRateEventStream: { Empty().eraseToAnyPublisher() },
-        refreshExchangeRateUSD: { }
+        refreshExchangeRateUSD: { },
+        selectedCurrency: { .usd }
     )
 }

--- a/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift
+++ b/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift
@@ -122,10 +122,19 @@ extension UserPreferencesStorage {
     struct ExchangeRate: Equatable, Codable {
         let manual: Bool
         let automatic: Bool
+        let currency: CurrencyISO4217
 
-        init(manual: Bool, automatic: Bool) {
+        init(manual: Bool, automatic: Bool, currency: CurrencyISO4217 = .usd) {
             self.manual = manual
             self.automatic = automatic
+            self.currency = currency
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            manual = try container.decode(Bool.self, forKey: .manual)
+            automatic = try container.decode(Bool.self, forKey: .automatic)
+            currency = try container.decodeIfPresent(CurrencyISO4217.self, forKey: .currency) ?? .usd
         }
     }
 }

--- a/secant/Sources/Features/CurrencyConversionSetup/CurrencyConversionSetupStore.swift
+++ b/secant/Sources/Features/CurrencyConversionSetup/CurrencyConversionSetupStore.swift
@@ -66,28 +66,36 @@ struct CurrencyConversionSetup {
         var activeSettingsOption: SettingsOptions?
         @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion? = nil
         var currentSettingsOption = SettingsOptions.optOut
+        var initialCurrency: CurrencyISO4217 = .usd
+        var isCurrencyPickerSheetPresented = false
         var isSettingsView: Bool = false
         var isTorOn = false
         var isTorSheetPresented = false
+        var selectedCurrency: CurrencyISO4217 = .usd
 
         var isSaveButtonDisabled: Bool {
-            currentSettingsOption == activeSettingsOption
+            currentSettingsOption == activeSettingsOption && selectedCurrency == initialCurrency
         }
-        
+
         init(
             activeSettingsOption: SettingsOptions? = nil,
             currentSettingsOption: SettingsOptions = .optOut,
-            isSettingsView: Bool = false
+            isSettingsView: Bool = false,
+            selectedCurrency: CurrencyISO4217 = .usd
         ) {
             self.activeSettingsOption = activeSettingsOption
             self.currentSettingsOption = currentSettingsOption
             self.isSettingsView = isSettingsView
+            self.selectedCurrency = selectedCurrency
+            self.initialCurrency = selectedCurrency
         }
     }
-    
+
     enum Action: BindableAction, Equatable {
         case binding(BindingAction<CurrencyConversionSetup.State>)
         case backToHomeTapped
+        case currencyChanged(CurrencyISO4217)
+        case currencyPickerTapped
         case delayedDismisalRequested
         case enableTapped
         case enableTorTapped
@@ -117,23 +125,36 @@ struct CurrencyConversionSetup {
             case .onAppear:
                 // __LD TESTED
                 state.isTorOn = walletStorage.exportTorSetupFlag() ?? false
-                if let automatic = userStoredPreferences.exchangeRate()?.automatic, automatic {
+                let savedExchangeRate = userStoredPreferences.exchangeRate()
+                if let automatic = savedExchangeRate?.automatic, automatic {
                     state.activeSettingsOption = .optIn
                     state.currentSettingsOption = .optIn
                 } else {
                     state.activeSettingsOption = .optOut
                     state.currentSettingsOption = .optOut
                 }
+                let currency = savedExchangeRate?.currency ?? .usd
+                state.selectedCurrency = currency
+                state.initialCurrency = currency
                 return .none
-                
+
             case .backToHomeTapped:
                 return .none
-                
+
             case .binding:
                 return .none
-                
+
+            case .currencyChanged(let currency):
+                state.selectedCurrency = currency
+                state.isCurrencyPickerSheetPresented = false
+                return .none
+
+            case .currencyPickerTapped:
+                state.isCurrencyPickerSheetPresented = true
+                return .none
+
             case .enableTapped:
-                try? userStoredPreferences.setExchangeRate(.init(manual: true, automatic: true))
+                try? userStoredPreferences.setExchangeRate(.init(manual: true, automatic: true, currency: state.selectedCurrency))
                 return .run { send in
                     do {
                         try await sdkSynchronizer.exchangeRateEnabled(true)
@@ -154,8 +175,11 @@ struct CurrencyConversionSetup {
                 return .none
                 
             case .saveChangesTapped:
-                try? userStoredPreferences.setExchangeRate(UserPreferencesStorage.ExchangeRate(manual: true, automatic: state.currentSettingsOption == .optIn))
+                try? userStoredPreferences.setExchangeRate(
+                    UserPreferencesStorage.ExchangeRate(manual: true, automatic: state.currentSettingsOption == .optIn, currency: state.selectedCurrency)
+                )
                 state.activeSettingsOption = state.currentSettingsOption
+                state.initialCurrency = state.selectedCurrency
                 let option = state.currentSettingsOption
                 let enabled = state.currentSettingsOption == .optIn
                 return .run { send in
@@ -174,7 +198,7 @@ struct CurrencyConversionSetup {
                 }
 
             case .skipTapped:
-                try? userStoredPreferences.setExchangeRate(.init(manual: false, automatic: false))
+                try? userStoredPreferences.setExchangeRate(.init(manual: false, automatic: false, currency: state.selectedCurrency))
                 return .none
                 
             case .enableTorTapped:

--- a/secant/Sources/Features/CurrencyConversionSetup/CurrencyConversionSetupView.swift
+++ b/secant/Sources/Features/CurrencyConversionSetup/CurrencyConversionSetupView.swift
@@ -41,6 +41,12 @@ struct CurrencyConversionSetupView: View {
             .zashiSheet(isPresented: $store.isTorSheetPresented) {
                 torSheetContent()
             }
+            .sheet(isPresented: $store.isCurrencyPickerSheetPresented) {
+                currencyPickerSheetContent()
+                    .applySheetBackground()
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
+            }
         }
         .navigationBarTitleDisplayMode(.inline)
         .applyScreenBackground()
@@ -132,11 +138,123 @@ struct CurrencyConversionSetupView: View {
                     }
                 }
             }
-            .padding(.bottom, 12)
+            .padding(.bottom, Design.Spacing._3xl)
+
+            if store.currentSettingsOption == .optIn {
+                currencyPickerSection()
+            }
         }
         .padding(.horizontal, 8)
     }
-    
+
+    private func currencyPickerSection() -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localizable: .currencyConversionSelectCurrencyTitle))
+                .zFont(.medium, size: 14, style: Design.Text.primary)
+
+            Button {
+                store.send(.currencyPickerTapped)
+            } label: {
+                HStack {
+                    Text("\(store.selectedCurrency.code)")
+                        .zFont(.medium, size: 16, style: Design.Dropdowns.Filled.textMain)
+
+                    Text("\(store.selectedCurrency.displayName)")
+                        .zFont(size: 16, style: Design.Text.tertiary)
+
+                    Spacer()
+
+                    Asset.Assets.chevronRight.image
+                        .zImage(size: 20, style: Design.Background.dark)
+                }
+                .padding(.vertical, 10)
+                .padding(.horizontal, 14)
+                .background {
+                    RoundedRectangle(cornerRadius: Design.Radius._xl)
+                        .fill(Design.Background.input.color(colorScheme))
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 12)
+    }
+
+    @ViewBuilder private func currencyPickerSheetContent() -> some View {
+        VStack(spacing: 0) {
+            ZStack {
+                Text(String(localizable: .currencyConversionSelectCurrencyTitle).uppercased())
+                    .zFont(.semiBold, size: 17, style: Design.Text.primary)
+
+                HStack {
+                    Button {
+                        store.send(.binding(.set(\.isCurrencyPickerSheetPresented, false)))
+                    } label: {
+                        if #available(iOS 26.0, *) {
+                            Asset.Assets.buttonCloseX.image
+                                .zImage(size: 20, style: Design.Text.primary)
+                                .padding(10)
+                                .glassEffect(.regular.interactive(), in: .circle)
+                        } else {
+                            Asset.Assets.buttonCloseX.image
+                                .zImage(size: 20, style: Design.Text.primary)
+                                .padding(10)
+                                .background {
+                                    Circle()
+                                        .fill(Design.Surfaces.bgTertiary.color(colorScheme))
+                                }
+                        }
+                    }
+
+                    Spacer()
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+            .padding(.bottom, 16)
+
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(Array(CurrencyISO4217.allCases.enumerated()), id: \.element) { index, currency in
+                        Button {
+                            store.send(.currencyChanged(currency))
+                        } label: {
+                            HStack(spacing: 8) {
+                                if store.selectedCurrency.code == currency.code {
+                                    Text(currency.code)
+                                        .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                                    Text(currency.displayName)
+                                        .zFont(.semiBold, size: 16, style: Design.Text.primary)
+                                } else {
+                                    Text(currency.code)
+                                        .zFont(.medium, size: 16, style: Design.Text.primary)
+
+                                    Text(currency.displayName)
+                                        .zFont(size: 16, style: Design.Text.primary)
+                                }
+
+                                Spacer()
+
+                                Asset.Assets.chevronRight.image
+                                    .zImage(size: 20, style: Design.Text.quaternary)
+                            }
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 20)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+
+                        if index < CurrencyISO4217.allCases.count - 1 {
+                            Design.Surfaces.divider.color(colorScheme)
+                                .frame(height: 1)
+                                .padding(.horizontal, 20)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private func learnMoreLayout() -> some View {
         VStack(alignment: .leading, spacing: 0) {
             header(String(localizable: .currencyConversionLearnMoreDesc))
@@ -148,7 +266,9 @@ struct CurrencyConversionSetupView: View {
                 }
                 .padding(.top, 20)
             }
-            .padding(.bottom, 12)
+            .padding(.bottom, Design.Spacing._3xl)
+
+            currencyPickerSection()
         }
         .screenHorizontalPadding()
     }

--- a/secant/Sources/Features/Home/HomeStore.swift
+++ b/secant/Sources/Features/Home/HomeStore.swift
@@ -265,7 +265,10 @@ struct Home {
 
             case .currencyConversionCloseTapped:
                 state.isRateEducationEnabled = false
-                try? userStoredPreferences.setExchangeRate(UserPreferencesStorage.ExchangeRate(manual: true, automatic: false))
+                let existingCurrency = userStoredPreferences.exchangeRate()?.currency ?? .usd
+                try? userStoredPreferences.setExchangeRate(
+                    UserPreferencesStorage.ExchangeRate(manual: true, automatic: false, currency: existingCurrency)
+                )
                 return .none
 
             case .rateTooltipTapped:

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -29,8 +29,10 @@ struct SendForm {
         var balancesState = Balances.State.initial
         @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion? = nil
         var currencyText: RedactableString = .empty
+        var currencyUnavailableSheetCurrency: CurrencyISO4217 = .usd
         var isAddressBookHintVisible = false
         var isCurrencyConversionEnabled = false
+        var isCurrencyUnavailableSheetPresented = false
         var isInsufficientBalance = false
         var isLatestInputFiat = false
         var isNotAddressInAddressBook = false
@@ -203,6 +205,8 @@ struct SendForm {
         case balancesBindingUpdated(Bool)
         case binding(BindingAction<SendForm.State>)
         case confirmationRequired(Confirmation)
+        case currencyUnavailableContinueInZECTapped
+        case currencyUnavailableSwitchToUSDTapped
         case dismissRequired
         case getProposal(Confirmation)
         case gotTexSupportTapped
@@ -295,6 +299,25 @@ struct SendForm {
                 } else {
                     state.isCurrencyConversionEnabled = false
                 }
+                let selectedCurrency = exchangeRate.selectedCurrency()
+                if state.isCurrencyConversionEnabled && selectedCurrency != .usd && state.currencyConversion == nil {
+                    state.currencyUnavailableSheetCurrency = selectedCurrency
+                    state.isCurrencyUnavailableSheetPresented = true
+                }
+                return .none
+
+            case .currencyUnavailableSwitchToUSDTapped:
+                let existing = userStoredPreferences.exchangeRate()
+                let automatic = existing?.automatic ?? true
+                try? userStoredPreferences.setExchangeRate(
+                    UserPreferencesStorage.ExchangeRate(manual: true, automatic: automatic, currency: .usd)
+                )
+                state.isCurrencyUnavailableSheetPresented = false
+                exchangeRate.refreshExchangeRateUSD()
+                return .none
+
+            case .currencyUnavailableContinueInZECTapped:
+                state.isCurrencyUnavailableSheetPresented = false
                 return .none
 
             case let .proposal(proposal):

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -326,9 +326,8 @@ struct SendForm {
 
             case .walletBalances(.exchangeRateEvent(let result)):
                 switch result {
-                case .value(let rate), .refreshEnable(let rate):
+                case .value(let rate, let currency), .refreshEnable(let rate, let currency):
                     if let rate {
-                        let currency = exchangeRate.selectedCurrency()
                         state.$currencyConversion.withLock { $0 = CurrencyConversion(currency, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970) }
                         return .send(.syncAmounts(true))
                     }

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -78,6 +78,15 @@ struct SendForm {
             currencyConversion?.iso4217.symbol ?? ""
         }
 
+        var currencyCode: String {
+            currencyConversion?.iso4217.code ?? CurrencyISO4217.usd.code
+        }
+
+        var hasCurrencySymbol: Bool {
+            guard let iso = currencyConversion?.iso4217 else { return false }
+            return iso.symbol != iso.code
+        }
+
         var feeFormat: String {
             "(\(ZatoshiStringRepresentation.feeFormat))"
         }
@@ -219,6 +228,7 @@ struct SendForm {
     @Dependency(\.addressBook) var addressBook
     @Dependency(\.audioServices) var audioServices
     @Dependency(\.derivationTool) var derivationTool
+    @Dependency(\.exchangeRate) var exchangeRate
     @Dependency(\.numberFormatter) var numberFormatter
     @Dependency(\.sdkSynchronizer) var sdkSynchronizer
     @Dependency(\.userStoredPreferences) var userStoredPreferences
@@ -295,7 +305,8 @@ struct SendForm {
                 switch result {
                 case .value(let rate), .refreshEnable(let rate):
                     if let rate {
-                        state.$currencyConversion.withLock { $0 = CurrencyConversion(.usd, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970) }
+                        let currency = exchangeRate.selectedCurrency()
+                        state.$currencyConversion.withLock { $0 = CurrencyConversion(currency, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970) }
                         return .send(.syncAmounts(true))
                     }
                 case .stale:

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -29,10 +29,10 @@ struct SendForm {
         var balancesState = Balances.State.initial
         @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion? = nil
         var currencyText: RedactableString = .empty
-        var currencyUnavailableSheetCurrency: CurrencyISO4217 = .usd
         var isAddressBookHintVisible = false
         var isCurrencyConversionEnabled = false
         var isCurrencyUnavailableSheetPresented = false
+        var selectedCurrency: CurrencyISO4217 = .usd
         var isInsufficientBalance = false
         var isLatestInputFiat = false
         var isNotAddressInAddressBook = false
@@ -77,15 +77,15 @@ struct SendForm {
         }
 
         var currencySymbol: String {
-            currencyConversion?.iso4217.symbol ?? ""
+            (currencyConversion?.iso4217 ?? selectedCurrency).symbol
         }
 
         var currencyCode: String {
-            currencyConversion?.iso4217.code ?? CurrencyISO4217.usd.code
+            (currencyConversion?.iso4217 ?? selectedCurrency).code
         }
 
         var hasCurrencySymbol: Bool {
-            guard let iso = currencyConversion?.iso4217 else { return false }
+            let iso = currencyConversion?.iso4217 ?? selectedCurrency
             return iso.symbol != iso.code
         }
 
@@ -299,9 +299,8 @@ struct SendForm {
                 } else {
                     state.isCurrencyConversionEnabled = false
                 }
-                let selectedCurrency = exchangeRate.selectedCurrency()
-                if state.isCurrencyConversionEnabled && selectedCurrency != .usd && state.currencyConversion == nil {
-                    state.currencyUnavailableSheetCurrency = selectedCurrency
+                state.selectedCurrency = exchangeRate.selectedCurrency()
+                if state.isCurrencyConversionEnabled && state.selectedCurrency != .usd && state.currencyConversion == nil {
                     state.isCurrencyUnavailableSheetPresented = true
                 }
                 return .none
@@ -312,6 +311,7 @@ struct SendForm {
                 try? userStoredPreferences.setExchangeRate(
                     UserPreferencesStorage.ExchangeRate(manual: true, automatic: automatic, currency: .usd)
                 )
+                state.selectedCurrency = .usd
                 state.isCurrencyUnavailableSheetPresented = false
                 exchangeRate.refreshExchangeRateUSD()
                 return .none

--- a/secant/Sources/Features/SendForm/SendFormView.swift
+++ b/secant/Sources/Features/SendForm/SendFormView.swift
@@ -322,13 +322,13 @@ struct SendFormView: View {
                 }
                 .padding(.top, 48)
 
-            Text(String(localizable: .sendCurrencyUnavailableTitle(store.currencyUnavailableSheetCurrency.code)))
+            Text(String(localizable: .sendCurrencyUnavailableTitle(store.selectedCurrency.code)))
                 .zFont(.semiBold, size: 24, style: Design.Text.primary)
                 .multilineTextAlignment(.center)
                 .padding(.top, 24)
                 .padding(.bottom, 8)
 
-            Text(String(localizable: .sendCurrencyUnavailableDesc(store.currencyUnavailableSheetCurrency.displayName)))
+            Text(String(localizable: .sendCurrencyUnavailableDesc(store.selectedCurrency.displayName)))
                 .zFont(size: 14, style: Design.Text.tertiary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)

--- a/secant/Sources/Features/SendForm/SendFormView.swift
+++ b/secant/Sources/Features/SendForm/SendFormView.swift
@@ -119,11 +119,15 @@ struct SendFormView: View {
                                                         
                                                         ZashiTextField(
                                                             text: store.bindingForCurrency,
-                                                            placeholder: String(localizable: .sendCurrencyPlaceholder),
+                                                            placeholder: store.currencyCode,
                                                             error: store.invalidCurrencyAmountErrorText,
                                                             prefixView:
-                                                                Asset.Assets.Icons.currencyDollar.image
-                                                                .zImage(size: 20, style: Design.Inputs.Default.text)
+                                                                Group {
+                                                                    if store.hasCurrencySymbol {
+                                                                        Text(store.currencySymbol)
+                                                                            .zFont(.semiBold, size: 24, style: Design.Inputs.Default.text)
+                                                                    }
+                                                                }
                                                         )
                                                         .keyboardType(.decimalPad)
                                                         .focused($isCurrencyFocused)

--- a/secant/Sources/Features/SendForm/SendFormView.swift
+++ b/secant/Sources/Features/SendForm/SendFormView.swift
@@ -217,6 +217,9 @@ struct SendFormView: View {
             .zashiSheet(isPresented: $store.isSheetTexAddressVisible) {
                 helpSheetContent()
             }
+            .zashiSheet(isPresented: $store.isCurrencyUnavailableSheetPresented) {
+                currencyUnavailableSheetContent()
+            }
             .insufficientFundsSheet(isPresented: $store.isInsufficientBalance)
             .alert(store: store.scope(
                 state: \.$alert,
@@ -304,6 +307,47 @@ struct SendFormView: View {
                     RoundedRectangle(cornerRadius: Design.Radius._md)
                         .stroke(Design.Btns.Secondary.border.color(colorScheme))
                 }
+        }
+    }
+
+    @ViewBuilder private func currencyUnavailableSheetContent() -> some View {
+        VStack(alignment: .center, spacing: 0) {
+            Asset.Assets.Icons.alertOutline.image
+                .zImage(size: 20, style: Design.Utility.ErrorRed._500)
+                .padding(12)
+                .background {
+                    Circle()
+                        .fill(Design.Utility.ErrorRed._100.color(colorScheme))
+                        .frame(width: 44, height: 44)
+                }
+                .padding(.top, 48)
+
+            Text(String(localizable: .sendCurrencyUnavailableTitle(store.currencyUnavailableSheetCurrency.code)))
+                .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                .multilineTextAlignment(.center)
+                .padding(.top, 24)
+                .padding(.bottom, 8)
+
+            Text(String(localizable: .sendCurrencyUnavailableDesc(store.currencyUnavailableSheetCurrency.displayName)))
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .lineSpacing(2)
+                .padding(.horizontal, 4)
+                .padding(.bottom, 24)
+
+            ZashiButton(String(localizable: .sendCurrencyUnavailableSwitchToUSD)) {
+                store.send(.currencyUnavailableSwitchToUSDTapped)
+            }
+            .padding(.bottom, 8)
+
+            ZashiButton(
+                String(localizable: .sendCurrencyUnavailableContinueInZEC),
+                type: .ghost
+            ) {
+                store.send(.currencyUnavailableContinueInZECTapped)
+            }
+            .padding(.bottom, Design.Spacing.sheetBottomSpace)
         }
     }
 

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -137,33 +137,30 @@ struct WalletBalances {
                 
             case .exchangeRateEvent(let result):
                 switch result {
-                case .value(let rate):
+                case .value(let rate, let currency):
                     guard let rate else {
                         return .none
                     }
 
-                    let currency = exchangeRate.selectedCurrency()
                     state.fiatCurrencyResult = rate
                     state.$currencyConversion.withLock {
                         $0 = CurrencyConversion(currency, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970)
                     }
                     state.isExchangeRateRefreshEnabled = false
                     state.isExchangeRateStale = false
-                case .refreshEnable(let rate):
+                case .refreshEnable(let rate, let currency):
                     guard let rate else {
                         return .none
                     }
 
-                    let currency = exchangeRate.selectedCurrency()
                     state.fiatCurrencyResult = rate
                     state.$currencyConversion.withLock {
                         $0 = CurrencyConversion(currency, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970)
                     }
                     state.isExchangeRateRefreshEnabled = true
                     state.isExchangeRateStale = false
-                case .stale(let rate):
+                case .stale(let rate, let currency):
                     if let rate {
-                        let currency = exchangeRate.selectedCurrency()
                         state.fiatCurrencyResult = rate
                         state.$currencyConversion.withLock {
                             $0 = CurrencyConversion(currency, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970)

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -143,10 +143,11 @@ struct WalletBalances {
                     guard let rate else {
                         return .none
                     }
-                    
+
+                    let currency = exchangeRate.selectedCurrency()
                     state.fiatCurrencyResult = rate
                     state.$currencyConversion.withLock {
-                        $0 = CurrencyConversion(.usd, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970)
+                        $0 = CurrencyConversion(currency, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970)
                     }
                     state.isExchangeRateRefreshEnabled = false
                     state.isExchangeRateStale = false
@@ -154,10 +155,11 @@ struct WalletBalances {
                     guard let rate else {
                         return .none
                     }
-                    
+
+                    let currency = exchangeRate.selectedCurrency()
                     state.fiatCurrencyResult = rate
                     state.$currencyConversion.withLock {
-                        $0 = CurrencyConversion(.usd, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970)
+                        $0 = CurrencyConversion(currency, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970)
                     }
                     state.isExchangeRateRefreshEnabled = true
                     state.isExchangeRateStale = false

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -132,9 +132,7 @@ struct WalletBalances {
                 return .none
 
             case .exchangeRateRefreshTapped:
-                if !state.isExchangeRateStale {
-                    exchangeRate.refreshExchangeRateUSD()
-                }
+                exchangeRate.refreshExchangeRateUSD()
                 return .none
                 
             case .exchangeRateEvent(let result):
@@ -163,12 +161,19 @@ struct WalletBalances {
                     }
                     state.isExchangeRateRefreshEnabled = true
                     state.isExchangeRateStale = false
-                case .stale:
-                    state.$currencyConversion.withLock {
-                        $0 = nil
+                case .stale(let rate):
+                    if let rate {
+                        let currency = exchangeRate.selectedCurrency()
+                        state.fiatCurrencyResult = rate
+                        state.$currencyConversion.withLock {
+                            $0 = CurrencyConversion(currency, ratio: rate.rate.doubleValue, timestamp: rate.date.timeIntervalSince1970)
+                        }
+                    } else {
+                        state.fiatCurrencyResult = nil
+                        state.$currencyConversion.withLock { $0 = nil }
                     }
                     state.isExchangeRateStale = true
-                    break
+                    state.isExchangeRateRefreshEnabled = true
                 }
                 
                 return .none

--- a/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
@@ -113,25 +113,34 @@ struct WalletBalancesView: View {
                     .padding(.vertical, 5)
                 }
                 
-                if store.currencyConversion != nil || store.isExchangeRateStale {
+                if store.currencyConversion == nil && store.isExchangeRateStale {
                     Button {
                         store.send(.exchangeRateRefreshTapped)
                     } label: {
-                        if store.isExchangeRateStale {
-                            HStack {
-                                Text(localizable: .tooltipExchangeRateTitle)
-                                    .font(.custom(FontFamily.Inter.semiBold.name, size: 14))
-                                    .foregroundColor(Asset.Colors.primary.color)
+                        HStack {
+                            Text(localizable: .tooltipExchangeRateTitle)
+                                .font(.custom(FontFamily.Inter.semiBold.name, size: 14))
+                                .foregroundColor(Asset.Colors.primary.color)
 
-                                Asset.Assets.infoCircle.image
-                                    .zImage(size: 20, color: Asset.Colors.primary.color)
-                            }
-                            .frame(maxWidth: .infinity)
-                            .anchorPreference(
-                                key: ExchangeRateStaleTooltipPreferenceKey.self,
-                                value: .bounds
-                            ) { $0 }
-                        } else if store.isExchangeRateRefreshEnabled {
+                            Asset.Assets.infoCircle.image
+                                .zImage(size: 20, color: Asset.Colors.primary.color)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .anchorPreference(
+                            key: ExchangeRateStaleTooltipPreferenceKey.self,
+                            value: .bounds
+                        ) { $0 }
+                    }
+                    .frame(height: 36)
+                    .padding(.top, 10)
+                    .padding(.vertical, 5)
+                }
+
+                if store.currencyConversion != nil {
+                    Button {
+                        store.send(.exchangeRateRefreshTapped)
+                    } label: {
+                        if store.isExchangeRateRefreshEnabled {
                             HStack {
                                 Text(store.currencyValue)
                                     .hiddenIfSet()

--- a/secant/Sources/Features/ZecKeyboard/ZecKeyboardStore.swift
+++ b/secant/Sources/Features/ZecKeyboard/ZecKeyboardStore.swift
@@ -28,11 +28,14 @@ struct ZecKeyboard {
         var humanReadableMainInput = ""
         var input = Constants.initialValue
         var isInputInZec = true
+        var isCurrencyConversionEnabled = false
         var isCurrencySymbolPrefix = false
+        var isCurrencyUnavailableSheetPresented = false
         var isValidInput = true
         var isZeroOutputAllowed = false
         var keys: [String] = []
         var localeCurrencySymbol = ""
+        var selectedCurrency: CurrencyISO4217 = .usd
 
         var isNextButtonDisabled: Bool {
             amount.amount == 0 && !isZeroOutputAllowed
@@ -41,7 +44,10 @@ struct ZecKeyboard {
         init() { }
     }
 
-    enum Action: Equatable {
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<ZecKeyboard.State>)
+        case currencyUnavailableContinueInZECTapped
+        case currencyUnavailableSwitchToUSDTapped
         case longKeyTapped(Int)
         case keyTapped(Int)
         case nextTapped
@@ -53,11 +59,19 @@ struct ZecKeyboard {
         case validateInputs
     }
 
+    @Dependency(\.exchangeRate) var exchangeRate
+    @Dependency(\.userStoredPreferences) var userStoredPreferences
+
     init() { }
 
     var body: some Reducer<State, Action> {
+        BindingReducer()
+
         Reduce { state, action in
             switch action {
+            case .binding:
+                return .none
+
             case .onAppear:
                 // __LD TESTED
                 if let decimalSeparator = Locale.current.decimalSeparator {
@@ -67,7 +81,27 @@ struct ZecKeyboard {
                 if state.input == Constants.initialValue {
                     state.isInputInZec = true
                 }
+                state.isCurrencyConversionEnabled = userStoredPreferences.exchangeRate()?.automatic ?? false
+                state.selectedCurrency = exchangeRate.selectedCurrency()
+                if state.isCurrencyConversionEnabled && state.selectedCurrency != .usd && state.currencyConversion == nil {
+                    state.isCurrencyUnavailableSheetPresented = true
+                }
                 return .send(.validateInputs)
+
+            case .currencyUnavailableSwitchToUSDTapped:
+                let existing = userStoredPreferences.exchangeRate()
+                let automatic = existing?.automatic ?? true
+                try? userStoredPreferences.setExchangeRate(
+                    UserPreferencesStorage.ExchangeRate(manual: true, automatic: automatic, currency: .usd)
+                )
+                state.selectedCurrency = .usd
+                state.isCurrencyUnavailableSheetPresented = false
+                exchangeRate.refreshExchangeRateUSD()
+                return .none
+
+            case .currencyUnavailableContinueInZECTapped:
+                state.isCurrencyUnavailableSheetPresented = false
+                return .none
                 
             case .swapCurrenciesTapped:
                 state.isInputInZec.toggle()

--- a/secant/Sources/Features/ZecKeyboard/ZecKeyboardView.swift
+++ b/secant/Sources/Features/ZecKeyboard/ZecKeyboardView.swift
@@ -22,7 +22,18 @@ struct ZecKeyboardView: View {
     
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 0) {
+            keyboardBody
+        }
+        .applyScreenBackground()
+        .zashiBack()
+        .screenTitle(String(localizable: .generalRequest))
+        .zashiSheet(isPresented: $store.isCurrencyUnavailableSheetPresented) {
+            currencyUnavailableSheetContent()
+        }
+    }
+
+    @ViewBuilder private var keyboardBody: some View {
+        VStack(spacing: 0) {
                 VStack(spacing: 0) {
                     if !store.isValidInput {
                         HStack(spacing: 0) {
@@ -156,12 +167,49 @@ struct ZecKeyboardView: View {
                 .disabled(store.isNextButtonDisabled)
                 .padding(.bottom, 24)
                 .screenHorizontalPadding()
-            }
-            .onAppear { store.send(.onAppear) }
         }
-        .applyScreenBackground()
-        .zashiBack()
-        .screenTitle(String(localizable: .generalRequest))
+        .onAppear { store.send(.onAppear) }
+    }
+
+    @ViewBuilder private func currencyUnavailableSheetContent() -> some View {
+        VStack(alignment: .center, spacing: 0) {
+            Asset.Assets.Icons.alertOutline.image
+                .zImage(size: 20, style: Design.Utility.ErrorRed._500)
+                .padding(12)
+                .background {
+                    Circle()
+                        .fill(Design.Utility.ErrorRed._100.color(colorScheme))
+                        .frame(width: 44, height: 44)
+                }
+                .padding(.top, 48)
+
+            Text(String(localizable: .sendCurrencyUnavailableTitle(store.selectedCurrency.code)))
+                .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                .multilineTextAlignment(.center)
+                .padding(.top, 24)
+                .padding(.bottom, 8)
+
+            Text(String(localizable: .sendCurrencyUnavailableDesc(store.selectedCurrency.displayName)))
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .lineSpacing(2)
+                .padding(.horizontal, 4)
+                .padding(.bottom, 24)
+
+            ZashiButton(String(localizable: .sendCurrencyUnavailableSwitchToUSD)) {
+                store.send(.currencyUnavailableSwitchToUSDTapped)
+            }
+            .padding(.bottom, 8)
+
+            ZashiButton(
+                String(localizable: .sendCurrencyUnavailableContinueInZEC),
+                type: .ghost
+            ) {
+                store.send(.currencyUnavailableContinueInZECTapped)
+            }
+            .padding(.bottom, Design.Spacing.sheetBottomSpace)
+        }
     }
 }
 

--- a/secant/Sources/Generated/DesignSystem.swift
+++ b/secant/Sources/Generated/DesignSystem.swift
@@ -237,11 +237,20 @@ public enum Design: Colorable {
             case active
         }
         
+        public enum Filled: Colorable {
+            case textMain
+        }
+        
         public enum Disabled: Colorable {
             case bg
             case stroke
             case dropdown
         }
+    }
+    
+    public enum Background: Colorable {
+        case dark
+        case input
     }
     
     public enum Utility {
@@ -727,12 +736,29 @@ public extension Design.Dropdowns.Default {
     }
 }
 
+public extension Design.Dropdowns.Filled {
+    func color(_ colorScheme: ColorScheme) -> Color {
+        switch self {
+        case .textMain: return Design.col(Asset.Colors.ZDesign.gray900.color, Asset.Colors.ZDesign.shark100.color, colorScheme)
+        }
+    }
+}
+
 public extension Design.Dropdowns.Disabled {
     func color(_ colorScheme: ColorScheme) -> Color {
         switch self {
         case .bg: return Design.col(Asset.Colors.ZDesign.gray50.color, Asset.Colors.ZDesign.shark900.color, colorScheme)
         case .stroke: return Design.col(Asset.Colors.ZDesign.gray200.color, Asset.Colors.ZDesign.shark800.color, colorScheme)
         case .dropdown: return Design.col(Asset.Colors.ZDesign.gray500.color, Asset.Colors.ZDesign.shark500.color, colorScheme)
+        }
+    }
+}
+
+public extension Design.Background {
+    func color(_ colorScheme: ColorScheme) -> Color {
+        switch self {
+        case .dark: return Design.col(Asset.Colors.ZDesign.Base.obsidian.color, Asset.Colors.ZDesign.Base.bone.color, colorScheme)
+        case .input: return Design.col(Asset.Colors.ZDesign.gray50.color, Asset.Colors.ZDesign.shark800.color, colorScheme)
         }
     }
 }

--- a/secant/Sources/Models/CMCRate.swift
+++ b/secant/Sources/Models/CMCRate.swift
@@ -12,13 +12,9 @@ struct CMCPrice: Codable {
 }
 
 struct CMCAsset: Codable {
-    let quote: CMCQuote
+    let quote: [String: CMCCurrencyQuote]
 }
 
-struct CMCQuote: Codable {
-    let USD: CMCUSDQuote
-}
-
-struct CMCUSDQuote: Codable {
+struct CMCCurrencyQuote: Codable {
     let price: Double
 }

--- a/secant/Sources/Models/Currency.swift
+++ b/secant/Sources/Models/Currency.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Lukáš Korba on 22.05.2024.
 //
@@ -9,17 +9,52 @@ import Foundation
 @preconcurrency import ZcashLightClientKit
 
 // Both will be defined in the SDK
-enum CurrencyISO4217: String, CaseIterable, Equatable {
+enum CurrencyISO4217: String, CaseIterable, Equatable, Codable {
     case usd = "USD"
-    
+    case eur = "EUR"
+    case gbp = "GBP"
+    case jpy = "JPY"
+    case cad = "CAD"
+    case aud = "AUD"
+    case chf = "CHF"
+    case cny = "CNY"
+    case krw = "KRW"
+    case brl = "BRL"
+    case inr = "INR"
+    case mxn = "MXN"
+    case sgd = "SGD"
+    case hkd = "HKD"
+    case nok = "NOK"
+    case sek = "SEK"
+    case dkk = "DKK"
+    case nzd = "NZD"
+    case ngn = "NGN"
+    case zar = "ZAR"
+    case `try` = "TRY"
+    case pln = "PLN"
+    case thb = "THB"
+
     var code: String {
         rawValue
     }
-    
+
     var symbol: String {
         switch self {
         case .usd: return "$"
+        case .eur: return "€"
+        case .gbp: return "£"
+        case .jpy, .cny: return "¥"
+        case .krw: return "₩"
+        case .inr: return "₹"
+        case .ngn: return "₦"
+        case .`try`: return "₺"
+        case .thb: return "฿"
+        default: return rawValue
         }
+    }
+
+    var displayName: String {
+        Locale.current.localizedString(forCurrencyCode: rawValue) ?? rawValue
     }
 }
 
@@ -27,21 +62,42 @@ struct CurrencyConversion: Equatable {
     let iso4217: CurrencyISO4217
     let ratio: Double
     let timestamp: TimeInterval
-    
+
     init(_ iso4217: CurrencyISO4217, ratio: Double, timestamp: TimeInterval) {
         self.iso4217 = iso4217
         self.ratio = (ratio * Double(1_000_000)).rounded(.down) / Double(1_000_000)
         self.timestamp = timestamp
     }
-    
+
     func convert(_ zatoshi: Zatoshi) -> Double {
         ratio * (Double(zatoshi.amount) / Double(100_000_000))
     }
-    
+
     func convert(_ zatoshi: Zatoshi) -> String {
-        Decimal(convert(zatoshi)).formatted(.currency(code: iso4217.code))
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = iso4217.code
+
+        // For currencies with a unicode symbol, use it directly.
+        // For others (symbol == rawValue), append a non-breaking space for readability.
+        if iso4217.symbol == iso4217.rawValue {
+            formatter.currencySymbol = iso4217.code + "\u{00A0}"
+        } else {
+            formatter.currencySymbol = iso4217.symbol
+        }
+
+        // Zero-decimal currencies should not show fractional digits
+        switch iso4217 {
+        case .jpy, .krw:
+            formatter.maximumFractionDigits = 0
+            formatter.minimumFractionDigits = 0
+        default:
+            break
+        }
+
+        return formatter.string(from: NSDecimalNumber(decimal: Decimal(convert(zatoshi)))) ?? ""
     }
-    
+
     func convert(_ currency: Double) -> Zatoshi {
         Zatoshi(Int64((currency / ratio) * Double(100_000_000)))
     }

--- a/zodlTests/CurrencyConversionTests/CurrencyConversionTests.swift
+++ b/zodlTests/CurrencyConversionTests/CurrencyConversionTests.swift
@@ -289,8 +289,8 @@ class CurrencyConversionTests: XCTestCase {
     func testCurrencyISO4217AllCases() {
         XCTAssertEqual(
             CurrencyISO4217.allCases.count,
-            1,
-            "CurrencyConversion tests: `testCurrencyISO4217AllCases` count is expected to be 1 but it is \(CurrencyISO4217.allCases.count)"
+            23,
+            "CurrencyConversion tests: `testCurrencyISO4217AllCases` count is expected to be 23 but it is \(CurrencyISO4217.allCases.count)"
         )
         XCTAssertTrue(
             CurrencyISO4217.allCases.contains(.usd),


### PR DESCRIPTION
## Summary
- Cherry-picks MOB-1125 (multi-currency conversion support) from the
  exploratory branch in LukasKorba/secant-ios-wallet, adapted to current
  main.
- Fixes the USD CMC → SDK fallback path: replaces the nilValuesCounter
  retry mechanism with explicit `isAwaitingSDKFallback` tracking and
  switches on `FiatCurrencyResult.State` so `.error` / nil-while-awaiting
  surfaces cleanly instead of being papered over.
- Aligns stale handling with Android: cached value stays visible on the
  home screen with refresh enabled; Send screen still disables the fiat
  field on stale to prevent sending against an outdated rate.

## Known caveat
- The SDK fallback exposes a pre-existing crash in
  `TorClient.getExchangeRateUSD()` (EXC_BREAKPOINT, separate SDK issue
  filed). Host-side behavior is correct.

## Test plan
- [ ] Opt in to currency conversion, default currency, fresh CMC key →
      USD value renders on home + Send.
- [ ] Switch currency to EUR / JPY → conversion uses selected code,
      symbol prefix renders correctly.
- [ ] Break CMC key → home shows "Exchange rate unavailable" (no cache)
      or last cached value (stale-with-cache); refresh button works.
- [ ] On Send while stale, fiat field is disabled.