### PR TITLE
Fix 4 bugs surfaced by new unit tests

### DIFF
--- a/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift
+++ b/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift
@@ -187,8 +187,8 @@ extension UserPreferencesStorage {
                     host = String(first)
                 } else if split.count == 3, let first = split.first {
                     let second = split[1]
-                    
-                    host = "\(String(first))\(String(second))"
+
+                    host = "\(String(first)):\(String(second))"
                 }
                 
                 return LightWalletEndpoint(

--- a/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift
+++ b/secant/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift
@@ -178,28 +178,26 @@ extension UserPreferencesStorage {
                 input = String(input.dropFirst(http.count))
             }
             
-            let split = input.split(separator: ":")
-            
-            if let portString = split.last, let port = Int(portString) {
-                var host = ""
-                
-                if split.count == 2, let first = split.first {
-                    host = String(first)
-                } else if split.count == 3, let first = split.first {
-                    let second = split[1]
-
-                    host = "\(String(first)):\(String(second))"
-                }
-                
-                return LightWalletEndpoint(
-                    address: host,
-                    port: port,
-                    secure: true,
-                    streamingCallTimeoutInMillis: streamingCallTimeoutInMillis
-                )
+            // Split on the LAST colon: everything after it is the port, everything before
+            // it is the host taken verbatim. This preserves any colons the host legitimately
+            // contains (e.g. IPv6) and never re-introduces a duplicate separator.
+            guard let separatorIndex = input.lastIndex(of: ":") else {
+                return nil
             }
-            
-            return nil
+
+            let host = String(input[..<separatorIndex])
+            let portString = input[input.index(after: separatorIndex)...]
+
+            guard !host.isEmpty, let port = Int(portString) else {
+                return nil
+            }
+
+            return LightWalletEndpoint(
+                address: host,
+                port: port,
+                secure: true,
+                streamingCallTimeoutInMillis: streamingCallTimeoutInMillis
+            )
         }
         
         static func config(for string: String, isCustom: Bool, streamingCallTimeoutInMillis: Int64) -> ServerConfig? {

--- a/secant/Sources/Features/TransactionsManager/TransactionsManagerStore.swift
+++ b/secant/Sources/Features/TransactionsManager/TransactionsManagerStore.swift
@@ -370,7 +370,12 @@ extension TransactionsManager.Filter {
         case .swap:
             return userMetadataProvider.isSwapTransaction(transaction.zAddress ?? "")
         case .unread:
-            return true
+            guard !transaction.isSentTransaction,
+                  !transaction.isShieldingTransaction,
+                  transaction.memoCount > 0 else {
+                return false
+            }
+            return !userMetadataProvider.isRead(transaction.id, transaction.timestamp)
         }
     }
 }

--- a/secant/Sources/Utils/Clamped.swift
+++ b/secant/Sources/Utils/Clamped.swift
@@ -27,6 +27,6 @@ struct Clamped<Value: Comparable> {
     }
     
     private func clamp(_ value: Value, using range: ClosedRange<Value>) -> Value {
-        min(range.upperBound, max(range.lowerBound, wrappedValue))
+        min(range.upperBound, max(range.lowerBound, value))
     }
 }

--- a/secant/Sources/Utils/Network.swift
+++ b/secant/Sources/Utils/Network.swift
@@ -26,7 +26,8 @@ enum NetworkError: Error {
             }
 
         case .httpStatus(let code):
-            return !(501...504).contains(code)
+            // Retry server errors (5xx); client errors (4xx) won't succeed on retry.
+            return (500...599).contains(code)
 
         case .unknown:
             return false

--- a/zodlTests/TransactionsManagerTests/TransactionsManagerLogicTests.swift
+++ b/zodlTests/TransactionsManagerTests/TransactionsManagerLogicTests.swift
@@ -28,14 +28,20 @@ import ComposableArchitecture
         #expect(TransactionsManager.Filter.swap.applyFilter(received, addressBookContacts: .empty, userMetadataProvider: provider(isSwap: true)))
     }
 
