### PR TITLE
Add unit-tests (zero production code changes)

### DIFF
--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		340D001F2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D001E2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift */; };
 		340D00252FE1F9EC0061AA14 /* TransactionsCoordFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00242FE1F9EC0061AA14 /* TransactionsCoordFlowCoordinatorTests.swift */; };
 		340D002B2FE1FA680061AA14 /* TorSetupGapsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D002A2FE1FA680061AA14 /* TorSetupGapsTests.swift */; };
+		340D00312FE1FAF90061AA14 /* FeatureFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00302FE1FAF90061AA14 /* FeatureFlagsTests.swift */; };
 		340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */; };
 		340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */; };
 		340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */; };
@@ -1659,6 +1660,7 @@
 		340D001E2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsLogicTests.swift; sourceTree = "<group>"; };
 		340D00242FE1F9EC0061AA14 /* TransactionsCoordFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsCoordFlowCoordinatorTests.swift; sourceTree = "<group>"; };
 		340D002A2FE1FA680061AA14 /* TorSetupGapsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorSetupGapsTests.swift; sourceTree = "<group>"; };
+		340D00302FE1FAF90061AA14 /* FeatureFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsTests.swift; sourceTree = "<group>"; };
 		340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalsTests.swift; sourceTree = "<group>"; };
 		340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializerTests.swift; sourceTree = "<group>"; };
 		340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayChunkedTests.swift; sourceTree = "<group>"; };
@@ -2513,6 +2515,7 @@
 				340D00102FE1F7B70061AA14 /* WalletStatusTests.swift */,
 				340D00122FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift */,
 				340D00142FE1F7BB0061AA14 /* ChainTokenTests.swift */,
+				340D00302FE1FAF90061AA14 /* FeatureFlagsTests.swift */,
 			);
 			path = ModelsTests;
 			sourceTree = "<group>";
@@ -5365,6 +5368,7 @@
 				F8D7DA12B79F620DB1AB1F78 /* MemoByteCountingTests.swift in Sources */,
 				340DFFB02FE1EA4F0061AA14 /* ZecKeyboardTests.swift in Sources */,
 				05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */,
+				340D00312FE1FAF90061AA14 /* FeatureFlagsTests.swift in Sources */,
 				340DFF962FE1E7520061AA14 /* StoredWalletTests.swift in Sources */,
 				8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */,
 				340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -11,6 +11,17 @@
 		05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE450F4E98D0B7054611598 /* PrivateDataConsentTests.swift */; };
 		161B27ACDB3C31A163EC8AFF /* SensitiveDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53B4B2244B2E608A11AC552 /* SensitiveDataTests.swift */; };
 		2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD04B216486D7A0AAB329F2 /* UserPreferencesStorageTests.swift */; };
+		340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */; };
+		340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */; };
+		340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */; };
+		340DFF642FE1E44F0061AA14 /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF632FE1E44F0061AA14 /* NetworkErrorTests.swift */; };
+		340DFF662FE1E4550061AA14 /* AnyDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF652FE1E4550061AA14 /* AnyDecodableTests.swift */; };
+		340DFF6B2FE1E4620061AA14 /* StringsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF6A2FE1E4620061AA14 /* StringsTests.swift */; };
+		340DFF712FE1E5D10061AA14 /* ClampedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF702FE1E5D10061AA14 /* ClampedTests.swift */; };
+		340DFF762FE1E5DC0061AA14 /* BalanceFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF752FE1E5DC0061AA14 /* BalanceFormatterTests.swift */; };
+		340DFF792FE1E5E40061AA14 /* SwapAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */; };
+		340DFF7E2FE1E5F00061AA14 /* SwapMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */; };
+		340DFF842FE1E60F0061AA14 /* TransactionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -48,6 +59,9 @@
 		349CE5D62FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5D52FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift */; };
 		349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5E92FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift */; };
 		349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */; };
+		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
+		349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */; };
+		349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */; };
 		349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */; };
 		34AA6DD82F85774F00D244E2 /* SwapAndPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CF82F85774F00D244E2 /* SwapAndPayStore.swift */; };
 		34AA6DD92F85774F00D244E2 /* RemoteStorageInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C102F85774F00D244E2 /* RemoteStorageInterface.swift */; };
@@ -1432,9 +1446,6 @@
 		37D0F0000000000000000024 /* RoundAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0F0000000000000000002 /* RoundAuthenticator.swift */; };
 		38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E83225E24EEF486F002B79 /* RecoveryPhraseBackupTests.swift */; };
-		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
-		349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */; };
-		349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */; };
 		63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D430BF2CF73CFB82A13F1CB /* SecItemClientTests.swift */; };
 		7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */; };
 		8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1983F0BB6D025B08BBD186B /* QRCodeGeneratorTests.swift */; };
@@ -1609,6 +1620,17 @@
 		0DFE93DE272C6D4B000FCCA5 /* RecoveryPhraseBackupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseBackupTests.swift; sourceTree = "<group>"; };
 		0F94E337360CE50FACFB04CE /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
 		315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CurrencyConversionTests.swift; sourceTree = "<group>"; };
+		340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalsTests.swift; sourceTree = "<group>"; };
+		340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializerTests.swift; sourceTree = "<group>"; };
+		340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayChunkedTests.swift; sourceTree = "<group>"; };
+		340DFF632FE1E44F0061AA14 /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
+		340DFF652FE1E4550061AA14 /* AnyDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodableTests.swift; sourceTree = "<group>"; };
+		340DFF6A2FE1E4620061AA14 /* StringsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringsTests.swift; sourceTree = "<group>"; };
+		340DFF702FE1E5D10061AA14 /* ClampedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClampedTests.swift; sourceTree = "<group>"; };
+		340DFF752FE1E5DC0061AA14 /* BalanceFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceFormatterTests.swift; sourceTree = "<group>"; };
+		340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapAssetTests.swift; sourceTree = "<group>"; };
+		340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapMetadataTests.swift; sourceTree = "<group>"; };
+		340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionStateTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -1627,10 +1649,10 @@
 		349CE5D52FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiServerSubmissionTests.swift; sourceTree = "<group>"; };
 		349CE5E92FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiServerSubmitRoutingTests.swift; sourceTree = "<group>"; };
 		349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseDisplayTests.swift; sourceTree = "<group>"; };
-		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
 		349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTransactionHistoryTests.swift; sourceTree = "<group>"; };
 		349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportLogsTests.swift; sourceTree = "<group>"; };
 		349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorSetupTests.swift; sourceTree = "<group>"; };
+		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
 		34AA6BA42F85774F00D244E2 /* ABv1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABv1.swift; sourceTree = "<group>"; };
 		34AA6BA62F85774F00D244E2 /* AddressBookContacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookContacts.swift; sourceTree = "<group>"; };
 		34AA6BA72F85774F00D244E2 /* AddressBookEncryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEncryption.swift; sourceTree = "<group>"; };
@@ -2347,6 +2369,8 @@
 				349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */,
 				349CE6182FDC1B1500E2B9CF /* ExportLogsTests */,
 				349CE6262FDC1CEA00E2B9CF /* TorSetupTests */,
+				340DFF772FE1E5E40061AA14 /* SwapTests */,
+				340DFF822FE1E60F0061AA14 /* TransactionStateTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2381,6 +2405,23 @@
 			children = (
 			);
 			path = BalanceBreakdownTests;
+			sourceTree = "<group>";
+		};
+		340DFF772FE1E5E40061AA14 /* SwapTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */,
+				340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */,
+			);
+			path = SwapTests;
+			sourceTree = "<group>";
+		};
+		340DFF822FE1E60F0061AA14 /* TransactionStateTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */,
+			);
+			path = TransactionStateTests;
 			sourceTree = "<group>";
 		};
 		343CF3F429BB5A14009E44DF /* Frameworks */ = {
@@ -2429,14 +2470,6 @@
 			path = SendTests;
 			sourceTree = "<group>";
 		};
-		349CE6582FDC358500E2B9CF /* SettingsTests */ = {
-			isa = PBXGroup;
-			children = (
-				349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */,
-			);
-			path = SettingsTests;
-			sourceTree = "<group>";
-		};
 		349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2459,6 +2492,14 @@
 				349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */,
 			);
 			path = TorSetupTests;
+			sourceTree = "<group>";
+		};
+		349CE6582FDC358500E2B9CF /* SettingsTests */ = {
+			isa = PBXGroup;
+			children = (
+				349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */,
+			);
+			path = SettingsTests;
 			sourceTree = "<group>";
 		};
 		34AA6BA52F85774F00D244E2 /* Migration */ = {
@@ -4404,6 +4445,14 @@
 				348EC4CB2FD7FD96008495FB /* TransactionGuardTests.swift */,
 				9EF8135B27ECC25E0075AF48 /* UserPreferencesStorageTests.swift */,
 				9E39112D283F91600073DD9A /* ZatoshiTests.swift */,
+				340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */,
+				340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */,
+				340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */,
+				340DFF632FE1E44F0061AA14 /* NetworkErrorTests.swift */,
+				340DFF652FE1E4550061AA14 /* AnyDecodableTests.swift */,
+				340DFF6A2FE1E4620061AA14 /* StringsTests.swift */,
+				340DFF702FE1E5D10061AA14 /* ClampedTests.swift */,
+				340DFF752FE1E5DC0061AA14 /* BalanceFormatterTests.swift */,
 			);
 			path = UtilTests;
 			sourceTree = "<group>";
@@ -5108,18 +5157,25 @@
 			buildActionMask = 2147483647;
 			files = (
 				349CE5D62FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift in Sources */,
+				340DFF6B2FE1E4620061AA14 /* StringsTests.swift in Sources */,
 				34D06C912FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift in Sources */,
+				340DFF7E2FE1E5F00061AA14 /* SwapMetadataTests.swift in Sources */,
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
 				349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
 				AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */,
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,
 				AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */,
+				340DFF792FE1E5E40061AA14 /* SwapAssetTests.swift in Sources */,
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
 				54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */,
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
+				340DFF642FE1E44F0061AA14 /* NetworkErrorTests.swift in Sources */,
+				340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */,
+				340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */,
 				349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */,
 				349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */,
+				340DFF662FE1E4550061AA14 /* AnyDecodableTests.swift in Sources */,
 				349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */,
 				7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */,
 				DB87FBCDB6C1FC4EA9311A26 /* DeeplinkURLParsingTests.swift in Sources */,
@@ -5127,15 +5183,19 @@
 				F8D7DA12B79F620DB1AB1F78 /* MemoByteCountingTests.swift in Sources */,
 				05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */,
 				8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */,
+				340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */,
 				BD09B2C5A52C10AD52B24E58 /* ReviewRequestTests.swift in Sources */,
 				161B27ACDB3C31A163EC8AFF /* SensitiveDataTests.swift in Sources */,
 				985D6A4AAAD20B2071C9997D /* DatabaseFilesTests.swift in Sources */,
 				348EC4CC2FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift in Sources */,
 				348EC4CD2FD7FD96008495FB /* ServerEndpointsTests.swift in Sources */,
 				348EC4CE2FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift in Sources */,
+				340DFF712FE1E5D10061AA14 /* ClampedTests.swift in Sources */,
 				348EC4CF2FD7FD96008495FB /* ServerSetupStoreTests.swift in Sources */,
 				348EC4D02FD7FD96008495FB /* TransactionGuardTests.swift in Sources */,
 				348EC4D12FD7FD96008495FB /* AutoServerSelectionClientTests.swift in Sources */,
+				340DFF842FE1E60F0061AA14 /* TransactionStateTests.swift in Sources */,
+				340DFF762FE1E5DC0061AA14 /* BalanceFormatterTests.swift in Sources */,
 				921B3D95249329CD65C36E1B /* LoggerTests.swift in Sources */,
 				63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */,
 				2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		340D00152FE1F7BB0061AA14 /* ChainTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00142FE1F7BB0061AA14 /* ChainTokenTests.swift */; };
 		340D00172FE1F7BF0061AA14 /* DateReadableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00162FE1F7BF0061AA14 /* DateReadableTests.swift */; };
 		340D001F2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D001E2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift */; };
+		340D00252FE1F9EC0061AA14 /* TransactionsCoordFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00242FE1F9EC0061AA14 /* TransactionsCoordFlowCoordinatorTests.swift */; };
+		340D002B2FE1FA680061AA14 /* TorSetupGapsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D002A2FE1FA680061AA14 /* TorSetupGapsTests.swift */; };
 		340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */; };
 		340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */; };
 		340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */; };
@@ -1655,6 +1657,8 @@
 		340D00142FE1F7BB0061AA14 /* ChainTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainTokenTests.swift; sourceTree = "<group>"; };
 		340D00162FE1F7BF0061AA14 /* DateReadableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateReadableTests.swift; sourceTree = "<group>"; };
 		340D001E2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsLogicTests.swift; sourceTree = "<group>"; };
+		340D00242FE1F9EC0061AA14 /* TransactionsCoordFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsCoordFlowCoordinatorTests.swift; sourceTree = "<group>"; };
+		340D002A2FE1FA680061AA14 /* TorSetupGapsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorSetupGapsTests.swift; sourceTree = "<group>"; };
 		340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalsTests.swift; sourceTree = "<group>"; };
 		340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializerTests.swift; sourceTree = "<group>"; };
 		340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayChunkedTests.swift; sourceTree = "<group>"; };
@@ -2575,6 +2579,7 @@
 			children = (
 				340DFFEF2FE1F3850061AA14 /* TransactionsManagerLogicTests.swift */,
 				340DFFFC2FE1F5300061AA14 /* TransactionListTests.swift */,
+				340D00242FE1F9EC0061AA14 /* TransactionsCoordFlowCoordinatorTests.swift */,
 			);
 			path = TransactionsManagerTests;
 			sourceTree = "<group>";
@@ -2645,6 +2650,7 @@
 			isa = PBXGroup;
 			children = (
 				349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */,
+				340D002A2FE1FA680061AA14 /* TorSetupGapsTests.swift */,
 			);
 			path = TorSetupTests;
 			sourceTree = "<group>";
@@ -5371,6 +5377,7 @@
 				340DFFA22FE1E8880061AA14 /* AddressBookSerializationTests.swift in Sources */,
 				348EC4CE2FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift in Sources */,
 				340DFFD52FE1F0AE0061AA14 /* MnemonicClientTests.swift in Sources */,
+				340D002B2FE1FA680061AA14 /* TorSetupGapsTests.swift in Sources */,
 				340DFF712FE1E5D10061AA14 /* ClampedTests.swift in Sources */,
 				340DFFBF2FE1EC580061AA14 /* BalancesTests.swift in Sources */,
 				348EC4CF2FD7FD96008495FB /* ServerSetupStoreTests.swift in Sources */,
@@ -5382,6 +5389,7 @@
 				340DFF762FE1E5DC0061AA14 /* BalanceFormatterTests.swift in Sources */,
 				921B3D95249329CD65C36E1B /* LoggerTests.swift in Sources */,
 				340D00112FE1F7B70061AA14 /* WalletStatusTests.swift in Sources */,
+				340D00252FE1F9EC0061AA14 /* TransactionsCoordFlowCoordinatorTests.swift in Sources */,
 				63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */,
 				340D000A2FE1F7A90061AA14 /* RecoveryPhraseTests.swift in Sources */,
 				2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE450F4E98D0B7054611598 /* PrivateDataConsentTests.swift */; };
 		161B27ACDB3C31A163EC8AFF /* SensitiveDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53B4B2244B2E608A11AC552 /* SensitiveDataTests.swift */; };
 		2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD04B216486D7A0AAB329F2 /* UserPreferencesStorageTests.swift */; };
+		340D00032FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00022FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift */; };
 		340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */; };
 		340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */; };
 		340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */; };
@@ -40,6 +41,7 @@
 		340DFFE82FE1F2520061AA14 /* WalletStoragePureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFE72FE1F2520061AA14 /* WalletStoragePureTests.swift */; };
 		340DFFF02FE1F3850061AA14 /* TransactionsManagerLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFEF2FE1F3850061AA14 /* TransactionsManagerLogicTests.swift */; };
 		340DFFF72FE1F49E0061AA14 /* AddressBookLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFF62FE1F49E0061AA14 /* AddressBookLogicTests.swift */; };
+		340DFFFD2FE1F5300061AA14 /* TransactionListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFFC2FE1F5300061AA14 /* TransactionListTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1638,6 +1640,7 @@
 		0DFE93DE272C6D4B000FCCA5 /* RecoveryPhraseBackupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseBackupTests.swift; sourceTree = "<group>"; };
 		0F94E337360CE50FACFB04CE /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
 		315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CurrencyConversionTests.swift; sourceTree = "<group>"; };
+		340D00022FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsAuthGateTests.swift; sourceTree = "<group>"; };
 		340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalsTests.swift; sourceTree = "<group>"; };
 		340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializerTests.swift; sourceTree = "<group>"; };
 		340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayChunkedTests.swift; sourceTree = "<group>"; };
@@ -1667,6 +1670,7 @@
 		340DFFE72FE1F2520061AA14 /* WalletStoragePureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletStoragePureTests.swift; sourceTree = "<group>"; };
 		340DFFEF2FE1F3850061AA14 /* TransactionsManagerLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsManagerLogicTests.swift; sourceTree = "<group>"; };
 		340DFFF62FE1F49E0061AA14 /* AddressBookLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookLogicTests.swift; sourceTree = "<group>"; };
+		340DFFFC2FE1F5300061AA14 /* TransactionListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionListTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2542,6 +2546,7 @@
 			isa = PBXGroup;
 			children = (
 				340DFFEF2FE1F3850061AA14 /* TransactionsManagerLogicTests.swift */,
+				340DFFFC2FE1F5300061AA14 /* TransactionListTests.swift */,
 			);
 			path = TransactionsManagerTests;
 			sourceTree = "<group>";
@@ -2620,6 +2625,7 @@
 			isa = PBXGroup;
 			children = (
 				349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */,
+				340D00022FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift */,
 			);
 			path = SettingsTests;
 			sourceTree = "<group>";
@@ -5305,6 +5311,8 @@
 				340DFFE82FE1F2520061AA14 /* WalletStoragePureTests.swift in Sources */,
 				340DFF642FE1E44F0061AA14 /* NetworkErrorTests.swift in Sources */,
 				340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */,
+				340D00032FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift in Sources */,
+				340DFFFD2FE1F5300061AA14 /* TransactionListTests.swift in Sources */,
 				340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */,
 				349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */,
 				349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		340D00132FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00122FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift */; };
 		340D00152FE1F7BB0061AA14 /* ChainTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00142FE1F7BB0061AA14 /* ChainTokenTests.swift */; };
 		340D00172FE1F7BF0061AA14 /* DateReadableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00162FE1F7BF0061AA14 /* DateReadableTests.swift */; };
+		340D001F2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D001E2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift */; };
 		340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */; };
 		340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */; };
 		340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */; };
@@ -1653,6 +1654,7 @@
 		340D00122FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusSnapshotTests.swift; sourceTree = "<group>"; };
 		340D00142FE1F7BB0061AA14 /* ChainTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainTokenTests.swift; sourceTree = "<group>"; };
 		340D00162FE1F7BF0061AA14 /* DateReadableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateReadableTests.swift; sourceTree = "<group>"; };
+		340D001E2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsLogicTests.swift; sourceTree = "<group>"; };
 		340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalsTests.swift; sourceTree = "<group>"; };
 		340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializerTests.swift; sourceTree = "<group>"; };
 		340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayChunkedTests.swift; sourceTree = "<group>"; };
@@ -2432,6 +2434,7 @@
 				340DFFBD2FE1EC580061AA14 /* BalancesTests */,
 				340DFFC32FE1ED9A0061AA14 /* RequestZecTests */,
 				340DFFEE2FE1F3850061AA14 /* TransactionsManagerTests */,
