### PR TITLE
[MOB-1352] Guard Flexa against Keystone accounts; end Flexa session on account switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Changed
 - QR / payment-request (ZIP-321) codes that contain more than one recipient are now rejected instead of silently processing only the first recipient, so what you review is always exactly what gets signed.
 
+### Fixed
+- Paying with Flexa now requires a Zodl (mobile) account and is blocked for Keystone (hardware) accounts, which have no on-device key to sign with. Switching accounts also ends any open Flexa session so a payment can't bind to the wrong account.
+
 ## 3.7.0 build 1
 
 ### Changed

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -9624,13 +9624,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Flexa payments require a Zodl (mobile) account. Switch to a Zodl account to pay with Flexa."
+            "value" : "Flexa payments require a ZODL account. Switch to a ZODL account to pay with Flexa."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los pagos con Flexa requieren una cuenta Zodl (móvil). Cambia a una cuenta Zodl para pagar con Flexa."
+            "state" : "needs_review",
+            "value" : "Los pagos con Flexa requieren una cuenta ZODL. Cambia a una cuenta ZODL para pagar con Flexa."
           }
         }
       }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -9618,6 +9618,23 @@
         }
       }
     },
+    "partners.flexa.keystoneNotSupportedMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flexa payments require a Zodl (mobile) account. Switch to a Zodl account to pay with Flexa."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los pagos con Flexa requieren una cuenta Zodl (móvil). Cambia a una cuenta Zodl para pagar con Flexa."
+          }
+        }
+      }
+    },
     "partners.flexa.transactionFailedMessage" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -43,7 +43,10 @@ extension Root {
                         .send(.resolveMetadataEncryptionKeys),
                         .send(.loadUserMetadata)
                     ),
-                    .send(.fetchTransactionsForTheSelectedAccount)
+                    .send(.fetchTransactionsForTheSelectedAccount),
+                    // SECURITY (MOB-1352): end any open Flexa session bound to the previous account so a
+                    // pending Flexa transaction request can't bind to the newly-selected account.
+                    .cancel(id: state.CancelFlexaId)
                 )
 
                 // MARK: - Add Keystone HW Wallet Coord Flow

--- a/secant/Sources/Features/Root/RootDestination.swift
+++ b/secant/Sources/Features/Root/RootDestination.swift
@@ -102,6 +102,13 @@ extension Root {
                     return .none
                 }
                 flexaHandler.clearTransactionRequest()
