### PR TITLE
[MOB-1353] Bind swap quote to selected account; reject on mid-flow account switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Security
 - Cross-chain swap quotes are now verified against your request before the transaction is signed: the ZEC amount, payout and refund addresses, assets, and slippage tolerance must match what you requested, and the swap is refused on any mismatch. This protects against a malicious or tampered swap-provider response redirecting your funds.
+- A cross-chain swap is now refused if you switch wallet accounts after requesting the quote, so the spend, refund address, and signing key always belong to the same account you started the swap from.
 
 ## 3.5.2 build 1 (20026-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Removed
 - A hidden legacy debug menu (reachable via a gesture on the splash screen) that could copy the seed phrase to the clipboard without Face ID / Touch ID.
 
+### Security
+- Cross-chain swap quotes are now verified against your request before the transaction is signed: the ZEC amount, payout and refund addresses, assets, and slippage tolerance must match what you requested, and the swap is refused on any mismatch. This protects against a malicious or tampered swap-provider response redirecting your funds.
+
 ## 3.5.2 build 1 (20026-06-08)
 
 ### Changed

--- a/docs/superpowers/specs/2026-06-22-mob-1353-bind-swap-quote-to-account-design.md
+++ b/docs/superpowers/specs/2026-06-22-mob-1353-bind-swap-quote-to-account-design.md
@@ -1,0 +1,70 @@
+# MOB-1353 — Bind swap quote to the selected account (reject on mid-flow switch)
+
+- **Linear:** [MOB-1353](https://linear.app/zodl/issue/MOB-1353) (sub-issue of MOB-1276; iOS parity for Android #19 / MOB-1344)
+- **Priority:** Medium
+- **Branch:** `michal/MOB-1276/MOB-1353-bind-swap-quote-to-account`
+- **Base / PR target:** `michal/MOB-1276/MOB-1388-swap-security-hardening` (PR #1834; retarget to `main` after it merges)
+- **Date:** 2026-06-22
+
+## 1. Verification — iOS IS exposed (and MOB-1388 does not cover this)
+
+The swap flow reads the selected account at **three** points, none snapshotted:
+
+1. **`.getQuote`** (`SwapAndPayStore.swift:675`): `refundTo = state.selectedWalletAccount?.privateUnifiedAddress` — the refund address baked into the NEAR quote request comes from the account selected **now**.
+2. **`.swapQuoteLoaded`** (`:732`, `:760`): re-reads `state.selectedWalletAccount` and builds the proposal with `proposeTransfer(account.id, …)`.
+3. **`.swapRequested`** (`SwapAndPayCoordFlowCoordinator.swift:297`, `:341`): re-reads `state.selectedWalletAccount?.zip32AccountIndex` and derives the **spending key** from it.
+
+If the user switches accounts during the quote → review → biometric window:
+- a switch during the quote API call → the quote's **refund address is account A's** while the proposal + spending key bind to **account B** (funds spent from B, any NEAR refund goes to A);
+- a switch during review/biometric → the proposal (built for A) is signed with **account B's** spending key (TOCTOU mismatch).
+
+**MOB-1388 (#1834)** added `matchesSigningIntent` (recipient / origin & destination asset ids) — it does **not** bind the wallet account. So this is a distinct, still-open defect. This is the iOS parity of Android #19 ("swap quote not bound to account uuid").
+
+## 2. Fix — snapshot the account at quote request, reject on change
+
+Bind the whole flow to the account selected when the quote is requested. The account `id` is the binding key — the refund address and the `zip32AccountIndex` both derive from it, so verifying the id covers them (a same-session id is also stable across seed, so an explicit `seedFingerprint` check adds nothing in practice).
+
+- **State:** add `var quoteAccountId: AccountUUID?` to `SwapAndPay.State`.
+- **`.getQuote`:** snapshot `state.quoteAccountId = state.selectedWalletAccount?.id` (the refund address sent in the same request is this account's).
+- **`.swapQuoteLoaded`:** after the swap-to-ZEC early return and before building the proposal, fail closed if the selection changed:
+  ```swift
+  guard account.id == state.quoteAccountId else {
+      return .send(.sendFailed("selected account changed during the swap".toZcashError()))
+  }
+  ```
+- **`.swapRequested`** (coordinator): require the current selection to still match the quote account, and derive the spending key from **that** account:
+  ```swift
+  guard let account = state.selectedWalletAccount,
+        account.id == state.swapAndPayState.quoteAccountId,
+        let zip32AccountIndex = account.zip32AccountIndex else {
+      return .send(.sendFailed("selected account changed during the swap".toZcashError(), false))
+  }
+  ```
+
+`quoteAccountId` is re-set on every `.getQuote`, so each new quote re-binds; no stale binding can block a fresh quote.
+
+**Scope note:** swap-to-ZEC (`isSwapToZecExperienceEnabled`) returns early in `.swapQuoteLoaded` and never builds a `proposeTransfer` spend (the user sends funds manually), so the binding guard applies to the swap-from-ZEC / CrossPay spend path — which is where the account-bound `proposeTransfer` + spending key live.
+
+## 3. Tests (`zodlTests/SwapTests/SwapAccountBindingTests.swift`, Swift Testing; added to the Classic-groups project via XcodeWrite)
+
+Drive the `SwapAndPay` reducer (plain `Store` + poll, like the existing swap CoordFlow tests; `@Suite(.serialized)` for `selectedWalletAccount`):
+
+- **Reject on switch:** `state.quoteAccountId = A`, `selectedWalletAccount = B`, send `.swapQuoteLoaded(quote)` → no proposal built (`proposeTransfer` never called) and the quote-unavailable/sendFailed path is taken.
+- **Happy path (regression):** `quoteAccountId = A`, `selectedWalletAccount = A`, matching intent → `proposeTransfer` called once → `.proposal` set.
+
+## 4. Acceptance criteria mapping
+
+- ✅ Verify whether iOS re-reads the selected account at proposal/submit rather than a snapshot — **yes, exposed**; documented (§1).
+- ✅ Snapshot `(account id, …, refund address, destination address)` at quote request and reject on mid-flow change (§2). (Destination is already bound by #1388's `matchesSigningIntent`; refund address follows from the account id.)
+- ✅ Covers the quote → review → biometric → submit window (guards at `.swapQuoteLoaded` and `.swapRequested`).
+
+## 5. Changelog
+
+Under `[Unreleased]` → "Security":
+> A cross-chain swap is now refused if you switch wallet accounts after requesting the quote, so the spend, refund address, and signing key always belong to the same account you started the swap from.
+
+## 6. Manual test plan (for the PR)
+
+1. **Switch mid-swap (the fix).** With two accounts, start a swap on account A, get the quote, then switch to account B (account picker) and confirm. **Expected:** the swap is refused (quote-unavailable / failure), nothing is signed or broadcast.
+2. **Normal swap (regression).** Start and complete a swap without switching accounts — unchanged behaviour.
+3. **Swap-to-ZEC (regression).** The swap-to-ZEC deposit flow still shows the deposit address as before.

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		34755C662F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C692F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C6A2F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
+		3487F7F82FE9575700502768 /* SwapAccountBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3487F7F72FE9575700502768 /* SwapAccountBindingTests.swift */; };
 		348EC4CC2FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348EC4C72FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift */; };
 		348EC4CD2FD7FD96008495FB /* ServerEndpointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348EC4C92FD7FD96008495FB /* ServerEndpointsTests.swift */; };
 		348EC4CE2FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */; };
@@ -58,6 +59,9 @@
 		349CE5D62FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5D52FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift */; };
 		349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5E92FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift */; };
 		349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */; };
+		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
+		349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */; };
+		349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */; };
 		349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */; };
 		34AA6DD82F85774F00D244E2 /* SwapAndPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6CF82F85774F00D244E2 /* SwapAndPayStore.swift */; };
 		34AA6DD92F85774F00D244E2 /* RemoteStorageInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA6C102F85774F00D244E2 /* RemoteStorageInterface.swift */; };
@@ -1442,9 +1446,6 @@
 		37D0F0000000000000000024 /* RoundAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0F0000000000000000002 /* RoundAuthenticator.swift */; };
 		38923B93B161EE61D86F3070 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F94E337360CE50FACFB04CE /* AccessibilityID.swift */; };
 		54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E83225E24EEF486F002B79 /* RecoveryPhraseBackupTests.swift */; };
-		349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */; };
-		349CE6192FDC1B1500E2B9AB /* ExportLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */; };
-		349CE6272FDC1CEA00E2B9AB /* TorSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */; };
 		63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D430BF2CF73CFB82A13F1CB /* SecItemClientTests.swift */; };
 		7F2ADC6502AEA05DC52D423E /* CurrencyConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */; };
 		8A7BC563281CD8FAF2463BBC /* QRCodeGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1983F0BB6D025B08BBD186B /* QRCodeGeneratorTests.swift */; };
@@ -1627,6 +1628,7 @@
 		341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Near1ClickQuoteMapperTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
+		3487F7F72FE9575700502768 /* SwapAccountBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapAccountBindingTests.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
 		348EC4C72FD7FD96008495FB /* AutomaticServerSelectionStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionStorageTests.swift; sourceTree = "<group>"; };
 		348EC4C82FD7FD96008495FB /* AutoServerSelectionClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoServerSelectionClientTests.swift; sourceTree = "<group>"; };
@@ -1643,10 +1645,10 @@
 		349CE5D52FDC0EDF00E2B9CF /* MultiServerSubmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiServerSubmissionTests.swift; sourceTree = "<group>"; };
 		349CE5E92FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiServerSubmitRoutingTests.swift; sourceTree = "<group>"; };
 		349CE5F72FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseDisplayTests.swift; sourceTree = "<group>"; };
-		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
 		349CE60A2FDC18E700E2B9CF /* ExportTransactionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTransactionHistoryTests.swift; sourceTree = "<group>"; };
 		349CE6192FDC1B1500E2B9CF /* ExportLogsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportLogsTests.swift; sourceTree = "<group>"; };
 		349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorSetupTests.swift; sourceTree = "<group>"; };
+		349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsTests.swift; sourceTree = "<group>"; };
 		34AA6BA42F85774F00D244E2 /* ABv1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABv1.swift; sourceTree = "<group>"; };
 		34AA6BA62F85774F00D244E2 /* AddressBookContacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookContacts.swift; sourceTree = "<group>"; };
 		34AA6BA72F85774F00D244E2 /* AddressBookEncryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEncryption.swift; sourceTree = "<group>"; };
@@ -2407,6 +2409,7 @@
 				341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */,
 				341C34292FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift */,
 				341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */,
+				3487F7F72FE9575700502768 /* SwapAccountBindingTests.swift */,
 			);
 			path = SwapTests;
 			sourceTree = "<group>";
@@ -2457,14 +2460,6 @@
 			path = SendTests;
 			sourceTree = "<group>";
 		};
-		349CE6582FDC358500E2B9CF /* SettingsTests */ = {
-			isa = PBXGroup;
-			children = (
-				349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */,
-			);
-			path = SettingsTests;
-			sourceTree = "<group>";
-		};
 		349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2487,6 +2482,14 @@
 				349CE6272FDC1CEA00E2B9CF /* TorSetupTests.swift */,
 			);
 			path = TorSetupTests;