+				340D001D2FE1F9290061AA14 /* TransactionDetailsTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2466,6 +2469,14 @@
 			children = (
 			);
 			path = BalanceBreakdownTests;
+			sourceTree = "<group>";
+		};
+		340D001D2FE1F9290061AA14 /* TransactionDetailsTests */ = {
+			isa = PBXGroup;
+			children = (
+				340D001E2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift */,
+			);
+			path = TransactionDetailsTests;
 			sourceTree = "<group>";
 		};
 		340DFF772FE1E5E40061AA14 /* SwapTests */ = {
@@ -5376,6 +5387,7 @@
 				2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */,
 				BFE03A2F84B2F8B97831CD9F /* ZatoshiTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,
+				340D001F2FE1F9290061AA14 /* TransactionDetailsLogicTests.swift in Sources */,
 				340DFF912FE1E7480061AA14 /* EncryptionKeysTests.swift in Sources */,
 				A409BF1DAB30483E4CDB0DCB /* ZatoshiStringRepresentationTests.swift in Sources */,
 			);

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		340DFFA92FE1E94B0061AA14 /* UMSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */; };
 		340DFFB02FE1EA4F0061AA14 /* ZecKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFAF2FE1EA4F0061AA14 /* ZecKeyboardTests.swift */; };
 		340DFFB72FE1EB3F0061AA14 /* WalletBalancesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFB62FE1EB3F0061AA14 /* WalletBalancesTests.swift */; };
+		340DFFBF2FE1EC580061AA14 /* BalancesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFBE2FE1EC580061AA14 /* BalancesTests.swift */; };
+		340DFFC52FE1ED9A0061AA14 /* RequestZecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFC42FE1ED9A0061AA14 /* RequestZecTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1649,6 +1651,8 @@
 		340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UMSerializationTests.swift; sourceTree = "<group>"; };
 		340DFFAF2FE1EA4F0061AA14 /* ZecKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZecKeyboardTests.swift; sourceTree = "<group>"; };
 		340DFFB62FE1EB3F0061AA14 /* WalletBalancesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBalancesTests.swift; sourceTree = "<group>"; };
+		340DFFBE2FE1EC580061AA14 /* BalancesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalancesTests.swift; sourceTree = "<group>"; };
+		340DFFC42FE1ED9A0061AA14 /* RequestZecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestZecTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2395,6 +2399,8 @@
 				340DFFA72FE1E94B0061AA14 /* UserMetadataTests */,
 				340DFFAE2FE1EA4F0061AA14 /* ZecKeyboardTests */,
 				340DFFB52FE1EB3F0061AA14 /* WalletBalancesTests */,
+				340DFFBD2FE1EC580061AA14 /* BalancesTests */,
+				340DFFC32FE1ED9A0061AA14 /* RequestZecTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2497,6 +2503,22 @@
 				340DFFB62FE1EB3F0061AA14 /* WalletBalancesTests.swift */,
 			);
 			path = WalletBalancesTests;
+			sourceTree = "<group>";
+		};
+		340DFFBD2FE1EC580061AA14 /* BalancesTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFFBE2FE1EC580061AA14 /* BalancesTests.swift */,
+			);
+			path = BalancesTests;
+			sourceTree = "<group>";
+		};
+		340DFFC32FE1ED9A0061AA14 /* RequestZecTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFFC42FE1ED9A0061AA14 /* RequestZecTests.swift */,
+			);
+			path = RequestZecTests;
 			sourceTree = "<group>";
 		};
 		343CF3F429BB5A14009E44DF /* Frameworks */ = {
@@ -5237,6 +5259,7 @@
 				34D06C912FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift in Sources */,
 				340DFF7E2FE1E5F00061AA14 /* SwapMetadataTests.swift in Sources */,
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
+				340DFFC52FE1ED9A0061AA14 /* RequestZecTests.swift in Sources */,
 				349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
 				340DFFB72FE1EB3F0061AA14 /* WalletBalancesTests.swift in Sources */,
@@ -5273,6 +5296,7 @@
 				340DFFA22FE1E8880061AA14 /* AddressBookSerializationTests.swift in Sources */,
 				348EC4CE2FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift in Sources */,
 				340DFF712FE1E5D10061AA14 /* ClampedTests.swift in Sources */,
+				340DFFBF2FE1EC580061AA14 /* BalancesTests.swift in Sources */,
 				348EC4CF2FD7FD96008495FB /* ServerSetupStoreTests.swift in Sources */,
 				348EC4D02FD7FD96008495FB /* TransactionGuardTests.swift in Sources */,
 				340DFF8B2FE1E7390061AA14 /* CMCRateTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@
 		161B27ACDB3C31A163EC8AFF /* SensitiveDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53B4B2244B2E608A11AC552 /* SensitiveDataTests.swift */; };
 		2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD04B216486D7A0AAB329F2 /* UserPreferencesStorageTests.swift */; };
 		340D00032FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00022FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift */; };
+		340D000A2FE1F7A90061AA14 /* RecoveryPhraseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00092FE1F7A90061AA14 /* RecoveryPhraseTests.swift */; };
+		340D000F2FE1F7B50061AA14 /* WalletAccountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D000E2FE1F7B50061AA14 /* WalletAccountTests.swift */; };
+		340D00112FE1F7B70061AA14 /* WalletStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00102FE1F7B70061AA14 /* WalletStatusTests.swift */; };
+		340D00132FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00122FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift */; };
+		340D00152FE1F7BB0061AA14 /* ChainTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00142FE1F7BB0061AA14 /* ChainTokenTests.swift */; };
+		340D00172FE1F7BF0061AA14 /* DateReadableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D00162FE1F7BF0061AA14 /* DateReadableTests.swift */; };
 		340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */; };
 		340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */; };
 		340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */; };
@@ -1641,6 +1647,12 @@
 		0F94E337360CE50FACFB04CE /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
 		315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CurrencyConversionTests.swift; sourceTree = "<group>"; };
 		340D00022FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsAuthGateTests.swift; sourceTree = "<group>"; };
+		340D00092FE1F7A90061AA14 /* RecoveryPhraseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseTests.swift; sourceTree = "<group>"; };
+		340D000E2FE1F7B50061AA14 /* WalletAccountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccountTests.swift; sourceTree = "<group>"; };
+		340D00102FE1F7B70061AA14 /* WalletStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletStatusTests.swift; sourceTree = "<group>"; };
+		340D00122FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusSnapshotTests.swift; sourceTree = "<group>"; };
+		340D00142FE1F7BB0061AA14 /* ChainTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainTokenTests.swift; sourceTree = "<group>"; };
+		340D00162FE1F7BF0061AA14 /* DateReadableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateReadableTests.swift; sourceTree = "<group>"; };
 		340DFF572FE1E42D0061AA14 /* DecimalsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalsTests.swift; sourceTree = "<group>"; };
 		340DFF5C2FE1E4410061AA14 /* SerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializerTests.swift; sourceTree = "<group>"; };
 		340DFF5E2FE1E4450061AA14 /* ArrayChunkedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayChunkedTests.swift; sourceTree = "<group>"; };
@@ -2481,6 +2493,11 @@
 				340DFF952FE1E7520061AA14 /* StoredWalletTests.swift */,
 				340DFF972FE1E7580061AA14 /* WalletConfigTests.swift */,
 				340DFF992FE1E75A0061AA14 /* SpendabilityTests.swift */,
+				340D00092FE1F7A90061AA14 /* RecoveryPhraseTests.swift */,
+				340D000E2FE1F7B50061AA14 /* WalletAccountTests.swift */,
+				340D00102FE1F7B70061AA14 /* WalletStatusTests.swift */,
+				340D00122FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift */,
+				340D00142FE1F7BB0061AA14 /* ChainTokenTests.swift */,
 			);
 			path = ModelsTests;
 			sourceTree = "<group>";
@@ -4585,6 +4602,7 @@
 				340DFFD92FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift */,
 				340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */,
 				340DFFE72FE1F2520061AA14 /* WalletStoragePureTests.swift */,
+				340D00162FE1F7BF0061AA14 /* DateReadableTests.swift */,
 			);
 			path = UtilTests;
 			sourceTree = "<group>";
@@ -5298,6 +5316,7 @@
 				349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */,
 				340DFFF72FE1F49E0061AA14 /* AddressBookLogicTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
+				340D00152FE1F7BB0061AA14 /* ChainTokenTests.swift in Sources */,
 				340DFFF02FE1F3850061AA14 /* TransactionsManagerLogicTests.swift in Sources */,
 				340DFFB72FE1EB3F0061AA14 /* WalletBalancesTests.swift in Sources */,
 				AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */,
@@ -5306,10 +5325,12 @@
 				340DFF792FE1E5E40061AA14 /* SwapAssetTests.swift in Sources */,
 				340DFFE22FE1F1960061AA14 /* DerivationToolTests.swift in Sources */,
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
+				340D00172FE1F7BF0061AA14 /* DateReadableTests.swift in Sources */,
 				54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */,
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
 				340DFFE82FE1F2520061AA14 /* WalletStoragePureTests.swift in Sources */,
 				340DFF642FE1E44F0061AA14 /* NetworkErrorTests.swift in Sources */,
+				340D00132FE1F7B90061AA14 /* SyncStatusSnapshotTests.swift in Sources */,
 				340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */,
 				340D00032FE1F5B90061AA14 /* AdvancedSettingsAuthGateTests.swift in Sources */,
 				340DFFFD2FE1F5300061AA14 /* TransactionListTests.swift in Sources */,
@@ -5344,11 +5365,14 @@
 				348EC4CF2FD7FD96008495FB /* ServerSetupStoreTests.swift in Sources */,
 				348EC4D02FD7FD96008495FB /* TransactionGuardTests.swift in Sources */,
 				340DFF8B2FE1E7390061AA14 /* CMCRateTests.swift in Sources */,
+				340D000F2FE1F7B50061AA14 /* WalletAccountTests.swift in Sources */,
 				348EC4D12FD7FD96008495FB /* AutoServerSelectionClientTests.swift in Sources */,
 				340DFF842FE1E60F0061AA14 /* TransactionStateTests.swift in Sources */,
 				340DFF762FE1E5DC0061AA14 /* BalanceFormatterTests.swift in Sources */,
 				921B3D95249329CD65C36E1B /* LoggerTests.swift in Sources */,
+				340D00112FE1F7B70061AA14 /* WalletStatusTests.swift in Sources */,
 				63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */,
+				340D000A2FE1F7A90061AA14 /* RecoveryPhraseTests.swift in Sources */,
 				2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */,
 				BFE03A2F84B2F8B97831CD9F /* ZatoshiTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		340DFFA22FE1E8880061AA14 /* AddressBookSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFA12FE1E8880061AA14 /* AddressBookSerializationTests.swift */; };
 		340DFFA92FE1E94B0061AA14 /* UMSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */; };
 		340DFFB02FE1EA4F0061AA14 /* ZecKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFAF2FE1EA4F0061AA14 /* ZecKeyboardTests.swift */; };
+		340DFFB72FE1EB3F0061AA14 /* WalletBalancesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFB62FE1EB3F0061AA14 /* WalletBalancesTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1647,6 +1648,7 @@
 		340DFFA12FE1E8880061AA14 /* AddressBookSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookSerializationTests.swift; sourceTree = "<group>"; };
 		340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UMSerializationTests.swift; sourceTree = "<group>"; };
 		340DFFAF2FE1EA4F0061AA14 /* ZecKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZecKeyboardTests.swift; sourceTree = "<group>"; };
+		340DFFB62FE1EB3F0061AA14 /* WalletBalancesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBalancesTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2392,6 +2394,7 @@
 				340DFFA02FE1E8880061AA14 /* AddressBookTests */,
 				340DFFA72FE1E94B0061AA14 /* UserMetadataTests */,
 				340DFFAE2FE1EA4F0061AA14 /* ZecKeyboardTests */,
+				340DFFB52FE1EB3F0061AA14 /* WalletBalancesTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2486,6 +2489,14 @@
 				340DFFAF2FE1EA4F0061AA14 /* ZecKeyboardTests.swift */,
 			);
 			path = ZecKeyboardTests;
+			sourceTree = "<group>";
+		};
+		340DFFB52FE1EB3F0061AA14 /* WalletBalancesTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFFB62FE1EB3F0061AA14 /* WalletBalancesTests.swift */,
+			);
+			path = WalletBalancesTests;
 			sourceTree = "<group>";
 		};
 		343CF3F429BB5A14009E44DF /* Frameworks */ = {
@@ -5228,6 +5239,7 @@
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
 				349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
+				340DFFB72FE1EB3F0061AA14 /* WalletBalancesTests.swift in Sources */,
 				AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */,
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,
 				AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -30,9 +30,7 @@
 		340DFF6B2FE1E4620061AA14 /* StringsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF6A2FE1E4620061AA14 /* StringsTests.swift */; };
 		340DFF712FE1E5D10061AA14 /* ClampedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF702FE1E5D10061AA14 /* ClampedTests.swift */; };
 		340DFF762FE1E5DC0061AA14 /* BalanceFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF752FE1E5DC0061AA14 /* BalanceFormatterTests.swift */; };
-		340DFF792FE1E5E40061AA14 /* SwapAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */; };
 		340DFF7E2FE1E5F00061AA14 /* SwapMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */; };
-		340DFF842FE1E60F0061AA14 /* TransactionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */; };
 		340DFF8B2FE1E7390061AA14 /* CMCRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF8A2FE1E7390061AA14 /* CMCRateTests.swift */; };
 		340DFF912FE1E7480061AA14 /* EncryptionKeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF902FE1E7480061AA14 /* EncryptionKeysTests.swift */; };
 		340DFF962FE1E7520061AA14 /* StoredWalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF952FE1E7520061AA14 /* StoredWalletTests.swift */; };
@@ -1669,9 +1667,7 @@
 		340DFF6A2FE1E4620061AA14 /* StringsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringsTests.swift; sourceTree = "<group>"; };
 		340DFF702FE1E5D10061AA14 /* ClampedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClampedTests.swift; sourceTree = "<group>"; };
 		340DFF752FE1E5DC0061AA14 /* BalanceFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceFormatterTests.swift; sourceTree = "<group>"; };
-		340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapAssetTests.swift; sourceTree = "<group>"; };
 		340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapMetadataTests.swift; sourceTree = "<group>"; };
-		340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionStateTests.swift; sourceTree = "<group>"; };
 		340DFF8A2FE1E7390061AA14 /* CMCRateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMCRateTests.swift; sourceTree = "<group>"; };
 		340DFF902FE1E7480061AA14 /* EncryptionKeysTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeysTests.swift; sourceTree = "<group>"; };
 		340DFF952FE1E7520061AA14 /* StoredWalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredWalletTests.swift; sourceTree = "<group>"; };
@@ -2430,7 +2426,6 @@
 				349CE6182FDC1B1500E2B9CF /* ExportLogsTests */,
 				349CE6262FDC1CEA00E2B9CF /* TorSetupTests */,
 				340DFF772FE1E5E40061AA14 /* SwapTests */,
-				340DFF822FE1E60F0061AA14 /* TransactionStateTests */,
 				340DFF892FE1E7390061AA14 /* ModelsTests */,
 				340DFF8F2FE1E7480061AA14 /* EncryptionTests */,
 				340DFFA02FE1E8880061AA14 /* AddressBookTests */,
@@ -2488,19 +2483,10 @@
 		340DFF772FE1E5E40061AA14 /* SwapTests */ = {
 			isa = PBXGroup;
 			children = (
-				340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */,
 				340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */,
 				340DFFDF2FE1F18F0061AA14 /* Near1ClickTests.swift */,
 			);
 			path = SwapTests;
-			sourceTree = "<group>";
-		};
-		340DFF822FE1E60F0061AA14 /* TransactionStateTests */ = {
-			isa = PBXGroup;
-			children = (
-				340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */,
-			);
-			path = TransactionStateTests;
 			sourceTree = "<group>";
 		};
 		340DFF892FE1E7390061AA14 /* ModelsTests */ = {
@@ -5342,7 +5328,6 @@
 				AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */,
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,
 				AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */,
-				340DFF792FE1E5E40061AA14 /* SwapAssetTests.swift in Sources */,
 				340DFFE22FE1F1960061AA14 /* DerivationToolTests.swift in Sources */,
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
 				340D00172FE1F7BF0061AA14 /* DateReadableTests.swift in Sources */,
@@ -5389,7 +5374,6 @@
 				340DFF8B2FE1E7390061AA14 /* CMCRateTests.swift in Sources */,
 				340D000F2FE1F7B50061AA14 /* WalletAccountTests.swift in Sources */,
 				348EC4D12FD7FD96008495FB /* AutoServerSelectionClientTests.swift in Sources */,
-				340DFF842FE1E60F0061AA14 /* TransactionStateTests.swift in Sources */,
 				340DFF762FE1E5DC0061AA14 /* BalanceFormatterTests.swift in Sources */,
 				921B3D95249329CD65C36E1B /* LoggerTests.swift in Sources */,
 				340D00112FE1F7B70061AA14 /* WalletStatusTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		340DFFE02FE1F18F0061AA14 /* Near1ClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFDF2FE1F18F0061AA14 /* Near1ClickTests.swift */; };
 		340DFFE22FE1F1960061AA14 /* DerivationToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */; };
 		340DFFE82FE1F2520061AA14 /* WalletStoragePureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFE72FE1F2520061AA14 /* WalletStoragePureTests.swift */; };
+		340DFFF02FE1F3850061AA14 /* TransactionsManagerLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFEF2FE1F3850061AA14 /* TransactionsManagerLogicTests.swift */; };
+		340DFFF72FE1F49E0061AA14 /* AddressBookLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFF62FE1F49E0061AA14 /* AddressBookLogicTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1663,6 +1665,8 @@
 		340DFFDF2FE1F18F0061AA14 /* Near1ClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Near1ClickTests.swift; sourceTree = "<group>"; };
 		340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivationToolTests.swift; sourceTree = "<group>"; };
 		340DFFE72FE1F2520061AA14 /* WalletStoragePureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletStoragePureTests.swift; sourceTree = "<group>"; };
+		340DFFEF2FE1F3850061AA14 /* TransactionsManagerLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsManagerLogicTests.swift; sourceTree = "<group>"; };
+		340DFFF62FE1F49E0061AA14 /* AddressBookLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookLogicTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2411,6 +2415,7 @@
 				340DFFB52FE1EB3F0061AA14 /* WalletBalancesTests */,
 				340DFFBD2FE1EC580061AA14 /* BalancesTests */,
 				340DFFC32FE1ED9A0061AA14 /* RequestZecTests */,
+				340DFFEE2FE1F3850061AA14 /* TransactionsManagerTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2488,6 +2493,7 @@
 			isa = PBXGroup;
 			children = (
 				340DFFA12FE1E8880061AA14 /* AddressBookSerializationTests.swift */,
+				340DFFF62FE1F49E0061AA14 /* AddressBookLogicTests.swift */,
 			);
 			path = AddressBookTests;
 			sourceTree = "<group>";
@@ -2530,6 +2536,14 @@
 				340DFFC42FE1ED9A0061AA14 /* RequestZecTests.swift */,
 			);
 			path = RequestZecTests;
+			sourceTree = "<group>";
+		};
+		340DFFEE2FE1F3850061AA14 /* TransactionsManagerTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFFEF2FE1F3850061AA14 /* TransactionsManagerLogicTests.swift */,
+			);
+			path = TransactionsManagerTests;
 			sourceTree = "<group>";
 		};
 		343CF3F429BB5A14009E44DF /* Frameworks */ = {
@@ -5276,7 +5290,9 @@
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
 				340DFFC52FE1ED9A0061AA14 /* RequestZecTests.swift in Sources */,
 				349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */,
+				340DFFF72FE1F49E0061AA14 /* AddressBookLogicTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
+				340DFFF02FE1F3850061AA14 /* TransactionsManagerLogicTests.swift in Sources */,
 				340DFFB72FE1EB3F0061AA14 /* WalletBalancesTests.swift in Sources */,
 				AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */,
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		340DFFB72FE1EB3F0061AA14 /* WalletBalancesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFB62FE1EB3F0061AA14 /* WalletBalancesTests.swift */; };
 		340DFFBF2FE1EC580061AA14 /* BalancesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFBE2FE1EC580061AA14 /* BalancesTests.swift */; };
 		340DFFC52FE1ED9A0061AA14 /* RequestZecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFC42FE1ED9A0061AA14 /* RequestZecTests.swift */; };
+		340DFFD52FE1F0AE0061AA14 /* MnemonicClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFD42FE1F0AE0061AA14 /* MnemonicClientTests.swift */; };
+		340DFFDA2FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFD92FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift */; };
+		340DFFE02FE1F18F0061AA14 /* Near1ClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFDF2FE1F18F0061AA14 /* Near1ClickTests.swift */; };
+		340DFFE22FE1F1960061AA14 /* DerivationToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1653,6 +1657,10 @@
 		340DFFB62FE1EB3F0061AA14 /* WalletBalancesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBalancesTests.swift; sourceTree = "<group>"; };
 		340DFFBE2FE1EC580061AA14 /* BalancesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalancesTests.swift; sourceTree = "<group>"; };
 		340DFFC42FE1ED9A0061AA14 /* RequestZecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestZecTests.swift; sourceTree = "<group>"; };
+		340DFFD42FE1F0AE0061AA14 /* MnemonicClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MnemonicClientTests.swift; sourceTree = "<group>"; };
+		340DFFD92FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConfigEndpointTests.swift; sourceTree = "<group>"; };
+		340DFFDF2FE1F18F0061AA14 /* Near1ClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Near1ClickTests.swift; sourceTree = "<group>"; };
+		340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivationToolTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2442,6 +2450,7 @@
 			children = (
 				340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */,
 				340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */,
