### PR TITLE
[MOB-1351] Fix swap fee display mismatch (0.5% → 0.67%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - Sending, swapping, shielding, and Flexa payments now broadcast your transaction to multiple servers at once when you're in Automatic server mode (Manual mode still uses the server you selected), so a single slow or unreachable server is less likely to make a submission fail. If a server times out before confirming, you now see a clear message that your transaction may still have been broadcast, rather than an outright failure.
 
 ### Fixed
+- The swap / CrossPay confirmation now shows the correct total service fee (0.67%) instead of an understated 0.5%, matching what is actually charged.
 - A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
 - Opening the Recovery Phrase from Advanced Settings now always requires Face ID / Touch ID, and the seed words are only loaded and rendered after a successful authentication.
 - The tax CSV export is now written to a protected location and deleted as soon as the share sheet closes, instead of remaining in temporary storage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Removed
 - A hidden legacy debug menu (reachable via a gesture on the splash screen) that could copy the seed phrase to the clipboard without Face ID / Touch ID.
 
+### Security
+- Cross-chain swap quotes are now verified against your request before the transaction is signed: the ZEC amount, payout and refund addresses, assets, and slippage tolerance must match what you requested, and the swap is refused on any mismatch. This protects against a malicious or tampered swap-provider response redirecting your funds.
+
 ## 3.5.2 build 1 (20026-06-08)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - Sending, swapping, shielding, and Flexa payments now broadcast your transaction to multiple servers at once when you're in Automatic server mode (Manual mode still uses the server you selected), so a single slow or unreachable server is less likely to make a submission fail. If a server times out before confirming, you now see a clear message that your transaction may still have been broadcast, rather than an outright failure.
 
 ### Fixed
-- The swap / CrossPay confirmation now shows the correct total service fee (0.67%) instead of an understated 0.5%, matching what is actually charged.
+- The swap / CrossPay confirmation and the completed swap transaction details now show the correct total service fee (0.67%) instead of an understated 0.5%, matching what is actually charged.
 - A sent transaction that broadcast on an older app version and never mined now correctly shows as "Failed" in the Activity list once its expiry passes the network chain tip. Previously it could stay stuck on "Sending" indefinitely after updating the app.
 - Opening the Recovery Phrase from Advanced Settings now always requires Face ID / Touch ID, and the seed words are only loaded and rendered after a successful authentication.
 - The tax CSV export is now written to a protected location and deleted as soon as the share sheet closes, instead of remaining in temporary storage.

--- a/docs/superpowers/specs/2026-06-22-mob-1351-swap-fee-display-design.md
+++ b/docs/superpowers/specs/2026-06-22-mob-1351-swap-fee-display-design.md
@@ -1,0 +1,58 @@
+# MOB-1351 — Swap fee display mismatch (UI shows 0.5%, backend charges 0.67%)
+
+- **Linear:** [MOB-1351](https://linear.app/zodl/issue/MOB-1351) (sub-issue of MOB-1276; dossier iOS-Z9)
+- **Priority:** High
+- **Branch:** `michal/MOB-1276/MOB-1351-swap-fee-display-mismatch`
+- **Base / PR target:** `michal/MOB-1276/MOB-1388-swap-security-hardening` (stacked on the open MOB-1388 PR #1834 per the agreed swap-ticket strategy; retarget to `main` after #1834 merges)
+- **Date:** 2026-06-22
+
+## 1. Root cause (confirmed at HEAD of the MOB-1388 branch)
+
+The Zashi affiliate fee is computed **two different ways** in `SwapAndPayStore.swift`:
+
+| Property | Coefficient | Result | Drives |
+|---|---|---|---|
+| `zashiFeeStr` (1412), `zashiFeeUsdStr` (1428) | `Decimal(zashiFeeBps) / 10_000` = **0.67%** ✓ | correct | the standalone "Zashi fee" line |
+| `totalFees` (1514), `swapToZecTotalFees` (1746) | hardcoded `* 0.005` = **0.5%** ✗ | wrong | `totalFeesStr` / `totalUSDFees` / `totalFeesUsdStr` / swap-to-ZEC total — **the totals shown on the CrossPay/Swap confirmation** (`CrossPayConfirmationView.swift:144`, `SwapComponents.swift:408`) |
+
+The backend actually charges `zashiFeeBps = 67` (sent at `Near1Click.swift:357`). So the **total** the user reviews understates the fee (0.5% vs 0.67%), and it's even internally inconsistent with the app's own standalone fee line. `SwapAndPayInterface.swift:25` (`zashiFeeBps = 67`) is the real source of truth; there is no localized "0.5%" string — the mismatch is purely these two `0.005` literals.
+
+## 2. Fix — single source of truth
+
+Add a derived coefficient next to the bps constant in `SwapAndPayClient.Constants`:
+
+```swift
+/// Affiliate fee in basis points
+static let zashiFeeBps = 67
+/// Affiliate fee as a decimal coefficient (e.g. 67 bps -> 0.0067). Single source of truth for fee math/display.
+static let zashiFeeCoefficient = Decimal(zashiFeeBps) / Decimal(10_000)
+```
+
+Then route all four fee-coefficient sites through it:
+- `zashiFeeStr` (1412), `zashiFeeUsdStr` (1428): `Decimal(zashiFeeBps)/Decimal(10_000)` → `SwapAndPayClient.Constants.zashiFeeCoefficient` (behaviour-preserving DRY).
+- `totalFees` (1514): `quote.amountIn * 0.005` → `quote.amountIn * SwapAndPayClient.Constants.zashiFeeCoefficient` (**fix**: 0.5% → 0.67%).
+- `swapToZecTotalFees` (1746): same (**fix**).
+
+After this, the displayed total and standalone fee line both equal exactly what is charged (`zashiFeeBps`); changing the bps in one place updates everything.
+
+## 3. Tests (`zodlTests/SwapTests/SwapFeeDisplayTests.swift`, Swift Testing)
+
+- **`totalFees` uses 0.67%, not 0.5%:** build `SwapAndPay.State()` with `quote.amountIn = 100_000_000` (1 ZEC) and `proposal = .testOnlyFakeProposal(totalFee: 10_000)`; assert `state.totalFees == 10_000 + 670_000` (the 0.67% affiliate fee), and explicitly `!= 10_000 + 500_000` (the old 0.5% bug).
+- **Source-of-truth lock:** `#expect(SwapAndPayClient.Constants.zashiFeeCoefficient == Decimal(67) / Decimal(10_000))` so a future `zashiFeeBps` change flows through and the `0.005` literal can't creep back.
+
+## 4. Acceptance criteria mapping
+
+- ✅ Displayed fee matches the fee actually charged (`zashiFeeBps`), driven from one source of truth (§2).
+- ✅ Audited `SwapAndPayInterface.swift`, `CrossPayConfirmationView.swift`, and the confirmation/summary surfaces — the only hardcoded fee literals were the two `0.005`; no hardcoded "0.5%" strings exist (§1).
+
+## 5. Changelog
+
+Under `[Unreleased]` → "Fixed":
+> The swap / CrossPay confirmation now shows the correct total service fee (0.67%) instead of an
+> understated 0.5%, matching what is actually charged.
+
+## 6. Manual test plan (for the PR)
+
+1. **CrossPay / Swap total fee.** Start a swap (or CrossPay) and reach the confirmation screen. Note the **total fees** value. **Expected:** it includes the Zashi affiliate fee at **0.67%** of the input amount (≈ `amountIn × 0.0067`), consistent with the standalone "Zashi fee" line. Before the fix the total used 0.5% (a smaller number than the standalone fee line implied).
+2. **Swap-to-ZEC total fee.** In the swap-to-ZEC summary, confirm the fee shown reflects 0.67%.
+3. **Cross-check.** The standalone fee line and the total's affiliate-fee portion now agree (both 0.67%).

--- a/docs/superpowers/specs/2026-06-22-mob-1351-swap-fee-display-design.md
+++ b/docs/superpowers/specs/2026-06-22-mob-1351-swap-fee-display-design.md
@@ -15,7 +15,9 @@ The Zashi affiliate fee is computed **two different ways** in `SwapAndPayStore.s
 | `zashiFeeStr` (1412), `zashiFeeUsdStr` (1428) | `Decimal(zashiFeeBps) / 10_000` = **0.67%** ✓ | correct | the standalone "Zashi fee" line |
 | `totalFees` (1514), `swapToZecTotalFees` (1746) | hardcoded `* 0.005` = **0.5%** ✗ | wrong | `totalFeesStr` / `totalUSDFees` / `totalFeesUsdStr` / swap-to-ZEC total — **the totals shown on the CrossPay/Swap confirmation** (`CrossPayConfirmationView.swift:144`, `SwapComponents.swift:408`) |
 
-The backend actually charges `zashiFeeBps = 67` (sent at `Near1Click.swift:357`). So the **total** the user reviews understates the fee (0.5% vs 0.67%), and it's even internally inconsistent with the app's own standalone fee line. `SwapAndPayInterface.swift:25` (`zashiFeeBps = 67`) is the real source of truth; there is no localized "0.5%" string — the mismatch is purely these two `0.005` literals.
+The backend actually charges `zashiFeeBps = 67` (sent at `Near1Click.swift:357`). So the **total** the user reviews understates the fee (0.5% vs 0.67%), and it's even internally inconsistent with the app's own standalone fee line. `SwapAndPayInterface.swift:25` (`zashiFeeBps = 67`) is the real source of truth; there is no localized "0.5%" string — the mismatch is in the hardcoded `0.005` literals.
+
+A **third** `0.005` literal lives outside `SwapAndPayStore.swift`, in `TransactionDetailsStore.swift:707` (`totalSwapToZecFee`), which drives the **Total fees** row on the completed swap-to-ZEC transaction-detail screen (`TransactionDetailsView.swift:580`). It is the same affiliate fee, so it must be fixed too — otherwise the post-swap detail keeps showing 0.5% while the confirmation shows 0.67%, re-creating the mismatch on a different screen.
 
 ## 2. Fix — single source of truth
 
@@ -28,10 +30,11 @@ static let zashiFeeBps = 67
 static let zashiFeeCoefficient = Decimal(zashiFeeBps) / Decimal(10_000)
 ```
 
-Then route all four fee-coefficient sites through it:
+Then route every fee-coefficient site through it — four in `SwapAndPayStore.swift` plus one in `TransactionDetailsStore.swift`:
 - `zashiFeeStr` (1412), `zashiFeeUsdStr` (1428): `Decimal(zashiFeeBps)/Decimal(10_000)` → `SwapAndPayClient.Constants.zashiFeeCoefficient` (behaviour-preserving DRY).
 - `totalFees` (1514): `quote.amountIn * 0.005` → `quote.amountIn * SwapAndPayClient.Constants.zashiFeeCoefficient` (**fix**: 0.5% → 0.67%).
 - `swapToZecTotalFees` (1746): same (**fix**).
+- `totalSwapToZecFee` (`TransactionDetailsStore.swift:707`): `amountIn * 0.005` → `amountIn * SwapAndPayClient.Constants.zashiFeeCoefficient` (**fix**: the post-swap transaction-detail "Total fees" row, in a different feature from the four above).
 
 After this, the displayed total and standalone fee line both equal exactly what is charged (`zashiFeeBps`); changing the bps in one place updates everything.
 
@@ -39,20 +42,22 @@ After this, the displayed total and standalone fee line both equal exactly what 
 
 - **`totalFees` uses 0.67%, not 0.5%:** build `SwapAndPay.State()` with `quote.amountIn = 100_000_000` (1 ZEC) and `proposal = .testOnlyFakeProposal(totalFee: 10_000)`; assert `state.totalFees == 10_000 + 670_000` (the 0.67% affiliate fee), and explicitly `!= 10_000 + 500_000` (the old 0.5% bug).
 - **Source-of-truth lock:** `#expect(SwapAndPayClient.Constants.zashiFeeCoefficient == Decimal(67) / Decimal(10_000))` so a future `zashiFeeBps` change flows through and the `0.005` literal can't creep back.
+- **Transaction-detail total uses 0.67%, not 0.5%:** build `TransactionDetails.State(transaction:)` with `swapDetails.amountInFormatted = 10_000` and assert `totalSwapToZecFee` equals the 0.67% value and not the old 0.5%, comparing against the store's own `conversionFormatter` so the assertion is locale-independent.
 
 ## 4. Acceptance criteria mapping
 
 - ✅ Displayed fee matches the fee actually charged (`zashiFeeBps`), driven from one source of truth (§2).
-- ✅ Audited `SwapAndPayInterface.swift`, `CrossPayConfirmationView.swift`, and the confirmation/summary surfaces — the only hardcoded fee literals were the two `0.005`; no hardcoded "0.5%" strings exist (§1).
+- ✅ Audited `SwapAndPayInterface.swift`, `CrossPayConfirmationView.swift`, the confirmation/summary surfaces, and the transaction-detail screen — the hardcoded fee literals were the two `0.005` in `SwapAndPayStore.swift` and a third in `TransactionDetailsStore.swift:707`, all now routed through `zashiFeeCoefficient`; no hardcoded "0.5%" strings exist (§1). The remaining `0.005` in `Decimals.swift:17` is an unrelated rounding tolerance.
 
 ## 5. Changelog
 
 Under `[Unreleased]` → "Fixed":
-> The swap / CrossPay confirmation now shows the correct total service fee (0.67%) instead of an
-> understated 0.5%, matching what is actually charged.
+> The swap / CrossPay confirmation and the completed swap transaction details now show the correct
+> total service fee (0.67%) instead of an understated 0.5%, matching what is actually charged.
 
 ## 6. Manual test plan (for the PR)
 
 1. **CrossPay / Swap total fee.** Start a swap (or CrossPay) and reach the confirmation screen. Note the **total fees** value. **Expected:** it includes the Zashi affiliate fee at **0.67%** of the input amount (≈ `amountIn × 0.0067`), consistent with the standalone "Zashi fee" line. Before the fix the total used 0.5% (a smaller number than the standalone fee line implied).
 2. **Swap-to-ZEC total fee.** In the swap-to-ZEC summary, confirm the fee shown reflects 0.67%.
-3. **Cross-check.** The standalone fee line and the total's affiliate-fee portion now agree (both 0.67%).
+3. **Post-swap transaction detail.** Open a completed swap-to-ZEC from Activity and view its detail. **Expected:** the **Total fees** row shows 0.67% of the input amount, matching the confirmation screen. Before the fix this screen still showed 0.5%.
+4. **Cross-check.** The standalone fee line and the total's affiliate-fee portion now agree (both 0.67%).

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		341C34202FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
 		341C34212FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
 		341C34232FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */; };
+		341C342A2FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34292FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift */; };
+		341C342F2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1621,6 +1623,8 @@
 		341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidationTests.swift; sourceTree = "<group>"; };
 		341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNumericConversions.swift; sourceTree = "<group>"; };
 		341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNumericConversionsTests.swift; sourceTree = "<group>"; };