+                // SECURITY (MOB-1352): Flexa signs with a LOCAL spending key derived from the device
+                // seed, which only exists for Zodl (local-seed) accounts. A Keystone (hardware) account
+                // has no local seed, so this path must never run for it — block and prompt the user to
+                // switch to a Zodl account rather than signing with the wrong key.
+                guard account.vendor == .zcash else {
+                    return .send(.flexaTransactionFailed(String(localizable: .partnersFlexaKeystoneNotSupportedMessage)))
+                }
                 return .run { send in
                     do {
                         if await !localAuthentication.authenticate() {
@@ -112,7 +119,13 @@ extension Root {
                         let recipient = try Recipient(transaction.address, network: zcashSDKEnvironment.network().networkType)
                         let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, transaction.amount, nil)
 
-                        // make the actual send
+                        // make the actual send — defensive backstop: the vendor guard above already
+                        // blocks non-Zodl accounts; re-assert before touching the seed so a future
+                        // refactor can't reintroduce signing a Keystone payment with the local seed.
+                        guard account.vendor == .zcash else {
+                            assertionFailure("Flexa reached spending-key derivation for a non-Zodl account")
+                            return
+                        }
                         let storedWallet = try walletStorage.exportWallet()
                         let seedBytes = try mnemonic.toSeed(storedWallet.seedPhrase.value())
                         let network = zcashSDKEnvironment.network().networkType

--- a/zodlTests/FlexaTests/FlexaSecurityTests.swift
+++ b/zodlTests/FlexaTests/FlexaSecurityTests.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+@preconcurrency import Combine
 import Testing
 import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
@@ -20,10 +21,10 @@ import ComposableArchitecture
         static let recipientAddress = "tmP3uLtGx5GPddkq8a6ddmXhqJJ3vy6tpTE"
     }
 
-    private func walletAccount(keystone: Bool) -> WalletAccount {
+    private func walletAccount(keystone: Bool, idByte: UInt8) -> WalletAccount {
         WalletAccount(
             Account(
-                id: AccountUUID(id: [UInt8](repeating: keystone ? 1 : 0, count: 16)),
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
                 name: keystone ? "Keystone" : "Zodl",
                 keySource: keystone ? String(localizable: .accountsKeystone).lowercased() : nil,
                 seedFingerprint: nil,
@@ -49,7 +50,7 @@ import ComposableArchitecture
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             let initialState = Root.State.initial
-            initialState.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true) }
+            initialState.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true, idByte: 1) }
 
             let store = Store(initialState: initialState) {
                 Root()
@@ -81,6 +82,81 @@ import ComposableArchitecture
             #expect(transactionSentCalls.withValue { $0.isEmpty })    // nothing signed / reported sent
             #expect(alertCalls.withValue { $0.count } == 1)           // user is prompted (blocked)
             #expect(proposeCalls.withValue { $0 } == 0)               // proposal / seed path never entered
+        }
+    }
+
+    /// Switching the wallet account must end any open Flexa session: the subscription opened under the
+    /// previous account is cancelled (`CancelFlexaId`), so a request delivered afterwards can no longer
+    /// bind a payment to the newly-selected account. (MOB-1352, Tier 2.)
+    @Test func switchingWalletAccountCancelsOpenFlexaSession() async {
+        let clearRequestCalls = LockIsolated<Int>(0)
+        let alertCalls = LockIsolated<Int>(0)
+        let proposeCalls = LockIsolated<Int>(0)
+        let subscribed = LockIsolated(false)
+        let cancelled = LockIsolated(false)
+        let requests = PassthroughSubject<FlexaTransaction?, Never>()
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let initialState = Root.State.initial
+            initialState.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true, idByte: 1) }
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                $0.derivationTool = .liveValue
+                $0.flexaHandler = .noOp
+                // The Flexa session delivers transaction requests through this publisher; `.flexaOpenRequest`
+                // subscribes to it under `CancelFlexaId`. The flags let the test await the subscribe and the
+                // cancel instead of racing them.
+                $0.flexaHandler.onTransactionRequest = {
+                    requests
+                        .handleEvents(
+                            receiveSubscription: { _ in subscribed.withValue { $0 = true } },
+                            receiveCancel: { cancelled.withValue { $0 = true } }
+                        )
+                        .eraseToAnyPublisher()
+                }
+                $0.flexaHandler.clearTransactionRequest = { clearRequestCalls.withValue { $0 += 1 } }
+                $0.flexaHandler.flexaAlert = { _, _ in alertCalls.withValue { $0 += 1 } }
+                $0.localAuthentication = .mockAuthenticationSucceeded
+                $0.mainQueue = .immediate
+                $0.mnemonic = .mock
+                $0.readTransactionsStorage.resetZashi = { }
+                $0.sdkSynchronizer = .noOp
+                $0.sdkSynchronizer.proposeTransfer = { _, _, _, _ in
+                    proposeCalls.withValue { $0 += 1 }
+                    return .testOnlyFakeProposal(totalFee: 0)
+                }
+                $0.userMetadataProvider.load = { _ in }
+                $0.walletStorage = .noOp
+                $0.zcashSDKEnvironment = .testnet
+            }
+
+            // Open a Flexa session under account #1 and wait until the subscription is live.
+            store.send(.flexaOpenRequest)
+            await waitForFlexaStore { subscribed.withValue { $0 } }
+
+            // Control: with the session open, a delivered request reaches the handler. (A Keystone account
+            // is blocked at the vendor guard, so it surfaces one alert and never proposes — here that just
+            // proves the subscription is live and delivering.)
+            requests.send(makeFlexaTransaction())
+            await waitForFlexaStore { clearRequestCalls.withValue { $0 } == 1 }
+            #expect(alertCalls.withValue { $0 } == 1)
+
+            // Switch to a different account. SECURITY (MOB-1352): this must cancel the open session.
+            store.send(.home(.walletAccountTapped(walletAccount(keystone: true, idByte: 2))))
+            await waitForFlexaStore { cancelled.withValue { $0 } }
+
+            // A request delivered after the switch must be dropped: the session is gone, so the handler
+            // never runs again. Without `.cancel(id: state.CancelFlexaId)` the subscription survives,
+            // `cancelled` never flips (the wait above fails), and this request would be processed.
+            requests.send(makeFlexaTransaction())
+
+            #expect(clearRequestCalls.withValue { $0 } == 1)          // handler not entered a second time
+            #expect(alertCalls.withValue { $0 } == 1)                 // no second alert
+            #expect(proposeCalls.withValue { $0 } == 0)               // signing path never touched
         }
     }
 }