-    @Test func unreadFilterIsBuggyAndMatchesEveryTransaction() {
-        // See coverage-uplift-plan.md §6.1: the `.unread` filter returns `true` unconditionally,
-        // so it never excludes a sent transaction (which can never be unread). Intended behaviour
-        // recorded as a known issue.
-        withKnownIssue("Bug coverage-uplift-plan.md §6.1: .unread filter returns true unconditionally") {
-            let sent = tx(isSent: true, memoCount: 0)
-            #expect(!TransactionsManager.Filter.unread.applyFilter(sent, addressBookContacts: .empty, userMetadataProvider: provider()))
-        }
+    @Test func unreadFilterMatchesOnlyUnreadTransactions() {
+        // Sent and shielding transactions are never "unread".
+        #expect(!unread(tx(isSent: true, memoCount: 1), isRead: false))
+        #expect(!unread(tx(isShielding: true, memoCount: 1), isRead: false))
+        // A received transaction without memos is not unread.
+        #expect(!unread(tx(isSent: false, memoCount: 0), isRead: false))
+        // A received transaction with memos that has already been read is not unread.
+        #expect(!unread(tx(isSent: false, memoCount: 1), isRead: true))
+        // A received transaction with memos that has NOT been read is unread.
+        #expect(unread(tx(isSent: false, memoCount: 1), isRead: false))
+    }
+
+    private func unread(_ transaction: TransactionState, isRead: Bool) -> Bool {
+        TransactionsManager.Filter.unread.applyFilter(transaction, addressBookContacts: .empty, userMetadataProvider: provider(isRead: isRead))
     }
 
     // MARK: - isUnread / isSwap

--- a/zodlTests/UtilTests/ClampedTests.swift
+++ b/zodlTests/UtilTests/ClampedTests.swift
@@ -2,7 +2,7 @@
 //  ClampedTests.swift
 //  zodlTests
 //
-//  Batch 1 — pure logic. Covers the @Clamped property wrapper (Utils/Clamped.swift).
+//  Covers the @Clamped property wrapper (Utils/Clamped.swift).
 //
 
 import Testing
@@ -21,7 +21,6 @@ import Testing
         @Clamped(0...10) var value: Int = -5
     }
 
-    // Initialiser clamping works correctly (clamp() reads the freshly-stored value).
     @Test func initialValueWithinRangeIsKept() {
         #expect(InRangeBox().value == 5)
     }
@@ -34,31 +33,21 @@ import Testing
         #expect(BelowRangeBox().value == 0)
     }
 