+			sourceTree = "<group>";
+		};
+		349CE6582FDC358500E2B9CF /* SettingsTests */ = {
+			isa = PBXGroup;
+			children = (
+				349CE6592FDC358500E2B9CF /* AdvancedSettingsTests.swift */,
+			);
+			path = SettingsTests;
 			sourceTree = "<group>";
 		};
 		34AA6BA52F85774F00D244E2 /* Migration */ = {
@@ -5175,6 +5178,7 @@
 				341C342F2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,
 				A409BF1DAB30483E4CDB0DCB /* ZatoshiStringRepresentationTests.swift in Sources */,
+				3487F7F82FE9575700502768 /* SwapAccountBindingTests.swift in Sources */,
 				341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		341C34202FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
 		341C34212FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
 		341C34232FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */; };
+		341C342A2FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34292FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift */; };
+		341C342F2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1621,6 +1623,8 @@
 		341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidationTests.swift; sourceTree = "<group>"; };
 		341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNumericConversions.swift; sourceTree = "<group>"; };
 		341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNumericConversionsTests.swift; sourceTree = "<group>"; };
+		341C34292FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteIntentTests.swift; sourceTree = "<group>"; };
+		341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Near1ClickQuoteMapperTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2401,6 +2405,8 @@
 			children = (
 				341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */,
 				341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */,
+				341C34292FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift */,
+				341C342E2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift */,
 			);
 			path = SwapTests;
 			sourceTree = "<group>";
@@ -5135,6 +5141,7 @@
 				34D06C912FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift in Sources */,
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
 				349CE65A2FDC358500E2B9CF /* AdvancedSettingsTests.swift in Sources */,
+				341C342A2FDFF1EC000DD8DA /* SwapQuoteIntentTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
 				AD0D00232D00000100000001 /* VotingServiceConfigTests.swift in Sources */,
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,
@@ -5165,6 +5172,7 @@
 				63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */,
 				2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */,
 				BFE03A2F84B2F8B97831CD9F /* ZatoshiTests.swift in Sources */,
+				341C342F2FDFF203000DD8DA /* Near1ClickQuoteMapperTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,
 				A409BF1DAB30483E4CDB0DCB /* ZatoshiStringRepresentationTests.swift in Sources */,
 				341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		05F96BC8C109B80ED685D9CD /* PrivateDataConsentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE450F4E98D0B7054611598 /* PrivateDataConsentTests.swift */; };
 		161B27ACDB3C31A163EC8AFF /* SensitiveDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53B4B2244B2E608A11AC552 /* SensitiveDataTests.swift */; };
 		2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD04B216486D7A0AAB329F2 /* UserPreferencesStorageTests.swift */; };
+		341C34012FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
+		341C34022FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
+		341C34032FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
+		341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1609,6 +1613,8 @@
 		0DFE93DE272C6D4B000FCCA5 /* RecoveryPhraseBackupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseBackupTests.swift; sourceTree = "<group>"; };
 		0F94E337360CE50FACFB04CE /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
 		315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CurrencyConversionTests.swift; sourceTree = "<group>"; };
+		341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidation.swift; sourceTree = "<group>"; };
+		341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidationTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2347,6 +2353,7 @@
 				349CE6092FDC18E700E2B9CF /* ExportTransactionHistoryTests */,
 				349CE6182FDC1B1500E2B9CF /* ExportLogsTests */,
 				349CE6262FDC1CEA00E2B9CF /* TorSetupTests */,
+				341C34042FDFE1DE000DD8DA /* SwapTests */,
 			);
 			path = zodlTests;
 			sourceTree = "<group>";
@@ -2381,6 +2388,14 @@
 			children = (
 			);
 			path = BalanceBreakdownTests;
+			sourceTree = "<group>";
+		};
+		341C34042FDFE1DE000DD8DA /* SwapTests */ = {
+			isa = PBXGroup;
+			children = (
+				341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */,
+			);
+			path = SwapTests;
 			sourceTree = "<group>";
 		};
 		343CF3F429BB5A14009E44DF /* Frameworks */ = {
@@ -2784,6 +2799,7 @@
 				34AA6C272F85774F00D244E2 /* SwapQuote.swift */,
 				34AA6C282F85774F00D244E2 /* SwapQuoteRequest.swift */,
 				34AA6C292F85774F00D244E2 /* SwapSubmitHash.swift */,
+				341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -5142,6 +5158,7 @@
 				BFE03A2F84B2F8B97831CD9F /* ZatoshiTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,
 				A409BF1DAB30483E4CDB0DCB /* ZatoshiStringRepresentationTests.swift in Sources */,
+				341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5186,6 +5203,7 @@
 				34AA74AF2F85774F00D244E2 /* SwapForm.swift in Sources */,
 				34AA74B02F85774F00D244E2 /* CrossPayForm.swift in Sources */,
 				34AA74B12F85774F00D244E2 /* DerivationToolInterface.swift in Sources */,
+				341C34012FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */,
 				34AA74B22F85774F00D244E2 /* TransactionState.swift in Sources */,
 				34AA74B32F85774F00D244E2 /* SwapAndPayForm.swift in Sources */,
 				34AA74B42F85774F00D244E2 /* ExportLogs.swift in Sources */,
@@ -5656,6 +5674,7 @@
 				34AA714B2F85774F00D244E2 /* SwapForm.swift in Sources */,
 				34AA714C2F85774F00D244E2 /* CrossPayForm.swift in Sources */,
 				34AA714D2F85774F00D244E2 /* DerivationToolInterface.swift in Sources */,
+				341C34022FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */,
 				34AA714E2F85774F00D244E2 /* TransactionState.swift in Sources */,
 				34AA714F2F85774F00D244E2 /* SwapAndPayForm.swift in Sources */,
 				34AA71502F85774F00D244E2 /* ExportLogs.swift in Sources */,
@@ -6126,6 +6145,7 @@
 				34AA6DE72F85774F00D244E2 /* SwapForm.swift in Sources */,
 				34AA6DE82F85774F00D244E2 /* CrossPayForm.swift in Sources */,
 				34AA6DE92F85774F00D244E2 /* DerivationToolInterface.swift in Sources */,
+				341C34032FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */,
 				34AA6DEA2F85774F00D244E2 /* TransactionState.swift in Sources */,
 				34AA6DEB2F85774F00D244E2 /* SwapAndPayForm.swift in Sources */,
 				34AA6DEC2F85774F00D244E2 /* ExportLogs.swift in Sources */,

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		341C34022FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
 		341C34032FDFE1D9000DD8DA /* SwapQuoteValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */; };
 		341C34062FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */; };
+		341C341F2FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
+		341C34202FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
+		341C34212FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */; };
+		341C34232FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */; };
 		34755C632F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
 		34755C642F8647B00093FC84 /* DisconnectHWWalletStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */; };
 		34755C652F8647B00093FC84 /* DisconnectHWWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */; };
@@ -1615,6 +1619,8 @@
 		315332C8DF63DFCDB9187BF2 /* CurrencyConversionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CurrencyConversionTests.swift; sourceTree = "<group>"; };
 		341C34002FDFE1D9000DD8DA /* SwapQuoteValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidation.swift; sourceTree = "<group>"; };
 		341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapQuoteValidationTests.swift; sourceTree = "<group>"; };
+		341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNumericConversions.swift; sourceTree = "<group>"; };
+		341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNumericConversionsTests.swift; sourceTree = "<group>"; };
 		34755C602F8647B00093FC84 /* DisconnectHWWalletStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletStore.swift; sourceTree = "<group>"; };
 		34755C612F8647B00093FC84 /* DisconnectHWWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectHWWalletView.swift; sourceTree = "<group>"; };
 		348EC4C62FD7FD96008495FB /* AutomaticServerSelectionMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticServerSelectionMigrationTests.swift; sourceTree = "<group>"; };
@@ -2394,6 +2400,7 @@
 			isa = PBXGroup;
 			children = (
 				341C34052FDFE1DE000DD8DA /* SwapQuoteValidationTests.swift */,
+				341C34222FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift */,
 			);
 			path = SwapTests;
 			sourceTree = "<group>";
@@ -3908,6 +3915,7 @@
 				34AA6DCF2F85774F00D244E2 /* WalletLogger.swift */,
 				34AA6DD02F85774F00D244E2 /* ZcashError+DetailedMessage.swift */,
 				34AA6DBC2F85774F00D244E2 /* Logging */,
+				341C341E2FDFEEE3000DD8DA /* SafeNumericConversions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5132,6 +5140,7 @@
 				349CE5EA2FDC12D400E2B9CF /* MultiServerSubmitRoutingTests.swift in Sources */,
 				AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */,
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
+				341C34232FDFEEE9000DD8DA /* SafeNumericConversionsTests.swift in Sources */,
 				54B3A48C4A5790F1E38FEB6C /* RecoveryPhraseBackupTests.swift in Sources */,
 				349CE5F82FDC167400E2B9CF /* RecoveryPhraseDisplayTests.swift in Sources */,
 				349CE60A2FDC18E700E2B9AB /* ExportTransactionHistoryTests.swift in Sources */,
@@ -5507,6 +5516,7 @@
 				348EC4F22FD7FE54008495FB /* TransactionGuardLiveKey.swift in Sources */,
 				34AA75C22F85774F00D244E2 /* TransactionDetailsView.swift in Sources */,
 				34AA75C32F85774F00D244E2 /* Swaps.swift in Sources */,
+				341C341F2FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */,
 				34AA75C42F85774F00D244E2 /* UserMetadataProviderLiveKey.swift in Sources */,
 				34AA75C52F85774F00D244E2 /* LocalAuthenticationLiveKey.swift in Sources */,
 				34AA75C62F85774F00D244E2 /* SendFormView.swift in Sources */,
@@ -5978,6 +5988,7 @@
 				348EC4FA2FD7FE54008495FB /* TransactionGuardLiveKey.swift in Sources */,
 				34AA725E2F85774F00D244E2 /* TransactionDetailsView.swift in Sources */,
 				34AA725F2F85774F00D244E2 /* Swaps.swift in Sources */,
+				341C34212FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */,
 				34AA72602F85774F00D244E2 /* UserMetadataProviderLiveKey.swift in Sources */,
 				34AA72612F85774F00D244E2 /* LocalAuthenticationLiveKey.swift in Sources */,
 				34AA72622F85774F00D244E2 /* SendFormView.swift in Sources */,
@@ -6449,6 +6460,7 @@
 				348EC4F62FD7FE54008495FB /* TransactionGuardLiveKey.swift in Sources */,
 				34AA6EFA2F85774F00D244E2 /* TransactionDetailsView.swift in Sources */,
 				34AA6EFB2F85774F00D244E2 /* Swaps.swift in Sources */,
