### PR TITLE
Fix LoggerTests parallel-suite OSLog pollution

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -290,14 +290,22 @@ jobs:
       # Key is per-run-id so each successful run produces a fresh
       # cache entry; restore-keys falls back to the most recent
       # matching prefix.
+      #
+      # Prefix bumped v1 → v2 (2026-06-16) to invalidate existing
+      # caches. A stale v1 cache from a past run had scanned_tip at
+      # chain tip but left an unscanned range covering the wallet's
+      # spend transactions — wallet reported 0.39 ZEC total / 0
+      # spendable while the actual on-chain balance was ~0.1 ZEC.
+      # The zodl-qa verifier now also requires unscanned_ranges == 0
+      # (was OR-gated, masking this exact failure mode).
       - name: Restore Zcash SDK DB cache
         if: ${{ matrix.phase == 2 }}
         uses: actions/cache/restore@v5
         with:
           path: ~/.zodl-qa/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-zodl-qa-ios-sdk-db-${{ github.run_id }}
+          key: ${{ runner.os }}-${{ runner.arch }}-zodl-qa-ios-sdk-db-v2-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-zodl-qa-ios-sdk-db-
+            ${{ runner.os }}-${{ runner.arch }}-zodl-qa-ios-sdk-db-v2-
 
       - name: Run smoke tests
         env:
@@ -358,7 +366,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.zodl-qa/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-zodl-qa-ios-sdk-db-${{ github.run_id }}
+          key: ${{ runner.os }}-${{ runner.arch }}-zodl-qa-ios-sdk-db-v2-${{ github.run_id }}
 
       - name: Upload test results
         if: always()