+				340DFFDF2FE1F18F0061AA14 /* Near1ClickTests.swift */,
 			);
 			path = SwapTests;
 			sourceTree = "<group>";
@@ -4550,6 +4559,9 @@
 				340DFF6A2FE1E4620061AA14 /* StringsTests.swift */,
 				340DFF702FE1E5D10061AA14 /* ClampedTests.swift */,
 				340DFF752FE1E5DC0061AA14 /* BalanceFormatterTests.swift */,
+				340DFFD42FE1F0AE0061AA14 /* MnemonicClientTests.swift */,
+				340DFFD92FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift */,
+				340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */,
 			);
 			path = UtilTests;
 			sourceTree = "<group>";
@@ -5267,6 +5279,7 @@
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,
 				AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */,
 				340DFF792FE1E5E40061AA14 /* SwapAssetTests.swift in Sources */,
+				340DFFE22FE1F1960061AA14 /* DerivationToolTests.swift in Sources */,
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
 				54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */,
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
@@ -5281,6 +5294,8 @@
 				340DFFA92FE1E94B0061AA14 /* UMSerializationTests.swift in Sources */,
 				DB87FBCDB6C1FC4EA9311A26 /* DeeplinkURLParsingTests.swift in Sources */,
 				051F035A06D6092E00704BAB /* HomeTests.swift in Sources */,
+				340DFFE02FE1F18F0061AA14 /* Near1ClickTests.swift in Sources */,
+				340DFFDA2FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift in Sources */,
 				F8D7DA12B79F620DB1AB1F78 /* MemoByteCountingTests.swift in Sources */,
 				340DFFB02FE1EA4F0061AA14 /* ZecKeyboardTests.swift in Sources */,
 				05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */,
@@ -5295,6 +5310,7 @@
 				348EC4CD2FD7FD96008495FB /* ServerEndpointsTests.swift in Sources */,
 				340DFFA22FE1E8880061AA14 /* AddressBookSerializationTests.swift in Sources */,
 				348EC4CE2FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift in Sources */,
+				340DFFD52FE1F0AE0061AA14 /* MnemonicClientTests.swift in Sources */,
 				340DFF712FE1E5D10061AA14 /* ClampedTests.swift in Sources */,
 				340DFFBF2FE1EC580061AA14 /* BalancesTests.swift in Sources */,
 				348EC4CF2FD7FD96008495FB /* ServerSetupStoreTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		340DFFDA2FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFD92FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift */; };
 		340DFFE02FE1F18F0061AA14 /* Near1ClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFDF2FE1F18F0061AA14 /* Near1ClickTests.swift */; };
 		340DFFE22FE1F1960061AA14 /* DerivationToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */; };
+		340DFFE82FE1F2520061AA14 /* WalletStoragePureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFE72FE1F2520061AA14 /* WalletStoragePureTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1661,6 +1662,7 @@
 		340DFFD92FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConfigEndpointTests.swift; sourceTree = "<group>"; };
 		340DFFDF2FE1F18F0061AA14 /* Near1ClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Near1ClickTests.swift; sourceTree = "<group>"; };
 		340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivationToolTests.swift; sourceTree = "<group>"; };
+		340DFFE72FE1F2520061AA14 /* WalletStoragePureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletStoragePureTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -4562,6 +4564,7 @@
 				340DFFD42FE1F0AE0061AA14 /* MnemonicClientTests.swift */,
 				340DFFD92FE1F0BB0061AA14 /* ServerConfigEndpointTests.swift */,
 				340DFFE12FE1F1960061AA14 /* DerivationToolTests.swift */,
+				340DFFE72FE1F2520061AA14 /* WalletStoragePureTests.swift */,
 			);
 			path = UtilTests;
 			sourceTree = "<group>";
@@ -5283,6 +5286,7 @@
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
 				54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */,
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
+				340DFFE82FE1F2520061AA14 /* WalletStoragePureTests.swift in Sources */,
 				340DFF642FE1E44F0061AA14 /* NetworkErrorTests.swift in Sources */,
 				340DFF582FE1E42D0061AA14 /* DecimalsTests.swift in Sources */,
 				340DFF5D2FE1E4410061AA14 /* SerializerTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -22,6 +22,13 @@
 		340DFF792FE1E5E40061AA14 /* SwapAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */; };
 		340DFF7E2FE1E5F00061AA14 /* SwapMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */; };
 		340DFF842FE1E60F0061AA14 /* TransactionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */; };
+		340DFF8B2FE1E7390061AA14 /* CMCRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF8A2FE1E7390061AA14 /* CMCRateTests.swift */; };
+		340DFF912FE1E7480061AA14 /* EncryptionKeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF902FE1E7480061AA14 /* EncryptionKeysTests.swift */; };
+		340DFF962FE1E7520061AA14 /* StoredWalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF952FE1E7520061AA14 /* StoredWalletTests.swift */; };
+		340DFF982FE1E7580061AA14 /* WalletConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF972FE1E7580061AA14 /* WalletConfigTests.swift */; };
+		340DFF9A2FE1E75A0061AA14 /* SpendabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF992FE1E75A0061AA14 /* SpendabilityTests.swift */; };
+		340DFFA22FE1E8880061AA14 /* AddressBookSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFA12FE1E8880061AA14 /* AddressBookSerializationTests.swift */; };
+		340DFFA92FE1E94B0061AA14 /* UMSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1631,6 +1638,13 @@
 		340DFF782FE1E5E40061AA14 /* SwapAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapAssetTests.swift; sourceTree = "<group>"; };
 		340DFF7D2FE1E5F00061AA14 /* SwapMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapMetadataTests.swift; sourceTree = "<group>"; };
 		340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionStateTests.swift; sourceTree = "<group>"; };
+		340DFF8A2FE1E7390061AA14 /* CMCRateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMCRateTests.swift; sourceTree = "<group>"; };
+		340DFF902FE1E7480061AA14 /* EncryptionKeysTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeysTests.swift; sourceTree = "<group>"; };
+		340DFF952FE1E7520061AA14 /* StoredWalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredWalletTests.swift; sourceTree = "<group>"; };
+		340DFF972FE1E7580061AA14 /* WalletConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConfigTests.swift; sourceTree = "<group>"; };
+		340DFF992FE1E75A0061AA14 /* SpendabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendabilityTests.swift; sourceTree = "<group>"; };
+		340DFFA12FE1E8880061AA14 /* AddressBookSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookSerializationTests.swift; sourceTree = "<group>"; };
+		340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UMSerializationTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2371,6 +2385,10 @@
 				349CE6262FDC1CEA00E2B9CF /* TorSetupTests */,
 				340DFF772FE1E5E40061AA14 /* SwapTests */,
 				340DFF822FE1E60F0061AA14 /* TransactionStateTests */,
+				340DFF892FE1E7390061AA14 /* ModelsTests */,
+				340DFF8F2FE1E7480061AA14 /* EncryptionTests */,
+				340DFFA02FE1E8880061AA14 /* AddressBookTests */,
+				340DFFA72FE1E94B0061AA14 /* UserMetadataTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2422,6 +2440,41 @@
 				340DFF832FE1E60F0061AA14 /* TransactionStateTests.swift */,
 			);
 			path = TransactionStateTests;
+			sourceTree = "<group>";
+		};
+		340DFF892FE1E7390061AA14 /* ModelsTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFF8A2FE1E7390061AA14 /* CMCRateTests.swift */,
+				340DFF952FE1E7520061AA14 /* StoredWalletTests.swift */,
+				340DFF972FE1E7580061AA14 /* WalletConfigTests.swift */,
+				340DFF992FE1E75A0061AA14 /* SpendabilityTests.swift */,
+			);
+			path = ModelsTests;
+			sourceTree = "<group>";
+		};
+		340DFF8F2FE1E7480061AA14 /* EncryptionTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFF902FE1E7480061AA14 /* EncryptionKeysTests.swift */,
+			);
+			path = EncryptionTests;
+			sourceTree = "<group>";
+		};
+		340DFFA02FE1E8880061AA14 /* AddressBookTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFFA12FE1E8880061AA14 /* AddressBookSerializationTests.swift */,
+			);
+			path = AddressBookTests;
+			sourceTree = "<group>";
+		};
+		340DFFA72FE1E94B0061AA14 /* UserMetadataTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */,
+			);
+			path = UserMetadataTests;
 			sourceTree = "<group>";
 		};
 		343CF3F429BB5A14009E44DF /* Frameworks */ = {
@@ -5156,6 +5209,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				340DFF9A2FE1E75A0061AA14 /* SpendabilityTests.swift in Sources */,
 				349CE5D62FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift in Sources */,
 				340DFF6B2FE1E4620061AA14 /* StringsTests.swift in Sources */,
 				34D06C912FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift in Sources */,
@@ -5178,21 +5232,26 @@
 				340DFF662FE1E4550061AA14 /* AnyDecodableTests.swift in Sources */,
 				349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */,
 				7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */,
+				340DFFA92FE1E94B0061AA14 /* UMSerializationTests.swift in Sources */,
 				DB87FBCDB6C1FC4EA9311A26 /* DeeplinkURLParsingTests.swift in Sources */,
 				051F035A06D6092E00704BAB /* HomeTests.swift in Sources */,
 				F8D7DA12B79F620DB1AB1F78 /* MemoByteCountingTests.swift in Sources */,
 				05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */,
+				340DFF962FE1E7520061AA14 /* StoredWalletTests.swift in Sources */,
 				8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */,
 				340DFF5F2FE1E4450061AA14 /* ArrayChunkedTests.swift in Sources */,
 				BD09B2C5A52C10AD52B24E58 /* ReviewRequestTests.swift in Sources */,
+				340DFF982FE1E7580061AA14 /* WalletConfigTests.swift in Sources */,
 				161B27ACDB3C31A163EC8AFF /* SensitiveDataTests.swift in Sources */,
 				985D6A4AAAD20B2071C9997D /* DatabaseFilesTests.swift in Sources */,
 				348EC4CC2FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift in Sources */,
 				348EC4CD2FD7FD96008495FB /* ServerEndpointsTests.swift in Sources */,
+				340DFFA22FE1E8880061AA14 /* AddressBookSerializationTests.swift in Sources */,
 				348EC4CE2FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift in Sources */,
 				340DFF712FE1E5D10061AA14 /* ClampedTests.swift in Sources */,
 				348EC4CF2FD7FD96008495FB /* ServerSetupStoreTests.swift in Sources */,
 				348EC4D02FD7FD96008495FB /* TransactionGuardTests.swift in Sources */,
+				340DFF8B2FE1E7390061AA14 /* CMCRateTests.swift in Sources */,
 				348EC4D12FD7FD96008495FB /* AutoServerSelectionClientTests.swift in Sources */,
 				340DFF842FE1E60F0061AA14 /* TransactionStateTests.swift in Sources */,
 				340DFF762FE1E5DC0061AA14 /* BalanceFormatterTests.swift in Sources */,
@@ -5201,6 +5260,7 @@
 				2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */,
 				BFE03A2F84B2F8B97831CD9F /* ZatoshiTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,
+				340DFF912FE1E7480061AA14 /* EncryptionKeysTests.swift in Sources */,
 				A409BF1DAB30483E4CDB0DCB /* ZatoshiStringRepresentationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		340DFF9A2FE1E75A0061AA14 /* SpendabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFF992FE1E75A0061AA14 /* SpendabilityTests.swift */; };
 		340DFFA22FE1E8880061AA14 /* AddressBookSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFA12FE1E8880061AA14 /* AddressBookSerializationTests.swift */; };
 		340DFFA92FE1E94B0061AA14 /* UMSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */; };
+		340DFFB02FE1EA4F0061AA14 /* ZecKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340DFFAF2FE1EA4F0061AA14 /* ZecKeyboardTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1645,6 +1646,7 @@
 		340DFF992FE1E75A0061AA14 /* SpendabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendabilityTests.swift; sourceTree = "<group>"; };
 		340DFFA12FE1E8880061AA14 /* AddressBookSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookSerializationTests.swift; sourceTree = "<group>"; };
 		340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UMSerializationTests.swift; sourceTree = "<group>"; };
+		340DFFAF2FE1EA4F0061AA14 /* ZecKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZecKeyboardTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2389,6 +2391,7 @@
 				340DFF8F2FE1E7480061AA14 /* EncryptionTests */,
 				340DFFA02FE1E8880061AA14 /* AddressBookTests */,
 				340DFFA72FE1E94B0061AA14 /* UserMetadataTests */,
+				340DFFAE2FE1EA4F0061AA14 /* ZecKeyboardTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2475,6 +2478,14 @@
 				340DFFA82FE1E94B0061AA14 /* UMSerializationTests.swift */,
 			);
 			path = UserMetadataTests;
+			sourceTree = "<group>";
+		};
+		340DFFAE2FE1EA4F0061AA14 /* ZecKeyboardTests */ = {
+			isa = PBXGroup;
+			children = (
+				340DFFAF2FE1EA4F0061AA14 /* ZecKeyboardTests.swift */,
+			);
+			path = ZecKeyboardTests;
 			sourceTree = "<group>";
 		};
 		343CF3F429BB5A14009E44DF /* Frameworks */ = {
@@ -5236,6 +5247,7 @@
 				DB87FBCDB6C1FC4EA9311A26 /* DeeplinkURLParsingTests.swift in Sources */,
 				051F035A06D6092E00704BAB /* HomeTests.swift in Sources */,
 				F8D7DA12B79F620DB1AB1F78 /* MemoByteCountingTests.swift in Sources */,
+				340DFFB02FE1EA4F0061AA14 /* ZecKeyboardTests.swift in Sources */,
 				05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */,
 				340DFF962FE1E7520061AA14 /* StoredWalletTests.swift in Sources */,
 				8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */,

--- a/zodlTests/AddressBookTests/AddressBookLogicTests.swift
+++ b/zodlTests/AddressBookTests/AddressBookLogicTests.swift
@@ -1,0 +1,101 @@
+//
+//  AddressBookLogicTests.swift
+//  zodlTests
+//
+//  Batch 5 — address book. Covers AddressBook.State computed props (validation / error text /
+//  context filtering / save-button gating) (Features/AddressBook/AddressBookStore.swift).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite(.serialized) struct AddressBookLogicTests {
+    @Test func uniqueIdCombinesAddressAndChain() {
+        var state = AddressBook.State()
+        state.address = "addr"
+        #expect(state.uniqueId == "addr-zcash")
+        state.selectedChain = SwapAsset(provider: "", chain: "eth", token: "x", assetId: "", usdPrice: 0, decimals: 0)
+        #expect(state.uniqueId == "addr-eth")
+    }
+
+    @Test func isNameOverMaxLength() {
+        var state = AddressBook.State()
+        state.name = "Alice"
+        #expect(!state.isNameOverMaxLength)
+        state.name = String(repeating: "a", count: 500)
+        #expect(state.isNameOverMaxLength)
+    }
+
+    @Test func invalidNameErrorText() {
+        var state = AddressBook.State()
+        state.name = "Alice"
+        #expect(state.invalidNameErrorText == nil)
+        state.name = String(repeating: "a", count: 500)
+        #expect(state.invalidNameErrorText == String(localizable: .addressBookErrorNameLength))
+        state.name = "Alice"
+        state.nameAlreadyExists = true
+        #expect(state.invalidNameErrorText == String(localizable: .addressBookErrorNameExists))
+    }
+
+    @Test func addressBookContactsToShowFiltersByContext() {
+        var state = AddressBook.State()
+        let date = Date(timeIntervalSince1970: 0)
+        state.$addressBookContacts.withLock {
+            $0 = AddressBookContacts(lastUpdated: date, version: 2, contacts: [
+                Contact(address: "zcashaddr", name: "Z", lastUpdated: date, chainId: nil),
+                Contact(address: "ethaddr", name: "E", lastUpdated: date, chainId: "eth")
+            ])
+        }
+        state.context = .swap
+        #expect(state.addressBookContactsToShow.contacts.map(\.name) == ["E"]) // chainId != nil
+        state.context = .send
+        #expect(state.addressBookContactsToShow.contacts.map(\.name) == ["Z"]) // chainId == nil
+        state.context = .settings
+        #expect(state.addressBookContactsToShow.contacts.count == 2) // all
+    }
+
+    @Test func invalidAddressErrorTextAddressExists() {
+        var state = AddressBook.State()
+        state.addressAlreadyExists = true
+        #expect(state.invalidAddressErrorText == String(localizable: .addressBookErrorAddressExists))
+    }
+
+    @Test func invalidAddressErrorTextSwapWithZcashAddress() {
+        var state = AddressBook.State()
+        state.context = .swap
+        state.isValidZcashAddress = true
+        #expect(state.invalidAddressErrorText == String(localizable: .swapAndPayAddressBookZcash))
+    }
+
+    @Test func invalidAddressErrorTextInvalidInSendContext() {
+        var state = AddressBook.State()
+        state.context = .send
+        state.address = "garbage"
+        state.isValidZcashAddress = false
+        #expect(state.invalidAddressErrorText == String(localizable: .addressBookErrorInvalidAddress))
+    }
+
+    @Test func invalidAddressErrorTextNilWhenValid() {
+        var state = AddressBook.State()
+        state.context = .send
+        state.address = "validaddr"
+        state.isValidZcashAddress = true
+        #expect(state.invalidAddressErrorText == nil)
+    }
+
+    @Test func saveButtonDisabledWhenNoChange() {
+        #expect(AddressBook.State().isSaveButtonDisabled)
+    }
+
+    @Test func saveButtonEnabledForValidNewContact() {
+        var state = AddressBook.State()
+        state.context = .settings
+        state.address = "validaddr"
+        state.name = "Alice"
+        state.isValidZcashAddress = true
+        state.isValidForm = true
+        #expect(!state.isSaveButtonDisabled)
+    }
+}