+				341C34202FDFEEE3000DD8DA /* SafeNumericConversions.swift in Sources */,
 				34AA6EFC2F85774F00D244E2 /* UserMetadataProviderLiveKey.swift in Sources */,
 				34AA6EFD2F85774F00D244E2 /* LocalAuthenticationLiveKey.swift in Sources */,
 				34AA6EFE2F85774F00D244E2 /* SendFormView.swift in Sources */,

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuote.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuote.swift
@@ -23,7 +23,13 @@ struct SwapQuote: Codable, Equatable, Hashable {
     let amountOutUsd: String
     /// Number of seconds it takes to process this quote
     let timeEstimate: TimeInterval
-    
+    /// Echoed off-chain payout recipient (the address the user typed); validated == request at parse time.
+    let recipient: String
+    /// Echoed origin assetId; validated == request at parse time.
+    let originAssetId: String
+    /// Echoed destination assetId; validated == request at parse time.
+    let destinationAssetId: String
+
     init(
         depositAddress: String,
         amountIn: Decimal,
@@ -31,7 +37,10 @@ struct SwapQuote: Codable, Equatable, Hashable {
         minAmountIn: Decimal,
         amountOut: Decimal,
         amountOutUsd: String,
-        timeEstimate: TimeInterval
+        timeEstimate: TimeInterval,
+        recipient: String,
+        originAssetId: String,
+        destinationAssetId: String
     ) {
         self.depositAddress = depositAddress
         self.amountIn = amountIn
@@ -40,5 +49,18 @@ struct SwapQuote: Codable, Equatable, Hashable {
         self.amountOut = amountOut
         self.amountOutUsd = amountOutUsd
         self.timeEstimate = timeEstimate
+        self.recipient = recipient
+        self.originAssetId = originAssetId
+        self.destinationAssetId = destinationAssetId
+    }
+}
+
+extension SwapQuote {
+    /// Re-binds the quote to current user intent immediately before signing (TOCTOU guard): the echoed
+    /// payout recipient and both asset ids must still match what the user is looking at.
+    func matchesSigningIntent(address: String, originAssetId: String, destinationAssetId: String) -> Bool {
+        recipient == address
+            && self.originAssetId == originAssetId
+            && self.destinationAssetId == destinationAssetId
     }
 }

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -19,7 +19,64 @@ enum SwapQuoteValidationError: Error, Equatable {
     case refundMismatch
 }
 
+/// The subset of the swap-quote response the validator inspects: the echoed `quoteRequest` fields plus
+/// the `quote` amounts, all already parsed into typed values.
+struct SwapQuoteResponseFields: Equatable {
+    let depositAddress: String
+    let echoedOriginAsset: String
+    let echoedDestinationAsset: String
+    let echoedSwapType: String
+    let echoedSlippageTolerance: Int
+    let echoedRecipient: String
+    let echoedRefundTo: String
+    let amountIn: Decimal
+    let amountInFormatted: Decimal
+    let minAmountIn: Decimal
+    let amountOut: Decimal
+    let amountOutFormatted: Decimal
+    let minAmountOut: Decimal
+}
+
 enum SwapQuoteValidator {
+    /// Validates a freshly-received quote against the request we sent. Throws the first failure; the caller
+    /// fails closed (maps to the "quote unavailable" path) on any throw.
+    static func validate(
+        request: SwapQuoteRequest,
+        response: SwapQuoteResponseFields,
+        originDecimals: Int,
+        destinationDecimals: Int
+    ) throws {
+        try requireMatchingAssetId(field: "originAsset", expected: request.originAsset, actual: response.echoedOriginAsset)
+        try requireMatchingAssetId(field: "destinationAsset", expected: request.destinationAsset, actual: response.echoedDestinationAsset)
+
+        if request.swapType != response.echoedSwapType {
+            throw SwapQuoteValidationError.swapTypeMismatch
+        }
+        if request.slippageTolerance != response.echoedSlippageTolerance {
+            throw SwapQuoteValidationError.slippageToleranceMismatch
+        }
+        if request.recipient != response.echoedRecipient {
+            throw SwapQuoteValidationError.recipientMismatch
+        }
+        if request.refundTo != response.echoedRefundTo {
+            throw SwapQuoteValidationError.refundMismatch
+        }
+        // amountInFormatted must be strictly positive (also fail closed on NaN — defends zecExchangeRate-style
+        // divisions downstream). It comes from Decimal(string:) which never yields NaN, but guard anyway.
+        guard !response.amountInFormatted.isNaN,
+              NSDecimalNumber(decimal: response.amountInFormatted).compare(NSDecimalNumber.zero) == ComparisonResult.orderedDescending else {
+            throw SwapQuoteValidationError.nonPositiveAmount(field: "amountInFormatted")
+        }
+
+        try requireConsistent(name: "amountIn", raw: response.amountIn, formatted: response.amountInFormatted, decimals: originDecimals)
+        try requireConsistent(name: "amountOut", raw: response.amountOut, formatted: response.amountOutFormatted, decimals: destinationDecimals)
+        try requireWithinSlippage(
+            swapType: request.swapType, amountIn: response.amountIn, amountOut: response.amountOut,
+            minAmountIn: response.minAmountIn, minAmountOut: response.minAmountOut, slippageToleranceBps: request.slippageTolerance
+        )
+        try requireMatchesRequestedAmount(swapType: request.swapType, requestedAmount: request.amount, rawAmountIn: response.amountIn, rawAmountOut: response.amountOut)
+    }
+
     /// The signed raw base-unit amount must equal the exact decimal expansion of the displayed
     /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
     /// must not be relaxed to a tolerance.

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -1,0 +1,32 @@
+//
+//  SwapQuoteValidation.swift
+//  Zashi
+//
+
+import Foundation
+
+/// Typed failures from validating a swap quote against the request we sent and the user's intent.
+/// Each is fail-closed: the caller maps any of these to the existing "quote unavailable" path.
+enum SwapQuoteValidationError: Error, Equatable {
+    case assetMismatch(field: String)
+    case swapTypeMismatch
+    case slippageToleranceMismatch
+    case amountInconsistency(field: String)
+    case nonPositiveAmount(field: String)
+    case slippageExceeded
+    case requestedAmountMismatch
+    case recipientMismatch
+    case refundMismatch
+}
+
+enum SwapQuoteValidator {
+    /// The signed raw base-unit amount must equal the exact decimal expansion of the displayed
+    /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
+    /// must not be relaxed to a tolerance.
+    static func requireConsistent(name: String, raw: Decimal, formatted: Decimal, decimals: Int) throws {
+        let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
+        if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
+    }
+}

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -84,7 +84,14 @@ enum SwapQuoteValidator {
         guard !raw.isNaN, !formatted.isNaN, (0...32).contains(decimals) else {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
-        let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
+        // A server-controlled `formatted` can be huge (e.g. "1e120"); the default NSDecimalNumber behavior
+        // raises an uncatchable NSDecimalNumberOverflowException on overflow, so use the non-raising handler
+        // and fail closed on the resulting NaN rather than crash.
+        let expected = NSDecimalNumber(decimal: formatted)
+            .multiplying(byPowerOf10: Int16(decimals), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
+        guard !expected.doubleValue.isNaN else {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
         if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
@@ -113,8 +120,11 @@ enum SwapQuoteValidator {
         case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
             // Output floats: minAmountOut must be >= amountOut * (1 - slippage), rounded DOWN.
             let floor = NSDecimalNumber(decimal: amountOut)
-                .multiplying(by: denominator.subtracting(bps))
+                .multiplying(by: denominator.subtracting(bps), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
                 .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundDownZeroScale)
+            guard !floor.doubleValue.isNaN else {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
             if NSDecimalNumber(decimal: minAmountOut).compare(floor) == ComparisonResult.orderedAscending {
                 throw SwapQuoteValidationError.slippageExceeded
             }
@@ -122,8 +132,11 @@ enum SwapQuoteValidator {
         case Near1Click.Constants.exactOutput:
             // Input floats: minAmountIn (worst-case max input) must be <= amountIn * (1 + slippage), rounded UP.
             let ceiling = NSDecimalNumber(decimal: amountIn)
-                .multiplying(by: denominator.adding(bps))
+                .multiplying(by: denominator.adding(bps), withBehavior: SwapQuoteValidator.nonRaisingNoScale)
                 .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundUpZeroScale)
+            guard !ceiling.doubleValue.isNaN else {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
             if NSDecimalNumber(decimal: minAmountIn).compare(ceiling) == ComparisonResult.orderedDescending {
                 throw SwapQuoteValidationError.slippageExceeded
             }
@@ -166,6 +179,14 @@ enum SwapQuoteValidator {
             throw SwapQuoteValidationError.requestedAmountMismatch
         }
     }
+
+    /// Full-precision, non-raising behavior for the consistency/slippage multiplications. A server-controlled
+    /// amount can overflow `Decimal`; the default behavior raises an uncatchable NSDecimalNumberOverflowException,
+    /// so this returns NaN on overflow and the callers fail closed instead of crashing.
+    static let nonRaisingNoScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.plain, scale: Int16(NSDecimalNoScale),
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
 
     static let roundDownZeroScale = NSDecimalNumberHandler(
         roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -44,7 +44,8 @@ enum SwapQuoteValidator {
         minAmountOut: Decimal,
         slippageToleranceBps: Int
     ) throws {
-        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN, slippageToleranceBps >= 0 else {
+        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN,
+              slippageToleranceBps >= 0, slippageToleranceBps <= 10_000 else {
             throw SwapQuoteValidationError.slippageExceeded
         }
 
@@ -71,6 +72,8 @@ enum SwapQuoteValidator {
             }
 
         default:
+            // Unknown swap type has no floating side to validate. swapType is pinned to the request by the
+            // validate() orchestrator, so this is unreachable in the integrated path; no-op here is safe.
             break
         }
     }

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -24,6 +24,9 @@ enum SwapQuoteValidator {
     /// `*Formatted` value. Exact-equality is intentional (the "trust the quote 0% or 100%" stance) and
     /// must not be relaxed to a tolerance.
     static func requireConsistent(name: String, raw: Decimal, formatted: Decimal, decimals: Int) throws {
+        guard !raw.isNaN, !formatted.isNaN, (0...32).contains(decimals) else {
+            throw SwapQuoteValidationError.amountInconsistency(field: name)
+        }
         let expected = NSDecimalNumber(decimal: formatted).multiplying(byPowerOf10: Int16(decimals))
         if NSDecimalNumber(decimal: raw).compare(expected) != ComparisonResult.orderedSame {
             throw SwapQuoteValidationError.amountInconsistency(field: name)

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -78,6 +78,38 @@ enum SwapQuoteValidator {
         }
     }
 
+    /// The returned asset id must exactly equal the asset id we requested (an opaque identifier from the
+    /// same token list, so exact-match is correct).
+    static func requireMatchingAssetId(field: String, expected: String, actual: String) throws {
+        if expected != actual {
+            throw SwapQuoteValidationError.assetMismatch(field: field)
+        }
+    }
+
+    /// The user-fixed side of the swap must equal the amount the user requested (exact, in base units).
+    /// EXACT_INPUT / FLEX_INPUT fix the input; EXACT_OUTPUT fixes the output. Fails closed on an
+    /// unparseable/NaN requested amount, a NaN quoted amount, or an unknown swap type.
+    static func requireMatchesRequestedAmount(swapType: String, requestedAmount: String, rawAmountIn: Decimal, rawAmountOut: Decimal) throws {
+        guard let requested = Decimal(string: requestedAmount, locale: Locale(identifier: "en_US_POSIX")), !requested.isNaN else {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        let userFixed: Decimal
+        switch swapType {
+        case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
+            userFixed = rawAmountIn
+        case Near1Click.Constants.exactOutput:
+            userFixed = rawAmountOut
+        default:
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        guard !userFixed.isNaN else {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+        if NSDecimalNumber(decimal: userFixed).compare(NSDecimalNumber(decimal: requested)) != ComparisonResult.orderedSame {
+            throw SwapQuoteValidationError.requestedAmountMismatch
+        }
+    }
+
     static let roundDownZeroScale = NSDecimalNumberHandler(
         roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
         raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -22,7 +22,6 @@ enum SwapQuoteValidationError: Error, Equatable {
 /// The subset of the swap-quote response the validator inspects: the echoed `quoteRequest` fields plus
 /// the `quote` amounts, all already parsed into typed values.
 struct SwapQuoteResponseFields: Equatable {
-    let depositAddress: String
     let echoedOriginAsset: String
     let echoedDestinationAsset: String
     let echoedSwapType: String

--- a/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/models/SwapQuoteValidation.swift
@@ -32,4 +32,56 @@ enum SwapQuoteValidator {
             throw SwapQuoteValidationError.amountInconsistency(field: name)
         }
     }
+
+    /// Fail-closed slippage check on the server-determined (floating) side of the quote. Integer base-unit
+    /// math with the server's own DOWN/UP truncation so legitimate boundary quotes are accepted. Fails
+    /// closed on NaN bounds (server-controlled strings can parse to NaN) and negative slippage.
+    static func requireWithinSlippage(
+        swapType: String,
+        amountIn: Decimal,
+        amountOut: Decimal,
+        minAmountIn: Decimal,
+        minAmountOut: Decimal,
+        slippageToleranceBps: Int
+    ) throws {
+        guard !amountIn.isNaN, !amountOut.isNaN, !minAmountIn.isNaN, !minAmountOut.isNaN, slippageToleranceBps >= 0 else {
+            throw SwapQuoteValidationError.slippageExceeded
+        }
+
+        let denominator = NSDecimalNumber(value: 10_000)
+        let bps = NSDecimalNumber(value: slippageToleranceBps)
+
+        switch swapType {
+        case Near1Click.Constants.exactInput, Near1Click.Constants.flexInput:
+            // Output floats: minAmountOut must be >= amountOut * (1 - slippage), rounded DOWN.
+            let floor = NSDecimalNumber(decimal: amountOut)
+                .multiplying(by: denominator.subtracting(bps))
+                .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundDownZeroScale)
+            if NSDecimalNumber(decimal: minAmountOut).compare(floor) == ComparisonResult.orderedAscending {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
+
+        case Near1Click.Constants.exactOutput:
+            // Input floats: minAmountIn (worst-case max input) must be <= amountIn * (1 + slippage), rounded UP.
+            let ceiling = NSDecimalNumber(decimal: amountIn)
+                .multiplying(by: denominator.adding(bps))
+                .dividing(by: denominator, withBehavior: SwapQuoteValidator.roundUpZeroScale)
+            if NSDecimalNumber(decimal: minAmountIn).compare(ceiling) == ComparisonResult.orderedDescending {
+                throw SwapQuoteValidationError.slippageExceeded
+            }
+
+        default:
+            break
+        }
+    }
+
+    static let roundDownZeroScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
+
+    static let roundUpZeroScale = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.up, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
 }

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -46,6 +46,7 @@ struct Near1Click {
         static let refundedAmountFormatted = "refundedAmountFormatted"
         static let amountInFormatted = "amountInFormatted"
         static let amountOutFormatted = "amountOutFormatted"
+        static let minAmountOut = "minAmountOut"
         static let recipient = "recipient"
         static let deadline = "deadline"
         static let timestamp = "timestamp"
@@ -166,6 +167,103 @@ struct Near1Click {
             throw SwapAndPayClient.EndpointError.message("Unknown error")
         }
     }
+
+    /// Parses a NEAR 1Click quote response and validates it against the request we sent, returning a
+    /// trusted `SwapQuote` or throwing. Throws `SwapQuoteValidationError` on a field/amount/slippage
+    /// mismatch and `SwapAndPayClient.EndpointError.message` on malformed JSON. Pure and unit-testable.
+    static func makeValidatedQuote(
+        jsonObject: [String: Any],
+        request: SwapQuoteRequest,
+        zecAsset: SwapAsset,
+        toAsset: SwapAsset,
+        isSwapToZec: Bool
+    ) throws -> SwapQuote {
+        guard let quote = jsonObject[Constants.quote] as? [String: Any],
+              let depositAddress = quote[Constants.depositAddress] as? String,
+              let amountInString = quote[Constants.amountIn] as? String,
+              let amountInUsdString = quote[Constants.amountInUsd] as? String,
+              let amountInFormattedString = quote[Constants.amountInFormatted] as? String,
+              let minAmountInString = quote[Constants.minAmountIn] as? String,
+              let minAmountOutString = quote[Constants.minAmountOut] as? String,
+              let amountOutString = quote[Constants.amountOut] as? String,
+              let amountOutUsdString = quote[Constants.amountOutUsd] as? String,
+              let amountOutFormattedString = quote[Constants.amountOutFormatted] as? String,
+              let timeEstimate = quote[Constants.timeEstimate] as? Int else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
+        }
+
+        guard let quoteRequestDict = jsonObject[Constants.quoteRequest] as? [String: Any],
+              let echoedOriginAsset = quoteRequestDict[Constants.originAsset] as? String,
+              let echoedDestinationAsset = quoteRequestDict[Constants.destinationAsset] as? String,
+              let echoedSwapType = quoteRequestDict[Constants.swapType] as? String,
+              let echoedSlippage = quoteRequestDict[Constants.slippageTolerance] as? Int,
+              let echoedRecipient = quoteRequestDict[Constants.recipient] as? String,
+              let echoedRefundTo = quoteRequestDict[Constants.refundTo] as? String else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote request echo failed.")
+        }
+
+        let posix = Locale(identifier: "en_US_POSIX")
+        let amountIn = NSDecimalNumber(string: amountInString).decimalValue
+        let minAmountIn = NSDecimalNumber(string: minAmountInString).decimalValue
+        let minAmountOut = NSDecimalNumber(string: minAmountOutString).decimalValue
+        let amountOut = NSDecimalNumber(string: amountOutString).decimalValue
+
+        guard let amountInFormatted = Decimal(string: amountInFormattedString, locale: posix),
+              let amountOutFormatted = Decimal(string: amountOutFormattedString, locale: posix) else {
+            throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
+        }
+
+        let response = SwapQuoteResponseFields(
+            depositAddress: depositAddress,
+            echoedOriginAsset: echoedOriginAsset,
+            echoedDestinationAsset: echoedDestinationAsset,
+            echoedSwapType: echoedSwapType,
+            echoedSlippageTolerance: echoedSlippage,
+            echoedRecipient: echoedRecipient,
+            echoedRefundTo: echoedRefundTo,
+            amountIn: amountIn,
+            amountInFormatted: amountInFormatted,
+            minAmountIn: minAmountIn,
+            amountOut: amountOut,
+            amountOutFormatted: amountOutFormatted,
+            minAmountOut: minAmountOut
+        )
+
+        try SwapQuoteValidator.validate(
+            request: request,
+            response: response,
+            originDecimals: isSwapToZec ? toAsset.decimals : zecAsset.decimals,
+            destinationDecimals: isSwapToZec ? zecAsset.decimals : toAsset.decimals
+        )
+
+        if isSwapToZec {
+            return SwapQuote(
+                depositAddress: depositAddress,
+                amountIn: amountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
+                amountInUsd: amountInUsdString,
+                minAmountIn: minAmountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
+                amountOut: amountOut / Decimal(pow(10.0, Double(zecAsset.decimals))),
+                amountOutUsd: amountOutUsdString,
+                timeEstimate: TimeInterval(timeEstimate),
+                recipient: echoedRecipient,
+                originAssetId: echoedOriginAsset,
+                destinationAssetId: echoedDestinationAsset
+            )
+        }
+
+        return SwapQuote(
+            depositAddress: depositAddress,
+            amountIn: amountIn,
+            amountInUsd: amountInUsdString,
+            minAmountIn: minAmountIn,
+            amountOut: amountOut / Decimal(pow(10.0, Double(toAsset.decimals))),
+            amountOutUsd: amountOutUsdString,
+            timeEstimate: TimeInterval(timeEstimate),
+            recipient: echoedRecipient,
+            originAssetId: echoedOriginAsset,
+            destinationAssetId: echoedDestinationAsset
+        )
+    }
 }
 
 extension Near1Click {
@@ -285,42 +383,19 @@ extension Near1Click {
                 )
             }
             
-            guard let quote = jsonObject[Constants.quote] as? [String: Any],
-                  let depositAddress = quote[Constants.depositAddress] as? String,
-                  let amountInString = quote[Constants.amountIn] as? String,
-                  let amountInUsdString = quote[Constants.amountInUsd] as? String,
-                  let minAmountInString = quote[Constants.minAmountIn] as? String,
-                  let amountOutString = quote[Constants.amountOut] as? String,
-                  let amountOutUsdString = quote[Constants.amountOutUsd] as? String,
-                  let timeEstimate = quote[Constants.timeEstimate] as? Int else {
-                throw SwapAndPayClient.EndpointError.message("Parse of the quote failed.")
-            }
-            
-            let amountIn = NSDecimalNumber(string: amountInString).decimalValue
-            let minAmountIn = NSDecimalNumber(string: minAmountInString).decimalValue
-            let amountOut = NSDecimalNumber(string: amountOutString).decimalValue
-            
-            if isSwapToZec {
-                return SwapQuote(
-                    depositAddress: depositAddress,
-                    amountIn: amountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
-                    amountInUsd: amountInUsdString,
-                    minAmountIn: minAmountIn / Decimal(pow(10.0, Double(toAsset.decimals))),
-                    amountOut: amountOut / Decimal(pow(10.0, Double(zecAsset.decimals))),
-                    amountOutUsd: amountOutUsdString,
-                    timeEstimate: TimeInterval(timeEstimate)
+            do {
+                return try Near1Click.makeValidatedQuote(
+                    jsonObject: jsonObject,
+                    request: requestData,
+                    zecAsset: zecAsset,
+                    toAsset: toAsset,
+                    isSwapToZec: isSwapToZec
+                )
+            } catch is SwapQuoteValidationError {
+                throw SwapAndPayClient.EndpointError.message(
+                    String(localizable: exactInput ? .swapQuoteUnavailableSwap : .swapQuoteUnavailable)
                 )
             }
-            
-            return SwapQuote(
-                depositAddress: depositAddress,
-                amountIn: amountIn,
-                amountInUsd: amountInUsdString,
-                minAmountIn: minAmountIn,
-                amountOut: amountOut / Decimal(pow(10.0, Double(toAsset.decimals))),
-                amountOutUsd: amountOutUsdString,
-                timeEstimate: TimeInterval(timeEstimate)
-            )
         },
         status: { depositAddress, isSwapToZec in
             let (data, response) = try await Near1Click.getCall(urlString: "\(Constants.statusUrl)\(depositAddress)", includeJwtKey: true)

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -214,7 +214,6 @@ struct Near1Click {
         }
 
         let response = SwapQuoteResponseFields(
-            depositAddress: depositAddress,
             echoedOriginAsset: echoedOriginAsset,
             echoedDestinationAsset: echoedDestinationAsset,
             echoedSwapType: echoedSwapType,

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
@@ -294,8 +294,13 @@ extension SwapAndPayCoordFlow {
                     // wallet the pending screen could be waiting for (matches SendConfirmation).
                     return .send(.sendFailed("missing proposal".toZcashError(), false))
                 }
-                guard let zip32AccountIndex = state.selectedWalletAccount?.zip32AccountIndex else {
-                    return .none
+                // SECURITY (MOB-1353): bind the spend to the account the quote was requested for. If the
+                // user switched accounts during review/biometric, fail closed rather than signing the
+                // proposal (built for the quote account) with a different account's spending key.
+                guard let account = state.selectedWalletAccount,
+                      account.id == state.swapAndPayState.quoteAccountId,
+                      let zip32AccountIndex = account.zip32AccountIndex else {
+                    return .send(.sendFailed("selected account changed during the swap".toZcashError(), false))
                 }
                 
                 // present sending screen

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -58,6 +58,9 @@ struct SwapAndPay {
         var selectedOperationChip = 0
         var proposal: Proposal?
         var quote: SwapQuote?
+        /// Account the in-flight quote was requested for (MOB-1353); the spend, refund address, and
+        /// spending key must all match it, so the swap is rejected if the selection changes mid-flow.
+        var quoteAccountId: AccountUUID?
         var quoteRequestedTime: TimeInterval = 0
         var quoteUnavailableErrorMsg = ""
         var searchTerm = ""
@@ -705,6 +708,10 @@ struct SwapAndPay {
                 }
                 state.isQuoteRequestInFlight = true
                 state.quoteRequestedTime = Date().timeIntervalSince1970
+                // SECURITY (MOB-1353): bind this quote to the account it was requested for. The refund
+                // address sent in the request above is this account's; the proposal and spending key
+                // must match it, so the swap is rejected if the selection changes before signing.
+                state.quoteAccountId = state.selectedWalletAccount?.id
                 return .run { [amountString] send in
                     do {
                         let swapQuote = try await swapAndPay.quote(
@@ -737,6 +744,12 @@ struct SwapAndPay {
                     state.isQuoteToZecPresented = true
                     state.isQuoteRequestInFlight = false
                     return .none
+                }
+                // SECURITY (MOB-1353): the spend must come from the account the quote was requested for.
+                // Reject if the selected account changed during the quote window (the refund address
+                // baked into the quote belongs to quoteAccountId, not the now-selected account).
+                guard account.id == state.quoteAccountId else {
+                    return .send(.sendFailed("selected account changed during the swap".toZcashError()))
                 }
                 // Defensive re-bind to current user intent before signing (TOCTOU guard). The quote was
                 // already validated against the request at parse time; this re-checks it against the state

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -738,13 +738,27 @@ struct SwapAndPay {
                     state.isQuoteRequestInFlight = false
                     return .none
                 }
-                let zecAmount = Zatoshi(NSDecimalNumber(decimal: quote.amountIn).int64Value)
+                // Defensive re-bind to current user intent before signing (TOCTOU guard). The quote was
+                // already validated against the request at parse time; this re-checks it against the state
+                // the user is looking at now and fails closed without building a proposal.
+                guard let selectedAsset = state.selectedAsset,
+                      let zecAsset = state.zecAsset,
+                      quote.matchesSigningIntent(
+                        address: state.address,
+                        originAssetId: zecAsset.assetId,
+                        destinationAssetId: selectedAsset.assetId
+                      ) else {
+                    return .send(.sendFailed("swap quote does not match request".toZcashError()))
+                }
+                guard let zecAmount = Zatoshi(safeZatoshiDecimal: quote.amountIn) else {
+                    return .send(.sendFailed("swap amount out of range".toZcashError()))
+                }
                 return .run { send in
                     do {
                         let recipient = try Recipient(quote.depositAddress, network: zcashSDKEnvironment.network().networkType)
 
                         let proposal = try await sdkSynchronizer.proposeTransfer(account.id, recipient, zecAmount, nil)
-                        
+
                         await send(.proposal(proposal))
                     } catch {
                         await send(.sendFailed(error.toZcashError()))

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -1411,7 +1411,7 @@ extension SwapAndPay.State {
         
         let zashiFeeCoeff = (Decimal(SwapAndPayClient.Constants.zashiFeeBps) / Decimal(10_000))
         let zashiFee = quote.amountIn * zashiFeeCoeff
-        let zatoshi = Zatoshi(Int64(truncating: NSDecimalNumber(decimal: zashiFee)))
+        let zatoshi = Zatoshi(NSDecimalNumber(decimal: zashiFee).clampedInt64Value)
         
         return zatoshi.decimalString()
     }
@@ -1454,7 +1454,7 @@ extension SwapAndPay.State {
         let swapCoeff: Decimal = isSwapExperienceEnabled ? 0.0 : 1.0
         let slippageDecimal = amountInUsdDecimal * slippage * 0.01 * swapCoeff
         let zatoshiDecimal = NSDecimalNumber(decimal: (slippageDecimal / zecAsset.usdPrice) * Decimal(Zatoshi.Constants.oneZecInZatoshi))
-        let zatoshi = Zatoshi(Int64(zatoshiDecimal.doubleValue))
+        let zatoshi = Zatoshi(zatoshiDecimal.clampedInt64Value)
         
         return zatoshi.decimalString()
     }
@@ -1512,7 +1512,7 @@ extension SwapAndPay.State {
         
         // zashi fee
         let zashiFee = quote.amountIn * 0.005
-        let zatoshiZashiFee = Int64(truncating: NSDecimalNumber(decimal: zashiFee))
+        let zatoshiZashiFee = NSDecimalNumber(decimal: zashiFee).clampedInt64Value
         
         return transactionFee + zatoshiZashiFee
     }

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -1,0 +1,41 @@
+//
+//  SafeNumericConversions.swift
+//  Zashi
+//
+
+import Foundation
+@preconcurrency import ZcashLightClientKit
+
+extension NSDecimalNumber {
+    /// `int64Value` clamped to the representable range. Never traps — unlike `Int64(self.doubleValue)`,
+    /// which traps when the value exceeds `Int64`'s range or is non-finite.
+    var clampedInt64Value: Int64 {
+        if self.compare(NSDecimalNumber(value: Int64.max)) != ComparisonResult.orderedAscending {
+            return Int64.max
+        }
+        if self.compare(NSDecimalNumber(value: Int64.min)) != ComparisonResult.orderedDescending {
+            return Int64.min
+        }
+        return self.int64Value
+    }
+}
+
+extension Zatoshi {
+    /// Builds a `Zatoshi` from a zatoshi-denominated `Decimal`, returning nil (instead of trapping or
+    /// wrapping) when the value is NaN, negative, or above the max ZEC supply. The fractional part is
+    /// truncated DOWN.
+    init?(safeZatoshiDecimal decimal: Decimal) {
+        guard !decimal.isNaN, decimal >= Decimal(0) else {
+            return nil
+        }
+        var rounded = Decimal()
+        var value = decimal
+        NSDecimalRound(&rounded, &value, 0, NSDecimalNumber.RoundingMode.down)
+
+        let maxZatoshi = Decimal(21_000_000) * Decimal(Zatoshi.Constants.oneZecInZatoshi)
+        guard rounded <= maxZatoshi else {
+            return nil
+        }
+        self = Zatoshi(NSDecimalNumber(decimal: rounded).clampedInt64Value)
+    }
+}

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -7,16 +7,30 @@ import Foundation
 @preconcurrency import ZcashLightClientKit
 
 extension NSDecimalNumber {
-    /// `int64Value` clamped to the representable range. Never traps — unlike `Int64(self.doubleValue)`,
-    /// which traps when the value exceeds `Int64`'s range or is non-finite.
+    private static let int64MaxValue = NSDecimalNumber(value: Int64.max)
+    private static let int64MinValue = NSDecimalNumber(value: Int64.min)
+    /// Truncates the fractional part DOWN before the `Int64` conversion. `NSDecimalNumber.int64Value`
+    /// returns 0 for any value with a fractional part, so it must be rounded to integer scale first.
+    private static let truncatingBehavior = NSDecimalNumberHandler(
+        roundingMode: NSDecimalNumber.RoundingMode.down, scale: 0,
+        raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false
+    )
+
+    /// `Int64` value clamped to the representable range, with any fractional part truncated DOWN. Never
+    /// traps — unlike `Int64(self.doubleValue)`, which traps when the value exceeds `Int64`'s range or is
+    /// non-finite. A NaN maps to `0`. `NSDecimalNumber.int64Value` returns `0` for any non-integer value,
+    /// so the value is rounded to integer scale before that conversion.
     var clampedInt64Value: Int64 {
-        if self.compare(NSDecimalNumber(value: Int64.max)) != ComparisonResult.orderedAscending {
+        if self.doubleValue.isNaN {
+            return 0
+        }
+        if self.compare(NSDecimalNumber.int64MaxValue) != ComparisonResult.orderedAscending {
             return Int64.max
         }
-        if self.compare(NSDecimalNumber(value: Int64.min)) != ComparisonResult.orderedDescending {
+        if self.compare(NSDecimalNumber.int64MinValue) != ComparisonResult.orderedDescending {
             return Int64.min
         }
-        return self.int64Value
+        return self.rounding(accordingToBehavior: NSDecimalNumber.truncatingBehavior).int64Value
     }
 }
 

--- a/secant/Sources/Utils/SafeNumericConversions.swift
+++ b/secant/Sources/Utils/SafeNumericConversions.swift
@@ -46,7 +46,7 @@ extension Zatoshi {
         var value = decimal
         NSDecimalRound(&rounded, &value, 0, NSDecimalNumber.RoundingMode.down)
 
-        let maxZatoshi = Decimal(21_000_000) * Decimal(Zatoshi.Constants.oneZecInZatoshi)
+        let maxZatoshi = Decimal(Zatoshi.Constants.maxZatoshi)
         guard rounded <= maxZatoshi else {
             return nil
         }

--- a/zodlTests/SendTests/MultiServerSubmitRoutingTests.swift
+++ b/zodlTests/SendTests/MultiServerSubmitRoutingTests.swift
@@ -295,6 +295,9 @@ import ComposableArchitecture
         initialState.swapAndPayState.address = "ztestaddr"
         initialState.swapAndPayState.proposal = .testOnlyFakeProposal(totalFee: 10_000)
         initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+        // SECURITY (MOB-1353): `.swapRequested` rejects the swap unless the selected account still
+        // matches the account the quote was bound to, so mirror that binding in the test setup.
+        initialState.swapAndPayState.quoteAccountId = testWalletAccount.id
 
         return Store(initialState: initialState) {
             SwapAndPayCoordFlow()

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -83,10 +83,51 @@ import Testing
         }
     }
 
-    @Test func rejectsMissingMinAmountOut() {
-        #expect(throws: (any Error).self) {
+    @Test func rejectsMissingMinAmountOutAsEndpointError() {
+        // A malformed/missing field surfaces as EndpointError (NOT a validation error), so it propagates
+        // out of the closure's `catch is SwapQuoteValidationError` and still fails closed downstream.
+        #expect(throws: SwapAndPayClient.EndpointError.self) {
             _ = try Near1Click.makeValidatedQuote(
                 jsonObject: self.json(includeMinAmountOut: false),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func acceptsValidSwapToZecQuote() throws {
+        // Swap-to-ZEC (token -> ZEC, FLEX_INPUT): user fixes the token input; amountIn is divided by the
+        // token's decimals and amountOut by ZEC's decimals when built.
+        let swapToZecRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.flexInput, slippageTolerance: 100,
+            originAsset: "btc.id", depositType: Near1Click.Constants.originChain, destinationAsset: "zec.id",
+            amount: "200000", refundTo: "user-btc-addr", refundType: Near1Click.Constants.originChain,
+            recipient: "wallet-ua", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let swapToZecJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "200000", "amountInUsd": "10",
+                "amountInFormatted": "0.002", "minAmountIn": "200000",
+                "amountOut": "100000000", "amountOutUsd": "10", "amountOutFormatted": "1", "minAmountOut": "99000000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "btc.id", "destinationAsset": "zec.id", "swapType": Near1Click.Constants.flexInput,
+                "slippageTolerance": 100, "recipient": "wallet-ua", "refundTo": "user-btc-addr"
+            ]
+        ]
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: swapToZecJson, request: swapToZecRequest, zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: true)
+        let expectedAmountIn = try #require(Decimal(string: "0.002", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(quote.amountIn == expectedAmountIn)
+        #expect(quote.amountOut == Decimal(1))
+        #expect(quote.originAssetId == "btc.id")
+        #expect(quote.destinationAssetId == "zec.id")
+    }
+
+    @Test func rejectsSwapTypeSubstitution() {
+        #expect(throws: SwapQuoteValidationError.swapTypeMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(swapType: Near1Click.Constants.exactOutput),
                 request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
             )
         }

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -1,0 +1,104 @@
+//
+//  Near1ClickQuoteMapperTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct Near1ClickQuoteMapperTests {
+    private let zecAsset = SwapAsset(provider: "near", chain: "zec", token: "ZEC", assetId: "zec.id", usdPrice: Decimal(30), decimals: 8)
+    private let btcAsset = SwapAsset(provider: "near", chain: "btc", token: "BTC", assetId: "btc.id", usdPrice: Decimal(60_000), decimals: 8)
+
+    private func request(amount: String = "100000000", recipient: String = "recipient", refundTo: String = "refund") -> SwapQuoteRequest {
+        SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactInput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: amount, refundTo: refundTo, refundType: Near1Click.Constants.originChain,
+            recipient: recipient, recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+    }
+
+    private func json(
+        depositAddress: String = "deposit", originAsset: String = "zec.id", destinationAsset: String = "btc.id",
+        swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100,
+        recipient: String = "recipient", refundTo: String = "refund",
+        amountIn: String = "100000000", amountInFormatted: String = "1", minAmountIn: String = "100000000",
+        amountOut: String = "200000", amountOutFormatted: String = "0.002", minAmountOut: String = "198000",
+        includeMinAmountOut: Bool = true
+    ) -> [String: Any] {
+        var quote: [String: Any] = [
+            "depositAddress": depositAddress, "amountIn": amountIn, "amountInUsd": "10",
+            "amountInFormatted": amountInFormatted, "minAmountIn": minAmountIn,
+            "amountOut": amountOut, "amountOutUsd": "10", "amountOutFormatted": amountOutFormatted,
+            "timeEstimate": 60
+        ]
+        if includeMinAmountOut {
+            quote["minAmountOut"] = minAmountOut
+        }
+        return [
+            "quote": quote,
+            "quoteRequest": [
+                "originAsset": originAsset, "destinationAsset": destinationAsset, "swapType": swapType,
+                "slippageTolerance": slippage, "recipient": recipient, "refundTo": refundTo
+            ]
+        ]
+    }
+
+    @Test func acceptsValidQuote() throws {
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: json(), request: request(), zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false)
+        #expect(quote.depositAddress == "deposit")
+        #expect(quote.amountIn == Decimal(100_000_000))
+        #expect(quote.recipient == "recipient")
+        #expect(quote.originAssetId == "zec.id")
+        #expect(quote.destinationAssetId == "btc.id")
+    }
+
+    @Test func rejectsInflatedAmountIn() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(amountIn: "200000000", amountInFormatted: "2", minAmountIn: "200000000"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsRecipientSubstitution() {
+        #expect(throws: SwapQuoteValidationError.recipientMismatch) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(recipient: "attacker"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsOriginAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(originAsset: "zec.tampered"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func rejectsMissingMinAmountOut() {
+        #expect(throws: (any Error).self) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(includeMinAmountOut: false),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
+    @Test func depositAddressSubstitutionAloneIsNotCaught() throws {
+        // Documented residual: binding cannot detect a swapped deposit address (server-generated, unverifiable).
+        // Only transport security (user-opt-in Tor) closes this; the quote still builds with the attacker address.
+        let quote = try Near1Click.makeValidatedQuote(
+            jsonObject: json(depositAddress: "attacker-deposit"),
+            request: request(), zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false
+        )
+        #expect(quote.depositAddress == "attacker-deposit")
+    }
+}

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -142,4 +142,60 @@ import Testing
         )
         #expect(quote.depositAddress == "attacker-deposit")
     }
+
+    @Test func acceptsValidCrosspayQuote() throws {
+        // Crosspay (ZEC -> token, EXACT_OUTPUT): user fixes the token OUTPUT; the ZEC input floats within the
+        // slippage ceiling. amountIn (ZEC) is kept raw for signing; amountOut is divided by the token decimals.
+        let crosspayRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactOutput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: "200000", refundTo: "refund", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let crosspayJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "300000000", "amountInUsd": "10",
+                "amountInFormatted": "3", "minAmountIn": "303000000",
+                "amountOut": "200000", "amountOutUsd": "10", "amountOutFormatted": "0.002", "minAmountOut": "200000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "zec.id", "destinationAsset": "btc.id", "swapType": Near1Click.Constants.exactOutput,
+                "slippageTolerance": 100, "recipient": "recipient", "refundTo": "refund"
+            ]
+        ]
+        let quote = try Near1Click.makeValidatedQuote(jsonObject: crosspayJson, request: crosspayRequest, zecAsset: zecAsset, toAsset: btcAsset, isSwapToZec: false)
+        #expect(quote.amountIn == Decimal(300_000_000))
+        let expectedAmountOut = try #require(Decimal(string: "0.002", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(quote.amountOut == expectedAmountOut)
+        #expect(quote.recipient == "recipient")
+    }
+
+    @Test func rejectsCrosspayInputAboveSlippageCeiling() {
+        // EXACT_OUTPUT input floats: ceiling = amountIn 300000000 × 1.01 = 303000000. A guaranteed worst-case
+        // input above that exceeds the user's slippage tolerance and must fail closed.
+        let crosspayRequest = SwapQuoteRequest(
+            dry: false, swapType: Near1Click.Constants.exactOutput, slippageTolerance: 100,
+            originAsset: "zec.id", depositType: Near1Click.Constants.originChain, destinationAsset: "btc.id",
+            amount: "200000", refundTo: "refund", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+        let crosspayJson: [String: Any] = [
+            "quote": [
+                "depositAddress": "deposit", "amountIn": "300000000", "amountInUsd": "10",
+                "amountInFormatted": "3", "minAmountIn": "400000000",
+                "amountOut": "200000", "amountOutUsd": "10", "amountOutFormatted": "0.002", "minAmountOut": "200000",
+                "timeEstimate": 60
+            ],
+            "quoteRequest": [
+                "originAsset": "zec.id", "destinationAsset": "btc.id", "swapType": Near1Click.Constants.exactOutput,
+                "slippageTolerance": 100, "recipient": "recipient", "refundTo": "refund"
+            ]
+        ]
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            _ = try Near1Click.makeValidatedQuote(jsonObject: crosspayJson, request: crosspayRequest, zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false)
+        }
+    }
 }

--- a/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
+++ b/zodlTests/SwapTests/Near1ClickQuoteMapperTests.swift
@@ -74,6 +74,17 @@ import Testing
         }
     }
 
+    @Test func rejectsOverflowingAmountFormatted() {
+        // A huge server amountInFormatted overflows the consistency multiply; it must fail closed as a
+        // validation error, not crash the validator with an uncatchable NSDecimalNumberOverflowException.
+        #expect(throws: SwapQuoteValidationError.self) {
+            _ = try Near1Click.makeValidatedQuote(
+                jsonObject: self.json(amountInFormatted: "1e120"),
+                request: self.request(), zecAsset: self.zecAsset, toAsset: self.btcAsset, isSwapToZec: false
+            )
+        }
+    }
+
     @Test func rejectsOriginAssetSubstitution() {
         #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
             _ = try Near1Click.makeValidatedQuote(

--- a/zodlTests/SwapTests/SafeNumericConversionsTests.swift
+++ b/zodlTests/SwapTests/SafeNumericConversionsTests.swift
@@ -1,0 +1,44 @@
+//
+//  SafeNumericConversionsTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct SafeNumericConversionsTests {
+    @Test func clampedInt64ReturnsValueInRange() {
+        #expect(NSDecimalNumber(value: 100).clampedInt64Value == 100)
+    }
+
+    @Test func clampedInt64ClampsAboveMax() {
+        let huge = NSDecimalNumber(string: "99999999999999999999")
+        #expect(huge.clampedInt64Value == Int64.max)
+    }
+
+    @Test func clampedInt64ClampsBelowMin() {
+        let veryNegative = NSDecimalNumber(string: "-99999999999999999999")
+        #expect(veryNegative.clampedInt64Value == Int64.min)
+    }
+
+    @Test func safeZatoshiAcceptsNormalValue() {
+        let zatoshi = Zatoshi(safeZatoshiDecimal: Decimal(100_000_000))
+        #expect(zatoshi == Zatoshi(100_000_000))
+    }
+
+    @Test func safeZatoshiTruncatesFraction() throws {
+        let value = try #require(Decimal(string: "100000000.9", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(Zatoshi(safeZatoshiDecimal: value) == Zatoshi(100_000_000))
+    }
+
+    @Test func safeZatoshiRejectsNegative() {
+        #expect(Zatoshi(safeZatoshiDecimal: Decimal(-1)) == nil)
+    }
+
+    @Test func safeZatoshiRejectsOverMaxSupply() throws {
+        let overMax = try #require(Decimal(string: "99999999999999999999", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(Zatoshi(safeZatoshiDecimal: overMax) == nil)
+    }
+}

--- a/zodlTests/SwapTests/SafeNumericConversionsTests.swift
+++ b/zodlTests/SwapTests/SafeNumericConversionsTests.swift
@@ -23,6 +23,19 @@ import Testing
         #expect(veryNegative.clampedInt64Value == Int64.min)
     }
 
+    @Test func clampedInt64TruncatesNonInteger() {
+        // Regression: NSDecimalNumber.int64Value returns 0 for any value with a fractional part, so an
+        // in-range non-integer (e.g. the slippage buffer in swapSlippageStr) must be truncated, not zeroed.
+        #expect(NSDecimalNumber(string: "333333.3333").clampedInt64Value == 333_333)
+        #expect(NSDecimalNumber(string: "0.9").clampedInt64Value == 0)
+        #expect(NSDecimalNumber(string: "100.5").clampedInt64Value == 100)
+    }
+
+    @Test func clampedInt64MapsNaNToZero() {
+        // A NaN (e.g. a Decimal division by a server usdPrice of 0) must fall back to 0, not Int64.min.
+        #expect(NSDecimalNumber.notANumber.clampedInt64Value == 0)
+    }
+
     @Test func safeZatoshiAcceptsNormalValue() {
         let zatoshi = Zatoshi(safeZatoshiDecimal: Decimal(100_000_000))
         #expect(zatoshi == Zatoshi(100_000_000))

--- a/zodlTests/SwapTests/SwapAccountBindingTests.swift
+++ b/zodlTests/SwapTests/SwapAccountBindingTests.swift
@@ -1,0 +1,126 @@
+//
+//  SwapAccountBindingTests.swift
+//  zodlTests
+//
+//  MOB-1353 — a swap quote is bound to the account it was requested for. If the selected account
+//  changes between quote and signing, the swap must fail closed rather than spending from / refunding
+//  to a different account than the one the quote (and its refund address) was built for.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// Serialized: drives the SwapAndPay reducer which reads the process-global `selectedWalletAccount`
+// @Shared state. Each test binds `@Shared` to a fresh in-memory store so parallel suites can't clobber it.
+@Suite(.serialized) @MainActor struct SwapAccountBindingTests {
+    private let testnetAddress =
+        "utest1vergg5jkp4xy8sqfasw6s5zkdpnxvfxlxh35uuc3me7dp596y2r05t6dv9htwe3pf8ksrfr8ksca2lskzjanqtl8uqp5vln3zyy246ejtx86vqftp73j7jg9099jxafyjhfm6u956j3"
+
+    private func account(byte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: byte, count: 16)),
+                name: "Test",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private let zecAsset = SwapAsset(provider: "near", chain: "zec", token: "ZEC", assetId: "zec.id", usdPrice: Decimal(30), decimals: 8)
+    private let btcAsset = SwapAsset(provider: "near", chain: "btc", token: "BTC", assetId: "btc.id", usdPrice: Decimal(60_000), decimals: 8)
+
+    private func matchingQuote() -> SwapQuote {
+        SwapQuote(
+            depositAddress: testnetAddress,
+            amountIn: Decimal(100_000_000),
+            amountInUsd: "10",
+            minAmountIn: Decimal(0),
+            amountOut: Decimal(1),
+            amountOutUsd: "1",
+            timeEstimate: 0,
+            recipient: "recipient-addr",
+            originAssetId: "zec.id",
+            destinationAssetId: "btc.id"
+        )
+    }
+
+    private func makeState(selected: WalletAccount, quoteAccountId: AccountUUID?) -> SwapAndPay.State {
+        var state = SwapAndPayCoordFlow.State().swapAndPayState
+        state.$selectedWalletAccount.withLock { $0 = selected }
+        state.quoteAccountId = quoteAccountId
+        state.selectedAsset = btcAsset
+        state.zecAsset = zecAsset
+        state.address = "recipient-addr"
+        state.isSwapExperienceEnabled = true
+        state.isSwapToZecExperienceEnabled = false
+        return state
+    }
+
+    private func makeStore(_ state: SwapAndPay.State, proposeCalls: LockIsolated<Int>) -> StoreOf<SwapAndPay> {
+        Store(initialState: state) {
+            SwapAndPay()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            $0.zcashSDKEnvironment = .testnet
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeTransfer = { _, _, _, _ in
+                proposeCalls.withValue { $0 += 1 }
+                return .testOnlyFakeProposal(totalFee: 0)
+            }
+        }
+    }
+
+    /// Account switched after the quote was requested → fail closed, no proposal built.
+    @Test func rejectsWhenAccountSwitchedAfterQuote() async {
+        let accountA = account(byte: 0)
+        let accountB = account(byte: 1)
+        let proposeCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(makeState(selected: accountB, quoteAccountId: accountA.id), proposeCalls: proposeCalls)
+            store.send(.swapQuoteLoaded(matchingQuote()))
+            await waitForSwapStore { store.state.isQuoteUnavailablePresented }
+
+            #expect(proposeCalls.withValue { $0 } == 0) // never builds a proposal for the wrong account
+            #expect(store.state.proposal == nil)
+        }
+    }
+
+    /// Selected account still matches the quote account → proceeds to build the proposal (regression).
+    @Test func proposesWhenAccountMatchesQuote() async {
+        let accountA = account(byte: 0)
+        let proposeCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(makeState(selected: accountA, quoteAccountId: accountA.id), proposeCalls: proposeCalls)
+            store.send(.swapQuoteLoaded(matchingQuote()))
+            await waitForSwapStore { proposeCalls.withValue { $0 == 1 } }
+
+            #expect(proposeCalls.withValue { $0 } == 1)
+        }
+    }
+}
+
+@MainActor
+private func waitForSwapStore(
+    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for SwapAndPay store state", sourceLocation: sourceLocation)
+}

--- a/zodlTests/SwapTests/SwapQuoteIntentTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteIntentTests.swift
@@ -1,0 +1,30 @@
+//
+//  SwapQuoteIntentTests.swift
+//  Zashi
+//
+
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct SwapQuoteIntentTests {
+    private func quote(recipient: String = "addr", origin: String = "zec.id", destination: String = "btc.id") -> SwapQuote {
+        SwapQuote(
+            depositAddress: "deposit", amountIn: Decimal(100_000_000), amountInUsd: "10",
+            minAmountIn: Decimal(100_000_000), amountOut: Decimal(2_000_000), amountOutUsd: "10",
+            timeEstimate: 60, recipient: recipient, originAssetId: origin, destinationAssetId: destination
+        )
+    }
+
+    @Test func matchesWhenAllFieldsAgree() {
+        #expect(quote().matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "btc.id"))
+    }
+
+    @Test func failsWhenRecipientDiffers() {
+        #expect(!quote(recipient: "other").matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "btc.id"))
+    }
+
+    @Test func failsWhenDestinationAssetDiffers() {
+        #expect(!quote().matchesSigningIntent(address: "addr", originAssetId: "zec.id", destinationAssetId: "eth.id"))
+    }
+}

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -1,3 +1,8 @@
+//
+//  SwapQuoteValidationTests.swift
+//  Zashi
+//
+
 import Foundation
 import Testing
 @testable import zodl_internal
@@ -18,5 +23,22 @@ import Testing
         #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
             try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(2), decimals: 8)
         }
+    }
+
+    @Test func requireConsistentThrowsOnNaNRaw() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal.nan, formatted: Decimal(1), decimals: 8)
+        }
+    }
+
+    @Test func requireConsistentThrowsOnOutOfRangeDecimals() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(1), decimals: 1000)
+        }
+    }
+
+    @Test func requireConsistentPassesForFractionalFormatted() throws {
+        let formatted = try #require(Decimal(string: "0.00000001", locale: Locale(identifier: "en_US_POSIX")))
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -205,7 +205,7 @@ import Testing
         minAmountOut: Decimal = Decimal(1_980_000)
     ) -> SwapQuoteResponseFields {
         SwapQuoteResponseFields(
-            depositAddress: "deposit-addr", echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
+            echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
             echoedSwapType: swapType, echoedSlippageTolerance: slippage, echoedRecipient: recipient, echoedRefundTo: refundTo,
             amountIn: amountIn, amountInFormatted: amountInFormatted, minAmountIn: minAmountIn,
             amountOut: amountOut, amountOutFormatted: amountOutFormatted, minAmountOut: minAmountOut

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -42,6 +42,16 @@ import Testing
         try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
 
+    @Test func requireConsistentFailsClosedOnOverflowingFormatted() throws {
+        // A server-controlled `formatted` can overflow when multiplied by 10^decimals; the default
+        // NSDecimalNumber behavior would raise an uncatchable NSDecimalNumberOverflowException (crash).
+        // It must instead fail closed.
+        let huge = try #require(Decimal(string: "1e120", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: huge, decimals: 8)
+        }
+    }
+
     // MARK: requireWithinSlippage — server's worst-case guarantee must respect requested slippage
 
     @Test func slippageOutputFloatingPassesAtAndAboveFloor() throws {
@@ -108,6 +118,24 @@ import Testing
         // minAmountOut passes (bypass). The bound must make this fail closed.
         #expect(throws: SwapQuoteValidationError.slippageExceeded) {
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
+        }
+    }
+
+    @Test func slippageFailsClosedOnOverflowingOutput() throws {
+        // amountOut * (10000 - bps) overflows Decimal; the multiply must not trap, and the NaN result
+        // must fail closed (output-floating side).
+        let huge = try #require(Decimal(string: "1e125", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: huge, minAmountIn: Decimal(1000), minAmountOut: Decimal(1), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnOverflowingInput() throws {
+        // amountIn * (10000 + bps) overflows Decimal on the EXACT_OUTPUT ceiling. compare(NaN) is
+        // orderedAscending, so without the explicit NaN guard this would bypass — it must fail closed.
+        let huge = try #require(Decimal(string: "1e125", locale: Locale(identifier: "en_US_POSIX")))
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: huge, amountOut: Decimal(1000), minAmountIn: Decimal(1), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
         }
     }
 

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -110,4 +110,48 @@ import Testing
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
         }
     }
+
+    // MARK: requireMatchingAssetId
+
+    @Test func requireMatchingAssetIdPassesOnEqual() throws {
+        try SwapQuoteValidator.requireMatchingAssetId(field: "originAsset", expected: "nep141:zec.omft.near", actual: "nep141:zec.omft.near")
+    }
+
+    @Test func requireMatchingAssetIdThrowsOnDifferent() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            try SwapQuoteValidator.requireMatchingAssetId(field: "originAsset", expected: "a", actual: "b")
+        }
+    }
+
+    // MARK: requireMatchesRequestedAmount — user-fixed side must equal requested base units
+
+    @Test func requestedAmountExactInputBindsAmountIn() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+    }
+
+    @Test func requestedAmountExactOutputBindsAmountOut() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactOutput, requestedAmount: "2000000", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+    }
+
+    @Test func requestedAmountFlexInputBindsAmountIn() throws {
+        try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.flexInput, requestedAmount: "2000000", rawAmountIn: Decimal(2_000_000), rawAmountOut: Decimal(100_000_000))
+    }
+
+    @Test func requestedAmountThrowsOnInflatedAmountIn() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal(200_000_000), rawAmountOut: Decimal(2_000_000))
+        }
+    }
+
+    @Test func requestedAmountFailsClosedOnNaNAmount() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "100000000", rawAmountIn: Decimal.nan, rawAmountOut: Decimal(2_000_000))
+        }
+    }
+
+    @Test func requestedAmountFailsClosedOnUnparseableRequest() {
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "not-a-number", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -154,4 +154,106 @@ import Testing
             try SwapQuoteValidator.requireMatchesRequestedAmount(swapType: Near1Click.Constants.exactInput, requestedAmount: "not-a-number", rawAmountIn: Decimal(100_000_000), rawAmountOut: Decimal(2_000_000))
         }
     }