+		341C34292FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteIntentTests.swift; sourceTree = "<group>"; };
+		341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Near1ClickQuoteMapperTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2401,6 +2405,8 @@
 			children = (
 				341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */,
 				341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */,
+				341C34292FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift */,
+				341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */,
 			);
 			path = SwapTests;
 			sourceTree = "<group>";
@@ -5135,6 +5141,7 @@
 				34D06C912FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift in Sources */,
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
 				349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */,
+				341C342A2FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
 				AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */,
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,
@@ -5165,6 +5172,7 @@
 				63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */,
 				2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */,
 				BFE03A2F84B2F8B97831CD9F /* ZatoshiTests.swift in Sources */,
+				341C342F2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,
 				A409BF1DAB30483E4CDB0DCB /* ZatoshiStringRepresentationTests.swift in Sources */,
 				341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		34755C662F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C692F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C6A2F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
+		3487E5582FE94F7F00502768 /* SwapFeeDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3487E5572FE94F7F00502768 /* SwapFeeDisplayTests.swift */; };
 		348EC4CC2FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348EC4C72FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift */; };
 		348EC4CD2FD7FD96008495FB /* ServerEndpointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348EC4C92FD7FD96008495FB /* ServerEndpointsTests.swift */; };
 		348EC4CE2FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */; };
@@ -58,6 +59,9 @@
 		349CE5D62FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5D52FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift */; };
 		349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5E92FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift */; };
 		349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */; };
+		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
+		349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */; };
+		349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */; };
 		349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */; };
 		34AA6DD82F85774F00D244E2 /* SwapAndPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CF82F85774F00D244E2 /* SwapAndPayStore.swift */; };
 		34AA6DD92F85774F00D244E2 /* RemoteStorageInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C102F85774F00D244E2 /* RemoteStorageInterface.swift */; };
@@ -1442,9 +1446,6 @@
 		37D0F0000000000000000024 /* RoundAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0F0000000000000000002 /* RoundAuthenticator.swift */; };
 		38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E83225E24EEF486F002B79 /* RecoveryPhraseBackupTests.swift */; };
-		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
-		349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */; };
-		349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */; };
 		63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D430BF2CF73CFB82A13F1CB /* SecItemClientTests.swift */; };
 		7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */; };
 		8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1983F0BB6D025B08BBD186B /* QRCodeGeneratorTests.swift */; };
@@ -1627,6 +1628,7 @@
 		341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Near1ClickQuoteMapperTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
+		3487E5572FE94F7F00502768 /* SwapFeeDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapFeeDisplayTests.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
 		348EC4C72FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionStorageTests.swift; sourceTree = "<group>"; };
 		348EC4C82FD7FD96008495FB /* AutoServerSelectionClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoServerSelectionClientTests.swift; sourceTree = "<group>"; };
@@ -1643,10 +1645,10 @@
 		349CE5D52FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiServerSubmissionTests.swift; sourceTree = "<group>"; };
 		349CE5E92FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiServerSubmitRoutingTests.swift; sourceTree = "<group>"; };
 		349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseDisplayTests.swift; sourceTree = "<group>"; };
-		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
 		349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTransactionHistoryTests.swift; sourceTree = "<group>"; };
 		349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportLogsTests.swift; sourceTree = "<group>"; };
 		349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorSetupTests.swift; sourceTree = "<group>"; };
+		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
 		34AA6BA42F85774F00D244E2 /* ABv1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABv1.swift; sourceTree = "<group>"; };
 		34AA6BA62F85774F00D244E2 /* AddressBookContacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookContacts.swift; sourceTree = "<group>"; };
 		34AA6BA72F85774F00D244E2 /* AddressBookEncryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEncryption.swift; sourceTree = "<group>"; };
@@ -2407,6 +2409,7 @@
 				341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */,
 				341C34292FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift */,
 				341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */,
+				3487E5572FE94F7F00502768 /* SwapFeeDisplayTests.swift */,
 			);
 			path = SwapTests;
 			sourceTree = "<group>";
@@ -2457,14 +2460,6 @@
 			path = SendTests;
 			sourceTree = "<group>";
 		};
-		349CE6582FDC358500E2B9CF /* SettingsTests */ = {
-			isa = PBXGroup;
-			children = (
-				349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */,
-			);
-			path = SettingsTests;
-			sourceTree = "<group>";
-		};
 		349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2487,6 +2482,14 @@
 				349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */,
 			);
 			path = TorSetupTests;
+			sourceTree = "<group>";
+		};
+		349CE6582FDC358500E2B9CF /* SettingsTests */ = {
+			isa = PBXGroup;
+			children = (
+				349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */,
+			);
+			path = SettingsTests;
 			sourceTree = "<group>";
 		};
 		34AA6BA52F85774F00D244E2 /* Migration */ = {
@@ -5161,6 +5164,7 @@
 				8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */,
 				BD09B2C5A52C10AD52B24E58 /* ReviewRequestTests.swift in Sources */,
 				161B27ACDB3C31A163EC8AFF /* SensitiveDataTests.swift in Sources */,
+				3487E5582FE94F7F00502768 /* SwapFeeDisplayTests.swift in Sources */,
 				985D6A4AAAD20B2071C9997D /* DatabaseFilesTests.swift in Sources */,
 				348EC4CC2FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift in Sources */,
 				348EC4CD2FD7FD96008495FB /* ServerEndpointsTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE450F4E98D0B7054611598 /* PrivateDataConsentTests.swift */; };
 		161B27ACDB3C31A163EC8AFF /* SensitiveDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53B4B2244B2E608A11AC552 /* SensitiveDataTests.swift */; };
 		2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD04B216486D7A0AAB329F2 /* UserPreferencesStorageTests.swift */; };
+		341C34012FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
+		341C34022FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
+		341C34032FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
+		341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1609,6 +1613,8 @@
 		0DFE93DE272C6D4B000FCCA5 /* RecoveryPhraseBackupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseBackupTests.swift; sourceTree = "<group>"; };
 		0F94E337360CE50FACFB04CE /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
 		315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CurrencyConversionTests.swift; sourceTree = "<group>"; };
+		341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidation.swift; sourceTree = "<group>"; };
+		341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidationTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2347,6 +2353,7 @@
 				349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */,
 				349CE6182FDC1B1500E2B9CF /* ExportLogsTests */,
 				349CE6262FDC1CEA00E2B9CF /* TorSetupTests */,
+				341C34042FDFE1DE000DD8DA /* SwapTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2381,6 +2388,14 @@
 			children = (
 			);
 			path = BalanceBreakdownTests;
+			sourceTree = "<group>";
+		};
+		341C34042FDFE1DE000DD8DA /* SwapTests */ = {
+			isa = PBXGroup;
+			children = (
+				341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */,
+			);
+			path = SwapTests;
 			sourceTree = "<group>";
 		};
 		343CF3F429BB5A14009E44DF /* Frameworks */ = {
@@ -2784,6 +2799,7 @@
 				34AA6C272F85774F00D244E2 /* SwapQuote.swift */,
 				34AA6C282F85774F00D244E2 /* SwapQuoteRequest.swift */,
 				34AA6C292F85774F00D244E2 /* SwapSubmitHash.swift */,
+				341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -5142,6 +5158,7 @@
 				BFE03A2F84B2F8B97831CD9F /* ZatoshiTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,
 				A409BF1DAB30483E4CDB0DCB /* ZatoshiStringRepresentationTests.swift in Sources */,
+				341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5186,6 +5203,7 @@
 				34AA74AF2F85774F00D244E2 /* SwapForm.swift in Sources */,
 				34AA74B02F85774F00D244E2 /* CrossPayForm.swift in Sources */,
 				34AA74B12F85774F00D244E2 /* DerivationToolInterface.swift in Sources */,
+				341C34012FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */,
 				34AA74B22F85774F00D244E2 /* TransactionState.swift in Sources */,
 				34AA74B32F85774F00D244E2 /* SwapAndPayForm.swift in Sources */,
 				34AA74B42F85774F00D244E2 /* ExportLogs.swift in Sources */,
@@ -5656,6 +5674,7 @@
 				34AA714B2F85774F00D244E2 /* SwapForm.swift in Sources */,
 				34AA714C2F85774F00D244E2 /* CrossPayForm.swift in Sources */,
 				34AA714D2F85774F00D244E2 /* DerivationToolInterface.swift in Sources */,
+				341C34022FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */,
 				34AA714E2F85774F00D244E2 /* TransactionState.swift in Sources */,
 				34AA714F2F85774F00D244E2 /* SwapAndPayForm.swift in Sources */,
 				34AA71502F85774F00D244E2 /* ExportLogs.swift in Sources */,
@@ -6126,6 +6145,7 @@
 				34AA6DE72F85774F00D244E2 /* SwapForm.swift in Sources */,
 				34AA6DE82F85774F00D244E2 /* CrossPayForm.swift in Sources */,
 				34AA6DE92F85774F00D244E2 /* DerivationToolInterface.swift in Sources */,
+				341C34032FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */,
 				34AA6DEA2F85774F00D244E2 /* TransactionState.swift in Sources */,
 				34AA6DEB2F85774F00D244E2 /* SwapAndPayForm.swift in Sources */,
 				34AA6DEC2F85774F00D244E2 /* ExportLogs.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		341C34022FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
 		341C34032FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
 		341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */; };