--- a/zodlTests/FlexaTests/FlexaSecurityTests.swift
+++ b/zodlTests/FlexaTests/FlexaSecurityTests.swift
@@ -1,0 +1,99 @@
+//
+//  FlexaSecurityTests.swift
+//  zodlTests
+//
+//  MOB-1352 — Flexa must never derive a local spending key for a Keystone (hardware) account,
+//  which has no on-device seed. A Keystone selection must fail closed (block + prompt) before any
+//  proposal/seed-export path runs, rather than signing with the wrong key.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// Serialized: drives a Root store sharing the process-global `selectedWalletAccount` @Shared state.
+@Suite(.serialized) @MainActor struct FlexaSecurityTests {
+    private enum Const {
+        static let commerceSessionId = "commerce-session-id"
+        static let recipientAddress = "tmP3uLtGx5GPddkq8a6ddmXhqJJ3vy6tpTE"
+    }
+
+    private func walletAccount(keystone: Bool) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: keystone ? 1 : 0, count: 16)),
+                name: keystone ? "Keystone" : "Zodl",
+                keySource: keystone ? String(localizable: .accountsKeystone).lowercased() : nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private func makeFlexaTransaction() -> FlexaTransaction {
+        FlexaTransaction(amount: Zatoshi(100_000), address: Const.recipientAddress, commerceSessionId: Const.commerceSessionId)
+    }
+
+    /// A Keystone account must be blocked: an alert is shown, nothing is reported sent, and the
+    /// proposal/seed-derivation path is never entered.
+    @Test func keystoneAccountIsBlockedAndNeverProposes() async {
+        let transactionSentCalls = LockIsolated<[(String, String)]>([])
+        let alertCalls = LockIsolated<[(String, String)]>([])
+        let proposeCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let initialState = Root.State.initial
+            initialState.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true) }
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                $0.derivationTool = .liveValue
+                $0.flexaHandler = .noOp
+                $0.flexaHandler.clearTransactionRequest = { }
+                $0.flexaHandler.transactionSent = { commerceSessionId, txId in
+                    transactionSentCalls.withValue { $0.append((commerceSessionId, txId)) }
+                }
+                $0.flexaHandler.flexaAlert = { title, message in
+                    alertCalls.withValue { $0.append((title, message)) }
+                }
+                $0.localAuthentication = .mockAuthenticationSucceeded
+                $0.mainQueue = .immediate
+                $0.mnemonic = .mock
+                $0.sdkSynchronizer = .noOp
+                $0.sdkSynchronizer.proposeTransfer = { _, _, _, _ in
+                    proposeCalls.withValue { $0 += 1 }
+                    return .testOnlyFakeProposal(totalFee: 0)
+                }
+                $0.walletStorage = .noOp
+                $0.zcashSDKEnvironment = .testnet
+            }
+
+            store.send(.flexaOnTransactionRequest(makeFlexaTransaction()))
+            await waitForFlexaStore { alertCalls.withValue { !$0.isEmpty } }
+
+            #expect(transactionSentCalls.withValue { $0.isEmpty })    // nothing signed / reported sent
+            #expect(alertCalls.withValue { $0.count } == 1)           // user is prompted (blocked)
+            #expect(proposeCalls.withValue { $0 } == 0)               // proposal / seed path never entered
+        }
+    }
+}
+
+@MainActor
+private func waitForFlexaStore(
+    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for Flexa Root store state", sourceLocation: sourceLocation)
+}