+
+    // MARK: validate — full orchestration over a baseline valid EXACT_INPUT quote
+
+    private func baselineRequest(swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100, amount: String = "100000000") -> SwapQuoteRequest {
+        SwapQuoteRequest(
+            dry: false, swapType: swapType, slippageTolerance: slippage,
+            originAsset: "origin.id", depositType: Near1Click.Constants.originChain, destinationAsset: "dest.id",
+            amount: amount, refundTo: "refund-addr", refundType: Near1Click.Constants.originChain,
+            recipient: "recipient-addr", recipientType: Near1Click.Constants.destinationChain,
+            deadline: "", referral: Near1Click.Constants.referral, quoteWaitingTimeMs: 3000, appFees: nil
+        )
+    }
+
+    private func baselineResponse(
+        originAsset: String = "origin.id", destinationAsset: String = "dest.id",
+        swapType: String = Near1Click.Constants.exactInput, slippage: Int = 100,
+        recipient: String = "recipient-addr", refundTo: String = "refund-addr",
+        amountIn: Decimal = Decimal(100_000_000), amountInFormatted: Decimal = Decimal(1),
+        minAmountIn: Decimal = Decimal(100_000_000),
+        amountOut: Decimal = Decimal(2_000_000), amountOutFormatted: Decimal = Decimal(2),
+        minAmountOut: Decimal = Decimal(1_980_000)
+    ) -> SwapQuoteResponseFields {
+        SwapQuoteResponseFields(
+            depositAddress: "deposit-addr", echoedOriginAsset: originAsset, echoedDestinationAsset: destinationAsset,
+            echoedSwapType: swapType, echoedSlippageTolerance: slippage, echoedRecipient: recipient, echoedRefundTo: refundTo,
+            amountIn: amountIn, amountInFormatted: amountInFormatted, minAmountIn: minAmountIn,
+            amountOut: amountOut, amountOutFormatted: amountOutFormatted, minAmountOut: minAmountOut
+        )
+    }
+
+    private func validateBaseline(request: SwapQuoteRequest? = nil, response: SwapQuoteResponseFields? = nil) throws {
+        try SwapQuoteValidator.validate(
+            request: request ?? baselineRequest(),
+            response: response ?? baselineResponse(),
+            originDecimals: 8, destinationDecimals: 6
+        )
+    }
+
+    @Test func validateAcceptsConsistentQuote() throws {
+        try validateBaseline()
+    }
+
+    @Test func validateRejectsOriginAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "originAsset")) {
+            try self.validateBaseline(response: self.baselineResponse(originAsset: "origin.tampered"))
+        }
+    }
+
+    @Test func validateRejectsDestinationAssetSubstitution() {
+        #expect(throws: SwapQuoteValidationError.assetMismatch(field: "destinationAsset")) {
+            try self.validateBaseline(response: self.baselineResponse(destinationAsset: "dest.tampered"))
+        }
+    }
+
+    @Test func validateRejectsSwapTypeSubstitution() {
+        #expect(throws: SwapQuoteValidationError.swapTypeMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(swapType: Near1Click.Constants.exactOutput))
+        }
+    }
+
+    @Test func validateRejectsWidenedSlippageTolerance() {
+        #expect(throws: SwapQuoteValidationError.slippageToleranceMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(slippage: 10_000))
+        }
+    }
+
+    @Test func validateRejectsRecipientSubstitution() {
+        #expect(throws: SwapQuoteValidationError.recipientMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(recipient: "attacker-addr"))
+        }
+    }
+
+    @Test func validateRejectsRefundSubstitution() {
+        #expect(throws: SwapQuoteValidationError.refundMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(refundTo: "attacker-addr"))
+        }
+    }
+
+    @Test func validateRejectsNonPositiveAmountIn() {
+        #expect(throws: SwapQuoteValidationError.nonPositiveAmount(field: "amountInFormatted")) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(0), amountInFormatted: Decimal(0), minAmountIn: Decimal(0)))
+        }
+    }
+
+    @Test func validateRejectsRawFormattedInconsistency() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(999)))
+        }
+    }
+
+    @Test func validateRejectsInflatedAmountIn() {
+        // Consistent at 8 decimals (2 × 1e8 == 200_000_000) but not what the user requested (1 ZEC).
+        #expect(throws: SwapQuoteValidationError.requestedAmountMismatch) {
+            try self.validateBaseline(response: self.baselineResponse(amountIn: Decimal(200_000_000), amountInFormatted: Decimal(2), minAmountIn: Decimal(200_000_000)))
+        }
+    }
+
+    @Test func validateRejectsSlippageBelowFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try self.validateBaseline(response: self.baselineResponse(minAmountOut: Decimal(1_900_000)))
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -41,4 +41,59 @@ import Testing
         let formatted = try #require(Decimal(string: "0.00000001", locale: Locale(identifier: "en_US_POSIX")))
         try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(1), formatted: formatted, decimals: 8)
     }