+		341C341F2FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
+		341C34202FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
+		341C34212FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
+		341C34232FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1615,6 +1619,8 @@
 		315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CurrencyConversionTests.swift; sourceTree = "<group>"; };
 		341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidation.swift; sourceTree = "<group>"; };
 		341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidationTests.swift; sourceTree = "<group>"; };
+		341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNumericConversions.swift; sourceTree = "<group>"; };
+		341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNumericConversionsTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2394,6 +2400,7 @@
 			isa = PBXGroup;
 			children = (
 				341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */,
+				341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */,
 			);
 			path = SwapTests;
 			sourceTree = "<group>";
@@ -3908,6 +3915,7 @@
 				34AA6DCF2F85774F00D244E2 /* WalletLogger.swift */,
 				34AA6DD02F85774F00D244E2 /* ZcashError+DetailedMessage.swift */,
 				34AA6DBC2F85774F00D244E2 /* Logging */,
+				341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5132,6 +5140,7 @@
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,
 				AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */,
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
+				341C34232FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift in Sources */,
 				54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */,
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
 				349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */,
@@ -5507,6 +5516,7 @@
 				348EC4F22FD7FE54008495FB /* TransactionGuardLiveKey.swift in Sources */,
 				34AA75C22F85774F00D244E2 /* TransactionDetailsView.swift in Sources */,
 				34AA75C32F85774F00D244E2 /* Swaps.swift in Sources */,
+				341C341F2FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */,
 				34AA75C42F85774F00D244E2 /* UserMetadataProviderLiveKey.swift in Sources */,
 				34AA75C52F85774F00D244E2 /* LocalAuthenticationLiveKey.swift in Sources */,
 				34AA75C62F85774F00D244E2 /* SendFormView.swift in Sources */,
@@ -5978,6 +5988,7 @@
 				348EC4FA2FD7FE54008495FB /* TransactionGuardLiveKey.swift in Sources */,
 				34AA725E2F85774F00D244E2 /* TransactionDetailsView.swift in Sources */,
 				34AA725F2F85774F00D244E2 /* Swaps.swift in Sources */,
+				341C34212FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */,
 				34AA72602F85774F00D244E2 /* UserMetadataProviderLiveKey.swift in Sources */,
 				34AA72612F85774F00D244E2 /* LocalAuthenticationLiveKey.swift in Sources */,
 				34AA72622F85774F00D244E2 /* SendFormView.swift in Sources */,
@@ -6449,6 +6460,7 @@
 				348EC4F62FD7FE54008495FB /* TransactionGuardLiveKey.swift in Sources */,
 				34AA6EFA2F85774F00D244E2 /* TransactionDetailsView.swift in Sources */,
 				34AA6EFB2F85774F00D244E2 /* Swaps.swift in Sources */,
+				341C34202FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */,
 				34AA6EFC2F85774F00D244E2 /* UserMetadataProviderLiveKey.swift in Sources */,
 				34AA6EFD2F85774F00D244E2 /* LocalAuthenticationLiveKey.swift in Sources */,
 				34AA6EFE2F85774F00D244E2 /* SendFormView.swift in Sources */,

--- a/secant/Sources/Dependencies/SwapAndPay/SwapAndPayInterface.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/SwapAndPayInterface.swift
@@ -6,6 +6,7 @@
 //
 
 import ComposableArchitecture
