### PR TITLE
Unified markdown parser for localized strings

### DIFF
--- a/docs/superpowers/specs/2026-06-22-unified-markdown-parser-design.md
+++ b/docs/superpowers/specs/2026-06-22-unified-markdown-parser-design.md
@@ -1,0 +1,217 @@
+# Unified Markdown Parser for Localized Strings
+
+**Date:** 2026-06-22
+**Status:** Approved — implementing
+**Branch:** `michal/unified-markdown-parser`
+
+## Problem
+
+Localized strings carry inline styling using Apple's **proprietary** custom-attribute
+markdown syntax:
+
+```
+^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is restored.
+```
+
+This `^[text](style: '...')` form is an Apple-only extension parsed by
+`AttributedString(markdown:including:\.zashiApp)`, where `ZashiTextAttribute` conforms to
+`MarkdownDecodableAttributedStringKey` ([ZashiText.swift](../../../secant/Sources/UIComponents/Text/ZashiText.swift)).
+It cannot be shared with Android.
+
+**Goal:** unify the markdown used in localized strings with Android by replacing the
+Apple-specific mechanism with a self-contained, hand-written parser that understands a
+small, standard-markdown-based grammar shared by both platforms.
+
+## Why this is a contained change
+
+Parsing and rendering are already separate concerns:
+
+- **Parse** (the part we replace): turn marked-up text into *semantic* style attributes
+  (`zStyle == .boldPrimary`). Today done by Apple's markdown parser via the
+  `MarkdownDecodableAttributedStringKey` hook.
+- **Render** (`ZashiText.annotateStyle`, unchanged): walk runs and resolve each semantic
+  `zStyle` to concrete SwiftUI font / color / underline using runtime context
+  (`colorScheme`, `textColor`, `textSize`).
+
+We swap the parse step and leave the render step alone, so visual-regression risk is low.
+
+Investigation findings that bound the scope:
+
+- **Only `boldPrimary` is used in static strings** — 26 markers across ~8 logical keys
+  (× EN/ES, some with `%@` interpolation). No `bold`, `italic`, `boldItalic`, or link
+  markers exist in `Localizable.xcstrings`.
+- **No tests exist** for `ZashiText` — the parser is greenfield-testable.
+- **All 11 call sites are identical**: `try? AttributedString(markdown: s, including: \.zashiApp)`
+  → `ZashiText(withAttributedString:)`. They collapse to one new init.
+- **Links / dynamic markdown come from outside static strings** (WhatsNew bulletpoints from
+  the server; a couple of `text` params) — a cross-team coordination item, not a code problem.
+
+Two correctness wins come for free:
+
+- Today `try?` makes a malformed string render **nothing** (text silently vanishes). A
+  hand-written parser is **total** — worst case it shows raw text.
+- Apple's `AttributedString(markdown:)` collapses newlines / whitespace runs. Our parser
+  preserves them exactly.
+
+## Grammar (the shared iOS/Android contract)
+
+| Style | Token | Standard markdown? |
+|---|---|---|
+| `bold` | `**text**` | ✅ |
+| `italic` | `*text*` | ✅ |
+| `boldItalic` | `***text***` | ✅ |
+| `link` | `[text](url)` | ✅ |
+| `boldPrimary` | `==text==` | ⚙️ one custom extension |
+
+### Tokenization rules (v1)
+
+1. **Delimiter runs.** A run of `*` of length 3/2/1 opens `boldItalic`/`bold`/`italic`. A run
+   of exactly two `=` opens `boldPrimary`. An opener is matched by the **next identical run**
+   (same character, same length) later in the input.
+2. **Flat, no nesting.** The text inside a styled span is emitted literally — it is **not**
+   re-parsed. Sequential spans at the top level are fine
+   (`==Warning:== text [docs](url) more`); true nesting (emphasis inside a link, bold inside
+   italic) is **out of scope for v1** and must be agreed as out of scope on Android too.
+3. **Links.** `[visible text](url)` emits the visible text with both Foundation's `.link`
+   attribute (the `URL`, which makes SwiftUI `Text` tappable) **and** `zStyle == .link` (which
+   `annotateStyle` renders as an underline). A `[` with no matching `](url)` is literal.
+4. **Unmatched / malformed delimiters render literally.** `**bold` with no closing `**`
+   produces the literal characters `**bold`. The parser never throws and never drops text.
+5. **Escaping.** A backslash escapes the immediately following markdown-significant character
+   (`* = [ ] ( ) \`), emitting it literally and consuming both characters. A backslash before
+   any other character is literal.
+6. **Whitespace & newlines are preserved verbatim.**
+7. **Interpolation happens before parsing.** `String(localizable: .key(arg))` produces the
+   fully-substituted string, which is then parsed. `==%@==` → `==123 ZEC==` → `boldPrimary`.
+   Known limitation (shared with the old Apple path): if an interpolated value itself contains
+   a delimiter character it may be mis-parsed — acceptable for v1.
+
+### Out of scope for v1
+
+Nested styles, block-level markdown (headings, lists, code blocks, blockquotes),
+reference-style links, autolinks, and images. The grammar above is the entire supported set.
+
+## Architecture
+
+### New: `ZashiMarkdown` parser
+
+`secant/Sources/UIComponents/Text/ZashiMarkdown.swift`
+
+```swift
+enum ZashiMarkdown {
+    /// Parses the unified Zashi/Android markdown grammar into a semantic AttributedString.
+    /// Total: never throws; unmatched markup is emitted as literal text.
+    static func parse(_ input: String) -> AttributedString
+}
+```
+
+A **linear scanner / state machine** (Approach A) — chosen over a regex pipeline (fragile
+`*`/`**`/`***` precedence, hard to prove identical to Android) and over a non-nesting
+pair-only scanner (least future-proof). The algorithm is a documented contract both platforms
+implement:
+
+```
+parse(input):
+    out = AttributedString("")
+    i = input.startIndex
+    while i < input.endIndex:
+        c = input[i]
+        if c == "\\" and next is escapable:
+            append literal next char (plain); advance 2; continue
+        if c == "[" and a "](url)" closes it:
+            append visible text with .link(url) + zStyle .link; advance past ")"; continue
+        if c starts a delimiter run ("*"×3/2/1 or "="×2):
+            if a matching closing run exists later:
+                append inner text (literal) with the run's zStyle; advance past closer; continue
+            else:
+                append the run's characters literally; advance past run; continue
+        append c literally (plain); advance
+```
+
+Emits the existing semantic attribute, e.g. `out[range].zStyle = .boldPrimary`, using the
+`AttributeScopes.ZashiAppAttributes` scope already defined in `ZashiText.swift`.
+
+### Modified: `ZashiText.swift`
+
+- **Drop** `MarkdownDecodableAttributedStringKey` (and the now-unneeded
+  `CodableAttributedStringKey`) from `ZashiTextAttribute` — it becomes a plain
+  `AttributedStringKey`. The `Value` enum, the `ZashiAppAttributes` scope, and the
+  `AttributeDynamicLookup` extension stay (the parser sets `zStyle` through them).
+- **Keep** `annotateStyle` unchanged — it already maps every `zStyle` case to fonts/colors,
+  including the `.link` → underline case. Tappability now comes from the `.link` URL our
+  parser sets (previously set by Apple's parser).
+- **Add** a parsing init:
+
+  ```swift
+  init(markdown: String, colorScheme: ColorScheme, textColor: Color? = nil, textSize: CGFloat? = nil) {
+      let parsed = ZashiMarkdown.parse(markdown)
+      self.attributedString = ZashiText.annotateStyle(
+          from: parsed, colorScheme: colorScheme, textColor: textColor, textSize: textSize)
+  }
+  ```
+
+- The old `^[...](style:...)` example comment is removed. The `init(_ localizedKey:)` and
+  `withAttributedString` inits are removed if no longer referenced after the call-site
+  migration (verify; remove only if unused).
+
+### Modified: 11 call sites
+
+Each collapses from the six-line optional dance to one line, e.g.:
+
+```swift
+// before
+if let attrText = try? AttributedString(markdown: someString, including: \.zashiApp) {
+    ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
+}
+// after
+ZashiText(markdown: someString, colorScheme: colorScheme)
+```
+
+Sites (all under `secant/Sources/Features/`): `WhatsNew/WhatsNewView`,
+`WalletBirthday/WalletBirthdayEstimatedHeightView`, `RestoreInfo/RestoreInfoView` (passes
+`textColor:`), `CoordFlows/RestoreWalletCoordFlowView`, `CoordFlows/AddKeystoneHWWalletCoordFlowView`,
+`TransactionDetails/TransactionSwapComponents`, `Receive/ReceiveView`,
+`ResyncWallet/ResyncWalletView`, `SwapAndPayForm/SwapComponents`, `Settings/SettingsView`,
+`RecoveryPhraseDisplay/RecoveryPhraseDisplayView`.
+
+### Modified: `Localizable.xcstrings`
+
+Rewrite the ~8 keys containing `^[X](style: 'boldPrimary')` → `==X==` for both EN and ES
+values (26 occurrences). **Only string values change — keys are untouched**, so SwiftGen
+output does not change. Example:
+
+```
+"^[Warning:](style: 'boldPrimary') Your funds..."  →  "==Warning:== Your funds..."
+```
+
+## Testing
+
+New Swift Testing suite `zodlTests/MarkdownTests/ZashiMarkdownParserTests.swift`
+(`@Suite` / `@Test` / `#expect`). No global state → no `.serialized` needed. Assert on the
+parsed `AttributedString` runs (`run.zStyle`, the run's substring, and `.link` URL). Cases:
+
+- Each style in isolation: `**b**`, `*i*`, `***bi***`, `==bp==`, `[t](https://x.io)`.
+- Plain text passthrough; text with no markers.
+- Multiple sequential spans in one string (the real `==Warning:== ... ==under 2%== ...` shape).
+- Unmatched openers → literal: `**bold`, `==x`, `[t](no-close`.
+- Escaping: `\*literal\*`, `\==`, `\\`.
+- Whitespace / newline preservation (multi-line info text).
+- Empty input; empty span `****`, `====`.
+- Interpolated-looking content: `==123 ZEC==`, `==50%==` (percent passthrough).
+- Link emits both `.link` URL and `zStyle == .link`.
+- Adjacent different styles: `**b**==p==`.
+
+## Risk & coordination
+
+- **Risk: low–medium.** Renderer untouched; parser fully unit-tested; string change is
+  value-only (no SwiftGen churn).
+- **Coordination (not code):**
+  - Android adopts the same grammar, especially `==boldPrimary==`. This spec's Grammar
+    section is the shared contract.
+  - WhatsNew server content and any link-bearing dynamic strings must emit the unified
+    syntax. Until they do, those surfaces keep rendering literally (no crash, no data loss).
+
+## Estimate
+
+~1–2 days of iOS work (parser + tests + 11 call-site swaps + string migration), excluding
+cross-team coordination.

--- a/docs/superpowers/specs/2026-06-22-unified-markdown-parser-design.md
+++ b/docs/superpowers/specs/2026-06-22-unified-markdown-parser-design.md
@@ -184,6 +184,14 @@ output does not change. Example:
 "^[Warning:](style: 'boldPrimary') Your funds..."  →  "==Warning:== Your funds..."
 ```
 
+### Modified: bundled WhatsNew JSON
+
+`WhatsNewProvider` loads its content from **bundled** resources
+(`Bundle.main.url(forResource:...)` in `WhatsNewProviderLiveKey`), not a remote server, so
+these ship with the app and must be migrated in lockstep:
+`secant/Resources/WhatsNew/whatsNew.json` (and `whatsNew_es.json`). The EN file contained two
+`^[X](style: 'bold')` markers → `**X**`; the ES file had none.
+
 ## Testing
 
 New Swift Testing suite `zodlTests/MarkdownTests/ZashiMarkdownParserTests.swift`
@@ -208,8 +216,10 @@ parsed `AttributedString` runs (`run.zStyle`, the run's substring, and `.link` U
 - **Coordination (not code):**
   - Android adopts the same grammar, especially `==boldPrimary==`. This spec's Grammar
     section is the shared contract.
-  - WhatsNew server content and any link-bearing dynamic strings must emit the unified
-    syntax. Until they do, those surfaces keep rendering literally (no crash, no data loss).
+  - All current in-app content (localized strings + bundled WhatsNew JSON) is migrated here.
+    Any *future* externally-sourced markdown (e.g. a remotely-pushed WhatsNew payload, if that
+    ever exists) must emit the unified syntax; until it does, such surfaces render literally
+    (no crash, no data loss — the parser is total).
 
 ## Estimate
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -8700,13 +8700,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[Warning:](style: 'boldPrimary') Your Zodl funds cannot be spent until your Keystone wallet is synced."
+            "value" : "==Warning:== Your Zodl funds cannot be spent until your Keystone wallet is synced."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos de Zodl hasta que tu billetera Keystone esté sincronizada."
+            "value" : "==Advertencia:== No podrás usar tus fondos de Zodl hasta que tu billetera Keystone esté sincronizada."
           }
         }
       }
@@ -8717,13 +8717,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is restored."
+            "value" : "==Warning:== Your funds cannot be spent until your wallet is restored."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera esté completamente restaurada."
+            "value" : "==Advertencia:== No podrás usar tus fondos hasta que tu billetera esté completamente restaurada."
           }
         }
       }
@@ -8734,13 +8734,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is resynced."
+            "value" : "==Warning:== Your funds cannot be spent until your wallet is resynced."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera se haya resincronizado."
+            "value" : "==Advertencia:== No podrás usar tus fondos hasta que tu billetera se haya resincronizado."
           }
         }
       }
@@ -11109,13 +11109,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[The Secret Recovery Phrase](style: 'boldPrimary') is a unique set of 24 words, appearing in a precise order. It can be used to gain full control of your funds from any device via any Zcash wallet app. Think of it as the master key to your wallet. It is stored in Zodl’s Advanced Settings."
+            "value" : "==The Secret Recovery Phrase== is a unique set of 24 words, appearing in a precise order. It can be used to gain full control of your funds from any device via any Zcash wallet app. Think of it as the master key to your wallet. It is stored in Zodl’s Advanced Settings."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[La Frase de Recuperación Secreta](style: 'boldPrimary') es un conjunto único de 24 palabras, que aparecen en un orden preciso. Se puede usar para obtener control total de tus fondos desde cualquier dispositivo a través de cualquier aplicación de billetera Zcash. Piensa en ella como la llave maestra de tu billetera. Se guarda en la Configuración Avanzada de Zodl."
+            "value" : "==La Frase de Recuperación Secreta== es un conjunto único de 24 palabras, que aparecen en un orden preciso. Se puede usar para obtener control total de tus fondos desde cualquier dispositivo a través de cualquier aplicación de billetera Zcash. Piensa en ella como la llave maestra de tu billetera. Se guarda en la Configuración Avanzada de Zodl."
           }
         }
       }
@@ -11178,13 +11178,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Zodl will scan and recover all transactions made after the following block number."
+            "value" : "Your wallet will be resynced from ==%@== (%@ blocks). Zodl will scan and recover all transactions made after the following block number."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
+            "value" : "Tu billetera se resincronizará desde ==%@== (%@ bloques).. Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
           }
         }
       }
@@ -11331,13 +11331,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Use the button below if you wish to change it."
+            "value" : "Your wallet will be resynced from ==%@== (%@ blocks). Use the button below if you wish to change it."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Usa el botón de abajo si deseas cambiarlo."
+            "value" : "Tu billetera se resincronizará desde ==%@== (%@ bloques).. Usa el botón de abajo si deseas cambiarlo."
           }
         }
       }
@@ -15528,13 +15528,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deposit an additional ^[%@ %@](style: 'boldPrimary') to complete this swap before ^[%@](style: 'boldPrimary'), or your deposit will be refunded."
+            "value" : "Deposit an additional ==%@ %@== to complete this swap before ==%@==, or your deposit will be refunded."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deposita ^[%@ %@](style: 'boldPrimary') adicionales para completar este intercambio antes del ^[%@](style: 'boldPrimary'), o tu depósito será reembolsado."
+            "value" : "Deposita ==%@ %@== adicionales para completar este intercambio antes del ==%@==, o tu depósito será reembolsado."
           }
         }
       }
@@ -16242,13 +16242,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[Warning:](style: 'boldPrimary') Slippage ^[under %@%%](style: 'boldPrimary') increases the chance your swap will be unsuccessful and refunded. Consider using ^[%@%% or higher](style: 'boldPrimary'), especially for larger amounts."
+            "value" : "==Warning:== Slippage ==under %@%%== increases the chance your swap will be unsuccessful and refunded. Consider using ==%@%% or higher==, especially for larger amounts."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[Advertencia:](style: 'boldPrimary') Un deslizamiento menor ^[al %@%%](style: 'boldPrimary') aumenta la probabilidad de que tu intercambio no se complete y sea reembolsado. Considera usar ^[%@%% o más](style: 'boldPrimary'), especialmente para montos mayores."
+            "value" : "==Advertencia:== Un deslizamiento menor ==al %@%%== aumenta la probabilidad de que tu intercambio no se complete y sea reembolsado. Considera usar ==%@%% o más==, especialmente para montos mayores."
           }
         }
       }
@@ -18543,13 +18543,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. It is important to provide the correct height because that determines the range of blocks we will scan to display your transaction history and wallet balance. If you have recovered a seed from a different hardware device, make sure to enter the block height of your original hardware device."
+            "value" : "==The Wallet Birthday Height== is the block height (block # in the blockchain) at which your wallet was created. It is important to provide the correct height because that determines the range of blocks we will scan to display your transaction history and wallet balance. If you have recovered a seed from a different hardware device, make sure to enter the block height of your original hardware device."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[La Altura de Creación de la Billetera (Wallet Birthday Height)](style: 'boldPrimary') corresponde a la altura del bloque (número de bloque en la cadena de bloques) en la que se creó tu billetera. Es importante proporcionar la altura correcta, ya que determina el rango de bloques que analizaremos para mostrar tu historial de transacciones y el saldo de tu billetera. Si recuperaste una semilla de otro dispositivo, asegúrate de ingresar la altura del bloque de tu dispositivo original."
+            "value" : "==La Altura de Creación de la Billetera (Wallet Birthday Height)== corresponde a la altura del bloque (número de bloque en la cadena de bloques) en la que se creó tu billetera. Es importante proporcionar la altura correcta, ya que determina el rango de bloques que analizaremos para mostrar tu historial de transacciones y el saldo de tu billetera. Si recuperaste una semilla de otro dispositivo, asegúrate de ingresar la altura del bloque de tu dispositivo original."
           }
         }
       }
@@ -18560,13 +18560,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. If you ever lose access to your Zodl app and need to recover your funds, providing the block height along with your recovery phrase can significantly speed up the process."
+            "value" : "==The Wallet Birthday Height== is the block height (block # in the blockchain) at which your wallet was created. If you ever lose access to your Zodl app and need to recover your funds, providing the block height along with your recovery phrase can significantly speed up the process."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "^[La Altura de Cumpleaños de la Billetera](style: 'boldPrimary') es la altura del bloque (número de bloque en la blockchain) en el que tu billetera fue creada. Si alguna vez pierdes acceso a tu aplicación Zodl y necesitas recuperar tus fondos, proporcionar la altura del bloque junto con tu frase de recuperación puede acelerar significativamente el proceso."
+            "value" : "==La Altura de Cumpleaños de la Billetera== es la altura del bloque (número de bloque en la blockchain) en el que tu billetera fue creada. Si alguna vez pierdes acceso a tu aplicación Zodl y necesitas recuperar tus fondos, proporcionar la altura del bloque junto con tu frase de recuperación puede acelerar significativamente el proceso."
           }
         }
       }

--- a/secant/Resources/WhatsNew/whatsNew.json
+++ b/secant/Resources/WhatsNew/whatsNew.json
@@ -1077,9 +1077,9 @@
                 {
                     "title": "Added:",
                     "bulletpoints": [
-                        "Highly requested ^[dark mode](style: 'bold') functionality added. Turn it on by switching into dark mode in your device settings. Enjoy!",
+                        "Highly requested **dark mode** functionality added. Turn it on by switching into dark mode in your device settings. Enjoy!",
                         "Scan QR code from an image stored in your photo library.",
-                        "Security feature added - ^[hide your balances](style: 'bold') and transaction history with an eye icon on the Account and Balances tabs."
+                        "Security feature added - **hide your balances** and transaction history with an eye icon on the Account and Balances tabs."
                     ]
                 },
                 {

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
@@ -68,14 +68,9 @@ struct AddKeystoneHWWalletCoordFlowView: View {
                 Asset.Assets.infoCircle.image
                     .zImage(size: 20, style: Design.Text.primary)
 
-                if let attrText = try? AttributedString(
-                    markdown: String(localizable: .walletBirthdayHelpDesc),
-                    including: \.zashiApp
-                ) {
-                    ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
-                        .zFont(size: 14, style: Design.Text.tertiary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                ZashiText(markdown: String(localizable: .walletBirthdayHelpDesc), colorScheme: colorScheme)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(.bottom, 32)
             

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowView.swift
@@ -148,14 +148,9 @@ struct RestoreWalletCoordFlowView: View {
             Asset.Assets.infoCircle.image
                 .zImage(size: 20, style: Design.Text.primary)
             
-            if let attrText = try? AttributedString(
-                markdown: text,
-                including: \.zashiApp
-            ) {
-                ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
-                    .zFont(size: 14, style: Design.Text.tertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            ZashiText(markdown: text, colorScheme: colorScheme)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/secant/Sources/Features/Receive/ReceiveView.swift
+++ b/secant/Sources/Features/Receive/ReceiveView.swift
@@ -272,14 +272,9 @@ struct ReceiveView: View {
                 .foregroundColor(Design.Text.tertiary.color(colorScheme))
                 .padding(.top, 8)
             
-            if let attrText = try? AttributedString(
-                markdown: text,
-                including: \.zashiApp
-            ) {
-                ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
-                    .zFont(size: 14, style: Design.Text.tertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            ZashiText(markdown: text, colorScheme: colorScheme)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
     

--- a/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
+++ b/secant/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
@@ -234,14 +234,9 @@ struct RecoveryPhraseDisplayView: View {
             Asset.Assets.infoCircle.image
                 .zImage(size: 20, style: Design.Text.primary)
             
-            if let attrText = try? AttributedString(
-                markdown: text,
-                including: \.zashiApp
-            ) {
-                ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
-                    .zFont(size: 14, style: Design.Text.tertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            ZashiText(markdown: text, colorScheme: colorScheme)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/secant/Sources/Features/RestoreInfo/RestoreInfoView.swift
+++ b/secant/Sources/Features/RestoreInfo/RestoreInfoView.swift
@@ -54,7 +54,7 @@ struct RestoreInfoView: View {
                 bulletpoint(String(localizable: .restoreInfoTip2))
                     .padding(.bottom, Design.Spacing._lg)
 
-                if let attrText = try? AttributedString(
+                ZashiText(
                     markdown: String(
                         localizable: store.isKeystoneFlow
                         ? .keepZodlOpenWarningHWWallet
@@ -62,18 +62,16 @@ struct RestoreInfoView: View {
                         ? .keepZodlOpenWarningResync
                         : .keepZodlOpenWarningRestore
                     ),
-                    including: \.zashiApp
-                ) {
-                    ZashiText(withAttributedString: attrText, colorScheme: colorScheme, textColor: Design.Utility.WarningYellow._900.color(colorScheme))
-                        .zFont(size: 14, style: Design.Utility.WarningYellow._900)
-                        .padding(.vertical, Design.Spacing._xl)
-                        .padding(.horizontal, Design.Spacing._2xl)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .background {
-                            RoundedRectangle(cornerRadius: Design.Radius._3xl)
-                                .fill(Design.Utility.WarningYellow._50.color(colorScheme))
-                            
-                        }
+                    colorScheme: colorScheme,
+                    textColor: Design.Utility.WarningYellow._900.color(colorScheme)
+                )
+                .zFont(size: 14, style: Design.Utility.WarningYellow._900)
+                .padding(.vertical, Design.Spacing._xl)
+                .padding(.horizontal, Design.Spacing._2xl)
+                .fixedSize(horizontal: false, vertical: true)
+                .background {
+                    RoundedRectangle(cornerRadius: Design.Radius._3xl)
+                        .fill(Design.Utility.WarningYellow._50.color(colorScheme))
                 }
                 
                 Spacer()

--- a/secant/Sources/Features/ResyncWallet/ResyncWalletView.swift
+++ b/secant/Sources/Features/ResyncWallet/ResyncWalletView.swift
@@ -71,15 +71,10 @@ struct ResyncWalletView: View {
     
     @ViewBuilder func bdBadge() -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let attrText = try? AttributedString(
-                markdown: String(localizable: .resyncWalletCurrentHeightInfo(store.birthdayDate, store.birthdayBlocks)),
-                including: \.zashiApp
-            ) {
-                ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
-                    .zFont(.medium, size: 14, style: Design.Text.tertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.bottom, Design.Spacing._xl)
-            }
+            ZashiText(markdown: String(localizable: .resyncWalletCurrentHeightInfo(store.birthdayDate, store.birthdayBlocks)), colorScheme: colorScheme)
+                .zFont(.medium, size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, Design.Spacing._xl)
 
             ZashiButton(
                 String(localizable: .resyncWalletChange),

--- a/secant/Sources/Features/Settings/SettingsView.swift
+++ b/secant/Sources/Features/Settings/SettingsView.swift
@@ -227,14 +227,9 @@ struct SettingsView: View {
                 Asset.Assets.infoCircle.image
                     .zImage(size: 20, style: Design.Text.primary)
 
-                if let attrText = try? AttributedString(
-                    markdown: String(localizable: .walletBirthdayHelpDesc),
-                    including: \.zashiApp
-                ) {
-                    ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
-                        .zFont(size: 14, style: Design.Text.tertiary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                ZashiText(markdown: String(localizable: .walletBirthdayHelpDesc), colorScheme: colorScheme)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(.bottom, 32)
             

--- a/secant/Sources/Features/SwapAndPayForm/SwapComponents.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapComponents.swift
@@ -233,26 +233,21 @@ extension SwapAndPayForm {
                 Spacer()
 
                 if store.slippageInSheet < 2.0 {
-                    if let attrText = try? AttributedString(
+                    ZashiText(
                         markdown: String(localizable: .swapAndPaySmallSlippageWarn("\(SwapAndPay.Constants.defaultSlippage)", "\(SwapAndPay.Constants.defaultSlippage)")),
-                        including: \.zashiApp
-                    ) {
-                        ZashiText(
-                            withAttributedString: attrText,
-                            colorScheme: colorScheme,
-                            textColor: Design.Utility.WarningYellow._900.color(colorScheme),
-                            textSize: 12
-                        )
-                        .zFont(size: 12, style: Design.Utility.WarningYellow._900)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 16)
-                        .background {
-                            RoundedRectangle(cornerRadius: Design.Radius._lg)
-                                .fill(Design.Utility.WarningYellow._100.color(colorScheme))
-                        }
-                        .padding(.bottom, 24)
+                        colorScheme: colorScheme,
+                        textColor: Design.Utility.WarningYellow._900.color(colorScheme),
+                        textSize: 12
+                    )
+                    .zFont(size: 12, style: Design.Utility.WarningYellow._900)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 16)
+                    .background {
+                        RoundedRectangle(cornerRadius: Design.Radius._lg)
+                            .fill(Design.Utility.WarningYellow._100.color(colorScheme))
                     }
+                    .padding(.bottom, 24)
                 }
 
                 ZashiButton(String(localizable: .generalConfirm)) {

--- a/secant/Sources/Features/TransactionDetails/TransactionSwapComponents.swift
+++ b/secant/Sources/Features/TransactionDetails/TransactionSwapComponents.swift
@@ -130,24 +130,19 @@ extension TransactionDetailsView {
                     .zFont(.medium, size: 14, style: Design.Utility.WarningYellow._700)
 
                 if let incompleteSwapData = store.incompleteSwapData {
-                    if let attrText = try? AttributedString(
+                    ZashiText(
                         markdown: String(localizable: .swapAndPayIncompleteInfo(
                             incompleteSwapData.missingFunds,
                             incompleteSwapData.tokenName,
                             incompleteSwapData.date
                         )),
-                        including: \.zashiApp
-                    ) {
-                        ZashiText(
-                            withAttributedString: attrText,
-                            colorScheme: colorScheme,
-                            textColor: Design.Utility.WarningYellow._900.color(colorScheme),
-                            textSize: 12
-                        )
-                        .zFont(size: 12, style: Design.Utility.WarningYellow._800)
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                    }
+                        colorScheme: colorScheme,
+                        textColor: Design.Utility.WarningYellow._900.color(colorScheme),
+                        textSize: 12
+                    )
+                    .zFont(size: 12, style: Design.Utility.WarningYellow._800)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }

--- a/secant/Sources/Features/WalletBirthday/WalletBirthdayEstimatedHeightView.swift
+++ b/secant/Sources/Features/WalletBirthday/WalletBirthdayEstimatedHeightView.swift
@@ -33,15 +33,10 @@ struct WalletBirthdayEstimatedHeightView: View {
                     .padding(.bottom, 8)
 
                 if store.isResyncFlow {
-                    if let attrText = try? AttributedString(
-                        markdown: String(localizable: .resyncEstimatedBlockHeightInfo(store.selectedDateString, store.estimatedHeightString)),
-                        including: \.zashiApp
-                    ) {
-                        ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
-                            .zFont(size: 14, style: Design.Text.primary)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .padding(.bottom, 56)
-                    }
+                    ZashiText(markdown: String(localizable: .resyncEstimatedBlockHeightInfo(store.selectedDateString, store.estimatedHeightString)), colorScheme: colorScheme)
+                        .zFont(size: 14, style: Design.Text.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.bottom, 56)
                 } else {
                     Text(localizable: .restoreWalletBirthdayEstimatedInfo)
                         .zFont(size: 14, style: Design.Text.primary)

--- a/secant/Sources/Features/WhatsNew/WhatsNewView.swift
+++ b/secant/Sources/Features/WhatsNew/WhatsNewView.swift
@@ -30,25 +30,21 @@ struct WhatsNewView: View {
     }
     
     @ViewBuilder func attributedText(_ sectionIndex: Int, index: Int) -> some View {
-        if let previewText = try? AttributedString(
-            markdown: store.latest.sections[sectionIndex].bulletpoints[index],
-            including: \.zashiApp) {
-            HStack {
-                VStack {
-                    Circle()
-                        .frame(width: 4, height: 4)
-                        .padding(.top, 7)
-                        .padding(.leading, 8)
-                    
-                    Spacer()
-                }
-                
-                ZashiText(withAttributedString: previewText, colorScheme: colorScheme)
-                    .zFont(size: 14, style: Design.Text.primary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .accentColor(Asset.Colors.primary.color)
-                    .lineSpacing(1.5)
+        HStack {
+            VStack {
+                Circle()
+                    .frame(width: 4, height: 4)
+                    .padding(.top, 7)
+                    .padding(.leading, 8)
+
+                Spacer()
             }
+
+            ZashiText(markdown: store.latest.sections[sectionIndex].bulletpoints[index], colorScheme: colorScheme)
+                .zFont(size: 14, style: Design.Text.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accentColor(Asset.Colors.primary.color)
+                .lineSpacing(1.5)
         }
     }
     

--- a/secant/Sources/UIComponents/Text/ZashiMarkdown.swift
+++ b/secant/Sources/UIComponents/Text/ZashiMarkdown.swift
@@ -1,0 +1,178 @@
+//
+//  ZashiMarkdown.swift
+//  Zashi
+//
+//  Self-contained parser for the unified Zashi/Android markdown grammar used in
+//  localized strings. Replaces Apple's proprietary `^[text](style:'...')`
+//  custom-attribute markdown (MarkdownDecodableAttributedStringKey).
+//
+//  Grammar (the shared iOS/Android contract):
+//    **bold**        -> .bold
+//    *italic*        -> .italic
+//    ***boldItalic***-> .boldItalic
+//    ==boldPrimary== -> .boldPrimary   (the one custom token)
+//    [text](url)     -> .link (+ Foundation .link URL, so SwiftUI Text is tappable)
+//
+//  Rules: flat (no nesting in v1), total (never throws; unmatched markup is emitted
+//  literally), backslash escapes a markdown-significant character, whitespace/newlines
+//  are preserved verbatim. See docs/superpowers/specs/2026-06-22-unified-markdown-parser-design.md
+//
+
+import Foundation
+
+enum ZashiMarkdown {
+    /// Characters a leading backslash can escape into a literal.
+    private static let escapable: Set<Character> = ["*", "=", "[", "]", "(", ")", "\\"]
+
+    /// A recognized opening/closing emphasis delimiter run.
+    private struct Delimiter {
+        let token: [Character]
+        let style: ZashiTextAttribute.Value
+    }
+
+    /// A successfully parsed `[text](url)` link.
+    private struct ParsedLink {
+        let text: String
+        let url: URL
+        let nextIndex: Int
+    }
+
+    /// Parses the unified Zashi/Android markdown grammar into a semantic `AttributedString`.
+    /// Total: never throws; unmatched markup is emitted as literal text.
+    static func parse(_ input: String) -> AttributedString {
+        let chars = Array(input)
+        let count = chars.count
+
+        var result = AttributedString("")
+        var literal = ""
+        var i = 0
+
+        func flushLiteral() {
+            guard !literal.isEmpty else { return }
+            result.append(AttributedString(literal))
+            literal = ""
+        }
+
+        func appendStyled(_ text: String, style: ZashiTextAttribute.Value, url: URL? = nil) {
+            guard !text.isEmpty else { return }
+            var piece = AttributedString(text)
+            piece.zStyle = style
+            if let url {
+                piece.link = url
+            }
+            result.append(piece)
+        }
+
+        while i < count {
+            let character = chars[i]
+
+            // 1. Escaping: a backslash makes the next significant character literal.
+            if character == "\\", i + 1 < count, escapable.contains(chars[i + 1]) {
+                literal.append(chars[i + 1])
+                i += 2
+                continue
+            }
+
+            // 2. Link: [text](url)
+            if character == "[", let link = ZashiMarkdown.parseLink(chars, from: i) {
+                flushLiteral()
+                appendStyled(link.text, style: .link, url: link.url)
+                i = link.nextIndex
+                continue
+            }
+
+            // 3. Emphasis delimiter run (** , * , *** , ==).
+            if let delimiter = ZashiMarkdown.delimiter(at: i, in: chars) {
+                let innerStart = i + delimiter.token.count
+                if let close = ZashiMarkdown.findClosing(delimiter, in: chars, after: innerStart) {
+                    flushLiteral()
+                    appendStyled(String(chars[innerStart..<close]), style: delimiter.style)
+                    i = close + delimiter.token.count
+                    continue
+                }
+                // Unmatched: emit the opening run literally and move past it.
+                literal.append(contentsOf: chars[i..<innerStart])
+                i = innerStart
+                continue
+            }
+
+            // 4. Plain character.
+            literal.append(character)
+            i += 1
+        }
+
+        flushLiteral()
+        return result
+    }
+
+    // MARK: - Helpers
+
+    /// Recognizes an emphasis delimiter run starting at `index`. The `*` run length is
+    /// capped at 3 (boldItalic); `==` is exactly two `=`.
+    private static func delimiter(at index: Int, in chars: [Character]) -> Delimiter? {
+        switch chars[index] {
+        case "*":
+            var run = 0
+            var j = index
+            while j < chars.count, chars[j] == "*" {
+                run += 1
+                j += 1
+            }
+            switch min(run, 3) {
+            case 3: return Delimiter(token: ["*", "*", "*"], style: .boldItalic)
+            case 2: return Delimiter(token: ["*", "*"], style: .bold)
+            default: return Delimiter(token: ["*"], style: .italic)
+            }
+        case "=":
+            if index + 1 < chars.count, chars[index + 1] == "=" {
+                return Delimiter(token: ["=", "="], style: .boldPrimary)
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    /// Finds the next occurrence of the delimiter's token at or after `start`,
+    /// returning the index of its first character, or nil if there is no match.
+    private static func findClosing(_ delimiter: Delimiter, in chars: [Character], after start: Int) -> Int? {
+        let token = delimiter.token
+        let length = token.count
+        var j = start
+        while j + length <= chars.count {
+            if Array(chars[j..<(j + length)]) == token {
+                return j
+            }
+            j += 1
+        }
+        return nil
+    }
+
+    /// Parses `[text](url)` starting at `start` (which must point at `[`).
+    /// Link text is taken literally (no nested parsing in v1). Returns nil on any
+    /// malformation or an unparseable URL, so the caller can fall back to literal text.
+    private static func parseLink(_ chars: [Character], from start: Int) -> ParsedLink? {
+        let count = chars.count
+        var j = start + 1
+        var text = ""
+        while j < count, chars[j] != "]" {
+            text.append(chars[j])
+            j += 1
+        }
+        guard j < count, chars[j] == "]" else { return nil }
+
+        let openParen = j + 1
+        guard openParen < count, chars[openParen] == "(" else { return nil }
+
+        var k = openParen + 1
+        var urlString = ""
+        while k < count, chars[k] != ")" {
+            urlString.append(chars[k])
+            k += 1
+        }
+        guard k < count, chars[k] == ")" else { return nil }
+        guard let url = URL(string: urlString) else { return nil }
+
+        return ParsedLink(text: text, url: url, nextIndex: k + 1)
+    }
+}

--- a/secant/Sources/UIComponents/Text/ZashiText.swift
+++ b/secant/Sources/UIComponents/Text/ZashiText.swift
@@ -9,22 +9,14 @@ import SwiftUI
 
 struct ZashiText: View {
     private var attributedString: AttributedString
-    
+
     var body: some View {
         Text(attributedString)
     }
-    
-    init(withAttributedString attributedString: AttributedString, colorScheme: ColorScheme, textColor: Color? = nil, textSize: CGFloat? = nil) {
-        self.attributedString = AttributedString("")
-        
-        self.attributedString = ZashiText.annotateStyle(from: attributedString, colorScheme: colorScheme, textColor: textColor, textSize: textSize)
-    }
 
-    init(_ localizedKey: String.LocalizationValue, colorScheme: ColorScheme) {
-        self.attributedString = AttributedString("")
-        
-        self.attributedString = ZashiText.annotateStyle(
-            from: AttributedString(localized: localizedKey, including: \.zashiApp), colorScheme: colorScheme)
+    init(markdown: String, colorScheme: ColorScheme, textColor: Color? = nil, textSize: CGFloat? = nil) {
+        let parsed = ZashiMarkdown.parse(markdown)
+        self.attributedString = ZashiText.annotateStyle(from: parsed, colorScheme: colorScheme, textColor: textColor, textSize: textSize)
     }
 
     private static func annotateStyle(from source: AttributedString, colorScheme: ColorScheme, textColor: Color? = nil, textSize: CGFloat? = nil) -> AttributedString {
@@ -59,7 +51,7 @@ struct ZashiText: View {
     }
 }
 
-enum ZashiTextAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+enum ZashiTextAttribute: AttributedStringKey {
     enum Value: String, Codable, Hashable {
         case bold
         case boldPrimary
@@ -67,7 +59,7 @@ enum ZashiTextAttribute: CodableAttributedStringKey, MarkdownDecodableAttributed
         case boldItalic
         case link
     }
-    
+
     static let name: String = "style"
 }
 
@@ -75,7 +67,7 @@ extension AttributeScopes {
     struct ZashiAppAttributes: AttributeScope {
         let zStyle: ZashiTextAttribute
     }
-    
+
     var zashiApp: ZashiAppAttributes.Type { ZashiAppAttributes.self }
 }
 
@@ -84,9 +76,3 @@ extension AttributeDynamicLookup {
         self[T.self]
     }
 }
-
-// Example:
-//let previewText = try? AttributedString(
-//    markdown: "Some ^[bold](style: 'bold') ^[italic](style: 'italic') ^[boldItalic](style: 'boldItalic') [link example](https://electriccoin.co) text.",
-//    including: \.zashiApp)
-//ZashiText(withAttributedString: previewText)

--- a/zodlTests/MarkdownTests/ZashiMarkdownParserTests.swift
+++ b/zodlTests/MarkdownTests/ZashiMarkdownParserTests.swift
@@ -1,0 +1,187 @@
+//
+//  ZashiMarkdownParserTests.swift
+//  zodlTests
+//
+//  Tests for the unified Zashi/Android markdown parser (ZashiMarkdown).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct ZashiMarkdownParserTests {
+    // MARK: - Helpers
+
+    private struct Span: Equatable {
+        let text: String
+        let style: ZashiTextAttribute.Value?
+        let link: URL?
+
+        init(_ text: String, _ style: ZashiTextAttribute.Value?, link: URL? = nil) {
+            self.text = text
+            self.style = style
+            self.link = link
+        }
+    }
+
+    private func spans(of string: AttributedString) -> [Span] {
+        string.runs.map { run in
+            Span(String(string[run.range].characters), run.zStyle, link: run.link)
+        }
+    }
+
+    private func plainText(of string: AttributedString) -> String {
+        String(string.characters)
+    }
+
+    // MARK: - Plain text
+
+    @Test func plainTextPassesThroughUnstyled() {
+        let result = ZashiMarkdown.parse("Hello world")
+        #expect(plainText(of: result) == "Hello world")
+        #expect(spans(of: result) == [Span("Hello world", nil)])
+    }
+
+    @Test func emptyInputProducesEmptyString() {
+        let result = ZashiMarkdown.parse("")
+        #expect(plainText(of: result) == "")
+    }
+
+    // MARK: - Single styles
+
+    @Test func boldDelimitersProduceBoldStyle() {
+        let result = ZashiMarkdown.parse("**bold**")
+        #expect(plainText(of: result) == "bold")
+        #expect(spans(of: result) == [Span("bold", .bold)])
+    }
+
+    @Test func italicDelimitersProduceItalicStyle() {
+        let result = ZashiMarkdown.parse("*italic*")
+        #expect(plainText(of: result) == "italic")
+        #expect(spans(of: result) == [Span("italic", .italic)])
+    }
+
+    @Test func tripleDelimitersProduceBoldItalicStyle() {
+        let result = ZashiMarkdown.parse("***both***")
+        #expect(plainText(of: result) == "both")
+        #expect(spans(of: result) == [Span("both", .boldItalic)])
+    }
+
+    @Test func doubleEqualsProducesBoldPrimaryStyle() {
+        let result = ZashiMarkdown.parse("==primary==")
+        #expect(plainText(of: result) == "primary")
+        #expect(spans(of: result) == [Span("primary", .boldPrimary)])
+    }
+
+    @Test func linkProducesLinkStyleAndURL() {
+        let url = URL(string: "https://electriccoin.co")
+        let result = ZashiMarkdown.parse("[ECC](https://electriccoin.co)")
+        #expect(plainText(of: result) == "ECC")
+        #expect(spans(of: result) == [Span("ECC", .link, link: url)])
+    }
+
+    // MARK: - Composition
+
+    @Test func styledSpanSurroundedByPlainText() {
+        let result = ZashiMarkdown.parse("a **bold** b")
+        #expect(plainText(of: result) == "a bold b")
+        #expect(spans(of: result) == [Span("a ", nil), Span("bold", .bold), Span(" b", nil)])
+    }
+
+    @Test func multipleSequentialStyledSpans() {
+        let result = ZashiMarkdown.parse("==Warning:== keep slippage ==under 2%== please")
+        #expect(plainText(of: result) == "Warning: keep slippage under 2% please")
+        #expect(spans(of: result) == [
+            Span("Warning:", .boldPrimary),
+            Span(" keep slippage ", nil),
+            Span("under 2%", .boldPrimary),
+            Span(" please", nil)
+        ])
+    }
+
+    @Test func adjacentDifferentStylesWithoutSeparator() {
+        let result = ZashiMarkdown.parse("**b**==p==")
+        #expect(spans(of: result) == [Span("b", .bold), Span("p", .boldPrimary)])
+    }
+
+    @Test func linkFollowedByBoldPrimary() {
+        let url = URL(string: "https://x.io")
+        let result = ZashiMarkdown.parse("[a](https://x.io) and ==b==")
+        #expect(spans(of: result) == [
+            Span("a", .link, link: url),
+            Span(" and ", nil),
+            Span("b", .boldPrimary)
+        ])
+    }
+
+    // MARK: - Unmatched / malformed → literal, never throws
+
+    @Test func unmatchedBoldRendersLiterally() {
+        let result = ZashiMarkdown.parse("**bold")
+        #expect(plainText(of: result) == "**bold")
+        #expect(spans(of: result) == [Span("**bold", nil)])
+    }
+
+    @Test func unmatchedBoldPrimaryRendersLiterally() {
+        let result = ZashiMarkdown.parse("==x")
+        #expect(plainText(of: result) == "==x")
+        #expect(spans(of: result) == [Span("==x", nil)])
+    }
+
+    @Test func unclosedLinkRendersLiterally() {
+        let result = ZashiMarkdown.parse("[text](no-close")
+        #expect(plainText(of: result) == "[text](no-close")
+        #expect(spans(of: result).allSatisfy { $0.style == nil })
+    }
+
+    // MARK: - Escaping
+
+    @Test func backslashEscapesDelimiter() {
+        let result = ZashiMarkdown.parse("\\*not italic\\*")
+        #expect(plainText(of: result) == "*not italic*")
+        #expect(spans(of: result) == [Span("*not italic*", nil)])
+    }
+
+    @Test func backslashEscapesEqualsRun() {
+        // The backslash escapes the first '=', breaking the '==' run so no boldPrimary forms.
+        let result = ZashiMarkdown.parse("\\==not primary==")
+        #expect(plainText(of: result) == "==not primary==")
+        #expect(spans(of: result).allSatisfy { $0.style == nil })
+    }
+
+    @Test func escapedBackslashIsLiteral() {
+        let result = ZashiMarkdown.parse("a \\\\ b")
+        #expect(plainText(of: result) == "a \\ b")
+    }
+
+    // MARK: - Whitespace / content preservation
+
+    @Test func newlinesAndWhitespacePreserved() {
+        let input = "line one\n\nline  two   end"
+        let result = ZashiMarkdown.parse(input)
+        #expect(plainText(of: result) == input)
+    }
+
+    @Test func percentSignIsNotSpecial() {
+        let result = ZashiMarkdown.parse("==50%==")
+        #expect(plainText(of: result) == "50%")
+        #expect(spans(of: result) == [Span("50%", .boldPrimary)])
+    }
+
+    @Test func interpolatedValueInsideBoldPrimary() {
+        let result = ZashiMarkdown.parse("from ==123 ZEC== now")
+        #expect(spans(of: result) == [
+            Span("from ", nil),
+            Span("123 ZEC", .boldPrimary),
+            Span(" now", nil)
+        ])
+    }
+
+    // MARK: - Link contract (flat, no nesting in v1)
+
+    @Test func linkTextIsNotReparsedForNesting() {
+        let url = URL(string: "https://x.io")
+        let result = ZashiMarkdown.parse("[a*b*c](https://x.io)")
+        #expect(spans(of: result) == [Span("a*b*c", .link, link: url)])
+    }
+}


### PR DESCRIPTION
## Why

Localized strings styled inline text using Apple's **proprietary** custom-attribute markdown — `^[Warning:](style: 'boldPrimary')` — parsed via `AttributedString(markdown:including:\.zashiApp)` and `MarkdownDecodableAttributedStringKey`. That syntax is Apple-only and can't be shared with Android.

This replaces it with a **self-contained parser** (no reliance on Apple's markdown) over a unified grammar both platforms can implement identically.

## Grammar (shared iOS/Android contract)

| Style | Token |
|---|---|
| `bold` | `**text**` |
| `italic` | `*text*` |
| `boldItalic` | `***text***` |
| `link` | `[text](url)` |
| `boldPrimary` | `==text==` (the one custom token) |

## What changed

- **New `ZashiMarkdown` parser** — a linear scanner. **Total** (never throws; unmatched markup renders literally), preserves whitespace/newlines, supports `\` escaping, flat (no nesting in v1). Emits the existing semantic `zStyle` attributes + a real `.link` URL so links stay tappable.
- **`ZashiText`** — `ZashiTextAttribute` drops `MarkdownDecodableAttributedStringKey`/`CodableAttributedStringKey` (now a plain `AttributedStringKey`); the `withAttributedString`/`localizedKey` inits collapse into one `init(markdown:)`. **The render path (`annotateStyle`) is untouched**, so existing screens look identical.
- **11 call sites** migrated from the `try? AttributedString(...)` optional dance to `ZashiText(markdown:)` (−65 lines net).
- **`Localizable.xcstrings`** — 26 `^[X](style: 'boldPrimary')` markers → `==X==` (values only; keys untouched, no SwiftGen churn).
- **Bundled `whatsNew.json`** — two `^[X](style: 'bold')` markers → `**X**` (this content is bundled, not server-driven).

## Two bonus fixes from going custom

- Malformed strings no longer silently vanish (the old `try?` returned `nil` and hid the text).
- Whitespace/newlines are preserved exactly (Apple's parser collapses them).

## Verification

- ✅ Build: compile **+** SwiftLint (build phase)
- ✅ New parser suite: **21/21** (Swift Testing) — every style, composition, unmatched/malformed input, escaping, whitespace, link URL contract
- ✅ Full suite: **633 passed, 0 failed**, 7 pre-existing `withKnownIssue` xfails
- ✅ Zero `^[…](style:…)` markers left anywhere; all JSON valid

## Follow-up (not code)

- **Android** adopts the same grammar, especially the custom `==boldPrimary==` token.
- **v1 is flat** (no nested styles, e.g. emphasis inside a link) — no current content nests; keep it agreed-as-out-of-scope on Android too.

Design doc: `docs/superpowers/specs/2026-06-22-unified-markdown-parser-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)