### PR TITLE
[MOB-1348] Fail closed on multi-recipient ZIP-321 payment requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Changed
+- QR / payment-request (ZIP-321) codes that contain more than one recipient are now rejected instead of silently processing only the first recipient, so what you review is always exactly what gets signed.
+
 ## 3.7.0 build 1
 
 ### Changed

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -235,10 +235,20 @@ extension ScanCoordFlow {
                 return .none
                 
             case .getProposal(let paymentRequest):
+                // SECURITY (MOB-1348 / dossier #37, Android mirror MOB-1341): iOS signs only a single
+                // explicit recipient/amount/memo (payments.first) via `proposeTransfer` — the raw
+                // ZIP-321 URI is never handed to the SDK, so hidden multi-recipient payments cannot be
+                // signed. Fail closed on any non-single-payment request instead of silently collapsing
+                // to payments[0]; honouring multiple payments would first require enumerating and
+                // displaying every recipient in review (otherwise it reintroduces the Android bug).
+                guard paymentRequest.payments.count == 1 else {
+                    return .send(.requestZecFailed)
+                }
+
                 guard let account = state.selectedWalletAccount else {
                     return .none
                 }
-                
+
                 do {
                     if let payment = paymentRequest.payments.first {
                         var textMemo = ""

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -242,6 +242,12 @@ extension ScanCoordFlow {
                 // to payments[0]; honouring multiple payments would first require enumerating and
                 // displaying every recipient in review (otherwise it reintroduces the Android bug).
                 guard paymentRequest.payments.count == 1 else {
+                    // Drop any recipient/amount/memo carried over from a previous scan: the guard fails
+                    // before the parse block below ever writes them, so without this reset the rejection
+                    // bounce-back would re-pre-fill the send form with the prior scan's stale details.
+                    state.recipient = nil
+                    state.amount = Zatoshi(0)
+                    state.memo = nil
                     return .send(.requestZecFailed)
                 }
 

--- a/zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift
+++ b/zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift
@@ -117,11 +117,49 @@ import ZcashPaymentURI
             #expect(recipients.first?.stringEncoded == testnetAddress)
         }
     }
+
+    /// Regression (MOB-1348): a multi-recipient request rejected *after* a prior successful
+    /// single-payment scan must not leave that earlier scan's recipient/amount/memo behind. The guard
+    /// fails closed before parsing, and those fields are only ever written when parsing succeeds, so
+    /// without an explicit reset the rejection's bounce-back re-pre-fills the send form with stale
+    /// payment data the user never re-scanned.
+    @Test func multiPaymentRejectionClearsStalePaymentDetails() async throws {
+        let singlePayment = try makePayment(amount: 0.001)
+        let singleRequest = PaymentRequest(singlePayment: singlePayment)
+        let multiRequest = try PaymentRequest(payments: [singlePayment, singlePayment])
+        let proposeCalls = LockIsolated<[Recipient]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(proposeCalls: proposeCalls)
+
+            // First scan: a valid single-payment QR populates recipient/amount/memo and builds a form.
+            store.send(.getProposal(singleRequest))
+            await waitForScanStore {
+                proposeCalls.withValue { $0.count == 1 } && store.state.path.count == 2
+            }
+            #expect(store.state.recipient != nil)
+
+            // Second scan: a crafted multi-recipient QR is rejected and bounces back to the send form.
+            store.send(.getProposal(multiRequest))
+            await waitForScanStore {
+                store.state.path.count == 1
+            }
+
+            // The rejected scan must leave nothing of the previous payment behind.
+            #expect(store.state.recipient == nil)
+            #expect(store.state.amount == Zatoshi(0))
+            #expect(store.state.memo == nil)
+            // ...and it must never have proposed a transfer for the multi-recipient request.
+            #expect(proposeCalls.withValue { $0.count == 1 })
+        }
+    }
 }
 
 @MainActor
 private func waitForScanStore(
-    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    timeoutNanoseconds: UInt64 = 60_000_000_000,
     sourceLocation: SourceLocation = #_sourceLocation,
     condition: @escaping @MainActor () -> Bool
 ) async {

--- a/zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift
+++ b/zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift
@@ -1,0 +1,133 @@
+//
+//  ScanCoordFlowZip321Tests.swift
+//  zodlTests
+//
+//  MOB-1348 — ZIP-321 multi-recipient guard. Confirms the scan → proposal chokepoint
+//  (ScanCoordFlow.getProposal) signs only a single explicit recipient and fails closed on a
+//  multi-payment ZIP-321 request, so a crafted multi-recipient QR can never hide a signed payment
+//  (the Android dossier-#37 / MOB-1341 bug). The raw URI is never handed to the SDK.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+import ZcashPaymentURI
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// Serialized: drives a TCA coordinator that touches the process-global `selectedWalletAccount`
+// @Shared state. `ScanCoordFlow.State` is not Equatable, so these tests drive a plain `Store` and
+// poll for the expected outcome (same approach as the Swap/Flexa CoordFlow suites). Each test also
+// binds `@Shared` to a fresh in-memory store so parallel suites can't clobber the selected account.
+@Suite(.serialized) @MainActor struct ScanCoordFlowZip321Tests {
+    private let testnetAddress =
+        "utest1vergg5jkp4xy8sqfasw6s5zkdpnxvfxlxh35uuc3me7dp596y2r05t6dv9htwe3pf8ksrfr8ksca2lskzjanqtl8uqp5vln3zyy246ejtx86vqftp73j7jg9099jxafyjhfm6u956j3"
+
+    private var testWalletAccount: WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: 0, count: 16)),
+                name: "Test",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private func makePayment(amount: Double) throws -> Payment {
+        let recipient = try #require(
+            RecipientAddress(value: testnetAddress, context: ParserContext.from(networkType: .testnet))
+        )
+        return try Payment(
+            recipientAddress: recipient,
+            amount: try Amount(value: amount),
+            memo: nil,
+            label: nil,
+            message: nil,
+            otherParams: nil
+        )
+    }
+
+    private func makeStore(proposeCalls: LockIsolated<[Recipient]>) -> StoreOf<ScanCoordFlow> {
+        let initialState = ScanCoordFlow.State()
+        initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+
+        return Store(initialState: initialState) {
+            ScanCoordFlow()
+        } withDependencies: {
+            $0.audioServices = AudioServicesClient(systemSoundVibrate: { })
+            $0.derivationTool = .liveValue
+            $0.mainQueue = .immediate
+            $0.mnemonic = .liveValue
+            $0.numberFormatter = .liveValue
+            $0.walletStorage = .noOp
+            $0.zcashSDKEnvironment = .testnet
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeTransfer = { _, recipient, _, _ in
+                proposeCalls.withValue { $0.append(recipient) }
+                return .testOnlyFakeProposal(totalFee: 10_000)
+            }
+        }
+    }
+
+    /// A crafted two-recipient ZIP-321 request must fail closed: no proposal is built, nothing is
+    /// signed, and the flow bounces back to the (empty) send form.
+    @Test func multiPaymentRequestFailsClosedAndNeverProposes() async throws {
+        let payment = try makePayment(amount: 0.001)
+        let multiRequest = try PaymentRequest(payments: [payment, payment])
+        let proposeCalls = LockIsolated<[Recipient]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(proposeCalls: proposeCalls)
+            store.send(.getProposal(multiRequest))
+
+            await waitForScanStore {
+                if case .sendForm = store.state.path.last { return true }
+                return false
+            }
+
+            #expect(proposeCalls.withValue { $0.isEmpty })
+        }
+    }
+
+    /// A normal single-recipient request is unaffected by the guard: it proposes exactly once for
+    /// that recipient (regression — the guard must not break ordinary payment-request QRs).
+    @Test func singlePaymentRequestProposesFirstPayment() async throws {
+        let payment = try makePayment(amount: 0.001)
+        let singleRequest = PaymentRequest(singlePayment: payment)
+        let proposeCalls = LockIsolated<[Recipient]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(proposeCalls: proposeCalls)
+            store.send(.getProposal(singleRequest))
+
+            await waitForScanStore {
+                proposeCalls.withValue { $0.count == 1 }
+            }
+
+            let recipients = proposeCalls.withValue { $0 }
+            #expect(recipients.count == 1)
+            #expect(recipients.first?.stringEncoded == testnetAddress)
+        }
+    }
+}
+
+@MainActor
+private func waitForScanStore(
+    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for ScanCoordFlow store state", sourceLocation: sourceLocation)
+}