+
+    // MARK: requireWithinSlippage — server's worst-case guarantee must respect requested slippage
+
+    @Test func slippageOutputFloatingPassesAtAndAboveFloor() throws {
+        // 10% slippage, amountOut=100 -> floor=90. minAmountIn is the fixed side (== amountIn) and ignored.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(90), slippageToleranceBps: 1000)
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.flexInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(95), slippageToleranceBps: 1000)
+    }
+
+    @Test func slippageOutputFloatingThrowsBelowFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(89), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageInputFloatingPassesAtAndBelowCeiling() throws {
+        // 10% slippage, amountIn=100 -> ceiling=110. minAmountOut is the fixed side and ignored.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(110), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(105), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+    }
+
+    @Test func slippageInputFloatingThrowsAboveCeiling() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(100), amountOut: Decimal(1000), minAmountIn: Decimal(111), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageOutputAcceptsServerIntegerTruncatedFloor() throws {
+        // Real NEAR 1Click $10 ZEC -> USDC @ 30%: amountOut=9897372 × 0.70 = 6928160.4, server truncates DOWN to 6928160.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(2_245_828), amountOut: Decimal(9_897_372), minAmountIn: Decimal(2_245_828), minAmountOut: Decimal(6_928_160), slippageToleranceBps: 3000)
+    }
+
+    @Test func slippageOutputRejectsOneBelowIntegerFloor() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(2_245_828), amountOut: Decimal(9_897_372), minAmountIn: Decimal(2_245_828), minAmountOut: Decimal(6_928_159), slippageToleranceBps: 3000)
+        }
+    }
+
+    @Test func slippageInputAcceptsServerIntegerRoundedCeiling() throws {
+        // amountIn=9897372 × 1.30 = 12866583.6, server rounds UP to 12866584.
+        try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(9_897_372), amountOut: Decimal(2_245_828), minAmountIn: Decimal(12_866_584), minAmountOut: Decimal(2_245_828), slippageToleranceBps: 3000)
+    }
+
+    @Test func slippageInputRejectsOneAboveIntegerCeiling() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal(9_897_372), amountOut: Decimal(2_245_828), minAmountIn: Decimal(12_866_585), minAmountOut: Decimal(2_245_828), slippageToleranceBps: 3000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnNaNBound() {
+        // Server-controlled min bounds parse to Decimal.nan on garbage; must fail closed, never bypass.
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal.nan, slippageToleranceBps: 1000)
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -96,4 +96,18 @@ import Testing
             try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal.nan, slippageToleranceBps: 1000)
         }
     }