+import Foundation
 
 extension DependencyValues {
     var swapAndPay: SwapAndPayClient {
@@ -23,6 +24,9 @@ struct SwapAndPayClient {
     enum Constants {
         /// Affiliate fee in basis points
         static let zashiFeeBps = 67
+        /// Affiliate fee as a decimal coefficient (e.g. 67 bps -> 0.0067). Single source of truth for
+        /// fee math/display so the amount shown always matches what `zashiFeeBps` actually charges.
+        static let zashiFeeCoefficient = Decimal(zashiFeeBps) / Decimal(10_000)
     }
     
     var submitDepositTxId: @Sendable (String, String) async throws -> Void

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuote.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuote.swift
@@ -23,7 +23,13 @@ struct SwapQuote: Codable, Equatable, Hashable {
     let amountOutUsd: String
     /// Number of seconds it takes to process this quote
     let timeEstimate: TimeInterval
-    
+    /// Echoed off-chain payout recipient (the address the user typed); validated == request at parse time.
+    let recipient: String
+    /// Echoed origin assetId; validated == request at parse time.
+    let originAssetId: String
+    /// Echoed destination assetId; validated == request at parse time.
+    let destinationAssetId: String
+
     init(
         depositAddress: String,
         amountIn: Decimal,
@@ -31,7 +37,10 @@ struct SwapQuote: Codable, Equatable, Hashable {
         minAmountIn: Decimal,
         amountOut: Decimal,
         amountOutUsd: String,
-        timeEstimate: TimeInterval
+        timeEstimate: TimeInterval,
+        recipient: String,
+        originAssetId: String,
+        destinationAssetId: String
     ) {
         self.depositAddress = depositAddress
         self.amountIn = amountIn
@@ -40,5 +49,18 @@ struct SwapQuote: Codable, Equatable, Hashable {
         self.amountOut = amountOut
         self.amountOutUsd = amountOutUsd
         self.timeEstimate = timeEstimate
+        self.recipient = recipient
+        self.originAssetId = originAssetId
+        self.destinationAssetId = destinationAssetId
+    }
+}
+
+extension SwapQuote {
+    /// Re-binds the quote to current user intent immediately before signing (TOCTOU guard): the echoed
+    /// payout recipient and both asset ids must still match what the user is looking at.
+    func matchesSigningIntent(address: String, originAssetId: String, destinationAssetId: String) -> Bool {
+        recipient == address
+            && self.originAssetId == originAssetId
+            && self.destinationAssetId == destinationAssetId
     }
 }

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -19,7 +19,64 @@ enum SwapQuoteValidationError: Error, Equatable {
     case refundMismatch
 }
 
+/// The subset of the swap-quote response the validator inspects: the echoed `quoteRequest` fields plus
+/// the `quote` amounts, all already parsed into typed values.
+struct SwapQuoteResponseFields: Equatable {
+    let depositAddress: String
+    let echoedOriginAsset: String
+    let echoedDestinationAsset: String
+    let echoedSwapType: String
+    let echoedSlippageTolerance: Int
+    let echoedRecipient: String
+    let echoedRefundTo: String
+    let amountIn: Decimal
+    let amountInFormatted: Decimal
+    let minAmountIn: Decimal
+    let amountOut: Decimal
+    let amountOutFormatted: Decimal
+    let minAmountOut: Decimal
+}
+
 enum SwapQuoteValidator {
+    /// Validates a freshly-received quote against the request we sent. Throws the first failure; the caller
+    /// fails closed (maps to the "quote unavailable" path) on any throw.
+    static func validate(
+        request: SwapQuoteRequest,
+        response: SwapQuoteResponseFields,
+        originDecimals: Int,
+        destinationDecimals: Int
+    ) throws {
+        try requireMatchingAssetId(field: "originAsset", expected: request.originAsset, actual: response.echoedOriginAsset)
+        try requireMatchingAssetId(field: "destinationAsset", expected: request.destinationAsset, actual: response.echoedDestinationAsset)
+
+        if request.swapType != response.echoedSwapType {
+            throw SwapQuoteValidationError.swapTypeMismatch
+        }
+        if request.slippageTolerance != response.echoedSlippageTolerance {
+            throw SwapQuoteValidationError.slippageToleranceMismatch
+        }
+        if request.recipient != response.echoedRecipient {
+            throw SwapQuoteValidationError.recipientMismatch
+        }
+        if request.refundTo != response.echoedRefundTo {
+            throw SwapQuoteValidationError.refundMismatch
+        }
+        // amountInFormatted must be strictly positive (also fail closed on NaN — defends zecExchangeRate-style
+        // divisions downstream). It comes from Decimal(string:) which never yields NaN, but guard anyway.
+        guard !response.amountInFormatted.isNaN,
+              NSDecimalNumber(decimal: response.amountInFormatted).compare(NSDecimalNumber.zero) == ComparisonResult.orderedDescending else {
+            throw SwapQuoteValidationError.nonPositiveAmount(field: "amountInFormatted")
+        }
+
+        try requireConsistent(name: "amountIn", raw: response.amountIn, formatted: response.amountInFormatted, decimals: originDecimals)
+        try requireConsistent(name: "amountOut", raw: response.amountOut, formatted: response.amountOutFormatted, decimals: destinationDecimals)
+        try requireWithinSlippage(
+            swapType: request.swapType, amountIn: response.amountIn, amountOut: response.amountOut,
+            minAmountIn: response.minAmountIn, minAmountOut: response.minAmountOut, slippageToleranceBps: request.slippageTolerance
+        )
+        try requireMatchesRequestedAmount(swapType: request.swapType, requestedAmount: request.amount, rawAmountIn: response.amountIn, rawAmountOut: response.amountOut)
+    }
+
     /// The signed raw base-unit amount must equal the exact decimal expansion of the displayed
     /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
     /// must not be relaxed to a tolerance.

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -1,0 +1,32 @@
+//
+//  SwapQuoteValidation.swift
+//  Zashi
+//
+
+import Foundation
+
+/// Typed failures from validating a swap quote against the request we sent and the user's intent.
+/// Each is fail-closed: the caller maps any of these to the existing "quote unavailable" path.
+enum SwapQuoteValidationError: Error, Equatable {
+    case assetMismatch(field: String)
+    case swapTypeMismatch
+    case slippageToleranceMismatch
+    case amountInconsistency(field: String)
+    case nonPositiveAmount(field: String)
+    case slippageExceeded
+    case requestedAmountMismatch
+    case recipientMismatch
+    case refundMismatch
+}
+
+enum SwapQuoteValidator {
+    /// The signed raw base-unit amount must equal the exact decimal expansion of the displayed
+    /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
+    /// must not be relaxed to a tolerance.
+    static func requireConsistent(name: String, raw: Decimal, formatted: Decimal, decimals: Int) throws {
+        let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
+        if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
+    }
+}

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -84,7 +84,14 @@ enum SwapQuoteValidator {
         guard !raw.isNaN, !formatted.isNaN, (0...32).contains(decimals) else {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
-        let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
+        // A server-controlled `formatted` can be huge (e.g. "1e120"); the default NSDecimalNumber behavior
+        // raises an uncatchable NSDecimalNumberOverflowException on overflow, so use the non-raising handler
+        // and fail closed on the resulting NaN rather than crash.
+        let expected = NSDecimalNumber(decimal: formatted)
+            .multiplying(byPowerOf10: Int16(decimals), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
+        guard !expected.doubleValue.isNaN else {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
         if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
@@ -113,8 +120,11 @@ enum SwapQuoteValidator {
         case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
             // Output floats: minAmountOut must be >= amountOut * (1 - slippage), rounded DOWN.
             let floor = NSDecimalNumber(decimal: amountOut)
-                .multiplying(by: denominator.subtracting(bps))
+                .multiplying(by: denominator.subtracting(bps), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
                 .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundDownZeroScale)
+            guard !floor.doubleValue.isNaN else {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
             if NSDecimalNumber(decimal: minAmountOut).compare(floor) == ComparisonResult.orderedAscending {
                 throw SwapQuoteValidationError.slippageExceeded
             }
@@ -122,8 +132,11 @@ enum SwapQuoteValidator {
         case Near1Click.Constants.exactOutput:
             // Input floats: minAmountIn (worst-case max input) must be <= amountIn * (1 + slippage), rounded UP.
             let ceiling = NSDecimalNumber(decimal: amountIn)
-                .multiplying(by: denominator.adding(bps))
+                .multiplying(by: denominator.adding(bps), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
                 .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundUpZeroScale)
+            guard !ceiling.doubleValue.isNaN else {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
             if NSDecimalNumber(decimal: minAmountIn).compare(ceiling) == ComparisonResult.orderedDescending {
                 throw SwapQuoteValidationError.slippageExceeded
             }
@@ -166,6 +179,14 @@ enum SwapQuoteValidator {
             throw SwapQuoteValidationError.requestedAmountMismatch
         }
     }
+
+    /// Full-precision, non-raising behavior for the consistency/slippage multiplications. A server-controlled
+    /// amount can overflow `Decimal`; the default behavior raises an uncatchable NSDecimalNumberOverflowException,
+    /// so this returns NaN on overflow and the callers fail closed instead of crashing.
+    static let nonRaisingNoScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.plain, scale: Int16(NSDecimalNoScale),
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
 
     static let roundDownZeroScale = NSDecimalNumberHandler(
         roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -44,7 +44,8 @@ enum SwapQuoteValidator {
         minAmountOut: Decimal,
         slippageToleranceBps: Int
     ) throws {
-        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN, slippageToleranceBps >= 0 else {
+        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN,
+              slippageToleranceBps >= 0, slippageToleranceBps <= 10_000 else {
             throw SwapQuoteValidationError.slippageExceeded
         }
 
@@ -71,6 +72,8 @@ enum SwapQuoteValidator {
             }
 
         default:
+            // Unknown swap type has no floating side to validate. swapType is pinned to the request by the
+            // validate() orchestrator, so this is unreachable in the integrated path; no-op here is safe.
             break
         }
     }

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -24,6 +24,9 @@ enum SwapQuoteValidator {
     /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
     /// must not be relaxed to a tolerance.
     static func requireConsistent(name: String, raw: Decimal, formatted: Decimal, decimals: Int) throws {
+        guard !raw.isNaN, !formatted.isNaN, (0...32).contains(decimals) else {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
         let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
         if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
             throw SwapQuoteValidationError.amountInconsistency(field: name)

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -78,6 +78,38 @@ enum SwapQuoteValidator {
         }
     }
 
+    /// The returned asset id must exactly equal the asset id we requested (an opaque identifier from the
+    /// same token list, so exact-match is correct).
+    static func requireMatchingAssetId(field: String, expected: String, actual: String) throws {
+        if expected != actual {
+            throw SwapQuoteValidationError.assetMismatch(field: field)
+        }
+    }
+
+    /// The user-fixed side of the swap must equal the amount the user requested (exact, in base units).
+    /// EXACT_INPUT / FLEX_INPUT fix the input; EXACT_OUTPUT fixes the output. Fails closed on an
+    /// unparseable/NaN requested amount, a NaN quoted amount, or an unknown swap type.
+    static func requireMatchesRequestedAmount(swapType: String, requestedAmount: String, rawAmountIn: Decimal, rawAmountOut: Decimal) throws {
+        guard let requested = Decimal(string: requestedAmount, locale: Locale(identifier: "en_US_POSIX")), !requested.isNaN else {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        let userFixed: Decimal
+        switch swapType {
+        case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
+            userFixed = rawAmountIn
+        case Near1Click.Constants.exactOutput:
+            userFixed = rawAmountOut
+        default:
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        guard !userFixed.isNaN else {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        if NSDecimalNumber(decimal: userFixed).compare(NSDecimalNumber(decimal: requested)) != ComparisonResult.orderedSame {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+    }
+
     static let roundDownZeroScale = NSDecimalNumberHandler(
         roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
         raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -22,7 +22,6 @@ enum SwapQuoteValidationError: Error, Equatable {
 /// The subset of the swap-quote response the validator inspects: the echoed `quoteRequest` fields plus
 /// the `quote` amounts, all already parsed into typed values.
 struct SwapQuoteResponseFields: Equatable {
-    let depositAddress: String
     let echoedOriginAsset: String
     let echoedDestinationAsset: String
     let echoedSwapType: String

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -32,4 +32,56 @@ enum SwapQuoteValidator {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
     }
+
+    /// Fail-closed slippage check on the server-determined (floating) side of the quote. Integer base-unit
+    /// math with the server's own DOWN/UP truncation so legitimate boundary quotes are accepted. Fails
+    /// closed on NaN bounds (server-controlled strings can parse to NaN) and negative slippage.
+    static func requireWithinSlippage(
+        swapType: String,
+        amountIn: Decimal,
+        amountOut: Decimal,
+        minAmountIn: Decimal,
+        minAmountOut: Decimal,
+        slippageToleranceBps: Int
+    ) throws {
+        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN, slippageToleranceBps >= 0 else {
+            throw SwapQuoteValidationError.slippageExceeded
+        }
+
+        let denominator = NSDecimalNumber(value: 10_000)
+        let bps = NSDecimalNumber(value: slippageToleranceBps)
+
+        switch swapType {
+        case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
+            // Output floats: minAmountOut must be >= amountOut * (1 - slippage), rounded DOWN.
+            let floor = NSDecimalNumber(decimal: amountOut)
+                .multiplying(by: denominator.subtracting(bps))
+                .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundDownZeroScale)
+            if NSDecimalNumber(decimal: minAmountOut).compare(floor) == ComparisonResult.orderedAscending {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
+
+        case Near1Click.Constants.exactOutput:
+            // Input floats: minAmountIn (worst-case max input) must be <= amountIn * (1 + slippage), rounded UP.
+            let ceiling = NSDecimalNumber(decimal: amountIn)
+                .multiplying(by: denominator.adding(bps))
+                .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundUpZeroScale)
+            if NSDecimalNumber(decimal: minAmountIn).compare(ceiling) == ComparisonResult.orderedDescending {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
+
+        default:
+            break
+        }
+    }
+
+    static let roundDownZeroScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
+
+    static let roundUpZeroScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.up, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
 }

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -46,6 +46,7 @@ struct Near1Click {
         static let refundedAmountFormatted = "refundedAmountFormatted"
         static let amountInFormatted = "amountInFormatted"
         static let amountOutFormatted = "amountOutFormatted"
+        static let minAmountOut = "minAmountOut"
         static let recipient = "recipient"
         static let deadline = "deadline"
         static let timestamp = "timestamp"
@@ -166,6 +167,103 @@ struct Near1Click {
             throw SwapAndPayClient.EndpointError.message("Unknown error")
         }
     }
+
+    /// Parses a NEAR 1Click quote response and validates it against the request we sent, returning a
+    /// trusted `SwapQuote` or throwing. Throws `SwapQuoteValidationError` on a field/amount/slippage
+    /// mismatch and `SwapAndPayClient.EndpointError.message` on malformed JSON. Pure and unit-testable.
+    static func makeValidatedQuote(
+        jsonObject: [String: Any],
+        request: SwapQuoteRequest,
+        zecAsset: SwapAsset,
+        toAsset: SwapAsset,
+        isSwapToZec: Bool
+    ) throws -> SwapQuote {
+        guard let quote = jsonObject[Constants.quote] as? [String: Any],
+              let depositAddress = quote[Constants.depositAddress] as? String,
+              let amountInString = quote[Constants.amountIn] as? String,
+              let amountInUsdString = quote[Constants.amountInUsd] as? String,
+              let amountInFormattedString = quote[Constants.amountInFormatted] as? String,
+              let minAmountInString = quote[Constants.minAmountIn] as? String,
+              let minAmountOutString = quote[Constants.minAmountOut] as? String,
+              let amountOutString = quote[Constants.amountOut] as? String,
+              let amountOutUsdString = quote[Constants.amountOutUsd] as? String,
+              let amountOutFormattedString = quote[Constants.amountOutFormatted] as? String,
+              let timeEstimate = quote[Constants.timeEstimate] as? Int else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
+        }
+
+        guard let quoteRequestDict = jsonObject[Constants.quoteRequest] as? [String: Any],
+              let echoedOriginAsset = quoteRequestDict[Constants.originAsset] as? String,
+              let echoedDestinationAsset = quoteRequestDict[Constants.destinationAsset] as? String,
+              let echoedSwapType = quoteRequestDict[Constants.swapType] as? String,
+              let echoedSlippage = quoteRequestDict[Constants.slippageTolerance] as? Int,
+              let echoedRecipient = quoteRequestDict[Constants.recipient] as? String,
+              let echoedRefundTo = quoteRequestDict[Constants.refundTo] as? String else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote request echo failed.")
+        }
+
+        let posix = Locale(identifier: "en_US_POSIX")
+        let amountIn = NSDecimalNumber(string: amountInString).decimalValue
+        let minAmountIn = NSDecimalNumber(string: minAmountInString).decimalValue
+        let minAmountOut = NSDecimalNumber(string: minAmountOutString).decimalValue
+        let amountOut = NSDecimalNumber(string: amountOutString).decimalValue
+
+        guard let amountInFormatted = Decimal(string: amountInFormattedString, locale: posix),
+              let amountOutFormatted = Decimal(string: amountOutFormattedString, locale: posix) else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
+        }
+
+        let response = SwapQuoteResponseFields(
+            depositAddress: depositAddress,
+            echoedOriginAsset: echoedOriginAsset,
+            echoedDestinationAsset: echoedDestinationAsset,
+            echoedSwapType: echoedSwapType,
+            echoedSlippageTolerance: echoedSlippage,
+            echoedRecipient: echoedRecipient,
+            echoedRefundTo: echoedRefundTo,
+            amountIn: amountIn,
+            amountInFormatted: amountInFormatted,
+            minAmountIn: minAmountIn,
+            amountOut: amountOut,
+            amountOutFormatted: amountOutFormatted,
+            minAmountOut: minAmountOut
+        )
+
+        try SwapQuoteValidator.validate(
+            request: request,
+            response: response,
+            originDecimals: isSwapToZec ? toAsset.decimals : zecAsset.decimals,
+            destinationDecimals: isSwapToZec ? zecAsset.decimals : toAsset.decimals
+        )
+
+        if isSwapToZec {
+            return SwapQuote(
+                depositAddress: depositAddress,
+                amountIn: amountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
+                amountInUsd: amountInUsdString,
+                minAmountIn: minAmountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
+                amountOut: amountOut / Decimal(pow(10.0, Double(zecAsset.decimals))),
+                amountOutUsd: amountOutUsdString,
+                timeEstimate: TimeInterval(timeEstimate),
+                recipient: echoedRecipient,
+                originAssetId: echoedOriginAsset,
+                destinationAssetId: echoedDestinationAsset
+            )
+        }
+
+        return SwapQuote(
+            depositAddress: depositAddress,
+            amountIn: amountIn,
+            amountInUsd: amountInUsdString,
+            minAmountIn: minAmountIn,
+            amountOut: amountOut / Decimal(pow(10.0, Double(toAsset.decimals))),
+            amountOutUsd: amountOutUsdString,
+            timeEstimate: TimeInterval(timeEstimate),
+            recipient: echoedRecipient,
+            originAssetId: echoedOriginAsset,
+            destinationAssetId: echoedDestinationAsset
+        )
+    }
 }
 
 extension Near1Click {
@@ -285,42 +383,19 @@ extension Near1Click {
                 )
             }
             
-            guard let quote = jsonObject[Constants.quote] as? [String: Any],
-                  let depositAddress = quote[Constants.depositAddress] as? String,
-                  let amountInString = quote[Constants.amountIn] as? String,
-                  let amountInUsdString = quote[Constants.amountInUsd] as? String,
-                  let minAmountInString = quote[Constants.minAmountIn] as? String,
-                  let amountOutString = quote[Constants.amountOut] as? String,
-                  let amountOutUsdString = quote[Constants.amountOutUsd] as? String,
-                  let timeEstimate = quote[Constants.timeEstimate] as? Int else {
-                throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
-            }
-            
-            let amountIn = NSDecimalNumber(string: amountInString).decimalValue
-            let minAmountIn = NSDecimalNumber(string: minAmountInString).decimalValue
-            let amountOut = NSDecimalNumber(string: amountOutString).decimalValue
-            
-            if isSwapToZec {
-                return SwapQuote(
-                    depositAddress: depositAddress,
-                    amountIn: amountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
-                    amountInUsd: amountInUsdString,
-                    minAmountIn: minAmountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
-                    amountOut: amountOut / Decimal(pow(10.0, Double(zecAsset.decimals))),
-                    amountOutUsd: amountOutUsdString,
-                    timeEstimate: TimeInterval(timeEstimate)
+            do {
+                return try Near1Click.makeValidatedQuote(
+                    jsonObject: jsonObject,
+                    request: requestData,
+                    zecAsset: zecAsset,
+                    toAsset: toAsset,
+                    isSwapToZec: isSwapToZec
+                )
+            } catch is SwapQuoteValidationError {
+                throw SwapAndPayClient.EndpointError.message(
+                    String(localizable: exactInput ? .swapQuoteUnavailableSwap : .swapQuoteUnavailable)
                 )
             }
-            
-            return SwapQuote(
-                depositAddress: depositAddress,
-                amountIn: amountIn,
-                amountInUsd: amountInUsdString,
-                minAmountIn: minAmountIn,
-                amountOut: amountOut / Decimal(pow(10.0, Double(toAsset.decimals))),
-                amountOutUsd: amountOutUsdString,
-                timeEstimate: TimeInterval(timeEstimate)
-            )
         },
         status: { depositAddress, isSwapToZec in
             let (data, response) = try await Near1Click.getCall(urlString: "\(Constants.statusUrl)\(depositAddress)", includeJwtKey: true)

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -214,7 +214,6 @@ struct Near1Click {
         }
 
         let response = SwapQuoteResponseFields(
-            depositAddress: depositAddress,
             echoedOriginAsset: echoedOriginAsset,
             echoedDestinationAsset: echoedDestinationAsset,
             echoedSwapType: echoedSwapType,

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -738,13 +738,27 @@ struct SwapAndPay {
                     state.isQuoteRequestInFlight = false
                     return .none
                 }
-                let zecAmount = Zatoshi(NSDecimalNumber(decimal: quote.amountIn).int64Value)
+                // Defensive re-bind to current user intent before signing (TOCTOU guard). The quote was
+                // already validated against the request at parse time; this re-checks it against the state
+                // the user is looking at now and fails closed without building a proposal.
+                guard let selectedAsset = state.selectedAsset,
+                      let zecAsset = state.zecAsset,
+                      quote.matchesSigningIntent(
+                        address: state.address,
+                        originAssetId: zecAsset.assetId,
+                        destinationAssetId: selectedAsset.assetId
+                      ) else {
+                    return .send(.sendFailed("swap quote does not match request".toZcashError()))
+                }
+                guard let zecAmount = Zatoshi(safeZatoshiDecimal: quote.amountIn) else {
+                    return .send(.sendFailed("swap amount out of range".toZcashError()))
+                }
                 return .run { send in
                     do {
                         let recipient = try Recipient(quote.depositAddress, network: zcashSDKEnvironment.network().networkType)
 
                         let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, zecAmount, nil)
-                        
+
                         await send(.proposal(proposal))
                     } catch {
                         await send(.sendFailed(error.toZcashError()))

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -1409,7 +1409,7 @@ extension SwapAndPay.State {
             return "0"
         }
         
-        let zashiFeeCoeff = (Decimal(SwapAndPayClient.Constants.zashiFeeBps) / Decimal(10_000))
+        let zashiFeeCoeff = SwapAndPayClient.Constants.zashiFeeCoefficient
         let zashiFee = quote.amountIn * zashiFeeCoeff
         let zatoshi = Zatoshi(NSDecimalNumber(decimal: zashiFee).clampedInt64Value)
         
@@ -1425,7 +1425,7 @@ extension SwapAndPay.State {
             return "0"
         }
         
-        let zashiFeeCoeff = (Decimal(SwapAndPayClient.Constants.zashiFeeBps) / Decimal(10_000))
+        let zashiFeeCoeff = SwapAndPayClient.Constants.zashiFeeCoefficient
         let zashiFee = ((quote.amountIn * zashiFeeCoeff) / Decimal(100_000_000)) * zecAsset.usdPrice
         
         if zashiFee < 0.01 {
@@ -1511,7 +1511,7 @@ extension SwapAndPay.State {
         let transactionFee = proposal.totalFeeRequired().amount
         
         // zashi fee
-        let zashiFee = quote.amountIn * 0.005
+        let zashiFee = quote.amountIn * SwapAndPayClient.Constants.zashiFeeCoefficient
         let zatoshiZashiFee = NSDecimalNumber(decimal: zashiFee).clampedInt64Value
         
         return transactionFee + zatoshiZashiFee
@@ -1743,7 +1743,7 @@ extension SwapAndPay.State {
         }
 
         // zashi fee
-        let zashiFee = quote.amountIn * 0.005
+        let zashiFee = quote.amountIn * SwapAndPayClient.Constants.zashiFeeCoefficient
 
         return conversionFormatter.string(from: NSDecimalNumber(decimal: zashiFee.simplified)) ?? "\(zashiFee.simplified)"
     }

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -1411,7 +1411,7 @@ extension SwapAndPay.State {
         
         let zashiFeeCoeff = (Decimal(SwapAndPayClient.Constants.zashiFeeBps) / Decimal(10_000))
         let zashiFee = quote.amountIn * zashiFeeCoeff
-        let zatoshi = Zatoshi(Int64(truncating: NSDecimalNumber(decimal: zashiFee)))
+        let zatoshi = Zatoshi(NSDecimalNumber(decimal: zashiFee).clampedInt64Value)
         
         return zatoshi.decimalString()
     }
@@ -1454,7 +1454,7 @@ extension SwapAndPay.State {
         let swapCoeff: Decimal = isSwapExperienceEnabled ? 0.0 : 1.0
         let slippageDecimal = amountInUsdDecimal * slippage * 0.01 * swapCoeff
         let zatoshiDecimal = NSDecimalNumber(decimal: (slippageDecimal / zecAsset.usdPrice) * Decimal(Zatoshi.Constants.oneZecInZatoshi))
-        let zatoshi = Zatoshi(Int64(zatoshiDecimal.doubleValue))
+        let zatoshi = Zatoshi(zatoshiDecimal.clampedInt64Value)
         
         return zatoshi.decimalString()
     }
@@ -1512,7 +1512,7 @@ extension SwapAndPay.State {
         
         // zashi fee
         let zashiFee = quote.amountIn * 0.005
-        let zatoshiZashiFee = Int64(truncating: NSDecimalNumber(decimal: zashiFee))
+        let zatoshiZashiFee = NSDecimalNumber(decimal: zashiFee).clampedInt64Value
         
         return transactionFee + zatoshiZashiFee
     }

--- a/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
+++ b/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
@@ -704,8 +704,8 @@ extension TransactionDetails.State {
             return nil
         }
         
-        let fee = amountIn * 0.005
-        
+        let fee = amountIn * SwapAndPayClient.Constants.zashiFeeCoefficient
+
         return conversionFormatter.string(from: NSDecimalNumber(decimal: fee)) ?? ""
     }
     

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -1,0 +1,41 @@
+//
+//  SafeNumericConversions.swift
+//  Zashi
+//
+
+import Foundation
+@preconcurrency import ZcashLightClientKit
+
+extension NSDecimalNumber {
+    /// `int64Value` clamped to the representable range. Never traps — unlike `Int64(self.doubleValue)`,
+    /// which traps when the value exceeds `Int64`'s range or is non-finite.
+    var clampedInt64Value: Int64 {
+        if self.compare(NSDecimalNumber(value: Int64.max)) != ComparisonResult.orderedAscending {
+            return Int64.max
+        }
+        if self.compare(NSDecimalNumber(value: Int64.min)) != ComparisonResult.orderedDescending {
+            return Int64.min
+        }
+        return self.int64Value
+    }
+}
+
+extension Zatoshi {
+    /// Builds a `Zatoshi` from a zatoshi-denominated `Decimal`, returning nil (instead of trapping or
+    /// wrapping) when the value is NaN, negative, or above the max ZEC supply. The fractional part is
+    /// truncated DOWN.
+    init?(safeZatoshiDecimal decimal: Decimal) {
+        guard !decimal.isNaN, decimal >= Decimal(0) else {
+            return nil
+        }
+        var rounded = Decimal()
+        var value = decimal
+        NSDecimalRound(&rounded, &value, 0, NSDecimalNumber.RoundingMode.down)
+
+        let maxZatoshi = Decimal(21_000_000) * Decimal(Zatoshi.Constants.oneZecInZatoshi)
+        guard rounded <= maxZatoshi else {
+            return nil
+        }
+        self = Zatoshi(NSDecimalNumber(decimal: rounded).clampedInt64Value)
+    }
+}

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -7,16 +7,30 @@ import Foundation
 @preconcurrency import ZcashLightClientKit
 
 extension NSDecimalNumber {
-    /// `int64Value` clamped to the representable range. Never traps — unlike `Int64(self.doubleValue)`,
-    /// which traps when the value exceeds `Int64`'s range or is non-finite.
+    private static let int64MaxValue = NSDecimalNumber(value: Int64.max)
+    private static let int64MinValue = NSDecimalNumber(value: Int64.min)
+    /// Truncates the fractional part DOWN before the `Int64` conversion. `NSDecimalNumber.int64Value`
+    /// returns 0 for any value with a fractional part, so it must be rounded to integer scale first.
+    private static let truncatingBehavior = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
+
+    /// `Int64` value clamped to the representable range, with any fractional part truncated DOWN. Never
+    /// traps — unlike `Int64(self.doubleValue)`, which traps when the value exceeds `Int64`'s range or is
+    /// non-finite. A NaN maps to `0`. `NSDecimalNumber.int64Value` returns `0` for any non-integer value,
+    /// so the value is rounded to integer scale before that conversion.
     var clampedInt64Value: Int64 {
-        if self.compare(NSDecimalNumber(value: Int64.max)) != ComparisonResult.orderedAscending {
+        if self.doubleValue.isNaN {
+            return 0
+        }
+        if self.compare(NSDecimalNumber.int64MaxValue) != ComparisonResult.orderedAscending {
             return Int64.max
         }
-        if self.compare(NSDecimalNumber(value: Int64.min)) != ComparisonResult.orderedDescending {
+        if self.compare(NSDecimalNumber.int64MinValue) != ComparisonResult.orderedDescending {
             return Int64.min
         }
-        return self.int64Value
+        return self.rounding(accordingToBehavior: NSDecimalNumber.truncatingBehavior).int64Value
     }
 }
 

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -46,7 +46,7 @@ extension Zatoshi {
         var value = decimal
         NSDecimalRound(&rounded, &value, 0, NSDecimalNumber.RoundingMode.down)
 
-        let maxZatoshi = Decimal(21_000_000) * Decimal(Zatoshi.Constants.oneZecInZatoshi)
+        let maxZatoshi = Decimal(Zatoshi.Constants.maxZatoshi)
         guard rounded <= maxZatoshi else {
             return nil
         }

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -83,10 +83,51 @@ import Testing
         }
     }
 
-    @Test func rejectsMissingMinAmountOut() {
-        #expect(throws: (any Error).self) {
+    @Test func rejectsMissingMinAmountOutAsEndpointError() {
+        // A malformed/missing field surfaces as EndpointError (NOT a validation error), so it propagates
+        // out of the closure's `catch is SwapQuoteValidationError` and still fails closed downstream.
+        #expect(throws: SwapAndPayClient.EndpointError.self) {
             _ = try Near1Click.makeValidatedQuote(
                 jsonObject: self.json(includeMinAmountOut: false),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func acceptsValidSwapToZecQuote() throws {
+        // Swap-to-ZEC (token -> ZEC, FLEX_INPUT): user fixes the token input; amountIn is divided by the
+        // token's decimals and amountOut by ZEC's decimals when built.
+        let swapToZecRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.flexInput, slippageTolerance: 100,
+            originAsset: "btc.id", depositType: Near1Click.Constants.originChain, destinationAsset: "zec.id",
+            amount: "200000", refundTo: "user-btc-addr", refundType: Near1Click.Constants.originChain,
+            recipient: "wallet-ua", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let swapToZecJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "200000", "amountInUsd": "10",
+                "amountInFormatted": "0.002", "minAmountIn": "200000",
+                "amountOut": "100000000", "amountOutUsd": "10", "amountOutFormatted": "1", "minAmountOut": "99000000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "btc.id", "destinationAsset": "zec.id", "swapType": Near1Click.Constants.flexInput,
+                "slippageTolerance": 100, "recipient": "wallet-ua", "refundTo": "user-btc-addr"
+            ]
+        ]
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: swapToZecJson, request: swapToZecRequest, zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: true)
+        let expectedAmountIn = try #require(Decimal(string: "0.002", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(quote.amountIn == expectedAmountIn)
+        #expect(quote.amountOut == Decimal(1))
+        #expect(quote.originAssetId == "btc.id")
+        #expect(quote.destinationAssetId == "zec.id")
+    }
+
+    @Test func rejectsSwapTypeSubstitution() {
+        #expect(throws: SwapQuoteValidationError.swapTypeMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(swapType: Near1Click.Constants.exactOutput),
                 request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
             )
         }

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -1,0 +1,104 @@
+//
+//  Near1ClickQuoteMapperTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct Near1ClickQuoteMapperTests {
+    private let zecAsset = SwapAsset(provider: "near", chain: "zec", token: "ZEC", assetId: "zec.id", usdPrice: Decimal(30), decimals: 8)
+    private let btcAsset = SwapAsset(provider: "near", chain: "btc", token: "BTC", assetId: "btc.id", usdPrice: Decimal(60_000), decimals: 8)
+
+    private func request(amount: String = "100000000", recipient: String = "recipient", refundTo: String = "refund") -> SwapQuoteRequest {
+        SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactInput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: amount, refundTo: refundTo, refundType: Near1Click.Constants.originChain,
+            recipient: recipient, recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+    }
+
+    private func json(
+        depositAddress: String = "deposit", originAsset: String = "zec.id", destinationAsset: String = "btc.id",
+        swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100,
+        recipient: String = "recipient", refundTo: String = "refund",
+        amountIn: String = "100000000", amountInFormatted: String = "1", minAmountIn: String = "100000000",
+        amountOut: String = "200000", amountOutFormatted: String = "0.002", minAmountOut: String = "198000",
+        includeMinAmountOut: Bool = true
+    ) -> [String: Any] {
+        var quote: [String: Any] = [
+            "depositAddress": depositAddress, "amountIn": amountIn, "amountInUsd": "10",
+            "amountInFormatted": amountInFormatted, "minAmountIn": minAmountIn,
+            "amountOut": amountOut, "amountOutUsd": "10", "amountOutFormatted": amountOutFormatted,
+            "timeEstimate": 60
+        ]
+        if includeMinAmountOut {
+            quote["minAmountOut"] = minAmountOut
+        }
+        return [
+            "quote": quote,
+            "quoteRequest": [
+                "originAsset": originAsset, "destinationAsset": destinationAsset, "swapType": swapType,
+                "slippageTolerance": slippage, "recipient": recipient, "refundTo": refundTo
+            ]
+        ]
+    }
+
+    @Test func acceptsValidQuote() throws {
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: json(), request: request(), zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false)
+        #expect(quote.depositAddress == "deposit")
+        #expect(quote.amountIn == Decimal(100_000_000))
+        #expect(quote.recipient == "recipient")
+        #expect(quote.originAssetId == "zec.id")
+        #expect(quote.destinationAssetId == "btc.id")
+    }
+
+    @Test func rejectsInflatedAmountIn() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(amountIn: "200000000", amountInFormatted: "2", minAmountIn: "200000000"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsRecipientSubstitution() {
+        #expect(throws: SwapQuoteValidationError.recipientMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(recipient: "attacker"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsOriginAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(originAsset: "zec.tampered"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsMissingMinAmountOut() {
+        #expect(throws: (any Error).self) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(includeMinAmountOut: false),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func depositAddressSubstitutionAloneIsNotCaught() throws {
+        // Documented residual: binding cannot detect a swapped deposit address (server-generated, unverifiable).
+        // Only transport security (user-opt-in Tor) closes this; the quote still builds with the attacker address.
+        let quote = try Near1Click.makeValidatedQuote(
+            jsonObject: json(depositAddress: "attacker-deposit"),
+            request: request(), zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false
+        )
+        #expect(quote.depositAddress == "attacker-deposit")
+    }
+}

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -142,4 +142,60 @@ import Testing
         )
         #expect(quote.depositAddress == "attacker-deposit")
     }
+
+    @Test func acceptsValidCrosspayQuote() throws {
+        // Crosspay (ZEC -> token, EXACT_OUTPUT): user fixes the token OUTPUT; the ZEC input floats within the
+        // slippage ceiling. amountIn (ZEC) is kept raw for signing; amountOut is divided by the token decimals.
+        let crosspayRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactOutput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: "200000", refundTo: "refund", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let crosspayJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "300000000", "amountInUsd": "10",
+                "amountInFormatted": "3", "minAmountIn": "303000000",
+                "amountOut": "200000", "amountOutUsd": "10", "amountOutFormatted": "0.002", "minAmountOut": "200000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "zec.id", "destinationAsset": "btc.id", "swapType": Near1Click.Constants.exactOutput,
+                "slippageTolerance": 100, "recipient": "recipient", "refundTo": "refund"
+            ]
+        ]
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: crosspayJson, request: crosspayRequest, zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false)
+        #expect(quote.amountIn == Decimal(300_000_000))
+        let expectedAmountOut = try #require(Decimal(string: "0.002", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(quote.amountOut == expectedAmountOut)
+        #expect(quote.recipient == "recipient")
+    }
+
+    @Test func rejectsCrosspayInputAboveSlippageCeiling() {
+        // EXACT_OUTPUT input floats: ceiling = amountIn 300000000 × 1.01 = 303000000. A guaranteed worst-case
+        // input above that exceeds the user's slippage tolerance and must fail closed.
+        let crosspayRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactOutput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: "200000", refundTo: "refund", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let crosspayJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "300000000", "amountInUsd": "10",
+                "amountInFormatted": "3", "minAmountIn": "400000000",
+                "amountOut": "200000", "amountOutUsd": "10", "amountOutFormatted": "0.002", "minAmountOut": "200000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "zec.id", "destinationAsset": "btc.id", "swapType": Near1Click.Constants.exactOutput,
+                "slippageTolerance": 100, "recipient": "recipient", "refundTo": "refund"
+            ]
+        ]
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            _ = try Near1Click.makeValidatedQuote(jsonObject: crosspayJson, request: crosspayRequest, zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false)
+        }
+    }
 }

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -74,6 +74,17 @@ import Testing
         }
     }
 
+    @Test func rejectsOverflowingAmountFormatted() {
+        // A huge server amountInFormatted overflows the consistency multiply; it must fail closed as a
+        // validation error, not crash the validator with an uncatchable NSDecimalNumberOverflowException.
+        #expect(throws: SwapQuoteValidationError.self) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(amountInFormatted: "1e120"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
     @Test func rejectsOriginAssetSubstitution() {
         #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
             _ = try Near1Click.makeValidatedQuote(

--- a/zodlTests/SwapTests/SafeNumericConversionsTests.swift
+++ b/zodlTests/SwapTests/SafeNumericConversionsTests.swift
@@ -1,0 +1,44 @@
+//
+//  SafeNumericConversionsTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct SafeNumericConversionsTests {
+    @Test func clampedInt64ReturnsValueInRange() {
+        #expect(NSDecimalNumber(value: 100).clampedInt64Value == 100)
+    }
+
+    @Test func clampedInt64ClampsAboveMax() {
+        let huge = NSDecimalNumber(string: "99999999999999999999")
+        #expect(huge.clampedInt64Value == Int64.max)
+    }
+
+    @Test func clampedInt64ClampsBelowMin() {
+        let veryNegative = NSDecimalNumber(string: "-99999999999999999999")
+        #expect(veryNegative.clampedInt64Value == Int64.min)
+    }
+
+    @Test func safeZatoshiAcceptsNormalValue() {
+        let zatoshi = Zatoshi(safeZatoshiDecimal: Decimal(100_000_000))
+        #expect(zatoshi == Zatoshi(100_000_000))
+    }
+
+    @Test func safeZatoshiTruncatesFraction() throws {
+        let value = try #require(Decimal(string: "100000000.9", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(Zatoshi(safeZatoshiDecimal: value) == Zatoshi(100_000_000))
+    }
+
+    @Test func safeZatoshiRejectsNegative() {
+        #expect(Zatoshi(safeZatoshiDecimal: Decimal(-1)) == nil)
+    }
+
+    @Test func safeZatoshiRejectsOverMaxSupply() throws {
+        let overMax = try #require(Decimal(string: "99999999999999999999", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(Zatoshi(safeZatoshiDecimal: overMax) == nil)
+    }
+}

--- a/zodlTests/SwapTests/SafeNumericConversionsTests.swift
+++ b/zodlTests/SwapTests/SafeNumericConversionsTests.swift
@@ -23,6 +23,19 @@ import Testing
         #expect(veryNegative.clampedInt64Value == Int64.min)
     }
 
+    @Test func clampedInt64TruncatesNonInteger() {
+        // Regression: NSDecimalNumber.int64Value returns 0 for any value with a fractional part, so an
+        // in-range non-integer (e.g. the slippage buffer in swapSlippageStr) must be truncated, not zeroed.
+        #expect(NSDecimalNumber(string: "333333.3333").clampedInt64Value == 333_333)
+        #expect(NSDecimalNumber(string: "0.9").clampedInt64Value == 0)
+        #expect(NSDecimalNumber(string: "100.5").clampedInt64Value == 100)
+    }
+
+    @Test func clampedInt64MapsNaNToZero() {
+        // A NaN (e.g. a Decimal division by a server usdPrice of 0) must fall back to 0, not Int64.min.
+        #expect(NSDecimalNumber.notANumber.clampedInt64Value == 0)
+    }
+
     @Test func safeZatoshiAcceptsNormalValue() {
         let zatoshi = Zatoshi(safeZatoshiDecimal: Decimal(100_000_000))
         #expect(zatoshi == Zatoshi(100_000_000))

--- a/zodlTests/SwapTests/SwapFeeDisplayTests.swift
+++ b/zodlTests/SwapTests/SwapFeeDisplayTests.swift
@@ -50,4 +50,38 @@ import Testing
         )
         #expect(SwapAndPayClient.Constants.zashiFeeCoefficient == Decimal(67) / Decimal(10_000))
     }
+
+    /// The post-swap transaction-detail screen must show the same 0.67% affiliate fee as the
+    /// confirmation screen, not the old hardcoded 0.5%. Guards `TransactionDetails.State.totalSwapToZecFee`
+    /// against the same `0.005` literal the confirmation sites were fixed for.
+    @Test func transactionDetailSwapToZecFeeUsesZashiFeeBpsNotHardcodedHalfPercent() {
+        let amountIn = Decimal(10_000)
+        var state = TransactionDetails.State(transaction: TransactionState.placeholder())
+        state.swapDetails = SwapDetails(
+            amountInFormatted: amountIn,
+            amountInUsd: nil,
+            amountOutFormatted: nil,
+            amountOutUsd: nil,
+            fromAsset: "nep141:btc.omft.near",
+            toAsset: "nep141:zec.omft.near",
+            isSwap: true,
+            slippage: nil,
+            status: .success,
+            refundedAmountFormatted: nil,
+            swapRecipient: nil,
+            addressToCheckShield: "",
+            whenInitiated: "",
+            deadline: "",
+            depositedAmountFormatted: nil
+        )
+
+        // Build the expected strings with the store's own formatter so the assertion is locale-independent.
+        let correctFee = amountIn * SwapAndPayClient.Constants.zashiFeeCoefficient
+        let correctDisplay = state.conversionFormatter.string(from: NSDecimalNumber(decimal: correctFee)) ?? ""
+        let oldHalfPercentFee = amountIn * (Decimal(5) / Decimal(1_000))
+        let oldHalfPercentDisplay = state.conversionFormatter.string(from: NSDecimalNumber(decimal: oldHalfPercentFee)) ?? ""
+
+        #expect(state.totalSwapToZecFee == correctDisplay)
+        #expect(state.totalSwapToZecFee != oldHalfPercentDisplay)
+    }
 }

--- a/zodlTests/SwapTests/SwapFeeDisplayTests.swift
+++ b/zodlTests/SwapTests/SwapFeeDisplayTests.swift
@@ -1,0 +1,53 @@
+//
+//  SwapFeeDisplayTests.swift
+//  zodlTests
+//
+//  MOB-1351 — the swap / CrossPay confirmation total must reflect the real affiliate fee
+//  (zashiFeeBps = 67 bps = 0.67%), not a hardcoded 0.5%. Single source of truth is
+//  SwapAndPayClient.Constants.zashiFeeCoefficient, derived from zashiFeeBps.
+//
+
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct SwapFeeDisplayTests {
+    private func makeQuote(amountIn: Decimal) -> SwapQuote {
+        SwapQuote(
+            depositAddress: "deposit",
+            amountIn: amountIn,
+            amountInUsd: "10",
+            minAmountIn: Decimal(0),
+            amountOut: Decimal(0),
+            amountOutUsd: "0",
+            timeEstimate: 0,
+            recipient: "recipient",
+            originAssetId: "origin",
+            destinationAssetId: "dest"
+        )
+    }
+
+    /// The confirmation total fee must use the real 0.67% affiliate fee, not the old hardcoded 0.5%.
+    @Test func totalFeesUsesZashiFeeBpsNotHardcodedHalfPercent() {
+        var state = SwapAndPayCoordFlow.State()
+        state.swapAndPayState.quote = makeQuote(amountIn: Decimal(100_000_000)) // 1 ZEC, in zatoshi
+        state.swapAndPayState.proposal = .testOnlyFakeProposal(totalFee: 10_000)
+
+        // The affiliate-fee portion of the total must be 0.67% of amountIn (670_000 zatoshi for 1 ZEC),
+        // not the old hardcoded 0.5% (500_000) — independent of whatever the network fee is.
+        let networkFee = state.swapAndPayState.proposal?.totalFeeRequired().amount ?? 0
+        #expect(state.swapAndPayState.totalFees == networkFee + 670_000)
+        #expect(state.swapAndPayState.totalFees != networkFee + 500_000)
+    }
+
+    /// Locks the single source of truth: the coefficient is derived from zashiFeeBps, so a future bps
+    /// change flows through everywhere and the `0.005` literal can't creep back.
+    @Test func zashiFeeCoefficientDerivesFromBps() {
+        #expect(
+            SwapAndPayClient.Constants.zashiFeeCoefficient
+                == Decimal(SwapAndPayClient.Constants.zashiFeeBps) / Decimal(10_000)
+        )
+        #expect(SwapAndPayClient.Constants.zashiFeeCoefficient == Decimal(67) / Decimal(10_000))
+    }
+}

--- a/zodlTests/SwapTests/SwapQuoteIntentTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteIntentTests.swift
@@ -1,0 +1,30 @@
+//
+//  SwapQuoteIntentTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct SwapQuoteIntentTests {
+    private func quote(recipient: String = "addr", origin: String = "zec.id", destination: String = "btc.id") -> SwapQuote {
+        SwapQuote(
+            depositAddress: "deposit", amountIn: Decimal(100_000_000), amountInUsd: "10",
+            minAmountIn: Decimal(100_000_000), amountOut: Decimal(2_000_000), amountOutUsd: "10",
+            timeEstimate: 60, recipient: recipient, originAssetId: origin, destinationAssetId: destination
+        )
+    }
+
+    @Test func matchesWhenAllFieldsAgree() {
+        #expect(quote().matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "btc.id"))
+    }
+
+    @Test func failsWhenRecipientDiffers() {
+        #expect(!quote(recipient: "other").matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "btc.id"))
+    }
+
+    @Test func failsWhenDestinationAssetDiffers() {
+        #expect(!quote().matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "eth.id"))
+    }
+}

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -1,3 +1,8 @@
+//
+//  SwapQuoteValidationTests.swift
+//  Zashi
+//
+
 import Foundation
 import Testing
 @testable import zodl_internal
@@ -18,5 +23,22 @@ import Testing
         #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
             try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(2), decimals: 8)
         }
+    }
+
+    @Test func requireConsistentThrowsOnNaNRaw() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal.nan, formatted: Decimal(1), decimals: 8)
+        }
+    }
+
+    @Test func requireConsistentThrowsOnOutOfRangeDecimals() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(1), decimals: 1000)
+        }
+    }
+
+    @Test func requireConsistentPassesForFractionalFormatted() throws {
+        let formatted = try #require(Decimal(string: "0.00000001", locale: Locale(identifier: "en_US_POSIX")))
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -205,7 +205,7 @@ import Testing
         minAmountOut: Decimal = Decimal(1_980_000)
     ) -> SwapQuoteResponseFields {
         SwapQuoteResponseFields(
-            depositAddress: "deposit-addr", echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
+            echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
             echoedSwapType: swapType, echoedSlippageTolerance: slippage, echoedRecipient: recipient, echoedRefundTo: refundTo,
             amountIn: amountIn, amountInFormatted: amountInFormatted, minAmountIn: minAmountIn,
             amountOut: amountOut, amountOutFormatted: amountOutFormatted, minAmountOut: minAmountOut

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -42,6 +42,16 @@ import Testing
         try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
 
+    @Test func requireConsistentFailsClosedOnOverflowingFormatted() throws {
+        // A server-controlled `formatted` can overflow when multiplied by 10^decimals; the default
+        // NSDecimalNumber behavior would raise an uncatchable NSDecimalNumberOverflowException (crash).
+        // It must instead fail closed.
+        let huge = try #require(Decimal(string: "1e120", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: huge, decimals: 8)
+        }
+    }
+
     // MARK: requireWithinSlippage — server's worst-case guarantee must respect requested slippage
 
     @Test func slippageOutputFloatingPassesAtAndAboveFloor() throws {
@@ -108,6 +118,24 @@ import Testing
         // minAmountOut passes (bypass). The bound must make this fail closed.
         #expect(throws: SwapQuoteValidationError.slippageExceeded) {
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
+        }
+    }
+
+    @Test func slippageFailsClosedOnOverflowingOutput() throws {
+        // amountOut * (10000 - bps) overflows Decimal; the multiply must not trap, and the NaN result
+        // must fail closed (output-floating side).
+        let huge = try #require(Decimal(string: "1e125", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: huge, minAmountIn: Decimal(1000), minAmountOut: Decimal(1), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnOverflowingInput() throws {
+        // amountIn * (10000 + bps) overflows Decimal on the EXACT_OUTPUT ceiling. compare(NaN) is
+        // orderedAscending, so without the explicit NaN guard this would bypass — it must fail closed.
+        let huge = try #require(Decimal(string: "1e125", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: huge, amountOut: Decimal(1000), minAmountIn: Decimal(1), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
         }
     }
 

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -110,4 +110,48 @@ import Testing
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
         }
     }