--- a/secant/Sources/Features/SendForm/SendFormView.swift
+++ b/secant/Sources/Features/SendForm/SendFormView.swift
@@ -57,6 +57,7 @@ struct SendFormView: View {
                                                 placeholder: String(localizable: .sendAddressPlaceholder),
                                                 title: String(localizable: .sendTo),
                                                 error: store.invalidAddressErrorText,
+                                                inputAccessibilityIdentifier: AccessibilityID.SendForm.zcashAddressField,
                                                 accessoryView:
                                                     HStack(spacing: 4) {
                                                         WithPerceptionTracking {
@@ -85,7 +86,6 @@ struct SendFormView: View {
                                                     .offset(x: 8)
                                             )
                                             .id(InputID.addressBookHint)
-                                            .accessibilityIdentifier(AccessibilityID.SendForm.zcashAddressField)
                                             .keyboardType(.alphabet)
                                             .focused($isAddressFocused)
                                             .submitLabel(.next)

--- a/secant/Sources/Features/SendForm/SendFormView.swift
+++ b/secant/Sources/Features/SendForm/SendFormView.swift
@@ -85,6 +85,7 @@ struct SendFormView: View {
                                                     .offset(x: 8)
                                             )
                                             .id(InputID.addressBookHint)
+                                            .accessibilityIdentifier(AccessibilityID.SendForm.zcashAddressField)
                                             .keyboardType(.alphabet)
                                             .focused($isAddressFocused)
                                             .submitLabel(.next)

--- a/secant/Sources/UIComponents/TextFields/ZashiTextField.swift
+++ b/secant/Sources/UIComponents/TextFields/ZashiTextField.swift
@@ -16,7 +16,16 @@ struct ZashiTextField<PrefixContent, InputReplacementContent, AccessoryContent>:
     var title: String?
     var error: String?
     let eraseAction: (() -> Void)?
-    
+    // Inner-TextField accessibility id (e2e affordance). Applied to
+    // the inner SwiftUI TextField directly so a maestro tap-by-id
+    // lands on the input's hit-test region, AND so the wrapper's
+    // accessory views (icon buttons) keep their own accessibility
+    // identifiers — without this, an outer `.accessibilityIdentifier(...)`
+    // modifier on ZashiTextField merges all inner elements into one
+    // accessibility node and the icon buttons stop being findable
+    // by their own ids.
+    var inputAccessibilityIdentifier: String?
+
     @ViewBuilder let accessoryView: AccessoryContent?
     @ViewBuilder let inputReplacementView: InputReplacementContent?
     @ViewBuilder let prefixView: PrefixContent?
@@ -28,6 +37,7 @@ struct ZashiTextField<PrefixContent, InputReplacementContent, AccessoryContent>:
         title: String? = nil,
         error: String? = nil,
         eraseAction: (() -> Void)? = nil,
+        inputAccessibilityIdentifier: String? = nil,
         accessoryView: AccessoryContent? = EmptyView(),
         inputReplacementView: InputReplacementContent? = EmptyView(),
         prefixView: PrefixContent? = EmptyView()
@@ -38,6 +48,7 @@ struct ZashiTextField<PrefixContent, InputReplacementContent, AccessoryContent>:
         self.title = title
         self.error = error
         self.eraseAction = eraseAction
+        self.inputAccessibilityIdentifier = inputAccessibilityIdentifier
         self.accessoryView = accessoryView
         self.inputReplacementView = inputReplacementView
         self.prefixView = prefixView
@@ -63,7 +74,7 @@ struct ZashiTextField<PrefixContent, InputReplacementContent, AccessoryContent>:
                 if let inputReplacementView, !(inputReplacementView is EmptyView) {
                     inputReplacementView
                 } else {
-                    TextField(
+                    let field = TextField(
                         "",
                         text: text,
                         prompt:
@@ -82,6 +93,11 @@ struct ZashiTextField<PrefixContent, InputReplacementContent, AccessoryContent>:
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .accentColor(Asset.Colors.primary.color)
+                    if let inputAccessibilityIdentifier {
+                        field.accessibilityIdentifier(inputAccessibilityIdentifier)
+                    } else {
+                        field
+                    }
                 }
                 
                 Spacer()

--- a/secant/Sources/Utils/AccessibilityID.swift
+++ b/secant/Sources/Utils/AccessibilityID.swift
@@ -32,6 +32,7 @@ enum AccessibilityID {
         static let addToContactsButton = "sendForm.addToContactsButton"
         static let scanButton = "sendForm.scanButton"
         static let reviewButton = "sendForm.reviewButton"
+        static let zcashAddressField = "sendForm.zcashAddressField"
     }
 
     enum SendConfirmation {

--- a/zodlTests/UtilTests/LoggerTests.swift
+++ b/zodlTests/UtilTests/LoggerTests.swift
@@ -173,6 +173,9 @@ import OSLog
     @Test func walletLoggerLogsViaProxy() throws {
         let category = "testWalletLogger"
         walletLogger = OSLogger(logLevel: .info, category: category)
+        // Restore the process-global so other suites' LoggerProxy
+        // calls don't keep landing in this test's category.
+        defer { walletLogger = nil }
         let testMessage = "wallet test message"
 
         LoggerProxy.info(testMessage)
@@ -182,11 +185,18 @@ import OSLog
 
         guard let logs else { return }
 
-        #expect(logs.count == 1)
-
-        let loggedMessage = logs[0].osLoggedMessage()
-
-        #expect(testMessage == loggedMessage)
+        // walletLogger is process-global. While this test holds it set
+        // to "testWalletLogger", any *parallel* suite that calls
+        // LoggerProxy.info (ServerHealthTracker, VotingAPIClient, the
+        // background-task client, etc.) will race-write into the same
+        // OSLog category. @Suite(.serialized) only serializes within
+        // this suite, not across the bundle — observed on CI as
+        // logs.count == 7 instead of 1.
+        //
+        // Assert the proxy delivered OUR message instead of demanding
+        // exclusive bucket ownership we can't enforce.
+        #expect(logs.count >= 1)
+        #expect(logs.contains { $0.osLoggedMessage() == testMessage })
     }
 }
 


### PR DESCRIPTION
## Problem

\`LoggerTests.walletLoggerLogsViaProxy\` fails on CI (\`run 27640596824\`, main HEAD):

> Expectation failed: (logs.count → 7) == 1

\`LoggerProxy.info\` writes to a process-global \`walletLogger\`. While this test holds \`walletLogger\` set to category \"testWalletLogger\", *parallel* suites that indirectly call \`LoggerProxy.info\` (\`ServerHealthTracker\`, \`VotingAPIClientLiveKey\`, \`BackgroundTaskClientLiveKey\`, etc.) race-write into the same OSLog category. \`@Suite(.serialized)\` only serializes within this suite, not across the bundle. Result on CI: 1 from this test + 6 from parallel suites = 7.

## Fix

- Assert \"our message is in the bucket\" (\`count >= 1\` + \`.contains { ... == testMessage }\`) instead of demanding exclusive bucket ownership we can't enforce given process-global state.
- \`defer { walletLogger = nil }\` so the global doesn't keep landing parallel suites' logs in this category after the test exits.
- In-place comment explains the constraint so future readers don't try to tighten the assertion back to \`== 1\`.

## Verification plan

- Re-run unit tests on this PR's CI — \`walletLoggerLogsViaProxy\` should pass.
- Manual: \`xcodebuild test -scheme zodl-internal -only-testing zodlTests/LoggerTests\` locally also passes (was passing before; the race only manifested under parallel-suite load on CI).