--- a/zodlTests/AddressBookTests/AddressBookSerializationTests.swift
+++ b/zodlTests/AddressBookTests/AddressBookSerializationTests.swift
@@ -1,0 +1,164 @@
+//
+//  AddressBookSerializationTests.swift
+//  zodlTests
+//
+//  Batch 2 — persistence/crypto. Covers AddressBookClient binary (de)serialization, v1->v2
+//  migration, and the encrypt/decrypt round-trip (Dependencies/AddressBookClient/AddressBookEncryption.swift).
+//
+
+import Testing
+import Foundation
+import CryptoKit
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct AddressBookSerializationTests {
+    private let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Primitives
+
+    @Test func intToBytesRoundTripsAndGuardsLength() {
+        for value in [0, 1, -1, 256, 123_456_789, Int.max, Int.min] {
+            #expect(AddressBookClient.bytesToInt(AddressBookClient.intToBytes(value)) == value)
+        }
+        #expect(AddressBookClient.bytesToInt([0, 0, 0]) == nil)
+        #expect(AddressBookClient.bytesToInt([]) == nil)
+    }
+
+    @Test func dateSerializationRoundTripsToWholeSeconds() throws {
+        var offset = 0
+        let recovered = try AddressBookClient.deserializeDate(from: Data(AddressBookClient.serializeDate(fixedDate)), at: &offset)
+        #expect(recovered == fixedDate)
+        #expect(offset == 8)
+    }
+
+    @Test func readStringReadsLengthPrefixedUTF8() throws {
+        let bytes = AddressBookClient.stringToBytes("hello")
+        var data = Data()
+        data.append(contentsOf: AddressBookClient.intToBytes(bytes.count))
+        data.append(contentsOf: bytes)
+        var offset = 0
+        #expect(try AddressBookClient.readString(from: data, at: &offset) == "hello")
+        #expect(offset == 8 + bytes.count)
+    }
+
+    @Test func readStringReturnsNilForZeroLength() throws {
+        var data = Data()
+        data.append(contentsOf: AddressBookClient.intToBytes(0))
+        var offset = 0
+        #expect(try AddressBookClient.readString(from: data, at: &offset) == nil)
+    }
+
+    @Test func readStringThrowsWhenTruncated() {
+        var data = Data()
+        data.append(contentsOf: AddressBookClient.intToBytes(10)) // claims 10 bytes...
+        data.append(contentsOf: AddressBookClient.stringToBytes("ab")) // ...but only 2 are present
+        var offset = 0
+        #expect(throws: (any Error).self) {
+            _ = try AddressBookClient.readString(from: data, at: &offset)
+        }
+    }
+
+    @Test func subdataReturnsRangeAndThrowsWhenOutOfBounds() throws {
+        let data = Data([1, 2, 3, 4])
+        #expect(try AddressBookClient.subdata(of: data, in: 0..<2) == Data([1, 2]))
+        #expect(throws: (any Error).self) {
+            _ = try AddressBookClient.subdata(of: data, in: 0..<5)
+        }
+    }
+
+    // MARK: - Contacts round-trip / migration
+
+    @Test func serializeAndDeserializeRoundTrip() throws {
+        let contacts = sampleContacts()
+        let data = AddressBookClient.serializeContacts(contacts)
+        let (result, migrated) = try AddressBookClient.contactsFrom(plainData: data)
+        #expect(!migrated)
+        #expect(result.version == 2)
+        #expect(result.contacts == contacts.contacts)
+    }
+
+    @Test func unknownVersionReturnsEmptyNotMigrated() throws {
+        var data = Data()
+        data.append(contentsOf: AddressBookClient.intToBytes(99))
+        let (result, migrated) = try AddressBookClient.contactsFrom(plainData: data)
+        #expect(result == AddressBookContacts.empty)
+        #expect(!migrated)
+    }
+
+    @Test func migratesVersion1BlobToLatestWithNilChainId() throws {
+        let blob = v1Blob(contacts: [(address: "addr1", name: "Alice"), (address: "addr2", name: "Bob")])
+        let (result, migrated) = try AddressBookClient.contactsFrom(plainData: blob)
+        #expect(migrated)
+        #expect(result.version == 2)
+        #expect(result.contacts.count == 2)
+        #expect(result.contacts.map(\.address) == ["addr1", "addr2"])
+        #expect(result.contacts.allSatisfy { $0.chainId == nil })
+        #expect(result.contacts.first?.lastUpdated == fixedDate)
+    }
+
+    // MARK: - Encrypt / decrypt round-trip (resolves coverage-uplift-plan.md §6.7)
+
+    @Test func encryptDecryptRoundTrip() throws {
+        let contacts = sampleContacts()
+        let testAccount = account()
+        let keys = AddressBookEncryptionKeys(keys: [0: try addressBookKey(byte: 0x42)])
+
+        try withDependencies {
+            $0.walletStorage.exportAddressBookEncryptionKeys = { keys }
+        } operation: {
+            let encrypted = try AddressBookClient.encryptContacts(contacts, account: testAccount)
+            let (decrypted, migrated) = try AddressBookClient.contactsFrom(encryptedData: encrypted, account: testAccount)
+            #expect(!migrated)
+            #expect(decrypted.contacts == contacts.contacts)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func sampleContacts() -> AddressBookContacts {
+        AddressBookContacts(
+            lastUpdated: fixedDate,
+            version: 2,
+            contacts: [
+                Contact(address: "addr1", name: "Alice", lastUpdated: fixedDate, chainId: nil),
+                Contact(address: "addr2", name: "Bob", lastUpdated: fixedDate, chainId: "eth")
+            ]
+        )
+    }
+
+    private func v1Blob(contacts: [(address: String, name: String)]) -> Data {
+        var data = Data()
+        data.append(contentsOf: AddressBookClient.intToBytes(1)) // version 1
+        data.append(contentsOf: AddressBookClient.serializeDate(fixedDate))
+        data.append(contentsOf: AddressBookClient.intToBytes(contacts.count))
+        for contact in contacts {
+            data.append(contentsOf: AddressBookClient.serializeDate(fixedDate))
+            let address = AddressBookClient.stringToBytes(contact.address)
+            data.append(contentsOf: AddressBookClient.intToBytes(address.count))
+            data.append(contentsOf: address)
+            let name = AddressBookClient.stringToBytes(contact.name)
+            data.append(contentsOf: AddressBookClient.intToBytes(name.count))
+            data.append(contentsOf: name)
+        }
+        return data
+    }
+
+    private func addressBookKey(byte: UInt8) throws -> AddressBookKey {
+        let encoded = try JSONEncoder().encode(Data(repeating: byte, count: 32))
+        return try JSONDecoder().decode(AddressBookKey.self, from: encoded)
+    }
+
+    private func account() -> Account {
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: "test",
+            keySource: "test",
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    }
+}

--- a/zodlTests/BalancesTests/BalancesTests.swift
+++ b/zodlTests/BalancesTests/BalancesTests.swift
@@ -1,0 +1,90 @@
+//
+//  BalancesTests.swift
+//  zodlTests
+//
+//  Batch 3 — balances. Covers Balances reducer computed flags + updateBalance(nil) spendability
+//  (Features/BalanceBreakdown/BalancesStore.swift).
+//  NOTE: the non-nil AccountBalance aggregation path is deferred (needs an SDK PoolBalance fixture).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct BalancesTests {
+    @Test func pendingFlags() {
+        let pending = state(changePending: Zatoshi(5), pendingTransactions: Zatoshi(7))
+        #expect(pending.isPendingChange)
+        #expect(pending.isPendingInProcess)
+
+        let idle = state()
+        #expect(!idle.isPendingChange)
+        #expect(!idle.isPendingInProcess)
+    }
+
+    @Test func shieldabilityFlags() {
+        let shieldable = state(transparentBalance: Zatoshi(2_000_000))
+        #expect(shieldable.isShieldableBalanceAvailable)
+        #expect(!shieldable.isShieldingButtonDisabled)
+
+        let belowThreshold = state(transparentBalance: Zatoshi(500))
+        #expect(!belowThreshold.isShieldableBalanceAvailable)
+        #expect(belowThreshold.isShieldingButtonDisabled)
+
+        let shielding = state(isShielding: true, transparentBalance: Zatoshi(2_000_000))
+        #expect(shielding.isShieldingButtonDisabled) // disabled while shielding even if available
+    }
+
+    @Test func isProcessingZeroAvailableBalance() {
+        var processing = state(shieldedBalance: .zero, transparentBalance: Zatoshi(10))
+        processing.autoShieldingThreshold = Zatoshi(50)
+        processing.totalBalance = Zatoshi(10)
+        #expect(processing.isProcessingZeroAvailableBalance)
+
+        var hasTransparentAboveThreshold = state(shieldedBalance: .zero, transparentBalance: Zatoshi(100))
+        hasTransparentAboveThreshold.autoShieldingThreshold = Zatoshi(50)
+        #expect(!hasTransparentAboveThreshold.isProcessingZeroAvailableBalance)
+    }
+
+    @Test func isPendingTransactionReflectsSharedTransactions() {
+        var state = state()
+        state.$transactions.withLock { $0 = [] }
+        #expect(!state.isPendingTransaction)
+        state.$transactions.withLock { $0 = [TransactionState(pendingSendId: "p", zecAmount: Zatoshi(1))] }
+        #expect(state.isPendingTransaction)
+    }
+
+    @MainActor @Test func updateBalanceWithNilZerosAndEmitsEverythingSpendable() async {
+        let store = TestStore(initialState: state(autoShieldingThreshold: Zatoshi(1_000_000))) {
+            Balances()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        }
+        store.exhaustivity = .off
+        await store.send(.updateBalance(nil))
+        await store.receive(\.everythingSpendable)
+        #expect(store.state.shieldedBalance == .zero)
+        #expect(store.state.totalBalance == .zero)
+        #expect(store.state.spendability == .everything)
+    }
+
+    private func state(
+        autoShieldingThreshold: Zatoshi = Zatoshi(1_000_000),
+        changePending: Zatoshi = .zero,
+        isShielding: Bool = false,
+        pendingTransactions: Zatoshi = .zero,
+        shieldedBalance: Zatoshi = .zero,
+        transparentBalance: Zatoshi = .zero
+    ) -> Balances.State {
+        Balances.State(
+            autoShieldingThreshold: autoShieldingThreshold,
+            changePending: changePending,
+            isShielding: isShielding,
+            pendingTransactions: pendingTransactions,
+            shieldedBalance: shieldedBalance,
+            transparentBalance: transparentBalance
+        )
+    }
+}

--- a/zodlTests/EncryptionTests/EncryptionKeysTests.swift
+++ b/zodlTests/EncryptionTests/EncryptionKeysTests.swift
@@ -1,0 +1,109 @@
+//
+//  EncryptionKeysTests.swift
+//  zodlTests
+//
+//  Batch 2 — crypto. Covers AddressBookKey / UserMetadataKeys HKDF derivation + file identifiers
+//  (Models/AddressBookEncryptionKeys.swift, Models/UserMetadataEncryptionKeys.swift).
+//
+
+import Testing
+import Foundation
+import CryptoKit
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct EncryptionKeysTests {
+    // MARK: - AddressBookKey
+
+    @Test func addressBookDeriveEncryptionKeyIsDeterministicAndSaltDependent() throws {
+        let key = try addressBookKey(byte: 0x01)
+        let salt = Data(repeating: 0x02, count: 32)
+        let otherSalt = Data(repeating: 0x03, count: 32)
+        #expect(bytes(key.deriveEncryptionKey(salt: salt)) == bytes(key.deriveEncryptionKey(salt: salt)))
+        #expect(bytes(key.deriveEncryptionKey(salt: salt)) != bytes(key.deriveEncryptionKey(salt: otherSalt)))
+    }
+
+    @Test func addressBookFileIdentifierIsPrefixedHex() throws {
+        let key = try addressBookKey(byte: 0x01)
+        let id = try #require(key.fileIdentifier())
+        #expect(id.hasPrefix("zashi-address-book-"))
+        #expect(id.count == "zashi-address-book-".count + 64)
+        #expect(key.fileIdentifier() == id) // deterministic
+    }
+
+    @Test func addressBookEncryptionKeysCodableRoundTrip() throws {
+        let keys = AddressBookEncryptionKeys(keys: [0: try addressBookKey(byte: 0x07)])
+        let data = try JSONEncoder().encode(keys)
+        let decoded = try JSONDecoder().decode(AddressBookEncryptionKeys.self, from: data)
+        #expect(decoded == keys)
+    }
+
+    @Test func addressBookEmptyHasNoKeys() {
+        #expect(AddressBookEncryptionKeys.empty.keys.isEmpty)
+    }
+
+    // MARK: - UserMetadataKeys
+
+    @Test func userMetadataEncryptionAndDecryptionKeysMatchForSingleKey() {
+        let keys = UserMetadataKeys(privateKeys: [Data(repeating: 0x01, count: 32)])
+        let salt = Data(repeating: 0x09, count: 32)
+        let decryptionKeys = keys.deriveDecryptionKeys(salt: salt)
+        #expect(decryptionKeys.count == 1)
+        #expect(bytes(decryptionKeys[0]) == bytes(keys.deriveEncryptionKey(salt: salt)))
+    }
+
+    @Test func userMetadataDeriveDecryptionKeysOnePerKey() {
+        let keys = UserMetadataKeys(privateKeys: [
+            Data(repeating: 0x01, count: 32),
+            Data(repeating: 0x02, count: 32)
+        ])
+        #expect(keys.deriveDecryptionKeys(salt: Data(repeating: 0x09, count: 32)).count == 2)
+    }
+
+    @Test func userMetadataFileIdentifierDomainSeparatesMetadataAndVoting() {
+        let keys = UserMetadataKeys(privateKeys: [Data(repeating: 0x01, count: 32)])
+        let account = account(name: "test")
+        let metaId = keys.fileIdentifier(account: account)
+        let voteId = keys.votingFileIdentifier(account: account)
+        #expect(metaId?.hasPrefix("test-metadata-") == true)
+        #expect(voteId?.hasPrefix("test-voting-") == true)
+        #expect(metaId != voteId)
+    }
+
+    @Test func userMetadataFileIdentifierAppliesZodlToZashiHotfix() {
+        let keys = UserMetadataKeys(privateKeys: [Data(repeating: 0x01, count: 32)])
+        let id = keys.fileIdentifier(account: account(name: "zodl"))
+        #expect(id?.hasPrefix("zashi-metadata-") == true)
+    }
+
+    @Test func userMetadataKeysCodableRoundTrip() throws {
+        let keys = UserMetadataKeys(privateKeys: [Data(repeating: 0x05, count: 32)])
+        let data = try JSONEncoder().encode(keys)
+        let decoded = try JSONDecoder().decode(UserMetadataKeys.self, from: data)
+        #expect(decoded == keys)
+    }
+
+    // MARK: - Helpers
+
+    private func addressBookKey(byte: UInt8) throws -> AddressBookKey {
+        let keyData = Data(repeating: byte, count: 32)
+        let encoded = try JSONEncoder().encode(keyData)
+        return try JSONDecoder().decode(AddressBookKey.self, from: encoded)
+    }
+
+    private func bytes(_ key: SymmetricKey) -> Data {
+        key.withUnsafeBytes { Data($0) }
+    }
+
+    private func account(name: String) -> Account {
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: name,
+            keySource: "test",
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    }
+}

--- a/zodlTests/ModelsTests/CMCRateTests.swift
+++ b/zodlTests/ModelsTests/CMCRateTests.swift
@@ -1,0 +1,31 @@
+//
+//  CMCRateTests.swift
+//  zodlTests
+//
+//  Batch 2 — persistence. Covers CMCPrice JSON decoding (Models/CMCRate.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct CMCRateTests {
+    @Test func decodesZecUsdPrice() throws {
+        let json = #"{"data":{"ZEC":{"quote":{"USD":{"price":123.45}}}}}"#
+        let decoded = try JSONDecoder().decode(CMCPrice.self, from: Data(json.utf8))
+        #expect(decoded.data["ZEC"]?.quote.USD.price == 123.45)
+    }
+
+    @Test func decodesWithMissingZecKey() throws {
+        let json = #"{"data":{}}"#
+        let decoded = try JSONDecoder().decode(CMCPrice.self, from: Data(json.utf8))
+        #expect(decoded.data["ZEC"] == nil)
+    }
+
+    @Test func throwsForMalformedPrice() {
+        let json = #"{"data":{"ZEC":{"quote":{"USD":{"price":"not-a-number"}}}}}"#
+        #expect(throws: (any Error).self) {
+            _ = try JSONDecoder().decode(CMCPrice.self, from: Data(json.utf8))
+        }
+    }
+}

--- a/zodlTests/ModelsTests/ChainTokenTests.swift
+++ b/zodlTests/ModelsTests/ChainTokenTests.swift
@@ -1,0 +1,23 @@
+//
+//  ChainTokenTests.swift
+//  zodlTests
+//
+//  Extended — pure logic. Covers ChainToken id + Codable (Models/ChainToken.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct ChainTokenTests {
+    @Test func idIsChainDotTokenAndNotLowercased() {
+        // Unlike SwapAsset.id, ChainToken.id preserves the original case.
+        #expect(ChainToken(chain: "ETH", token: "USDC").id == "ETH.USDC")
+    }
+
+    @Test func codableRoundTrip() throws {
+        let original = ChainToken(chain: "eth", token: "usdc")
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(ChainToken.self, from: data) == original)
+    }
+}

--- a/zodlTests/ModelsTests/FeatureFlagsTests.swift
+++ b/zodlTests/ModelsTests/FeatureFlagsTests.swift
@@ -1,0 +1,23 @@
+//
+//  FeatureFlagsTests.swift
+//  zodlTests
+//
+//  Extended — pure logic. Covers FeatureFlags default values (Models/FeatureFlags.swift).
+//
+
+import Testing
+@testable import zodl_internal
+
+@Suite struct FeatureFlagsTests {
+    @Test func defaultValues() {
+        let flags = FeatureFlags()
+        #expect(!flags.addUAtoMemo)
+        #expect(flags.appLaunchBiometric)
+        #expect(flags.flexa)
+        #expect(flags.selectText)
+    }
+
+    @Test func initialUsesDefaults() {
+        #expect(FeatureFlags.initial == FeatureFlags())
+    }
+}

--- a/zodlTests/ModelsTests/RecoveryPhraseTests.swift
+++ b/zodlTests/ModelsTests/RecoveryPhraseTests.swift
@@ -1,0 +1,29 @@
+//
+//  RecoveryPhraseTests.swift
+//  zodlTests
+//
+//  Extended — pure logic. Covers RecoveryPhrase toString / toGroups / Group.words (Models/RecoveryPhrase.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct RecoveryPhraseTests {
+    @Test func toStringJoinsWordsWithSpaces() {
+        let phrase = RecoveryPhrase(words: ["alpha", "bravo", "charlie"].map { $0.redacted })
+        #expect(phrase.toString().data == "alpha bravo charlie")
+    }
+
+    @Test func toGroupsSplitsTwentyFourWordsIntoThreeGroupsOfEight() {
+        let groups = RecoveryPhrase.placeholder.toGroups() // 24 words
+        #expect(groups.count == 3)
+        #expect(groups.map(\.words.count) == [8, 8, 8])
+        #expect(groups.map(\.startIndex) == [0, 8, 16])
+    }
+
+    @Test func groupWordsReplacesMissingIndexWithEmpty() {
+        let group = RecoveryPhrase.Group(startIndex: 0, words: ["one", "two", "three"].map { $0.redacted })
+        #expect(group.words(with: 1).map(\.data) == ["one", "", "three"])
+    }
+}

--- a/zodlTests/ModelsTests/SpendabilityTests.swift
+++ b/zodlTests/ModelsTests/SpendabilityTests.swift
@@ -1,0 +1,18 @@
+//
+//  SpendabilityTests.swift
+//  zodlTests
+//
+//  Batch 2 — persistence. Covers Spendability Codable round-trip (Models/Spendability.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct SpendabilityTests {
+    @Test(arguments: [Spendability.everything, .something, .nothing])
+    func codableRoundTrip(_ value: Spendability) throws {
+        let data = try JSONEncoder().encode(value)
+        #expect(try JSONDecoder().decode(Spendability.self, from: data) == value)
+    }
+}

--- a/zodlTests/ModelsTests/StoredWalletTests.swift
+++ b/zodlTests/ModelsTests/StoredWalletTests.swift
@@ -1,0 +1,31 @@
+//
+//  StoredWalletTests.swift
+//  zodlTests
+//
+//  Batch 2 — persistence. Covers StoredWallet Codable round-trip (Models/StoredWallet.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct StoredWalletTests {
+    @Test func placeholderCodableRoundTrip() throws {
+        let original = StoredWallet.placeholder
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(StoredWallet.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func codableRoundTripPreservesMutableFields() throws {
+        var original = StoredWallet.placeholder
+        original.birthday = Birthday(123_456)
+        original.hasUserPassedPhraseBackupTest = true
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(StoredWallet.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.birthday == Birthday(123_456))
+        #expect(decoded.hasUserPassedPhraseBackupTest)
+    }
+}

--- a/zodlTests/ModelsTests/SyncStatusSnapshotTests.swift
+++ b/zodlTests/ModelsTests/SyncStatusSnapshotTests.swift
@@ -1,0 +1,23 @@
+//
+//  SyncStatusSnapshotTests.swift
+//  zodlTests
+//
+//  Extended — pure logic. Covers SyncStatusSnapshot.snapshotFor message mapping
+//  (Models/SyncStatusSnapshot.swift).
+//
+
+import Testing
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct SyncStatusSnapshotTests {
+    @Test func snapshotProducesNonEmptyMessageForEachState() {
+        #expect(!SyncStatusSnapshot.snapshotFor(state: .upToDate).message.isEmpty)
+        #expect(!SyncStatusSnapshot.snapshotFor(state: .unprepared).message.isEmpty)
+        #expect(!SyncStatusSnapshot.snapshotFor(state: .stopped).message.isEmpty)
+    }
+
+    @Test func snapshotPreservesSyncStatusForUpToDate() {
+        #expect(SyncStatusSnapshot.snapshotFor(state: .upToDate).syncStatus == .upToDate)
+    }
+}

--- a/zodlTests/ModelsTests/WalletAccountTests.swift
+++ b/zodlTests/ModelsTests/WalletAccountTests.swift
@@ -1,0 +1,55 @@
+//
+//  WalletAccountTests.swift
+//  zodlTests
+//
+//  Extended — pure logic. Covers WalletAccount.Vendor + vendor derivation (Models/WalletAccount.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct WalletAccountTests {
+    @Test func vendorFlags() {
+        #expect(WalletAccount.Vendor.zcash.isDefault())
+        #expect(!WalletAccount.Vendor.keystone.isDefault())
+        #expect(WalletAccount.Vendor.keystone.isHWWallet())
+        #expect(!WalletAccount.Vendor.zcash.isHWWallet())
+    }
+
+    @Test func vendorRawValues() {
+        #expect(WalletAccount.Vendor.keystone.rawValue == 0)
+        #expect(WalletAccount.Vendor.zcash.rawValue == 1)
+    }
+
+    @Test(arguments: [WalletAccount.Vendor.keystone, .zcash])
+    func vendorCodableRoundTrip(_ vendor: WalletAccount.Vendor) throws {
+        let data = try JSONEncoder().encode(vendor)
+        #expect(try JSONDecoder().decode(WalletAccount.Vendor.self, from: data) == vendor)
+    }
+
+    @Test func vendorNames() {
+        #expect(WalletAccount.Vendor.keystone.name() == String(localizable: .accountsKeystone))
+        #expect(WalletAccount.Vendor.zcash.name() == String(localizable: .accountsZashi))
+    }
+
+    @Test func initDerivesVendorFromKeySource() {
+        let keystone = WalletAccount(account(keySource: String(localizable: .accountsKeystone).lowercased()))
+        #expect(keystone.vendor == .keystone)
+        let zashi = WalletAccount(account(keySource: "zashi"))
+        #expect(zashi.vendor == .zcash)
+    }
+
+    private func account(keySource: String) -> Account {
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: "name",
+            keySource: keySource,
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    }
+}