+
+    // MARK: requireMatchingAssetId
+
+    @Test func requireMatchingAssetIdPassesOnEqual() throws {
+        try SwapQuoteValidator.requireMatchingAssetId(field: "originAsset", expected: "nep141:zec.omft.near", actual: "nep141:zec.omft.near")
+    }
+
+    @Test func requireMatchingAssetIdThrowsOnDifferent() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            try SwapQuoteValidator.requireMatchingAssetId(field: "originAsset", expected: "a", actual: "b")
+        }
+    }
+
+    // MARK: requireMatchesRequestedAmount — user-fixed side must equal requested base units
+
+    @Test func requestedAmountExactInputBindsAmountIn() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+    }
+
+    @Test func requestedAmountExactOutputBindsAmountOut() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactOutput, requestedAmount: "2000000", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+    }
+
+    @Test func requestedAmountFlexInputBindsAmountIn() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.flexInput, requestedAmount: "2000000", rawAmountIn: Decimal(2_000_000), rawAmountOut: Decimal(100_000_000))
+    }
+
+    @Test func requestedAmountThrowsOnInflatedAmountIn() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal(200_000_000), rawAmountOut: Decimal(2_000_000))
+        }
+    }
+
+    @Test func requestedAmountFailsClosedOnNaNAmount() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal.nan, rawAmountOut: Decimal(2_000_000))
+        }
+    }
+
+    @Test func requestedAmountFailsClosedOnUnparseableRequest() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "not-a-number", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -154,4 +154,106 @@ import Testing
             try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "not-a-number", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
         }
     }
