### PR TITLE
[MOB-1125] Reword currency-conversion copy for Swap and Pay clarity

### DIFF
--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -6342,13 +6342,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Display your balance and payment amounts in USD. You can manage this feature in Advanced Settings."
+            "value" : "Display your balance and payment amounts in selected currency. For Swap and Pay, exchange rates will continue to be shown in USD. You can manage this feature in Advanced Settings."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Muestra tu saldo y los montos de pago en USD. Puedes gestionar esta función en Configuración Avanzada."
+            "value" : "Muestra tu saldo y los montos de pago en la moneda seleccionada. En Swap and Pay, las tasas de cambio seguirán mostrándose en USD. Puedes gestionar esta función en Configuración Avanzada."
           }
         }
       }
@@ -6495,13 +6495,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Display your balance and payment amounts in USD."
+            "value" : "Display your balance and payment amounts in your selected currency. For Swap and Pay, exchange rates will continue to be shown in USD."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Muestra tu saldo y los montos de pago en USD."
+            "value" : "Muestra tu saldo y los montos de pago en tu moneda seleccionada. En Swap and Pay, las tasas de cambio seguirán mostrándose en USD."
           }
         }
       }


### PR DESCRIPTION
## Summary
Multi-currency conversion landed in #1835, but two pieces of pre-existing copy still implied the selected currency applied everywhere. Since Swap and Pay continues to quote in USD only, the user could be surprised when a swap shows a USD rate instead of their chosen display currency. This PR makes the carve-out explicit.

- `currencyConversion.learnMoreDesc`: adds the Swap-and-Pay carve-out before the pointer to Advanced Settings.
- `currencyConversion.settingsDesc`: same carve-out, with "your selected currency" replacing the old "USD".

Spanish translations updated in lockstep, keeping "Swap and Pay" untranslated (matches the existing es convention of leaving "swap" as a loanword — see e.g. `cancelSwap` / `swapInfo` entries).

## Test plan
- [ ] Go to Currency Conversion settings → confirm the description reflects the new wording in EN and ES.
- [ ] Open the Learn More flow → confirm the longer description with the Advanced Settings pointer reads cleanly in EN and ES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)