--- a/zodlTests/ModelsTests/WalletConfigTests.swift
+++ b/zodlTests/ModelsTests/WalletConfigTests.swift
@@ -1,0 +1,38 @@
+//
+//  WalletConfigTests.swift
+//  zodlTests
+//
+//  Batch 2 — config. Covers WalletConfig / FeatureFlag (Models/WalletConfig.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct WalletConfigTests {
+    @Test func isEnabledReturnsFlagValueAndDefaultsToFalse() {
+        let config = WalletConfig(flags: [.showFiatConversion: true])
+        #expect(config.isEnabled(.showFiatConversion))
+        #expect(!config.isEnabled(.onboardingFlow)) // absent -> default false
+    }
+
+    @Test func allFeatureFlagsDisabledByDefault() {
+        for flag in FeatureFlag.allCases {
+            #expect(!flag.enabledByDefault)
+        }
+    }
+
+    @Test func initialExcludesTestFlagsAndDisablesEverything() {
+        let initial = WalletConfig.initial
+        #expect(initial.flags[.testFlag1] == nil)
+        #expect(initial.flags[.testFlag2] == nil)
+        #expect(initial.flags.count == FeatureFlag.allCases.count - 2)
+        #expect(!initial.isEnabled(.showFiatConversion))
+        #expect(!initial.isEnabled(.onboardingFlow))
+    }
+
+    @Test func featureFlagCodableRoundTrip() throws {
+        let data = try JSONEncoder().encode(FeatureFlag.showFiatConversion)
+        #expect(try JSONDecoder().decode(FeatureFlag.self, from: data) == .showFiatConversion)
+    }
+}

--- a/zodlTests/ModelsTests/WalletStatusTests.swift
+++ b/zodlTests/ModelsTests/WalletStatusTests.swift
@@ -1,0 +1,25 @@
+//
+//  WalletStatusTests.swift
+//  zodlTests
+//
+//  Extended — pure logic. Covers WalletStatus derivations (Models/WalletStatus.swift).
+//
+
+import Testing
+@testable import zodl_internal
+
+@Suite struct WalletStatusTests {
+    @Test func isNotReadyForFullySyncedOperation() {
+        #expect(WalletStatus.restoring.isNotReadyForFullySyncedOperation)
+        #expect(WalletStatus.resyncing.isNotReadyForFullySyncedOperation)
+        #expect(!WalletStatus.disconnected.isNotReadyForFullySyncedOperation)
+        #expect(!WalletStatus.none.isNotReadyForFullySyncedOperation)
+    }
+
+    @Test func text() {
+        #expect(WalletStatus.restoring.text() == String(localizable: .walletStatusRestoringWallet))
+        #expect(WalletStatus.disconnected.text() == String(localizable: .walletStatusDisconnected))
+        #expect(WalletStatus.none.text().isEmpty)
+        #expect(WalletStatus.resyncing.text().isEmpty)
+    }
+}

--- a/zodlTests/RequestZecTests/RequestZecTests.swift
+++ b/zodlTests/RequestZecTests/RequestZecTests.swift
@@ -1,0 +1,67 @@
+//
+//  RequestZecTests.swift
+//  zodlTests
+//
+//  Batch 3 — payment requests. Covers RequestZec ZIP-321 URI generation
+//  (Features/RequestZec/RequestZecStore.swift).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct RequestZecTests {
+    private let testnetAddress =
+        "utest1vergg5jkp4xy8sqfasw6s5zkdpnxvfxlxh35uuc3me7dp596y2r05t6dv9htwe3pf8ksrfr8ksca2lskzjanqtl8uqp5vln3zyy246ejtx86vqftp73j7jg9099jxafyjhfm6u956j3"
+
+    @MainActor @Test func generateQRCodeBuildsZip321RequestForAddressAndAmount() async {
+        let store = makeStore(address: testnetAddress, requestedZec: Zatoshi(100_000_000))
+        await store.send(.generateQRCode(false))
+        let output = store.state.encryptedOutput
+        #expect(output?.hasPrefix("zcash:") == true)
+        #expect(output?.contains(testnetAddress) == true)
+        #expect(output?.contains("amount=1") == true)
+        await store.receive(\.rememberQR)
+    }
+
+    @MainActor @Test func generateEnlargedQRCodeIncludesMemoWhenPresent() async {
+        let store = makeStore(address: testnetAddress, requestedZec: Zatoshi(100_000_000), memo: "hello")
+        await store.send(.generateEnlargedQRCode)
+        #expect(store.state.encryptedOutput?.contains("memo=") == true)
+        await store.receive(\.rememberEnlargedQR)
+    }
+
+    @MainActor @Test func generateQRCodeWithInvalidAddressProducesNoOutput() async {
+        let store = makeStore(address: "not-a-valid-address", requestedZec: Zatoshi(100_000_000))
+        await store.send(.generateQRCode(false))
+        #expect(store.state.encryptedOutput == nil)
+    }
+
+    @MainActor @Test func shareQRCopiesAndClearsEncryptedOutput() async {
+        let store = makeStore(address: testnetAddress, requestedZec: Zatoshi(100_000_000))
+        await store.send(.generateQRCode(false))
+        await store.receive(\.rememberQR)
+        await store.send(.shareQR)
+        #expect(store.state.encryptedOutputToBeShared == store.state.encryptedOutput)
+        await store.send(.shareFinished)
+        #expect(store.state.encryptedOutputToBeShared == nil)
+    }
+
+    @MainActor
+    private func makeStore(address: String, requestedZec: Zatoshi, memo: String = "") -> TestStoreOf<RequestZec> {
+        var state = RequestZec.State()
+        state.address = address.redacted
+        state.requestedZec = requestedZec
+        state.memoState.text = memo
+        let store = TestStore(initialState: state) {
+            RequestZec()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.network = { ZcashNetworkBuilder.network(for: .testnet) }
+            $0.zcashSDKEnvironment.memoCharLimit = { 512 }
+        }
+        store.exhaustivity = .off
+        return store
+    }
+}

--- a/zodlTests/SettingsTests/AdvancedSettingsAuthGateTests.swift
+++ b/zodlTests/SettingsTests/AdvancedSettingsAuthGateTests.swift
@@ -1,0 +1,72 @@
+//
+//  AdvancedSettingsAuthGateTests.swift
+//  zodlTests
+//
+//  Batch 6 — settings/security. Completes the AdvancedSettings auth-gate matrix
+//  (Features/Settings/AdvancedSettingsStore.swift). Complements AdvancedSettingsTests.
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct AdvancedSettingsAuthGateTests {
+    private static let sensitiveOperations: [AdvancedSettings.State.Operation] = [
+        .recoveryPhrase, .exportPrivateData, .exportTaxFile, .resetZashi, .disconnectHWWallet, .resyncWallet
+    ]
+
+    @MainActor @Test(arguments: sensitiveOperations)
+    func sensitiveOperationGrantedOnAuthSuccess(_ operation: AdvancedSettings.State.Operation) async {
+        let store = TestStore(initialState: AdvancedSettings.State()) {
+            AdvancedSettings()
+        } withDependencies: {
+            $0.localAuthentication = .mockAuthenticationSucceeded
+        }
+        await store.send(.operationAccessCheck(operation))
+        await store.receive(.operationAccessGranted(operation))
+        await store.finish()
+    }
+
+    @MainActor @Test(arguments: sensitiveOperations)
+    func sensitiveOperationDeniedOnAuthFailure(_ operation: AdvancedSettings.State.Operation) async {
+        let store = TestStore(initialState: AdvancedSettings.State()) {
+            AdvancedSettings()
+        } withDependencies: {
+            $0.localAuthentication = .mockAuthenticationFailed
+        }
+        // A failed authentication must NOT emit operationAccessGranted.
+        await store.send(.operationAccessCheck(operation))
+        await store.finish()
+    }
+
+    @MainActor @Test func torSetupBypassesAuthentication() async {
+        // localAuthentication is intentionally left unimplemented: torSetup must not invoke it.
+        let store = TestStore(initialState: AdvancedSettings.State()) {
+            AdvancedSettings()
+        }
+        await store.send(.operationAccessCheck(.torSetup))
+        await store.receive(.operationAccessGranted(.torSetup))
+        await store.finish()
+    }
+
+    @Test func isKeystoneConnectedReflectsWalletAccounts() {
+        var state = AdvancedSettings.State()
+        state.$walletAccounts.withLock { $0 = [] }
+        #expect(!state.isKeystoneConnected)
+        state.$walletAccounts.withLock { $0 = [keystoneAccount()] }
+        #expect(state.isKeystoneConnected)
+    }
+
+    private func keystoneAccount() -> WalletAccount {
+        WalletAccount(Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: "Keystone",
+            keySource: String(localizable: .accountsKeystone).lowercased(),
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        ))
+    }
+}

--- a/zodlTests/SwapTests/Near1ClickTests.swift
+++ b/zodlTests/SwapTests/Near1ClickTests.swift
@@ -1,0 +1,71 @@
+//
+//  Near1ClickTests.swift
+//  zodlTests
+//
+//  Batch 4 — dependency logic. Covers Near1Click.amountMessageResolution swap-error parsing
+//  (Dependencies/SwapAndPay/sources/Near1Click.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct Near1ClickTests {
+    @Test func unknownErrorWhenNoMessageKey() {
+        #expect(throws: SwapAndPayClient.EndpointError.message("Unknown error")) {
+            try Near1Click.amountMessageResolution(exactInput: false, isSwapToZec: false, toAsset: asset(), jsonObject: [:])
+        }
+    }
+
+    @Test func passesThroughUnrecognizedMessage() {
+        #expect(throws: SwapAndPayClient.EndpointError.message("some random error")) {
+            try Near1Click.amountMessageResolution(exactInput: false, isSwapToZec: false, toAsset: asset(), jsonObject: ["message": "some random error"])
+        }
+    }
+
+    @Test func failedToGetQuoteMapsToLocalizedMessage() {
+        #expect(throws: SwapAndPayClient.EndpointError.message(String(localizable: .swapQuoteUnavailableSwap))) {
+            try Near1Click.amountMessageResolution(exactInput: true, isSwapToZec: false, toAsset: asset(), jsonObject: ["message": "Failed to get quote"])
+        }
+        #expect(throws: SwapAndPayClient.EndpointError.message(String(localizable: .swapQuoteUnavailable))) {
+            try Near1Click.amountMessageResolution(exactInput: false, isSwapToZec: false, toAsset: asset(), jsonObject: ["message": "Failed to get quote"])
+        }
+    }
+
+    @Test func rescalesAmountTooLowToZec() {
+        do {
+            try Near1Click.amountMessageResolution(
+                exactInput: true,
+                isSwapToZec: false,
+                toAsset: asset(decimals: 6),
+                jsonObject: ["message": "Amount is too low for bridge, try at least 100000000"]
+            )
+            Issue.record("expected a throw")
+        } catch let SwapAndPayClient.EndpointError.message(msg) {
+            #expect(msg.hasPrefix("Amount is too low for bridge, try at least"))
+            #expect(msg.contains("ZEC"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func rescalesAmountTooLowToToken() {
+        do {
+            try Near1Click.amountMessageResolution(
+                exactInput: false,
+                isSwapToZec: false,
+                toAsset: asset(token: "USDC", decimals: 6),
+                jsonObject: ["message": "Amount is too low for bridge, try at least 1000000"]
+            )
+            Issue.record("expected a throw")
+        } catch let SwapAndPayClient.EndpointError.message(msg) {
+            #expect(msg.contains("USDC"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    private func asset(token: String = "ETH", decimals: Int = 18) -> SwapAsset {
+        SwapAsset(provider: "near", chain: "eth", token: token, assetId: "x", usdPrice: 0, decimals: decimals)
+    }
+}

--- a/zodlTests/SwapTests/SwapMetadataTests.swift
+++ b/zodlTests/SwapTests/SwapMetadataTests.swift
@@ -1,0 +1,83 @@
+//
+//  SwapMetadataTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers UMSwapId.swapStatus + UserMetadata Codable (Models/Swaps.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct SwapMetadataTests {
+    @Test func swapStatusMapsAllKnownStatuses() {
+        #expect(swapId(status: SwapConstants.failed).swapStatus == .failed)
+        #expect(swapId(status: SwapConstants.refunded).swapStatus == .refunded)
+        #expect(swapId(status: SwapConstants.expired).swapStatus == .expired)
+        #expect(swapId(status: SwapConstants.success).swapStatus == .completed)
+        #expect(swapId(status: SwapConstants.incompleteDeposit).swapStatus == .incomplete)
+        #expect(swapId(status: SwapConstants.pendingDeposit).swapStatus == .pending)
+        #expect(swapId(status: SwapConstants.processing).swapStatus == .pending)
+    }
+
+    @Test func swapStatusDefaultsToPendingForUnknown() {
+        #expect(swapId(status: "SOMETHING_ELSE").swapStatus == .pending)
+        #expect(swapId(status: "").swapStatus == .pending)
+    }
+
+    @Test func swapConstantsRawValues() {
+        #expect(SwapConstants.zecAssetIdOnNear == "near.zec.zec")
+        #expect(SwapConstants.pendingDeposit == "PENDING_DEPOSIT")
+        #expect(SwapConstants.success == "SUCCESS")
+    }
+
+    @Test func umSwapIdCodableRoundTrip() throws {
+        let original = swapId(status: SwapConstants.success)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(UMSwapId.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func userMetadataCodableRoundTripPreservesFields() throws {
+        let meta = UserMetadata(
+            version: 3,
+            lastUpdated: 42,
+            accountMetadata: UMAccount(
+                bookmarked: [UMBookmark(txId: "t", lastUpdated: 1, isBookmarked: true)],
+                annotations: [UMAnnotation(txId: "t", content: "note", lastUpdated: 2)],
+                read: ["r"],
+                swaps: UMSwaps(
+                    swapIds: [swapId(status: SwapConstants.success)],
+                    lastUsedAssetHistory: ["near.eth.usdc"],
+                    lastUpdated: 3
+                )
+            )
+        )
+
+        let data = try JSONEncoder().encode(meta)
+        let decoded = try JSONDecoder().decode(UserMetadata.self, from: data)
+
+        #expect(decoded.version == 3)
+        #expect(decoded.lastUpdated == 42)
+        #expect(decoded.accountMetadata.bookmarked.first?.isBookmarked == true)
+        #expect(decoded.accountMetadata.annotations.first?.content == "note")
+        #expect(decoded.accountMetadata.read == ["r"])
+        #expect(decoded.accountMetadata.swaps.swapIds.first == swapId(status: SwapConstants.success))
+        #expect(decoded.accountMetadata.swaps.lastUsedAssetHistory == ["near.eth.usdc"])
+    }
+
+    private func swapId(exactInput: Bool = true, status: String) -> UMSwapId {
+        UMSwapId(
+            depositAddress: "deposit",
+            provider: "near",
+            totalFees: 0,
+            totalUSDFees: "0",
+            lastUpdated: 0,
+            fromAsset: "a",
+            toAsset: "b",
+            exactInput: exactInput,
+            status: status,
+            amountOutFormatted: "0"
+        )
+    }
+}

--- a/zodlTests/TorSetupTests/TorSetupGapsTests.swift
+++ b/zodlTests/TorSetupTests/TorSetupGapsTests.swift
@@ -1,0 +1,59 @@
+//
+//  TorSetupGapsTests.swift
+//  zodlTests
+//
+//  Extended — settings/security. Covers TorSetup onAppear / option selection / save-gating gaps
+//  (Features/TorSetup/TorSetupStore.swift). Complements TorSetupTests.
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite(.serialized) struct TorSetupGapsTests {
+    @MainActor @Test func onAppearWithTorEnabledSelectsOptIn() async {
+        let store = makeStore(torFlag: true)
+        store.exhaustivity = .off
+        await store.send(.onAppear)
+        #expect(store.state.activeSettingsOption == .optIn)
+        #expect(store.state.currentSettingsOption == .optIn)
+    }
+
+    @MainActor @Test func onAppearWithTorDisabledOrUnsetSelectsOptOut() async {
+        for flag in [false, nil] as [Bool?] {
+            let store = makeStore(torFlag: flag)
+            store.exhaustivity = .off
+            await store.send(.onAppear)
+            #expect(store.state.activeSettingsOption == .optOut)
+            #expect(store.state.currentSettingsOption == .optOut)
+        }
+    }
+
+    @MainActor @Test func settingsOptionTappedUpdatesCurrentOption() async {
+        let store = makeStore(torFlag: false)
+        store.exhaustivity = .off
+        await store.send(.settingsOptionTapped(.optIn))
+        #expect(store.state.currentSettingsOption == .optIn)
+    }
+
+    @Test func isSaveButtonDisabledWhenCurrentEqualsActive() {
+        var state = TorSetup.State(activeSettingsOption: .optIn, currentSettingsOption: .optIn)
+        #expect(state.isSaveButtonDisabled)
+        state.currentSettingsOption = .optOut
+        #expect(!state.isSaveButtonDisabled)
+    }
+
+    @Test func settingsOptionsTitles() {
+        #expect(TorSetup.State.SettingsOptions.optIn.title() == String(localizable: .currencyConversionEnable))
+        #expect(TorSetup.State.SettingsOptions.optOut.title() == String(localizable: .currencyConversionLearnMoreOptionDisable))
+    }
+
+    @MainActor
+    private func makeStore(torFlag: Bool?) -> TestStoreOf<TorSetup> {
+        TestStore(initialState: TorSetup.State()) {
+            TorSetup()
+        } withDependencies: {
+            $0.walletStorage.exportTorSetupFlag = { torFlag }
+        }
+    }
+}

--- a/zodlTests/TransactionDetailsTests/TransactionDetailsLogicTests.swift
+++ b/zodlTests/TransactionDetailsTests/TransactionDetailsLogicTests.swift
@@ -1,0 +1,149 @@
+//
+//  TransactionDetailsLogicTests.swift
+//  zodlTests
+//
+//  Extended — transactions. Covers TransactionDetails.State computed props (footer ladder, swap-status
+//  mapping, asset lookup, missing funds, fee strings) (Features/TransactionDetails/TransactionDetailsStore.swift).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct TransactionDetailsLogicTests {
+    @Test func feeStrUsesTransactionFeeOrDefault() {
+        #expect(!state(transaction: tx(fee: Zatoshi(100_000))).feeStr.isEmpty)
+        #expect(state(transaction: tx(fee: nil)).feeStr == String(localizable: .transactionHistoryDefaultFee))
+    }
+
+    @Test func memosReadsSharedTransactionMemos() {
+        #expect(state(memos: ["hello", "world"]).memos == ["hello", "world"])
+        #expect(state().memos.isEmpty)
+    }
+
+    @Test func totalFeesStrFromUmSwapId() {
+        #expect(state(umSwapId: umSwap(totalFees: 100_000)).totalFeesStr != nil)
+        #expect(state().totalFeesStr == nil)
+    }
+
+    @Test func swapStatusNilWithoutDetailsAndMappedWithDetails() {
+        #expect(state().swapStatus == nil)
+        #expect(state(swap: swap(status: .success)).swapStatus == .success)
+        #expect(state(swap: swap(status: .failed)).swapStatus == .failed)
+    }
+
+    @Test func footerStateNonSwapShowsAddNote() {
+        var s = state(transaction: tx())
+        s.isSwap = false
+        s.swapDetails = nil
+        #expect(s.footerState == .addNote)
+    }
+
+    @Test func footerStateUnsuccessfulShowsContactSupport() {
+        #expect(state(swap: swap(status: .failed)).footerState == .contactSupport)
+        #expect(state(swap: swap(status: .refunded)).footerState == .contactSupport)
+        #expect(state(swap: swap(status: .expired)).footerState == .contactSupport)
+    }
+
+    @Test func footerStatePendingDepositShowsDepositInfo() {
+        var s = state(transaction: tx(), swap: swap(status: .pendingDeposit))
+        s.isSwap = true
+        #expect(s.footerState == .depositInfo)
+    }
+
+    @Test func swapToZecTitleMapsStatus() {
+        #expect(state(swap: swap(status: .success)).swapToZecTitle == String(localizable: .swapToZecSwapCompleted))
+        #expect(state(swap: swap(status: .refunded)).swapToZecTitle == String(localizable: .swapToZecSwapRefunded))
+        #expect(state().swapToZecTitle == nil)
+    }
+
+    @Test func swapFromAndToAssetLookupIsCaseInsensitive() {
+        let from = SwapAsset(provider: "near", chain: "eth", token: "ETH", assetId: "eth-id", usdPrice: 0, decimals: 18)
+        let to = SwapAsset(provider: "near", chain: "zec", token: "ZEC", assetId: "zec-id", usdPrice: 0, decimals: 8)
+        let s = state(
+            swap: swap(amountOut: Decimal(1), fromAsset: "ETH-ID", toAsset: "ZEC-ID"),
+            swapAssets: [from, to]
+        )
+        #expect(s.swapFromAsset?.assetId == "eth-id")
+        #expect(s.swapToAsset?.assetId == "zec-id")
+    }
+
+    @Test func missingFundsIsAmountInMinusDeposited() {
+        #expect(state(swap: swap(amountIn: Decimal(10), deposited: Decimal(3))).missingFunds != nil)
+        #expect(state().missingFunds == nil)
+    }
+
+    @Test func totalSwapToZecFeeNilWithoutAmount() {
+        // Value not asserted: it currently reflects a hardcoded 0.005 (see plan doc §6.5).
+        #expect(state().totalSwapToZecFee == nil)
+        #expect(state(swap: swap(amountIn: Decimal(100))).totalSwapToZecFee != nil)
+    }
+
+    @Test func swapToZecFeeInProgress() {
+        #expect(state(swap: swap(status: .success)).swapToZecFeeInProgress == false)
+        #expect(state(swap: swap(status: .pending)).swapToZecFeeInProgress == true)
+        #expect(state().swapToZecFeeInProgress == true)
+    }
+
+    // MARK: - Helpers
+
+    private func state(
+        transaction: TransactionState? = nil,
+        swap sd: SwapDetails? = nil,
+        swapAssets: [SwapAsset] = [],
+        umSwapId: UMSwapId? = nil,
+        memos: [String]? = nil
+    ) -> TransactionDetails.State {
+        var s = TransactionDetails.State(transaction: transaction ?? tx())
+        s.swapDetails = sd
+        s.isSwap = sd != nil
+        s.umSwapId = umSwapId
+        s.$swapAssets.withLock { $0 = IdentifiedArrayOf(uniqueElements: swapAssets) }
+        if let memos {
+            s.$transactionMemos.withLock { $0 = [s.transaction.id: memos] }
+        } else {
+            s.$transactionMemos.withLock { $0 = [:] }
+        }
+        return s
+    }
+
+    private func swap(
+        status: SwapDetails.Status = .pendingDeposit,
+        amountIn: Decimal? = nil,
+        amountOut: Decimal? = nil,
+        deposited: Decimal? = nil,
+        fromAsset: String? = nil,
+        toAsset: String? = nil
+    ) -> SwapDetails {
+        SwapDetails(
+            amountInFormatted: amountIn,
+            amountInUsd: nil,
+            amountOutFormatted: amountOut,
+            amountOutUsd: nil,
+            fromAsset: fromAsset,
+            toAsset: toAsset,
+            isSwap: true,
+            slippage: nil,
+            status: status,
+            refundedAmountFormatted: nil,
+            swapRecipient: nil,
+            addressToCheckShield: "addr",
+            whenInitiated: "2023-01-01T00:00:00.000Z",
+            deadline: "2023-01-01T00:00:00.000Z",
+            depositedAmountFormatted: deposited
+        )
+    }
+
+    private func umSwap(totalFees: Int64) -> UMSwapId {
+        UMSwapId(
+            depositAddress: "d", provider: "near", totalFees: totalFees, totalUSDFees: "0",
+            lastUpdated: 0, fromAsset: "a", toAsset: "b", exactInput: true, status: "SUCCESS", amountOutFormatted: "0"
+        )
+    }
+
+    private func tx(fee: Zatoshi? = Zatoshi(10_000)) -> TransactionState {
+        TransactionState(fee: fee, id: "tx-id", status: .received, zecAmount: Zatoshi(100_000_000))
+    }
+}

--- a/zodlTests/TransactionsManagerTests/TransactionListTests.swift
+++ b/zodlTests/TransactionsManagerTests/TransactionListTests.swift
@@ -1,0 +1,74 @@
+//
+//  TransactionListTests.swift
+//  zodlTests
+//
+//  Batch 5 — transactions. Covers TransactionList home-page truncation + isUnread/isSwap
+//  (Features/TransactionList/TransactionListStore.swift).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct TransactionListTests {
+    @MainActor @Test func transactionsUpdatedTakesHomePagePrefix() async {
+        var state = TransactionList.State()
+        let txs = (0..<7).map { tx(id: "tx\($0)") }
+        state.$transactions.withLock { $0 = IdentifiedArrayOf(uniqueElements: txs) }
+
+        let store = TestStore(initialState: state) { TransactionList() }
+        store.exhaustivity = .off
+        await store.send(.transactionsUpdated)
+
+        #expect(store.state.transactionListHomePage.count == 5)
+        #expect(store.state.latestTransactionId == "tx4") // 5th element
+        #expect(!store.state.isInvalidated)
+    }
+
+    @Test func isUnreadGuards() {
+        withDependencies {
+            $0.userMetadataProvider = provider(isRead: false)
+        } operation: {
+            #expect(!TransactionList.isUnread(tx(isSent: true, memoCount: 1)))
+            #expect(!TransactionList.isUnread(tx(isShielding: true, memoCount: 1)))
+            #expect(!TransactionList.isUnread(tx(memoCount: 0)))
+            #expect(TransactionList.isUnread(tx(memoCount: 1)))
+        }
+    }
+
+    @Test func isSwapUsesProvider() {
+        withDependencies {
+            $0.userMetadataProvider = provider(isSwap: true)
+        } operation: {
+            #expect(TransactionList.isSwap(tx(zAddress: "deposit")))
+        }
+    }
+
+    private func provider(isSwap: Bool = false, isRead: Bool = true) -> UserMetadataProviderClient {
+        var client = UserMetadataProviderClient()
+        client.isSwapTransaction = { _ in isSwap }
+        client.isRead = { _, _ in isRead }
+        return client
+    }
+
+    private func tx(
+        id: String = "tx-id",
+        isSent: Bool = false,
+        isShielding: Bool = false,
+        memoCount: Int = 0,
+        zAddress: String? = nil
+    ) -> TransactionState {
+        TransactionState(
+            memoCount: memoCount,
+            zAddress: zAddress,
+            fee: Zatoshi(10_000),
+            id: id,
+            status: isSent ? .paid : .received,
+            zecAmount: Zatoshi(100_000_000),
+            isSentTransaction: isSent,
+            isShieldingTransaction: isShielding
+        )
+    }
+}