-    // See docs/testing/coverage-uplift-plan.md §6.6.
-    // The setter's clamp() reads the *current stored* value instead of the incoming one,
-    // so assignments never take effect. These intended-behaviour assertions are recorded
-    // as known issues until the wrapper is fixed.
-    @Test func assigningInRangeValueShouldUpdateIt() {
-        withKnownIssue("Bug coverage-uplift-plan.md §6.6: Clamped setter ignores the new value") {
-            var box = InRangeBox()
-            box.value = 8
-            #expect(box.value == 8)
-        }
+    @Test func assigningInRangeValueUpdatesIt() {
+        var box = InRangeBox()
+        box.value = 8
+        #expect(box.value == 8)
     }
 
-    @Test func assigningAboveRangeShouldClampToUpper() {
-        withKnownIssue("Bug coverage-uplift-plan.md §6.6: Clamped setter ignores the new value") {
-            var box = InRangeBox()
-            box.value = 20
-            #expect(box.value == 10)
-        }
+    @Test func assigningAboveRangeClampsToUpper() {
+        var box = InRangeBox()
+        box.value = 20
+        #expect(box.value == 10)
     }
 
-    @Test func assigningBelowRangeShouldClampToLower() {
-        withKnownIssue("Bug coverage-uplift-plan.md §6.6: Clamped setter ignores the new value") {
-            var box = InRangeBox()
-            box.value = -5
-            #expect(box.value == 0)
-        }
+    @Test func assigningBelowRangeClampsToLower() {
+        var box = InRangeBox()
+        box.value = -5
+        #expect(box.value == 0)
     }
 }

--- a/zodlTests/UtilTests/NetworkErrorTests.swift
+++ b/zodlTests/UtilTests/NetworkErrorTests.swift
@@ -2,7 +2,7 @@
 //  NetworkErrorTests.swift
 //  zodlTests
 //
-//  Batch 1 — pure logic. Covers `NetworkError.allowsRetry` / `.message` (Utils/Network.swift).
+//  Covers NetworkError.allowsRetry / .message (Utils/Network.swift).
 //
 
 import Testing
@@ -40,23 +40,15 @@ import Foundation
         #expect(!NetworkError.transport(URLError(.timedOut)).message.isEmpty)
     }
 
-    // See docs/testing/coverage-uplift-plan.md §6.4.
-    // Intended: client errors (4xx) must NOT be retried. The current implementation
-    // `!(501...504).contains(code)` retries them, so these intended-behaviour assertions
-    // are recorded as known issues until the bug is fixed.
-    @Test func clientErrorsShouldNotRetry() {
-        withKnownIssue("Bug coverage-uplift-plan.md §6.4: 4xx HTTP statuses are incorrectly retryable") {
-            #expect(NetworkError.httpStatus(code: 400).allowsRetry == false)
-            #expect(NetworkError.httpStatus(code: 404).allowsRetry == false)
-        }
+    @Test func clientErrorsDoNotRetry() {
+        #expect(NetworkError.httpStatus(code: 400).allowsRetry == false)
+        #expect(NetworkError.httpStatus(code: 404).allowsRetry == false)
     }
 
-    // Intended: server errors (5xx) should be retried. The current implementation excludes 501...504.
-    @Test func serverErrorsShouldRetry() {
-        withKnownIssue("Bug coverage-uplift-plan.md §6.4: 502/503 server errors are incorrectly non-retryable") {
-            #expect(NetworkError.httpStatus(code: 502).allowsRetry == true)
-            #expect(NetworkError.httpStatus(code: 503).allowsRetry == true)
-        }
+    @Test func serverErrorsRetry() {
+        #expect(NetworkError.httpStatus(code: 500).allowsRetry == true)
+        #expect(NetworkError.httpStatus(code: 502).allowsRetry == true)
+        #expect(NetworkError.httpStatus(code: 503).allowsRetry == true)
     }
 }
 

--- a/zodlTests/UtilTests/ServerConfigEndpointTests.swift
+++ b/zodlTests/UtilTests/ServerConfigEndpointTests.swift
@@ -41,6 +41,23 @@ import Foundation
         #expect(result?.port == 443)
     }
 
+    @Test func fourComponentHostKeepsAllSeparators() {
+        let result = endpoint("a:b:c:443")
+        #expect(result?.host == "a:b:c")
+        #expect(result?.port == 443)
+    }
+
+    @Test func ipv6HostKeepsAllSeparators() {
+        let result = endpoint("2001:db8::1:9067")
+        #expect(result?.host == "2001:db8::1")
+        #expect(result?.port == 9067)
+    }
+
+    @Test func returnsNilWhenHostMissing() {
+        #expect(endpoint(":443") == nil)
+        #expect(endpoint("443") == nil)
+    }
+
     private func endpoint(_ string: String) -> LightWalletEndpoint? {
         UserPreferencesStorage.ServerConfig.endpoint(for: string, streamingCallTimeoutInMillis: 0)
     }

--- a/zodlTests/UtilTests/ServerConfigEndpointTests.swift
+++ b/zodlTests/UtilTests/ServerConfigEndpointTests.swift
@@ -2,7 +2,7 @@
 //  ServerConfigEndpointTests.swift
 //  zodlTests
 //
-//  Batch 4 — dependency logic. Covers UserPreferencesStorage.ServerConfig.endpoint(for:) parsing
+//  Covers UserPreferencesStorage.ServerConfig.endpoint(for:) parsing
 //  (Dependencies/UserPreferencesStorage/UserPreferencesStorage.swift).
 //
 
@@ -35,13 +35,10 @@ import Foundation
         #expect(endpoint("host.example.com") == nil)
     }
 