### PR DESCRIPTION
## Linear

[MOB-1348 — [Security] ZIP-321: confirm iOS exposure & enumerate/display all payments in review (multi-recipient QR)](https://linear.app/zodl/issue/MOB-1348) (sub-issue of MOB-1276; Android mirror MOB-1341 / iOS security report 2026-04-16, dossier finding `#37`)

## Background

A crafted ZIP-321 URI can encode extra payments (`address.1`, `amount.1`, …). On **Android** the review collapses to `payments[0]` while the **full URI** is signed → a hidden recipient gets paid (fund theft). The dossier asserts **iOS is not affected**; this ticket's first job was to confirm that at HEAD, then add a guard + regression test so a future refactor can't regress into the Android behaviour.

## Verification — iOS is NOT exposed (confirmed at HEAD)

- The scan → proposal chokepoint `ScanCoordFlow.getProposal` reads **only `paymentRequest.payments.first`** and builds the proposal via `sdkSynchronizer.proposeTransfer(account, recipient, amount, memo)` — the **single-recipient** SDK API. The raw ZIP-321 URI and any `payments[1…]` are never handed to the SDK.
- A repo-wide search finds only `proposeTransfer` (single recipient) and `proposeShielding` — there is **no** `proposeFulfillingPaymentURI` / URI→multi-output path (the API the Android bug relied on).
- The confirmation screen's address/amount are set from the same `state.recipient`/`state.amount` fed to `proposeTransfer`, so what you review is exactly what gets signed.

(The dossier's line refs `:254,278` drifted; the relevant logic is now `ScanCoordFlowCoordinator.swift:237-279`. Severity is **not** escalated.)

The only residual was non-security: a legitimate multi-payment URI was **silently truncated** to its first payment — and that is exactly the spot a future change could "fix" into a multi-output proposal while leaving a single-recipient review in place.

## Fix

- **Fail-closed guard** at `ScanCoordFlow.getProposal`: a request with anything other than exactly one payment routes to the existing `.requestZecFailed` path instead of silently using `payments[0]`. No new UI or localized strings.
- **Clear carried-over payment fields on rejection**: the guard fails *before* the parse block writes `state.recipient`/`amount`/`memo`, and those fields are never reset elsewhere — so it now clears all three before bouncing back. Otherwise a multi-recipient scan that follows a valid single-payment scan re-pre-filled the send form with the *previous* scan's stale recipient/amount. The reset lives only in the guard's `else`; the other `.requestZecFailed` paths (parse `catch`, `proposeTransfer` failure) intentionally restore the freshly-parsed values.
- **Regression tests** (`zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift`, Swift Testing):
  - multi-payment request → never calls `proposeTransfer`, bounces to the send form (fail closed);
  - single-payment request → calls `proposeTransfer` exactly once for that recipient (regression);
  - multi-payment scan *after* a successful single-payment scan → bounce-back leaves `recipient`/`amount`/`memo` cleared (no stale prefill) and never re-proposes.

## Verification

- ✅ Build succeeds (zodl-internal scheme).
- ✅ New tests pass (3/3).

## Manual testing steps

1. **Single-recipient QR (regression).** Generate a normal `zcash:<addr>?amount=0.001` request QR. Send → Scan it. **Expected:** review shows that address + 0.001 ZEC; confirm + biometrics signs and broadcasts exactly that (unchanged from today).
2. **Multi-recipient QR (the attack).** Build a QR for `zcash:?address=<addrA>&amount=0.001&address.1=<addrB>&amount.1=1.0`. Send → Scan it. **Expected:** the request is rejected (bounces back to the send form with nothing pre-filled into a signable proposal); there is **no** confirmation sheet for 0.001 with a hidden 1.0, and nothing is signed.
3. **Multi-recipient QR right after a valid single-recipient one (stale-state regression).** Scan a normal single-recipient QR (step 1), back out to the send form, then scan the multi-recipient QR (step 2). **Expected:** the rejection leaves the send form clean — the first scan's address/amount do **not** reappear.
4. **Address-only QR (regression).** `zcash:<addr>` (no amount) → Scan. **Expected:** address pre-fills into the send form as before; user enters the amount manually.

Design: `docs/superpowers/specs/2026-06-22-mob-1348-zip321-multi-recipient-guard-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