--- a/zodlTests/TransactionsManagerTests/TransactionsCoordFlowCoordinatorTests.swift
+++ b/zodlTests/TransactionsManagerTests/TransactionsCoordFlowCoordinatorTests.swift
@@ -1,0 +1,54 @@
+//
+//  TransactionsCoordFlowCoordinatorTests.swift
+//  zodlTests
+//
+//  Extended — coordinator nav. Covers TransactionsCoordFlow.coordinatorReduce routing
+//  (Features/CoordFlows/TransactionsCoordFlowCoordinator.swift).
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct TransactionsCoordFlowCoordinatorTests {
+    @Test func transactionTappedPushesTransactionDetailsForThatTransaction() {
+        var state = TransactionsCoordFlow.State()
+        state.$transactions.withLock { $0 = [tx(id: "txA"), tx(id: "txB")] }
+
+        _ = TransactionsCoordFlow().coordinatorReduce().reduce(
+            into: &state,
+            action: .transactionsManager(.transactionTapped("txB"))
+        )
+
+        #expect(state.path.count == 1)
+        if case let .transactionDetails(details)? = state.path.last {
+            #expect(details.transaction.id == "txB")
+        } else {
+            Issue.record("expected transactionDetails on the path")
+        }
+    }
+
+    @Test func saveAddressTappedPushesAddressBookContactSeededFromTransaction() {
+        var state = TransactionsCoordFlow.State()
+        state.transactionDetailsState.transaction = tx(id: "txC", zAddress: "u1recipient")
+
+        _ = TransactionsCoordFlow().coordinatorReduce().reduce(
+            into: &state,
+            action: .transactionDetails(.saveAddressTapped)
+        )
+
+        #expect(state.path.count == 1)
+        if case let .addressBookContact(addressBook)? = state.path.last {
+            #expect(addressBook.address == "u1recipient")
+            #expect(addressBook.context == .send)
+            #expect(addressBook.isValidZcashAddress)
+        } else {
+            Issue.record("expected addressBookContact on the path")
+        }
+    }
+
+    private func tx(id: String, zAddress: String? = nil) -> TransactionState {
+        TransactionState(zAddress: zAddress, fee: Zatoshi(10_000), id: id, status: .received, zecAmount: Zatoshi(100_000_000))
+    }
+}

--- a/zodlTests/TransactionsManagerTests/TransactionsManagerLogicTests.swift
+++ b/zodlTests/TransactionsManagerTests/TransactionsManagerLogicTests.swift
@@ -1,0 +1,161 @@
+//
+//  TransactionsManagerLogicTests.swift
+//  zodlTests
+//
+//  Batch 5 — transactions. Covers TransactionsManager filtering/search/time-bucketing/unread/swap
+//  (Features/TransactionsManager/TransactionsManagerStore.swift).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct TransactionsManagerLogicTests {
+    // MARK: - Filter.applyFilter
+
+    @Test func applyFilterCases() {
+        let received = tx(isSent: false, memoCount: 1)
+        let sent = tx(isSent: true)
+        #expect(TransactionsManager.Filter.received.applyFilter(received, addressBookContacts: .empty, userMetadataProvider: provider()))
+        #expect(!TransactionsManager.Filter.received.applyFilter(sent, addressBookContacts: .empty, userMetadataProvider: provider()))
+        #expect(TransactionsManager.Filter.sent.applyFilter(sent, addressBookContacts: .empty, userMetadataProvider: provider()))
+        #expect(TransactionsManager.Filter.memos.applyFilter(received, addressBookContacts: .empty, userMetadataProvider: provider()))
+        #expect(!TransactionsManager.Filter.memos.applyFilter(tx(memoCount: 0), addressBookContacts: .empty, userMetadataProvider: provider()))
+        #expect(TransactionsManager.Filter.bookmarked.applyFilter(received, addressBookContacts: .empty, userMetadataProvider: provider(isBookmarked: true)))
+        #expect(TransactionsManager.Filter.notes.applyFilter(received, addressBookContacts: .empty, userMetadataProvider: provider(annotation: "note")))
+        #expect(TransactionsManager.Filter.swap.applyFilter(received, addressBookContacts: .empty, userMetadataProvider: provider(isSwap: true)))
+    }
+
+    @Test func unreadFilterIsBuggyAndMatchesEveryTransaction() {
+        // See coverage-uplift-plan.md §6.1: the `.unread` filter returns `true` unconditionally,
+        // so it never excludes a sent transaction (which can never be unread). Intended behaviour
+        // recorded as a known issue.
+        withKnownIssue("Bug coverage-uplift-plan.md §6.1: .unread filter returns true unconditionally") {
+            let sent = tx(isSent: true, memoCount: 0)
+            #expect(!TransactionsManager.Filter.unread.applyFilter(sent, addressBookContacts: .empty, userMetadataProvider: provider()))
+        }
+    }
+
+    // MARK: - isUnread / isSwap
+
+    @Test func isUnreadGuards() {
+        withDependencies {
+            $0.userMetadataProvider = provider(isRead: false)
+        } operation: {
+            #expect(!TransactionsManager.isUnread(tx(isSent: true, memoCount: 1)))      // sent never unread
+            #expect(!TransactionsManager.isUnread(tx(isShielding: true, memoCount: 1))) // shielding never unread
+            #expect(!TransactionsManager.isUnread(tx(isSent: false, memoCount: 0)))     // no memo
+            #expect(TransactionsManager.isUnread(tx(isSent: false, memoCount: 1)))      // received + memo + unread
+        }
+    }
+
+    @Test func isUnreadFalseWhenAlreadyRead() {
+        withDependencies {
+            $0.userMetadataProvider = provider(isRead: true)
+        } operation: {
+            #expect(!TransactionsManager.isUnread(tx(isSent: false, memoCount: 1)))
+        }
+    }
+
+    @Test func isSwapUsesHardcodedIdAndProvider() {
+        withDependencies {
+            $0.userMetadataProvider = provider(isSwap: false)
+        } operation: {
+            #expect(TransactionsManager.isSwap(tx(id: "00b61343a47ccf5015fd075054a2500da06380c05513cd776bc74f3545f68cdf")))
+            #expect(!TransactionsManager.isSwap(tx(id: "other")))
+        }
+        withDependencies {
+            $0.userMetadataProvider = provider(isSwap: true)
+        } operation: {
+            #expect(TransactionsManager.isSwap(tx(id: "other", zAddress: "deposit")))
+        }
+    }
+
+    // MARK: - getTimePeriod / unicodeContains
+
+    @Test func getTimePeriodBuckets() {
+        let manager = TransactionsManager()
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(manager.getTimePeriod(for: now.addingTimeInterval(-3 * 86_400), now: now) == String(localizable: .filterPrevious7days))
+        #expect(manager.getTimePeriod(for: now.addingTimeInterval(-20 * 86_400), now: now) == String(localizable: .filterPrevious30days))
+
+        let old = now.addingTimeInterval(-60 * 86_400)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        #expect(manager.getTimePeriod(for: old, now: now) == formatter.string(from: old))
+    }
+
+    @Test func unicodeContainsIsCaseAndDiacriticInsensitive() {
+        let manager = TransactionsManager()
+        #expect(manager.unicodeContains("cafe", in: "Café Münchner"))
+        #expect(manager.unicodeContains("ALICE", in: "alice cooper"))
+        #expect(!manager.unicodeContains("xyz", in: "abcdef"))
+    }
+
+    // MARK: - checkSearchTerm
+
+    @Test func checkSearchTermMatchesAddress() {
+        withDependencies(prepareSearchDependencies) {
+            let manager = TransactionsManager()
+            let transaction = tx(isSent: false, zAddress: "u1someaddress")
+            #expect(manager.checkSearchTerm("someaddr", transaction: transaction, addressBookContacts: .empty))
+        }
+    }
+
+    @Test func checkSearchTermAmountThreshold() {
+        withDependencies(prepareSearchDependencies) {
+            let manager = TransactionsManager()
+            let transaction = tx(isSent: false, zecAmount: Zatoshi(100_000_000)) // 1 ZEC
+            #expect(manager.checkSearchTerm("<5", transaction: transaction, addressBookContacts: .empty))
+            #expect(!manager.checkSearchTerm(">5", transaction: transaction, addressBookContacts: .empty))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func prepareSearchDependencies(_ dependencies: inout DependencyValues) {
+        dependencies.numberFormatter.number = { string in
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 8
+            return formatter.number(from: string)
+        }
+        dependencies.userMetadataProvider = provider()
+    }
+
+    private func provider(
+        isBookmarked: Bool = false,
+        annotation: String? = nil,
+        isSwap: Bool = false,
+        isRead: Bool = true
+    ) -> UserMetadataProviderClient {
+        var client = UserMetadataProviderClient()
+        client.isBookmarked = { _ in isBookmarked }
+        client.annotationFor = { _ in annotation }
+        client.isSwapTransaction = { _ in isSwap }
+        client.isRead = { _, _ in isRead }
+        return client
+    }
+
+    private func tx(
+        id: String = "tx-id",
+        isSent: Bool = false,
+        isShielding: Bool = false,
+        memoCount: Int = 0,
+        zAddress: String? = nil,
+        zecAmount: Zatoshi = Zatoshi(100_000_000)
+    ) -> TransactionState {
+        TransactionState(
+            memoCount: memoCount,
+            zAddress: zAddress,
+            fee: Zatoshi(10_000),
+            id: id,
+            status: isSent ? .paid : .received,
+            zecAmount: zecAmount,
+            isSentTransaction: isSent,
+            isShieldingTransaction: isShielding
+        )
+    }
+}