+
+    // MARK: validate — full orchestration over a baseline valid EXACT_INPUT quote
+
+    private func baselineRequest(swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100, amount: String = "100000000") -> SwapQuoteRequest {
+        SwapQuoteRequest(
+            dry: false, swapType: swapType, slippageTolerance: slippage,
+            originAsset: "origin.id", depositType: Near1Click.Constants.originChain, destinationAsset: "dest.id",
+            amount: amount, refundTo: "refund-addr", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient-addr", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+    }
+
+    private func baselineResponse(
+        originAsset: String = "origin.id", destinationAsset: String = "dest.id",
+        swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100,
+        recipient: String = "recipient-addr", refundTo: String = "refund-addr",
+        amountIn: Decimal = Decimal(100_000_000), amountInFormatted: Decimal = Decimal(1),
+        minAmountIn: Decimal = Decimal(100_000_000),
+        amountOut: Decimal = Decimal(2_000_000), amountOutFormatted: Decimal = Decimal(2),
+        minAmountOut: Decimal = Decimal(1_980_000)
+    ) -> SwapQuoteResponseFields {
+        SwapQuoteResponseFields(
+            depositAddress: "deposit-addr", echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
+            echoedSwapType: swapType, echoedSlippageTolerance: slippage, echoedRecipient: recipient, echoedRefundTo: refundTo,
+            amountIn: amountIn, amountInFormatted: amountInFormatted, minAmountIn: minAmountIn,
+            amountOut: amountOut, amountOutFormatted: amountOutFormatted, minAmountOut: minAmountOut
+        )
+    }
+
+    private func validateBaseline(request: SwapQuoteRequest? = nil, response: SwapQuoteResponseFields? = nil) throws {
+        try SwapQuoteValidator.validate(
+            request: request ?? baselineRequest(),
+            response: response ?? baselineResponse(),
+            originDecimals: 8, destinationDecimals: 6
+        )
+    }
+
+    @Test func validateAcceptsConsistentQuote() throws {
+        try validateBaseline()
+    }
+
+    @Test func validateRejectsOriginAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            try self.validateBaseline(response: self.baselineResponse(originAsset: "origin.tampered"))
+        }
+    }
+
+    @Test func validateRejectsDestinationAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "destinationAsset")) {
+            try self.validateBaseline(response: self.baselineResponse(destinationAsset: "dest.tampered"))
+        }
+    }
+
+    @Test func validateRejectsSwapTypeSubstitution() {
+        #expect(throws: SwapQuoteValidationError.swapTypeMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(swapType: Near1Click.Constants.exactOutput))
+        }
+    }
+
+    @Test func validateRejectsWidenedSlippageTolerance() {
+        #expect(throws: SwapQuoteValidationError.slippageToleranceMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(slippage: 10_000))
+        }
+    }
+
+    @Test func validateRejectsRecipientSubstitution() {
+        #expect(throws: SwapQuoteValidationError.recipientMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(recipient: "attacker-addr"))
+        }
+    }
+
+    @Test func validateRejectsRefundSubstitution() {
+        #expect(throws: SwapQuoteValidationError.refundMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(refundTo: "attacker-addr"))
+        }
+    }
+
+    @Test func validateRejectsNonPositiveAmountIn() {
+        #expect(throws: SwapQuoteValidationError.nonPositiveAmount(field: "amountInFormatted")) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(0), amountInFormatted: Decimal(0), minAmountIn: Decimal(0)))
+        }
+    }
+
+    @Test func validateRejectsRawFormattedInconsistency() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(999)))
+        }
+    }
+
+    @Test func validateRejectsInflatedAmountIn() {
+        // Consistent at 8 decimals (2 × 1e8 == 200_000_000) but not what the user requested (1 ZEC).
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(200_000_000), amountInFormatted: Decimal(2), minAmountIn: Decimal(200_000_000)))
+        }
+    }
+
+    @Test func validateRejectsSlippageBelowFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try self.validateBaseline(response: self.baselineResponse(minAmountOut: Decimal(1_900_000)))
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -41,4 +41,59 @@ import Testing
         let formatted = try #require(Decimal(string: "0.00000001", locale: Locale(identifier: "en_US_POSIX")))
         try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