+
+    @Test func slippageFailsClosedOnNaNAmountInput() {
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactOutput, amountIn: Decimal.nan, amountOut: Decimal(1000), minAmountIn: Decimal(110), minAmountOut: Decimal(1000), slippageToleranceBps: 1000)
+        }
+    }
+
+    @Test func slippageFailsClosedOnAbsurdBps() {
+        // Without the <= 10_000 bound, bps=10_001 makes (10000 - bps) negative -> floor negative -> any
+        // minAmountOut passes (bypass). The bound must make this fail closed.
+        #expect(throws: SwapQuoteValidationError.slippageExceeded) {
+            try SwapQuoteValidator.requireWithinSlippage(swapType: Near1Click.Constants.exactInput, amountIn: Decimal(1000), amountOut: Decimal(100), minAmountIn: Decimal(1000), minAmountOut: Decimal(0), slippageToleranceBps: 10_001)
+        }
+    }
 }

--- a/zodlTests/SwapTests/SwapQuoteValidationTests.swift
+++ b/zodlTests/SwapTests/SwapQuoteValidationTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import zodl_internal
+
+@Suite struct SwapQuoteValidationTests {
+    // MARK: requireConsistent — raw base-unit amount must equal formatted × 10^decimals
+
+    @Test func requireConsistentPassesWhenRawMatchesFormatted() throws {
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(1), decimals: 8)
+    }
+
+    @Test func requireConsistentPassesRegardlessOfFormattedScale() throws {
+        let formatted = try #require(Decimal(string: "1.00", locale: Locale(identifier: "en_US_POSIX")))
+        try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: formatted, decimals: 8)
+    }
+
+    @Test func requireConsistentThrowsWhenRawDoesNotMatchFormatted() {
+        #expect(throws: SwapQuoteValidationError.amountInconsistency(field: "amountIn")) {
+            try SwapQuoteValidator.requireConsistent(name: "amountIn", raw: Decimal(100_000_000), formatted: Decimal(2), decimals: 8)
+        }
+    }
+}