--- a/zodlTests/UserMetadataTests/UMSerializationTests.swift
+++ b/zodlTests/UserMetadataTests/UMSerializationTests.swift
@@ -1,0 +1,136 @@
+//
+//  UMSerializationTests.swift
+//  zodlTests
+//
+//  Batch 2 — persistence/crypto. Covers UserMetadata serialization primitives, v1/v2 migrations,
+//  and the encrypt/decrypt round-trip (Dependencies/UserMetadataProvider/UMSerialization.swift + Migration/).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct UMSerializationTests {
+    // MARK: - Primitives
+
+    @Test func bytesToIntRoundTripsAndGuardsLength() {
+        #expect(UserMetadata.bytesToInt(Serializer.intToBytes(123_456)) == 123_456)
+        #expect(UserMetadata.bytesToInt(Serializer.intToBytes(-1)) == -1)
+        #expect(UserMetadata.bytesToInt([0, 0, 0]) == nil)
+    }
+
+    @Test func subdataThrowsWhenOutOfBounds() throws {
+        #expect(try UserMetadata.subdata(of: Data([1, 2, 3, 4]), in: 0..<2) == Data([1, 2]))
+        #expect(throws: (any Error).self) {
+            _ = try UserMetadata.subdata(of: Data([1, 2, 3]), in: 0..<5)
+        }
+    }
+
+    // MARK: - v1 -> latest migration
+
+    @Test func v1ToLatestCarriesOverFieldsAndAddsEmptySwaps() {
+        let v1 = UserMetadataV1(
+            version: 2,
+            lastUpdated: 100,
+            accountMetadata: UMAccountV1(
+                bookmarked: [UMBookmark(txId: "t", lastUpdated: 1, isBookmarked: true)],
+                annotations: [UMAnnotation(txId: "t", content: "note", lastUpdated: 2)],
+                read: ["r"]
+            )
+        )
+        let latest = UserMetadata.v1ToLatest(v1)
+        #expect(latest.version == 3)
+        #expect(latest.lastUpdated == 100)
+        #expect(latest.accountMetadata.bookmarked.first?.isBookmarked == true)
+        #expect(latest.accountMetadata.annotations.first?.content == "note")
+        #expect(latest.accountMetadata.read == ["r"])
+        #expect(latest.accountMetadata.swaps.swapIds.isEmpty)
+        #expect(latest.accountMetadata.swaps.lastUsedAssetHistory.isEmpty)
+    }
+
+    // MARK: - v2 -> latest migration (hardcoded swap defaults)
+
+    @Test func v2ToLatestHardcodesSwapDefaults() {
+        let v2 = makeV2(provider: "near.btc.near", totalFees: 7, lastUsed: ["near.eth.usdc"], swapsLastUpdated: 9)
+        let latest = UserMetadata.v2ToLatest(v2)
+        #expect(latest.version == 3)
+        #expect(latest.lastUpdated == 200)
+        #expect(latest.accountMetadata.swaps.lastUsedAssetHistory == ["near.eth.usdc"])
+        #expect(latest.accountMetadata.swaps.lastUpdated == 9)
+
+        let swap = latest.accountMetadata.swaps.swapIds.first
+        #expect(swap?.depositAddress == "deposit")
+        #expect(swap?.toAsset == "near.btc.near")                   // toAsset = original provider
+        #expect(swap?.fromAsset == SwapConstants.zecAssetIdOnNear)  // non-ZEC provider -> from ZEC
+        #expect(swap?.exactInput == true)
+        #expect(swap?.swapStatus == .completed)                     // status hardcoded to SUCCESS
+        #expect(swap?.totalFees == 7)
+    }
+
+    @Test func v2ToLatestClearsFromAssetWhenProviderIsZec() {
+        let v2 = makeV2(provider: SwapConstants.zecAssetIdOnNear, totalFees: 0, lastUsed: [], swapsLastUpdated: 0)
+        let swap = UserMetadata.v2ToLatest(v2).accountMetadata.swaps.swapIds.first
+        #expect(swap?.fromAsset == "")
+        #expect(swap?.toAsset == SwapConstants.zecAssetIdOnNear)
+    }
+
+    // MARK: - Encrypt / decrypt round-trip (latest version)
+
+    @Test func encryptDecryptRoundTripForLatestVersion() throws {
+        let meta = UserMetadata(
+            version: 3,
+            lastUpdated: 1,
+            accountMetadata: UMAccount(
+                bookmarked: [],
+                annotations: [],
+                read: ["tx1", "tx2"],
+                swaps: UMSwaps(swapIds: [], lastUsedAssetHistory: [], lastUpdated: 0)
+            )
+        )
+        let testAccount = account()
+        let keys = UserMetadataEncryptionKeys(keys: [0: UserMetadataKeys(privateKeys: [Data(repeating: 0x42, count: 32)])])
+
+        try withDependencies {
+            $0.walletStorage.exportUserMetadataEncryptionKeys = { _ in keys }
+        } operation: {
+            let encrypted = try UserMetadata.encryptUserMetadata(meta, account: testAccount)
+            let (decrypted, migrated) = try UserMetadata.userMetadataFrom(encryptedData: encrypted, account: testAccount)
+            #expect(!migrated)
+            #expect(decrypted?.version == 3)
+            #expect(decrypted?.accountMetadata.read == ["tx1", "tx2"])
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeV2(provider: String, totalFees: Int64, lastUsed: [String], swapsLastUpdated: Int64) -> UserMetadataV2 {
+        UserMetadataV2(
+            version: 3,
+            lastUpdated: 200,
+            accountMetadata: UMAccountV2(
+                bookmarked: [],
+                annotations: [],
+                read: [],
+                swaps: UMSwapsV2(
+                    swapIds: [UMSwapIdV2(depositAddress: "deposit", provider: provider, totalFees: totalFees, totalUSDFees: "1.0", lastUpdated: 5)],
+                    lastUsedAssetHistory: lastUsed,
+                    lastUpdated: swapsLastUpdated
+                )
+            )
+        )
+    }
+
+    private func account() -> Account {
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: "test",
+            keySource: "test",
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    }
+}

--- a/zodlTests/UtilTests/AnyDecodableTests.swift
+++ b/zodlTests/UtilTests/AnyDecodableTests.swift
@@ -1,0 +1,58 @@
+//
+//  AnyDecodableTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers `AnyDecodable` decode precedence (Utils/AnyDecodable.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct AnyDecodableTests {
+    @Test func decodesIntegerAsInt() throws {
+        let values = try decodeArray("[42]")
+        #expect(values.first as? Int == 42)
+    }
+
+    @Test func decodesFractionalAsDouble() throws {
+        let values = try decodeArray("[4.5]")
+        #expect(values.first as? Double == 4.5)
+    }
+
+    @Test func decodesBooleanAsBool() throws {
+        let values = try decodeArray("[true, false]")
+        #expect(values.count == 2)
+        #expect(values[0] as? Bool == true)
+        #expect(values[1] as? Bool == false)
+    }
+
+    @Test func decodesString() throws {
+        let values = try decodeArray("[\"hi\"]")
+        #expect(values.first as? String == "hi")
+    }
+
+    @Test func decodesNestedArray() throws {
+        let values = try decodeArray("[[1, 2, 3]]")
+        let nested = try #require(values.first as? [Any])
+        #expect(nested.compactMap { $0 as? Int } == [1, 2, 3])
+    }
+
+    @Test func decodesNestedObject() throws {
+        let values = try decodeArray("[{\"k\": 1, \"s\": \"v\"}]")
+        let dict = try #require(values.first as? [String: Any])
+        #expect(dict["k"] as? Int == 1)
+        #expect(dict["s"] as? String == "v")
+    }
+
+    @Test func decodingNullThrows() {
+        #expect(throws: (any Error).self) {
+            _ = try decodeArray("[null]")
+        }
+    }
+
+    private func decodeArray(_ json: String) throws -> [Any] {
+        let decoded = try JSONDecoder().decode([AnyDecodable].self, from: Data(json.utf8))
+        return decoded.map(\.value)
+    }
+}

--- a/zodlTests/UtilTests/ArrayChunkedTests.swift
+++ b/zodlTests/UtilTests/ArrayChunkedTests.swift
@@ -1,0 +1,49 @@
+//
+//  ArrayChunkedTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers Array.chunked / removingDuplicates (Utils/Array+Chunked.swift).
+//
+
+import Testing
+@testable import zodl_internal
+
+@Suite struct ArrayChunkedTests {
+    @Test func chunkedSplitsWithRemainder() {
+        #expect([1, 2, 3, 4, 5].chunked(into: 2) == [[1, 2], [3, 4], [5]])
+    }
+
+    @Test func chunkedSplitsEvenly() {
+        #expect([1, 2, 3, 4].chunked(into: 2) == [[1, 2], [3, 4]])
+    }
+
+    @Test func chunkedWithSizeLargerThanCountReturnsSingleChunk() {
+        #expect([1, 2].chunked(into: 5) == [[1, 2]])
+    }
+
+    @Test func chunkedEmptyArrayReturnsEmpty() {
+        #expect([Int]().chunked(into: 3) == [])
+    }
+
+    @Test func removingDuplicatesKeepsFirstOccurrencePreservingOrder() {
+        let items = [
+            Item(id: 1, tag: "a"),
+            Item(id: 1, tag: "b"),
+            Item(id: 2, tag: "c"),
+            Item(id: 2, tag: "d"),
+            Item(id: 3, tag: "e")
+        ]
+        let deduped = items.removingDuplicates()
+        #expect(deduped.map(\.id) == [1, 2, 3])
+        #expect(deduped.map(\.tag) == ["a", "c", "e"])
+    }
+
+    @Test func removingDuplicatesOnEmptyReturnsEmpty() {
+        #expect([Item]().removingDuplicates().isEmpty)
+    }
+}
+
+private struct Item: Identifiable, Equatable {
+    let id: Int
+    let tag: String
+}

--- a/zodlTests/UtilTests/BalanceFormatterTests.swift
+++ b/zodlTests/UtilTests/BalanceFormatterTests.swift
@@ -1,0 +1,49 @@
+//
+//  BalanceFormatterTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers Zatoshi balance formatters (Utils/BalanceFormatter.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct BalanceFormatterTests {
+    // MARK: - roundToAvoidDustSpend (pure integer math, rounds to nearest 5_000)
+
+    @Test func roundToAvoidDustSpendRoundsToNearestFiveThousand() {
+        #expect(Zatoshi(0).roundToAvoidDustSpend().amount == 0)
+        #expect(Zatoshi(5_000).roundToAvoidDustSpend().amount == 5_000)
+        #expect(Zatoshi(7_499).roundToAvoidDustSpend().amount == 5_000)
+        #expect(Zatoshi(7_500).roundToAvoidDustSpend().amount == 10_000)
+        #expect(Zatoshi(2_500).roundToAvoidDustSpend().amount == 5_000) // 0.5 rounds away from zero
+        #expect(Zatoshi(2_499).roundToAvoidDustSpend().amount == 0)
+        #expect(Zatoshi(100_000_000).roundToAvoidDustSpend().amount == 100_000_000)
+    }
+
+    // MARK: - en_US-pinned formatters (deterministic across locales)
+
+    @Test func decimalZashiUSFormattedUsesThreeFractionDigitsWithGrouping() {
+        #expect(Zatoshi(100_000_000).decimalZashiUSFormatted() == "1.000")
+        #expect(Zatoshi(123_456_789).decimalZashiUSFormatted() == "1.235") // halfUp at 3 places
+        #expect(Zatoshi(1_000_000_000_000).decimalZashiUSFormatted() == "10,000.000")
+    }
+
+    @Test func decimalZashiTaxUSFormattedHasNoGrouping() {
+        #expect(Zatoshi(100_000_000).decimalZashiTaxUSFormatted() == "1")
+        #expect(Zatoshi(1_000_000_000_000).decimalZashiTaxUSFormatted() == "10000")
+        #expect(Zatoshi(123_456_789).decimalZashiTaxUSFormatted() == "1.23456789")
+    }
+
+    // MARK: - locale-dependent formatters (assert structure only)
+
+    @Test func localeDependentFormattersProduceNonEmptyOutput() {
+        let oneZec = Zatoshi(100_000_000)
+        #expect(!oneZec.decimalZashiFormatted().isEmpty)
+        #expect(!oneZec.decimalZashiFullFormatted().isEmpty)
+        #expect(!oneZec.threeDecimalsZashiFormatted().isEmpty)
+        #expect(!oneZec.atLeastThreeDecimalsZashiFormatted().isEmpty)
+    }
+}

--- a/zodlTests/UtilTests/ClampedTests.swift
+++ b/zodlTests/UtilTests/ClampedTests.swift
@@ -1,0 +1,64 @@
+//
+//  ClampedTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers the @Clamped property wrapper (Utils/Clamped.swift).
+//
+
+import Testing
+@testable import zodl_internal
+
+@Suite struct ClampedTests {
+    private struct InRangeBox {
+        @Clamped(0...10) var value: Int = 5
+    }
+
+    private struct AboveRangeBox {
+        @Clamped(0...10) var value: Int = 20
+    }
+
+    private struct BelowRangeBox {
+        @Clamped(0...10) var value: Int = -5
+    }
+
+    // Initialiser clamping works correctly (clamp() reads the freshly-stored value).
+    @Test func initialValueWithinRangeIsKept() {
+        #expect(InRangeBox().value == 5)
+    }
+
+    @Test func initialValueAboveRangeIsClampedToUpper() {
+        #expect(AboveRangeBox().value == 10)
+    }
+
+    @Test func initialValueBelowRangeIsClampedToLower() {
+        #expect(BelowRangeBox().value == 0)
+    }
+
+    // See docs/testing/coverage-uplift-plan.md §6.6.
+    // The setter's clamp() reads the *current stored* value instead of the incoming one,
+    // so assignments never take effect. These intended-behaviour assertions are recorded
+    // as known issues until the wrapper is fixed.
+    @Test func assigningInRangeValueShouldUpdateIt() {
+        withKnownIssue("Bug coverage-uplift-plan.md §6.6: Clamped setter ignores the new value") {
+            var box = InRangeBox()
+            box.value = 8
+            #expect(box.value == 8)
+        }
+    }
+
+    @Test func assigningAboveRangeShouldClampToUpper() {
+        withKnownIssue("Bug coverage-uplift-plan.md §6.6: Clamped setter ignores the new value") {
+            var box = InRangeBox()
+            box.value = 20
+            #expect(box.value == 10)
+        }
+    }
+
+    @Test func assigningBelowRangeShouldClampToLower() {
+        withKnownIssue("Bug coverage-uplift-plan.md §6.6: Clamped setter ignores the new value") {
+            var box = InRangeBox()
+            box.value = -5
+            #expect(box.value == 0)
+        }
+    }
+}

--- a/zodlTests/UtilTests/DateReadableTests.swift
+++ b/zodlTests/UtilTests/DateReadableTests.swift
@@ -1,0 +1,25 @@
+//
+//  DateReadableTests.swift
+//  zodlTests
+//
+//  Extended — pure logic. Covers Date.timestamp / asHumanReadable formats (Utils/Date+Readable.swift).
+//  Asserts the format shape (timezone-independent) rather than an exact wall-clock string.
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct DateReadableTests {
+    private let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test func timestampMatchesFixedFormat() {
+        let value = date.timestamp()
+        #expect(value.range(of: #"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{4}$"#, options: .regularExpression) != nil)
+    }
+
+    @Test func asHumanReadableMatchesFixedFormat() {
+        let value = date.asHumanReadable()
+        #expect(value.range(of: #"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"#, options: .regularExpression) != nil)
+    }
+}

--- a/zodlTests/UtilTests/DecimalsTests.swift
+++ b/zodlTests/UtilTests/DecimalsTests.swift
@@ -1,0 +1,46 @@
+//
+//  DecimalsTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers `Decimal.simplified` (Utils/Decimals.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct DecimalsTests {
+    @Test func simplifiedOfZeroIsZero() {
+        #expect(Decimal(0).simplified == Decimal(0))
+    }
+
+    @Test func simplifiedKeepsExactTwoDecimalValue() throws {
+        let value = try #require(Decimal(string: "1.23"))
+        #expect(value.simplified == value)
+    }
+
+    @Test func simplifiedKeepsExactTwoDecimalValueWithTrailingDigits() throws {
+        let value = try #require(Decimal(string: "12.34"))
+        #expect(value.simplified == value)
+    }
+
+    @Test func simplifiedReducesToThreeDecimalsWhenWithinTolerance() throws {
+        // 0.12 is 2.8% off (> 0.5%), 0.123 is 0.37% off (<= 0.5%) -> scale 3 wins.
+        let value = try #require(Decimal(string: "0.123456789"))
+        let expected = try #require(Decimal(string: "0.123"))
+        #expect(value.simplified == expected)
+    }
+
+    @Test func simplifiedHandlesNegativeValues() throws {
+        let value = try #require(Decimal(string: "-0.123456789"))
+        let expected = try #require(Decimal(string: "-0.123"))
+        #expect(value.simplified == expected)
+    }
+
+    @Test func simplifiedCollapsesWithinHalfPercentTolerance() throws {
+        // 100.001 is within 0.5% of 100.00 at scale 2, so it simplifies to 100.
+        let value = try #require(Decimal(string: "100.001"))
+        let expected = try #require(Decimal(string: "100"))
+        #expect(value.simplified == expected)
+    }
+}

--- a/zodlTests/UtilTests/DerivationToolTests.swift
+++ b/zodlTests/UtilTests/DerivationToolTests.swift
@@ -1,0 +1,39 @@
+//
+//  DerivationToolTests.swift
+//  zodlTests
+//
+//  Batch 4 — dependency logic. Covers DerivationToolClient address classification
+//  (Dependencies/DerivationTool/DerivationToolLiveKey.swift).
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct DerivationToolTests {
+    private let testnetUnifiedAddress =
+        "utest1vergg5jkp4xy8sqfasw6s5zkdpnxvfxlxh35uuc3me7dp596y2r05t6dv9htwe3pf8ksrfr8ksca2lskzjanqtl8uqp5vln3zyy246ejtx86vqftp73j7jg9099jxafyjhfm6u956j3"
+
+    @Test func classifiesUnifiedAddress() {
+        let tool = DerivationToolClient.liveValue
+        #expect(tool.isUnifiedAddress(testnetUnifiedAddress, .testnet))
+        #expect(tool.isZcashAddress(testnetUnifiedAddress, .testnet))
+        #expect(tool.doesAddressSupportMemo(testnetUnifiedAddress, .testnet))
+        #expect(!tool.isSaplingAddress(testnetUnifiedAddress, .testnet))
+        #expect(!tool.isTransparentAddress(testnetUnifiedAddress, .testnet))
+        #expect(!tool.isTexAddress(testnetUnifiedAddress, .testnet))
+    }
+
+    @Test func rejectsInvalidAddress() {
+        let tool = DerivationToolClient.liveValue
+        #expect(!tool.isZcashAddress("definitely-not-an-address", .testnet))
+        #expect(!tool.isUnifiedAddress("definitely-not-an-address", .testnet))
+        #expect(!tool.doesAddressSupportMemo("definitely-not-an-address", .testnet))
+    }
+
+    @Test func mainnetContextRejectsTestnetAddress() {
+        // A testnet unified address must not validate under mainnet.
+        #expect(!DerivationToolClient.liveValue.isZcashAddress(testnetUnifiedAddress, .mainnet))
+    }
+}

--- a/zodlTests/UtilTests/MnemonicClientTests.swift
+++ b/zodlTests/UtilTests/MnemonicClientTests.swift
@@ -1,0 +1,49 @@
+//
+//  MnemonicClientTests.swift
+//  zodlTests
+//
+//  Batch 4 — dependency logic. Covers MnemonicClient.liveValue (Dependencies/MnemonicClient/MnemonicLiveKey.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct MnemonicClientTests {
+    private let validPhrase =
+        "still champion voice habit trend flight survey between bitter process artefact blind " +
+        "carbon truly provide dizzy crush flush breeze blouse charge solid fish spread"
+
+    @Test func randomMnemonicProducesTwentyFourValidWords() throws {
+        let client = MnemonicClient.liveValue
+        #expect(try client.randomMnemonicWords().count == 24)
+        try client.isValid(client.randomMnemonic()) // generated phrase validates
+    }
+
+    @Test func toSeedIsDeterministicAndSixtyFourBytes() throws {
+        let client = MnemonicClient.liveValue
+        let seed = try client.toSeed(validPhrase)
+        #expect(seed.count == 64)
+        #expect(try client.toSeed(validPhrase) == seed) // deterministic
+    }
+
+    @Test func isValidAcceptsValidPhrase() throws {
+        try MnemonicClient.liveValue.isValid(validPhrase)
+    }
+
+    @Test func isValidRejectsInvalidPhrase() {
+        #expect(throws: (any Error).self) {
+            try MnemonicClient.liveValue.isValid("totally not a valid mnemonic phrase at all")
+        }
+    }
+
+    @Test func suggestWordsFiltersByPrefix() throws {
+        let suggestions = try MnemonicClient.liveValue.suggestWords("aban")
+        #expect(suggestions.contains("abandon"))
+        #expect(suggestions.allSatisfy { $0.hasPrefix("aban") })
+    }
+
+    @Test func asWordsSplitsOnSpaces() throws {
+        #expect(try MnemonicClient.liveValue.asWords("alpha bravo charlie") == ["alpha", "bravo", "charlie"])
+    }
+}

--- a/zodlTests/UtilTests/NetworkErrorTests.swift
+++ b/zodlTests/UtilTests/NetworkErrorTests.swift
@@ -1,0 +1,65 @@
+//
+//  NetworkErrorTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers `NetworkError.allowsRetry` / `.message` (Utils/Network.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct NetworkErrorTests {
+    @Test(arguments: [
+        URLError.Code.timedOut,
+        .notConnectedToInternet,
+        .networkConnectionLost,
+        .cannotConnectToHost
+    ])
+    func transportRetryableCodesAllowRetry(_ code: URLError.Code) {
+        #expect(NetworkError.transport(URLError(code)).allowsRetry)
+    }
+
+    @Test(arguments: [
+        URLError.Code.badURL,
+        .cancelled,
+        .unsupportedURL,
+        .userAuthenticationRequired
+    ])
+    func transportNonRetryableCodesDoNotAllowRetry(_ code: URLError.Code) {
+        #expect(!NetworkError.transport(URLError(code)).allowsRetry)
+    }
+
+    @Test func unknownErrorDoesNotAllowRetry() {
+        #expect(!NetworkError.unknown(SampleError.boom).allowsRetry)
+    }
+
+    @Test func messageReflectsCase() {
+        #expect(NetworkError.httpStatus(code: 404).message == "404")
+        #expect(NetworkError.unknown(SampleError.boom).message == "unknown")
+        #expect(!NetworkError.transport(URLError(.timedOut)).message.isEmpty)
+    }
+
+    // See docs/testing/coverage-uplift-plan.md §6.4.
+    // Intended: client errors (4xx) must NOT be retried. The current implementation
+    // `!(501...504).contains(code)` retries them, so these intended-behaviour assertions
+    // are recorded as known issues until the bug is fixed.
+    @Test func clientErrorsShouldNotRetry() {
+        withKnownIssue("Bug coverage-uplift-plan.md §6.4: 4xx HTTP statuses are incorrectly retryable") {
+            #expect(NetworkError.httpStatus(code: 400).allowsRetry == false)
+            #expect(NetworkError.httpStatus(code: 404).allowsRetry == false)
+        }
+    }
+
+    // Intended: server errors (5xx) should be retried. The current implementation excludes 501...504.
+    @Test func serverErrorsShouldRetry() {
+        withKnownIssue("Bug coverage-uplift-plan.md §6.4: 502/503 server errors are incorrectly non-retryable") {
+            #expect(NetworkError.httpStatus(code: 502).allowsRetry == true)
+            #expect(NetworkError.httpStatus(code: 503).allowsRetry == true)
+        }
+    }
+}
+
+private enum SampleError: Error {
+    case boom
+}