+
+    // MARK: requireWithinSlippage — server's worst-case guarantee must respect requested slippage
+
+    @Test func slippageOutputFloatingPassesAtAndAboveFloor() throws {
+        // 10% slippage, amountOut=100 -> floor=90. minAmountIn is the fixed side (== amountIn) and ignored.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(90), slippageToleranceBps: 1000)
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.flexInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(95), slippageToleranceBps: 1000)
+    }
+
+    @Test func slippageOutputFloatingThrowsBelowFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(89), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageInputFloatingPassesAtAndBelowCeiling() throws {
+        // 10% slippage, amountIn=100 -> ceiling=110. minAmountOut is the fixed side and ignored.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(110), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(105), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+    }
+
+    @Test func slippageInputFloatingThrowsAboveCeiling() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(111), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageOutputAcceptsServerIntegerTruncatedFloor() throws {
+        // Real NEAR 1Click $10 ZEC -> USDC @ 30%: amountOut=9897372 × 0.70 = 6928160.4, server truncates DOWN to 6928160.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(2_245_828), amountOut: Decimal(9_897_372), minAmountIn: Decimal(2_245_828), minAmountOut: Decimal(6_928_160), slippageToleranceBps: 3000)
+    }
+
+    @Test func slippageOutputRejectsOneBelowIntegerFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(2_245_828), amountOut: Decimal(9_897_372), minAmountIn: Decimal(2_245_828), minAmountOut: Decimal(6_928_159), slippageToleranceBps: 3000)
+        }
+    }
+
+    @Test func slippageInputAcceptsServerIntegerRoundedCeiling() throws {
+        // amountIn=9897372 × 1.30 = 12866583.6, server rounds UP to 12866584.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(9_897_372), amountOut: Decimal(2_245_828), minAmountIn: Decimal(12_866_584), minAmountOut: Decimal(2_245_828), slippageToleranceBps: 3000)
+    }
+
+    @Test func slippageInputRejectsOneAboveIntegerCeiling() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(9_897_372), amountOut: Decimal(2_245_828), minAmountIn: Decimal(12_866_585), minAmountOut: Decimal(2_245_828), slippageToleranceBps: 3000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnNaNBound() {
+        // Server-controlled min bounds parse to Decimal.nan on garbage; must fail closed, never bypass.
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal.nan, slippageToleranceBps: 1000)
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -96,4 +96,18 @@ import Testing
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal.nan, slippageToleranceBps: 1000)
         }
     }