### PR DESCRIPTION
## Linear

[MOB-1353 — [Security] Bind swap quote to selected account (verify iOS exposure; reject on mid-flow switch)](https://linear.app/zodl/issue/MOB-1353) (sub-issue of MOB-1276; iOS parity for Android #19 / MOB-1344)

> **Stacked PR.** Base is `michal/MOB-1276/MOB-1388-swap-security-hardening` (PR #1834). Retarget to `main` after #1834 merges.

## Verification — iOS IS exposed (and #1388 does not cover this)

The swap flow read the selected account, un-snapshotted, at three points:
- **`.getQuote`** (`SwapAndPayStore.swift:675`) — the refund address baked into the NEAR quote request is the *currently* selected account's.
- **`.swapQuoteLoaded`** (`:732/:760`) — re-reads the account and builds the proposal.
- **`.swapRequested`** (`SwapAndPayCoordFlowCoordinator.swift:297/:341`) — re-reads the account and derives the **spending key**.

Switching accounts during the quote → review → biometric window could bind these to inconsistent accounts (e.g. refund address from account A, spend + signing key from account B). **MOB-1388's `matchesSigningIntent` binds the quote's recipient/asset ids — not the wallet account** — so this is a distinct, still-open defect (the iOS parity of Android #19).

## Fix — snapshot at quote request, reject on change

- New `SwapAndPay.State.quoteAccountId: AccountUUID?`, set at `.getQuote` to the account the quote (and its refund address) is requested for.
- `.swapQuoteLoaded` fails closed (no proposal built) if the selected account's id no longer matches `quoteAccountId`.
- `.swapRequested` fails closed (no spending-key derivation / submission) on the same mismatch, and derives the key from that account.

The account `id` is the binding key — the refund address and `zip32AccountIndex` both derive from it, so verifying the id keeps all three consistent. Swap-to-ZEC (no `proposeTransfer` spend) is unaffected.

## Tests

- **`zodlTests/SwapTests/SwapAccountBindingTests.swift`** (new):
  - `rejectsWhenAccountSwitchedAfterQuote` — `quoteAccountId = A`, selected = B → `.swapQuoteLoaded` fails closed, `proposeTransfer` never called, no proposal.
  - `proposesWhenAccountMatchesQuote` — matching account → proposes once (regression).
- **`zodlTests/SendTests/MultiServerSubmitRoutingTests.swift`** (updated): `MultiServerSubmitSwapRoutingTests.makeStore()` now sets `quoteAccountId` to the selected account — the new `.swapRequested` guard rejects the swap otherwise, which would fail-close `partialSubmissionRoutesToFailureSupportState` and `timeoutSubmissionRoutesToPendingWithTimeoutCopy` before they reach the mocked submission.

## Verification

- ✅ Build succeeds (zodl-internal).
- ✅ New `SwapAccountBindingTests` pass (2/2).
- ✅ Existing `MultiServerSubmitSwapRoutingTests` passes (5/5) after updating `makeStore()` for the new account-binding guard.

## Manual test plan

1. **Switch mid-swap (the fix).** With two accounts, start a swap on account A, get the quote, switch to account B, confirm. **Expected:** the swap is refused; nothing is signed or broadcast.
2. **Normal swap (regression).** Complete a swap without switching — unchanged.
3. **Swap-to-ZEC (regression).** The deposit flow still shows the deposit address as before.

Design: `docs/superpowers/specs/2026-06-22-mob-1353-bind-swap-quote-to-account-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