--- a/zodlTests/UtilTests/SerializerTests.swift
+++ b/zodlTests/UtilTests/SerializerTests.swift
@@ -1,0 +1,41 @@
+//
+//  SerializerTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers `Serializer` (Utils/Data+Serialization.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct SerializerTests {
+    @Test func stringBytesRoundTripASCII() {
+        let bytes = Serializer.stringToBytes("hello")
+        #expect(bytes == Array("hello".utf8))
+        #expect(Serializer.bytesToString(bytes) == "hello")
+    }
+
+    @Test func stringBytesRoundTripUnicode() {
+        let original = "Příliš žluťoučký 🎉"
+        let bytes = Serializer.stringToBytes(original)
+        #expect(Serializer.bytesToString(bytes) == original)
+    }
+
+    @Test func emptyStringRoundTrip() {
+        #expect(Serializer.stringToBytes("") == [])
+        #expect(Serializer.bytesToString([]) == "")
+    }
+
+    @Test func bytesToStringReturnsNilForInvalidUTF8() {
+        #expect(Serializer.bytesToString([0xFF]) == nil)
+    }
+
+    @Test func intToBytesIsBigEndianEightBytes() {
+        // `Int` is 64-bit on the test platform, so each value is 8 big-endian bytes.
+        #expect(Serializer.intToBytes(0) == [0, 0, 0, 0, 0, 0, 0, 0])
+        #expect(Serializer.intToBytes(1) == [0, 0, 0, 0, 0, 0, 0, 1])
+        #expect(Serializer.intToBytes(256) == [0, 0, 0, 0, 0, 0, 1, 0])
+        #expect(Serializer.intToBytes(-1) == [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
+    }
+}

--- a/zodlTests/UtilTests/ServerConfigEndpointTests.swift
+++ b/zodlTests/UtilTests/ServerConfigEndpointTests.swift
@@ -1,0 +1,50 @@
+//
+//  ServerConfigEndpointTests.swift
+//  zodlTests
+//
+//  Batch 4 — dependency logic. Covers UserPreferencesStorage.ServerConfig.endpoint(for:) parsing
+//  (Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift).
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct ServerConfigEndpointTests {
+    @Test func parsesHostAndPort() {
+        let result = endpoint("host.example.com:443")
+        #expect(result?.host == "host.example.com")
+        #expect(result?.port == 443)
+    }
+
+    @Test func stripsHttpsScheme() {
+        let result = endpoint("https://host.example.com:9067")
+        #expect(result?.host == "host.example.com")
+        #expect(result?.port == 9067)
+    }
+
+    @Test func stripsHttpScheme() {
+        let result = endpoint("http://host:8080")
+        #expect(result?.host == "host")
+        #expect(result?.port == 8080)
+    }
+
+    @Test func returnsNilWithoutPort() {
+        #expect(endpoint("hostonly") == nil)
+        #expect(endpoint("host.example.com") == nil)
+    }
+
+    // See docs/testing/coverage-uplift-plan.md §6.3.
+    // Intended: a 3-component "a:b:443" should keep the ':' between the first two segments.
+    // Current impl concatenates them ("ab"), so the intended assertion is a known issue.
+    @Test func threeComponentHostKeepsSeparator() {
+        withKnownIssue("Bug coverage-uplift-plan.md §6.3: endpoint(for:) drops the ':' separator for 3-component hosts") {
+            #expect(endpoint("a:b:443")?.host == "a:b")
+        }
+    }
+
+    private func endpoint(_ string: String) -> LightWalletEndpoint? {
+        UserPreferencesStorage.ServerConfig.endpoint(for: string, streamingCallTimeoutInMillis: 0)
+    }
+}

--- a/zodlTests/UtilTests/StringsTests.swift
+++ b/zodlTests/UtilTests/StringsTests.swift
@@ -1,0 +1,104 @@
+//
+//  StringsTests.swift
+//  zodlTests
+//
+//  Batch 1 — pure logic. Covers String truncation / USD parsing / ValidationType (Utils/Strings.swift).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct StringsTests {
+    // MARK: - zip316 / truncation
+
+    @Test func zip316KeepsShortStrings() {
+        let twenty = String(repeating: "a", count: 20)
+        #expect(twenty.zip316 == twenty)
+    }
+
+    @Test func zip316TruncatesOverTwenty() {
+        let input = String(repeating: "a", count: 21)
+        #expect(input.zip316 == "\(String(repeating: "a", count: 20))...")
+    }
+
+    @Test func trailingZip316FallsBackToZip316UpToTwentyFive() {
+        let input = String(repeating: "a", count: 25)
+        // 25 is not > 25, so it falls back to zip316 (which truncates anything > 20).
+        #expect(input.trailingZip316 == "\(String(repeating: "a", count: 20))...")
+    }
+
+    @Test func trailingZip316ShowsHeadAndTailOverTwentyFive() {
+        let input = "\(String(repeating: "a", count: 26))bcde" // length 30
+        #expect(input.trailingZip316 == "\(input.prefix(20))...\(input.suffix(4))")
+    }
+
+    @Test func truncateMiddleKeepsTenOrFewer() {
+        let ten = String(repeating: "a", count: 10)
+        #expect(ten.truncateMiddle == ten)
+    }
+
+    @Test func truncateMiddleShowsHeadAndTailOverTen() {
+        let input = String(repeating: "a", count: 11)
+        #expect(input.truncateMiddle == "\(input.prefix(5))...\(input.suffix(5))")
+    }
+
+    @Test func truncateMiddle10ShowsHeadAndTailOverTwenty() {
+        let input = String(repeating: "x", count: 21)
+        #expect(input.truncateMiddle10 == "\(input.prefix(10))...\(input.suffix(10))")
+    }
+
+    // MARK: - USD decimal parsing
+
+    @Test func usDecimalParsesInteger() throws {
+        let value = try #require("1234".usDecimal)
+        #expect(value == Decimal(1234))
+    }
+
+    @Test func usDecimalReturnsNilForGarbage() {
+        #expect("not a number".usDecimal == nil)
+    }
+
+    @Test func localeUsdDecimalParsesIntegerExactly() throws {
+        let value = try #require("100".localeUsdDecimal)
+        #expect(value == Decimal(100))
+    }
+
+    @Test func localeUsdDecimalReturnsNilForGarbage() {
+        #expect("not a number".localeUsdDecimal == nil)
+    }
+
+    // MARK: - ValidationType
+
+    @Test func nilValidationTypeIsAlwaysValid() {
+        #expect("anything".isValid(for: nil))
+    }
+
+    @Test(arguments: ["a@b.com", "user.name+tag@example.co"])
+    func emailValidationAcceptsValidAddresses(_ email: String) {
+        #expect(String.ValidationType.email.isValid(text: email))
+    }
+
+    @Test(arguments: ["notanemail", "missing@tld", ""])
+    func emailValidationRejectsInvalidAddresses(_ email: String) {
+        #expect(!String.ValidationType.email.isValid(text: email))
+    }
+
+    @Test func maxLengthRejectsEmptyEvenWithinLimit() {
+        // Notable behaviour: maxLength requires non-empty (text.count <= length && !text.isEmpty).
+        #expect(!String.ValidationType.maxLength(5).isValid(text: ""))
+        #expect(String.ValidationType.maxLength(5).isValid(text: "abc"))
+        #expect(!String.ValidationType.maxLength(5).isValid(text: "abcdef"))
+    }
+
+    @Test func minLengthBoundary() {
+        #expect(!String.ValidationType.minLength(3).isValid(text: "ab"))
+        #expect(String.ValidationType.minLength(3).isValid(text: "abc"))
+    }
+
+    @Test func customRegexValidation() {
+        let digitsOnly = String.ValidationType.custom("^[0-9]+$")
+        #expect(digitsOnly.isValid(text: "12345"))
+        #expect(!digitsOnly.isValid(text: "12a45"))
+    }
+}

--- a/zodlTests/UtilTests/WalletStoragePureTests.swift
+++ b/zodlTests/UtilTests/WalletStoragePureTests.swift
@@ -1,0 +1,53 @@
+//
+//  WalletStoragePureTests.swift
+//  zodlTests
+//
+//  Batch 4 — dependency logic. Covers WalletStorage pure key-derivation helpers + SwapAPIAccess Codable
+//  (Dependencies/WalletStorage/WalletStorage.swift).
+//  NOTE: the keychain import/export round-trip is deferred (needs a stateful in-memory SecItem fake).
+//
+
+import Testing
+import Foundation
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct WalletStoragePureTests {
+    @Test func votingHotkeyKeyEncodesAccountUUIDAsHex() {
+        let accountId = AccountUUID(id: [UInt8](repeating: 0x01, count: 16))
+        let key = WalletStorage.Constants.zcashStoredVotingHotkey(accountId: accountId)
+        #expect(key == "zcashStoredVotingHotkey_" + String(repeating: "01", count: 16))
+    }
+
+    @Test func votingHotkeyKeyDiffersPerAccount() {
+        let a = WalletStorage.Constants.zcashStoredVotingHotkey(accountId: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)))
+        let b = WalletStorage.Constants.zcashStoredVotingHotkey(accountId: AccountUUID(id: [UInt8](repeating: 0x02, count: 16)))
+        #expect(a != b)
+    }
+
+    @Test func accountMetadataFilenameUsesLowercasedAccountName() {
+        #expect(WalletStorage.Constants.accountMetadataFilename(account: account(name: "Zashi")) == "zcashStoredMetadataEncryptionKeys_zashi")
+    }
+
+    @Test func shieldingReminderKeyIncludesAccountName() {
+        #expect(WalletStorage.Constants.zcashStoredShieldingReminder(accountName: "main") == "zcashStoredShieldingReminder_main")
+    }
+
+    @Test(arguments: [WalletStorage.SwapAPIAccess.protected, .direct])
+    func swapAPIAccessCodableRoundTrip(_ value: WalletStorage.SwapAPIAccess) throws {
+        let data = try JSONEncoder().encode(value)
+        #expect(try JSONDecoder().decode(WalletStorage.SwapAPIAccess.self, from: data) == value)
+    }
+
+    private func account(name: String) -> Account {
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: name,
+            keySource: "test",
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    }
+}

--- a/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
@@ -1,0 +1,100 @@
+//
+//  WalletBalancesTests.swift
+//  zodlTests
+//
+//  Batch 3 — balances. Covers WalletBalances exchange-rate handling, nil-balance spendability,
+//  and computed props (Features/WalletBalances/WalletBalancesStore.swift).
+//  NOTE: the non-nil AccountBalance aggregation path is deferred (needs an SDK PoolBalance fixture).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct WalletBalancesTests {
+    // MARK: - Computed props
+
+    @Test func isProcessingZeroAvailableBalance() {
+        var transparentAboveThreshold = WalletBalances.State(shieldedBalance: .zero, totalBalance: Zatoshi(100), transparentBalance: Zatoshi(100))
+        transparentAboveThreshold.autoShieldingThreshold = Zatoshi(50)
+        #expect(!transparentAboveThreshold.isProcessingZeroAvailableBalance)
+
+        var shieldedZeroPending = WalletBalances.State(shieldedBalance: .zero, totalBalance: Zatoshi(10), transparentBalance: Zatoshi(10))
+        shieldedZeroPending.autoShieldingThreshold = Zatoshi(50)
+        #expect(shieldedZeroPending.isProcessingZeroAvailableBalance)
+
+        let hasShielded = WalletBalances.State(shieldedBalance: Zatoshi(100), totalBalance: Zatoshi(200), transparentBalance: Zatoshi(100))
+        #expect(!hasShielded.isProcessingZeroAvailableBalance)
+    }
+
+    @Test func currencyValueIsEmptyWithoutConversionAndFormattedWithIt() {
+        var state = WalletBalances.State(totalBalance: Zatoshi(100_000_000))
+        #expect(state.currencyValue.isEmpty)
+        state.$currencyConversion.withLock { $0 = CurrencyConversion(.usd, ratio: 30, timestamp: 0) }
+        #expect(!state.currencyValue.isEmpty)
+    }
+
+    // MARK: - balanceUpdated(nil)
+
+    @MainActor @Test func balanceUpdatedWithNilZerosBalancesAndMarksEverythingSpendable() async {
+        let store = TestStore(initialState: WalletBalances.State()) {
+            WalletBalances()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        }
+        store.exhaustivity = .off
+        await store.send(.balanceUpdated(nil))
+        #expect(store.state.shieldedBalance == .zero)
+        #expect(store.state.totalBalance == .zero)
+        #expect(store.state.spendability == .everything)
+    }
+
+    // MARK: - exchangeRateEvent
+
+    @MainActor @Test func exchangeRateValueSetsConversionAndClearsStale() async {
+        let store = makeStore()
+        let result = fiatResult(rate: 30)
+        await store.send(.exchangeRateEvent(.value(result)))
+        #expect(store.state.fiatCurrencyResult == result)
+        #expect(store.state.currencyConversion?.iso4217 == .usd)
+        #expect(!store.state.isExchangeRateStale)
+        #expect(!store.state.isExchangeRateRefreshEnabled)
+    }
+
+    @MainActor @Test func exchangeRateRefreshEnableSetsRefreshFlag() async {
+        let store = makeStore()
+        await store.send(.exchangeRateEvent(.refreshEnable(fiatResult(rate: 30))))
+        #expect(store.state.isExchangeRateRefreshEnabled)
+        #expect(store.state.currencyConversion != nil)
+    }
+
+    @MainActor @Test func exchangeRateStaleClearsConversion() async {
+        let store = makeStore(currencyConversion: CurrencyConversion(.usd, ratio: 30, timestamp: 0))
+        await store.send(.exchangeRateEvent(.stale(nil)))
+        #expect(store.state.currencyConversion == nil)
+        #expect(store.state.isExchangeRateStale)
+    }
+
+    @MainActor @Test func exchangeRateValueNilIsNoOp() async {
+        let store = makeStore(currencyConversion: CurrencyConversion(.usd, ratio: 30, timestamp: 0))
+        await store.send(.exchangeRateEvent(.value(nil)))
+        #expect(store.state.currencyConversion != nil)
+    }
+
+    // MARK: - Helpers
+
+    private func fiatResult(rate: Double) -> FiatCurrencyResult {
+        FiatCurrencyResult(date: Date(timeIntervalSince1970: 1000), rate: NSDecimalNumber(value: rate), state: .success)
+    }
+
+    @MainActor
+    private func makeStore(currencyConversion: CurrencyConversion? = nil) -> TestStoreOf<WalletBalances> {
+        var state = WalletBalances.State()
+        state.$currencyConversion.withLock { $0 = currencyConversion }
+        let store = TestStore(initialState: state) { WalletBalances() }
+        store.exhaustivity = .off
+        return store
+    }
+}

--- a/zodlTests/ZecKeyboardTests/ZecKeyboardTests.swift
+++ b/zodlTests/ZecKeyboardTests/ZecKeyboardTests.swift
@@ -1,0 +1,94 @@
+//
+//  ZecKeyboardTests.swift
+//  zodlTests
+//
+//  Batch 3 — amount entry. Covers the ZecKeyboard reducer's input/validation/conversion logic
+//  (Features/ZecKeyboard/ZecKeyboardStore.swift). Assertions use integer inputs (locale-independent).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct ZecKeyboardTests {
+    @Test func isNextButtonDisabledReflectsAmountAndZeroAllowed() {
+        var state = ZecKeyboard.State()
+        state.amount = .zero
+        #expect(state.isNextButtonDisabled)
+
+        state.isZeroOutputAllowed = true
+        #expect(!state.isNextButtonDisabled)
+
+        state.isZeroOutputAllowed = false
+        state.amount = Zatoshi(1)
+        #expect(!state.isNextButtonDisabled)
+    }
+
+    @MainActor @Test func tappingDigitReplacesLeadingZeroAndComputesZecAmount() async {
+        let store = makeStore()
+        await store.send(.keyTapped(4)) // "5"
+        await store.receive(\.validateInputs)
+        await store.receive(\.resolveHumanReadableStrings)
+        #expect(store.state.input == "5")
+        #expect(store.state.amount == Zatoshi(500_000_000)) // 5 ZEC
+    }
+
+    @MainActor @Test func eightFractionDigitsCapBlocksFurtherDigits() async {
+        let store = makeStore(input: "1.12345678") // already 8 fraction digits
+        await store.send(.keyTapped(0)) // "1" — must be ignored
+        #expect(store.state.input == "1.12345678")
+    }
+
+    @MainActor @Test func backspaceViaLongKeyResetsToZero() async {
+        let store = makeStore(input: "123")
+        await store.send(.longKeyTapped(11))
+        await store.receive(\.validateInputs)
+        await store.receive(\.resolveHumanReadableStrings)
+        #expect(store.state.input == "0")
+    }
+
+    @MainActor @Test func validateInputsExceedingMaxRevertsLastInput() async {
+        let store = makeStore(input: "100000000") // 1e8 ZEC -> exceeds max supply
+        await store.send(.validateInputs)
+        await store.receive(\.revertLastInput)
+        await store.receive(\.resolveHumanReadableStrings)
+        #expect(store.state.input == "10000000") // reverted to 1e7 ZEC
+        #expect(store.state.amount == Zatoshi(1_000_000_000_000_000))
+    }
+
+    @MainActor @Test func swapCurrenciesTogglesInputMode() async {
+        let store = makeStore()
+        #expect(store.state.isInputInZec)
+        await store.send(.swapCurrenciesTapped)
+        await store.receive(\.resolveHumanReadableStrings)
+        #expect(!store.state.isInputInZec)
+    }
+
+    @MainActor @Test func zecInputConvertsToFiatUsingConversionRatio() async {
+        let store = makeStore(currencyConversion: CurrencyConversion(.usd, ratio: 30, timestamp: 0), input: "1")
+        await store.send(.validateInputs)
+        await store.receive(\.resolveHumanReadableStrings)
+        #expect(store.state.amount == Zatoshi(100_000_000)) // 1 ZEC
+        #expect(store.state.currencyValue == 30) // 1 ZEC * $30
+    }
+
+    @MainActor
+    private func makeStore(
+        currencyConversion: CurrencyConversion? = nil,
+        input: String = "0",
+        isInputInZec: Bool = true,
+        decimalSeparator: String = "."
+    ) -> TestStoreOf<ZecKeyboard> {
+        var state = ZecKeyboard.State()
+        state.decimalSeparator = decimalSeparator
+        state.keys = ["1", "2", "3", "4", "5", "6", "7", "8", "9", decimalSeparator, "0", "x"]
+        state.input = input
+        state.isInputInZec = isInputInZec
+        state.$currencyConversion.withLock { $0 = currencyConversion }
+        let store = TestStore(initialState: state) { ZecKeyboard() }
+        store.exhaustivity = .off
+        return store
+    }
+}


### PR DESCRIPTION
## Summary

Adds **259 unit tests** (Swift Testing) across models, utils, dependencies, and TCA reducers, raising overall line coverage **12.59% → 15.49%** (targeted logic files went from ~0% to 80–100%). **Zero production-code changes** — this PR is tests + the audit/plan doc only.

## What's covered

- **Pure logic** (models/utils): Decimals, Serializer, Array+Chunked, NetworkError, AnyDecodable, Strings, Clamped, BalanceFormatter, SwapAsset, Swaps, TransactionState, RecoveryPhrase, WalletAccount, WalletStatus, SyncStatusSnapshot, ChainToken, Date+Readable, FeatureFlags, CMCRate, StoredWallet, WalletConfig, Spendability.
- **Crypto / persistence round-trips**: encryption-key HKDF derivation + file identifiers, AddressBook + UserMetadata serialization / v1→v2 migration / encrypt-decrypt.
- **Dependencies**: MnemonicClient, DerivationTool address classification, ServerConfig endpoint parsing, Near1Click swap-error rescaling, WalletStorage key derivation.
- **TCA reducers**: ZecKeyboard, WalletBalances, Balances, RequestZec (ZIP-321), TransactionsManager (filter / search / grouping), AddressBook, TransactionList, TransactionDetails, AdvancedSettings (auth-gate), TorSetup, and the TransactionsCoordFlow coordinator.

## Bugs surfaced

4 suspected bugs are documented as executable `withKnownIssue` tests (they fail-as-expected today and turn green when fixed): the `.unread` transaction filter no-op, the `ServerConfig.endpoint` 3-component colon drop, the `NetworkError` 4xx/5xx retry inversion, and the `@Clamped` setter clamping the old value. One earlier suspicion (address-book salt slicing) was investigated and resolved as a false alarm. Full audit + prioritized plan in `docs/testing/coverage-uplift-plan.md`.

## Verification

635 tests pass (628 passed + 7 expected-failures, 0 actual failures) on the `zodl-internal` scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