-    // See docs/testing/coverage-uplift-plan.md §6.3.
-    // Intended: a 3-component "a:b:443" should keep the ':' between the first two segments.
-    // Current impl concatenates them ("ab"), so the intended assertion is a known issue.
     @Test func threeComponentHostKeepsSeparator() {
-        withKnownIssue("Bug coverage-uplift-plan.md §6.3: endpoint(for:) drops the ':' separator for 3-component hosts") {
-            #expect(endpoint("a:b:443")?.host == "a:b")
-        }
+        let result = endpoint("a:b:443")
+        #expect(result?.host == "a:b")
+        #expect(result?.port == 443)
     }
 
     private func endpoint(_ string: String) -> LightWalletEndpoint? {


### PR DESCRIPTION
## Summary

New unit tests added for previously-uncovered utilities surfaced four real bugs. This PR fixes each bug and flips the corresponding tests (previously wrapped in `withKnownIssue`) to assert the corrected behaviour.

- **`TransactionsManager` `.unread` filter** — returned `true` for *every* transaction. Now matches only genuinely-unread transactions (not sent, not shielding, has a memo, and not yet marked read).
- **`ServerConfig.endpoint(for:)`** — multi-colon hosts were mis-parsed: a 3-component `host:host:port` lost its `:` separator, and any host with more colons (e.g. IPv6) produced an *empty* host. Now splits on the **last** colon and takes the host verbatim, so every colon is preserved exactly with no duplicate separator; empty-host inputs return `nil`.
- **`NetworkError.allowsRetry`** — the `501...504` check was inverted/backwards. Now retries 5xx server errors and rejects 4xx client errors.
- **`@Clamped` setter** — clamped the *current* stored value instead of the newly-assigned one, making assignments silent no-ops. Now clamps the incoming value.

## Test Plan

- [x] Full unit-test suite: **635 passed, 0 expected failures** (per commit)
- [x] The four affected tests now assert the corrected behaviour instead of documenting the bug via `withKnownIssue`.
- [x] Hardened `endpoint(for:)` host parsing (last-colon split) with 3 added tests for multi-colon / IPv6 / missing-host cases; `ServerConfigEndpointTests` (8) and the server-selection suites (16) pass via Xcode.

## Impact on the rest of the code

These are long-standing latent bugs, so the table below summarises what each fix actually touches in the shipping app. Short version: none of the four old behaviours is something other code currently relies on.

| Fix | Consumed by (production) | Effect on the rest of the code |
|---|---|---|
| `@Clamped` setter | Nothing — referenced only by `ClampedTests`. | **None.** Zero production usages, so shipping behaviour cannot change. |
| `TransactionsManager` `.unread` filter | Dormant — never added to the active filter set; `FiltersSheet` doesn't render it and its only reader `isUnreadFilterActive` is unused. | **None today.** The visible "unread" dot is driven by the *separate*, already-correct `isUnread(_:)` helpers, which are unchanged. |
| `ServerConfig.endpoint(for:)` | Saving a custom server, and reading the stored custom server on launch (`ServerSetup`, `ZcashSDKEnvironment`). | **Narrow.** Ordinary `host:port` inputs are unchanged, so existing saved servers are unaffected. Behaviour differs only for colon-containing hosts (now preserved verbatim) and host-less inputs like `:443` / `443` (now `nil` instead of a broken empty-host endpoint). |
| `NetworkError.allowsRetry` | Swap flow only — `SwapAndPayStore.refreshSwapAssets` and the `TransactionDetails` asset refresh; the quote call uses it for its error message only. | **Swap retries only.** Now retries all 5xx and no 4xx. The old logic retried 4xx (wasteful — never succeeds) and skipped 502/503/504 (gave up too early), so nothing benefited from it. |
