### PR TITLE
[MOD-1418]: Add multi-server / privacy info footer to Server Setup

### DIFF
--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -12979,6 +12979,23 @@
         }
       }
     },
+    "serverSetup.multiServerInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We may use multiple servers to optimize performance. To reduce metadata exposure, choose Manual connection mode to select your single server of choice, and ensure Tor is enabled in Advanced Settings."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Podemos usar varios servidores para optimizar el rendimiento. Para reducir la exposición de metadatos, selecciona el modo de conexión Manual para elegir un único servidor de tu preferencia y asegúrate de que Tor esté habilitado en Configuración Avanzada."
+          }
+        }
+      }
+    },
     "serverSetup.otherServers" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Features/ServerSetup/ServerSetupView.swift
+++ b/secant/Sources/Features/ServerSetup/ServerSetupView.swift
@@ -304,17 +304,16 @@ struct ServerSetupView: View {
 
     @ViewBuilder
     private func multiServerInfoFooter() -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Asset.Assets.infoCircle.image
-                .zImage(size: 16, style: Design.Text.tertiary)
-                .padding(.top, 2)
+        HStack(alignment: .top, spacing: 0) {
+            Asset.Assets.infoOutline.image
+                .zImage(size: 20, style: Design.Text.tertiary)
+                .padding(.trailing, 12)
 
             Text(localizable: .serverSetupMultiServerInfo)
-                .zFont(size: 12, style: Design.Text.tertiary)
-                .multilineTextAlignment(.leading)
         }
+        .zFont(size: 12, style: Design.Text.tertiary)
         .screenHorizontalPadding()
-        .padding(.bottom, 12)
+        .padding(.bottom, 20)
     }
 
     // MARK: - Save Button

--- a/secant/Sources/Features/ServerSetup/ServerSetupView.swift
+++ b/secant/Sources/Features/ServerSetup/ServerSetupView.swift
@@ -36,6 +36,9 @@ struct ServerSetupView: View {
                 .disabled(store.isUpdatingServer)
                 .padding(.vertical, 1)
 
+                // MARK: - Multi-server / privacy info
+                multiServerInfoFooter()
+
                 // MARK: - Save Button
                 saveButton()
             }
@@ -295,6 +298,23 @@ struct ServerSetupView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Multi-server / privacy info footer
+
+    @ViewBuilder
+    private func multiServerInfoFooter() -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Asset.Assets.infoCircle.image
+                .zImage(size: 16, style: Design.Text.tertiary)
+                .padding(.top, 2)
+
+            Text(localizable: .serverSetupMultiServerInfo)
+                .zFont(size: 12, style: Design.Text.tertiary)
+                .multilineTextAlignment(.leading)
+        }
+        .screenHorizontalPadding()
+        .padding(.bottom, 12)
     }
 
     // MARK: - Save Button


### PR DESCRIPTION
## Summary

Adds an info-circle + tertiary-text footer above the Save button on the
Server screen, telling Automatic-mode users their tx may go to multiple
servers and pointing them at Manual + Tor if they want single-server
submission.

## Changes

- `Localizable.xcstrings`: new `serverSetup.multiServerInfo` (en + es)
- `ServerSetupView.swift`: new `multiServerInfoFooter()` between ScrollView and Save

`es` marked `needs_review`.

## Test plan

- Build `secant-mainnet`
- Settings → Advanced → Choose a Server: footer renders above Save, both modes

<img width="437" height="918" alt="Screenshot 2026-06-19 at 1 59 31 PM" src="https://github.com/user-attachments/assets/21b23791-c579-4c91-af64-5ad2b5f00ded" />