### PR DESCRIPTION
## Linear

[MOB-1352 — [Security] Flexa: guard against Keystone account; fix session binding](https://linear.app/zodl/issue/MOB-1352) (sub-issue of MOB-1276; dossier "Flexa session binding, no vendor guard")

## Problem

`Root.flexaOnTransactionRequest` resolved the **currently-selected** account, checked only for a `zip32AccountIndex` (no vendor check), then `exportWallet()` → derived a **local** spending key → signed. Flexa's local-seed signing path only makes sense for **Zodl (local-seed)** accounts; a **Keystone** (hardware) account has no on-device seed, so a Keystone selection would sign with the wrong key. The Flexa subscription also wasn't torn down on a wallet-account switch.

## Fix (Tier 1 + 2 of the ticket)

- **Keystone vendor guard** (`RootDestination.flexaOnTransactionRequest`): fail closed when `account.vendor != .zcash` — block and prompt the user to switch to a Zodl account (new localized message), before any proposal/seed-export runs. Plus an `assertionFailure` **backstop** immediately before key derivation so a future refactor can't reintroduce signing a Keystone payment with the local seed.
- **End Flexa session on account switch** (`RootCoordinator.home(.walletAccountTapped)`): `.cancel(id: CancelFlexaId)` so a request from a session opened under the previous account can't bind to the newly-selected one. (The account is already re-resolved at callback time; this removes the stale session entirely.)

## Deferred to a follow-up (Tier 3)

The 2026-06-08 finding **ZODL-IOS-04** (native amount/address/fee confirmation before signing, to defend against a malicious Flexa service) is a larger, distinct UX feature and is tracked separately — see the linked follow-up issue. This PR closes the "wrong key / wrong account" fund-safety hole; the native-confirmation work is additive.

## Tests

- `zodlTests/FlexaTests/FlexaSecurityTests.swift`:
  - **Keystone blocked** (`keystoneAccountIsBlockedAndNeverProposes`) — a **Keystone** account is blocked: an alert is shown, nothing is reported sent, and `proposeTransfer` / the seed path is **never** entered.
  - **Account switch ends the session** (`switchingWalletAccountCancelsOpenFlexaSession`) — with a Flexa session open, switching the wallet account cancels the subscription (`CancelFlexaId`); a request delivered after the switch is dropped (the handler never re-enters). Verified red/green — removing `.cancel(id: CancelFlexaId)` makes this test fail.
- Existing `MultiServerSubmitFlexaRoutingTests` (6) still pass — the Zodl (`.zcash`) happy path is unaffected.

## Verification

- ✅ Build succeeds (zodl-internal).
- ✅ New tests pass (2/2); existing Flexa routing tests pass (6/6).

## Manual test plan

1. **Keystone blocked.** Add/select a **Keystone** account, open Pay with Flexa, start a payment. **Expected:** blocked with a clear "switch to a Zodl account" message; nothing signed.
2. **Zodl works (regression).** Select a Zodl account; complete a Flexa payment as before.
3. **Account switch ends session.** Open Flexa under a Zodl account, switch to another account, return. **Expected:** the prior session can't drive a signed payment against the new account.

Design: `docs/superpowers/specs/2026-06-22-mob-1352-flexa-keystone-guard-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