+
+    @Test func slippageFailsClosedOnNaNAmountInput() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal.nan, amountOut: Decimal(1000), minAmountIn: Decimal(110), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnAbsurdBps() {
+        // Without the <= 10_000 bound, bps=10_001 makes (10000 - bps) negative -> floor negative -> any
+        // minAmountOut passes (bypass). The bound must make this fail closed.
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct SwapQuoteValidationTests {
+    // MARK: requireConsistent — raw base-unit amount must equal formatted × 10^decimals
+
+    @Test func requireConsistentPassesWhenRawMatchesFormatted() throws {
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(1), decimals: 8)
+    }
+
+    @Test func requireConsistentPassesRegardlessOfFormattedScale() throws {
+        let formatted = try #require(Decimal(string: "1.00", locale: Locale(identifier: "en_US_POSIX")))
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: formatted, decimals: 8)
+    }
+
+    @Test func requireConsistentThrowsWhenRawDoesNotMatchFormatted() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(2), decimals: 8)
+        }
+    }
+}


### PR DESCRIPTION
## Linear

[MOB-1351 — [Security] Fix swap fee display mismatch (UI shows 0.5%, backend charges 0.67%)](https://linear.app/zodl/issue/MOB-1351) (sub-issue of MOB-1276; dossier iOS-Z9)

> **Stacked PR.** Base branch is `michal/MOB-1276/MOB-1388-swap-security-hardening` (open PR #1834), since both touch the swap files. Retarget to `main` once #1834 merges.

## Problem

The Zashi affiliate fee was computed two different ways in `SwapAndPayStore.swift`:

- `zashiFeeStr` / `zashiFeeUsdStr` correctly used `Decimal(zashiFeeBps) / 10_000` = **0.67%**.
- `totalFees` (line 1514) and `swapToZecTotalFees` (line 1746) hardcoded `quote.amountIn * 0.005` = **0.5%**.

`totalFees` feeds `totalFeesStr` — the **total shown on the CrossPay / Swap confirmation screens** (`CrossPayConfirmationView.swift:144`, `SwapComponents.swift:408`). The backend charges `zashiFeeBps = 67` (`Near1Click.swift:357`). So the user reviewed an understated total fee (0.5%), inconsistent even with the app's own standalone fee line (0.67%). There is no localized "0.5%" string — the mismatch is in the hardcoded `0.005` literals.

A **third** `0.005` literal also lives outside `SwapAndPayStore.swift`, in `totalSwapToZecFee` (`TransactionDetailsStore.swift:707`), which drives the **Total fees** row on the completed swap-to-ZEC transaction-detail screen (`TransactionDetailsView.swift:580`). Left unfixed, that screen kept showing 0.5% while the confirmation showed 0.67% — the same mismatch on a different surface.

## Fix

- Added `SwapAndPayClient.Constants.zashiFeeCoefficient = Decimal(zashiFeeBps) / Decimal(10_000)` as the **single source of truth**.
- Routed every fee-coefficient site through it — four in `SwapAndPayStore.swift` (the two already-correct sites as DRY, plus the two `0.005` sites as the fix: 0.5% → 0.67%) and the fifth in `TransactionDetailsStore.swift:707` (`totalSwapToZecFee`).

After this, the displayed total and the standalone fee line both equal exactly what is charged, on both the confirmation and the transaction-detail screens; changing `zashiFeeBps` updates every surface. The remaining `0.005` in `Decimals.swift:17` is an unrelated rounding tolerance.

## Tests (`zodlTests/SwapTests/SwapFeeDisplayTests.swift`)

- `totalFeesUsesZashiFeeBpsNotHardcodedHalfPercent` — the affiliate-fee portion of `totalFees` is 0.67% of `amountIn` (670_000 zatoshi for 1 ZEC), not the old 0.5% (500_000), independent of the network fee.
- `zashiFeeCoefficientDerivesFromBps` — locks the coefficient to `zashiFeeBps / 10_000` so the `0.005` literal can't creep back.
- `transactionDetailSwapToZecFeeUsesZashiFeeBpsNotHardcodedHalfPercent` — `totalSwapToZecFee` on the transaction-detail screen reflects 0.67%, not the old 0.5% (compared against the store's own formatter, so it's locale-independent).

## Verification

- ✅ Build succeeds (zodl-internal).
- ✅ New tests pass (3/3).

## Manual test plan

1. **CrossPay / Swap total fee.** Reach a swap or CrossPay confirmation screen and note the **total fees**. **Expected:** it includes the Zashi affiliate fee at **0.67%** of the input (≈ `amountIn × 0.0067`), consistent with the standalone "Zashi fee" line. Before the fix the total used 0.5%.
2. **Swap-to-ZEC total fee.** In the swap-to-ZEC summary, confirm the fee reflects 0.67%.
3. **Post-swap transaction detail.** Open a completed swap-to-ZEC from Activity and view its detail. **Expected:** the **Total fees** row shows 0.67% of the input amount, matching the confirmation screen. Before the fix this screen still showed 0.5%.
4. **Cross-check.** The standalone fee line and the total's affiliate-fee portion now agree.

Design: `docs/superpowers/specs/2026-06-22-mob-1351-swap-fee-display-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
