### PR TITLE
[MOB-1400] Stop unavailable sheet from firing during cold-start loading

### DIFF
--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateInterface.swift
@@ -32,7 +32,19 @@ struct ExchangeRateClient: Sendable {
         case sdk
     }
 
+    enum RateAvailability: Equatable, Sendable {
+        // No event consumed yet (or only the CurrentValueSubject's seed nil). The rate may
+        // still arrive — callers should not surface "unavailable" UX in this state.
+        case loading
+        // Most recent event delivered a rate.
+        case available
+        // Most recent event was `.stale`, i.e. the provider has given up on the current fetch
+        // attempt and there is no rate to show.
+        case unavailable
+    }
+
     var exchangeRateEventStream: @Sendable () -> AnyPublisher<EchangeRateEvent, Never> = { Empty().eraseToAnyPublisher() }
+    var rateAvailability: @Sendable () -> RateAvailability = { .loading }
     var refreshExchangeRateUSD: @Sendable () -> Void = { }
     var selectedCurrency: @Sendable () -> CurrencyISO4217 = { .usd }
 }

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateLiveKey.swift
@@ -253,6 +253,16 @@ extension ExchangeRateClient: DependencyKey {
 
         return ExchangeRateClient(
             exchangeRateEventStream: { exchangeRateProvider.eventStream.eraseToAnyPublisher() },
+            rateAvailability: {
+                switch exchangeRateProvider.eventStream.value {
+                case .value(nil, _):
+                    return .loading
+                case .value, .refreshEnable:
+                    return .available
+                case .stale:
+                    return .unavailable
+                }
+            },
             refreshExchangeRateUSD: {
                 Task { @MainActor in
                     exchangeRateProvider.refreshExchangeRateUSD()

--- a/secant/Sources/Dependencies/ExchangeRate/ExchangeRateTestKey.swift
+++ b/secant/Sources/Dependencies/ExchangeRate/ExchangeRateTestKey.swift
@@ -10,6 +10,7 @@
 extension ExchangeRateClient {
     static let noOp = Self(
         exchangeRateEventStream: { Empty().eraseToAnyPublisher() },
+        rateAvailability: { .loading },
         refreshExchangeRateUSD: { },
         selectedCurrency: { .usd }
     )

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -300,7 +300,12 @@ struct SendForm {
                     state.isCurrencyConversionEnabled = false
                 }
                 state.selectedCurrency = exchangeRate.selectedCurrency()
-                if state.isCurrencyConversionEnabled && state.selectedCurrency != .usd && state.currencyConversion == nil {
+                // Only present the sheet once the provider has surfaced an explicit `.unavailable`
+                // state — otherwise a cold-start fetch in flight is mistaken for failure and the
+                // user gets the Switch-to-USD prompt before there's been a chance to deliver a rate.
+                if state.isCurrencyConversionEnabled
+                    && state.selectedCurrency != .usd
+                    && exchangeRate.rateAvailability() == .unavailable {
                     state.isCurrencyUnavailableSheetPresented = true
                 }
                 return .none

--- a/secant/Sources/Features/ZecKeyboard/ZecKeyboardStore.swift
+++ b/secant/Sources/Features/ZecKeyboard/ZecKeyboardStore.swift
@@ -83,7 +83,12 @@ struct ZecKeyboard {
                 }
                 state.isCurrencyConversionEnabled = userStoredPreferences.exchangeRate()?.automatic ?? false
                 state.selectedCurrency = exchangeRate.selectedCurrency()
-                if state.isCurrencyConversionEnabled && state.selectedCurrency != .usd && state.currencyConversion == nil {
+                // Only present the sheet once the provider has surfaced an explicit `.unavailable`
+                // state — otherwise a cold-start fetch in flight is mistaken for failure and the
+                // user gets the Switch-to-USD prompt before there's been a chance to deliver a rate.
+                if state.isCurrencyConversionEnabled
+                    && state.selectedCurrency != .usd
+                    && exchangeRate.rateAvailability() == .unavailable {
                     state.isCurrencyUnavailableSheetPresented = true
                 }
                 return .send(.validateInputs)


### PR DESCRIPTION
## Summary
Reported UX flaw: cold-starting straight into Send (or Request ZEC) with a non-USD currency selected showed the "currency conversion unavailable" sheet while CMC's first fetch was still in flight. The sheet then offered Switch-to-USD before the rate ever had a chance to arrive, so the user was prompted to abandon their preferred currency for no real reason.

Root cause: both screens were gating on `currencyConversion == nil`, which is true both *during* an in-flight fetch and *after* a known failure. We had no way to tell those apart.

## Fix
Model the rate state explicitly on the `ExchangeRate` client.

- New `RateAvailability { loading, available, unavailable }` (nested in `ExchangeRateClient`).
- `live()` derives it from the event stream's current value:
  - initial / `.value(nil, _)` → `.loading`
  - any non-nil `.value` / `.refreshEnable` → `.available`
  - `.stale` → `.unavailable`
- `noOp` returns `.loading` for tests.

`SendForm.exchangeRateSetupChanged` and `ZecKeyboard.onAppear` now gate the sheet on `rateAvailability() == .unavailable` instead of `currencyConversion == nil`. The loading window stays silent; the sheet only appears once the provider has surrendered.

## Test plan
- [ ] Cold-start with a non-USD currency selected and a working CMC key → navigate straight to Send. No sheet, rate appears within a moment.
- [ ] Same flow into Request ZEC keyboard. No sheet.
- [ ] Break the CMC key, restart, navigate to Send. Sheet appears as before (now correctly tied to `.stale`).
- [ ] Same flow into Request ZEC. Sheet appears.
- [ ] Successful fetch followed by a navigation to Send → no sheet (`.available`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)