### PR TITLE
Fix Linear release tracking: run on version-tag push

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,43 +1,81 @@
 name: Linear release tracking
 
-# Runs when a GitHub Release is published. The single job runs Linear's release
-# action, which scans commits since the previous release tag for `MOB-###`
-# references and creates a matching release under the iOS Linear pipeline
-# (Settings → Releases → zodl-ios in Linear).
+# Records a release in Linear when a version tag is pushed. Runs Linear's release
+# action, which scans commits since the previous tag for `MOB-###` references and
+# creates a matching release under the iOS Linear pipeline (Settings → Releases →
+# zodl-ios in Linear), with those issues attached.
 #
-# Why `release: published` and not `push: tags`? For tag-push events GitHub runs
-# the workflow file *as it exists on the tagged commit*. Our release tags are cut
-# from a release branch that predates this workflow, so the file isn't present
-# there and nothing fires. `release` events run the workflow from the default
-# branch (main) instead, so this file is always used regardless of what the tag
-# points at — while still releasing exactly the tag's commit range.
+# The Linear action runs INLINE here — no GitHub Release and no GitHub App token
+# are involved. (We can't use an `on: release: published` trigger like Android:
+# iOS publishes no GitHub Releases, and a release made with the default
+# GITHUB_TOKEN would not cascade to other workflows anyway without an App token.)
 #
-# Requires the LINEAR_ACCESS_KEY repo secret, generated against the iOS
-# pipeline in Linear's UI.
+# Two trigger paths:
+#
+#   * push:tags — fires automatically when a `<major>.<minor>.<patch>` tag is
+#     pushed. NOTE: GitHub runs this file *as it exists on the tagged commit*,
+#     not on main. A release branch that forked from main BEFORE this file was
+#     added won't contain it, so the push trigger silently does nothing for that
+#     tag — this is exactly why tag `3.6.0` never fired. Release branches cut
+#     from main after this merges will carry the file and work automatically.
+#
+#   * workflow_dispatch — runs this file *from the selected branch* (default
+#     main), so it works for ANY existing tag regardless of whether the tagged
+#     commit carries this file. Escape hatch for the transition and for tags on
+#     older branches:
+#       gh workflow run linear-release.yml -f tag=3.6.0
+#
+# Requires the LINEAR_ACCESS_KEY repo secret, generated against the iOS pipeline
+# in Linear's UI.
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing version tag to track in Linear (e.g. 3.6.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
-# Serialize runs for a given tag. Editing/re-publishing a release can emit
-# `release: published` more than once; this prevents overlapping Linear syncs
-# for the same release. cancel-in-progress: false so a second event waits for
-# the first to finish rather than aborting it mid-sync.
+# Serialize runs for a given tag so a push and a manual dispatch for the same
+# version can't run overlapping Linear syncs. cancel-in-progress: false so the
+# second run waits rather than aborting the first mid-sync.
 concurrency:
-  group: linear-release-${{ github.event.release.tag_name }}
+  group: linear-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   linear-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Resolve target tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_REF: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="${PUSH_REF}"
+          fi
+          if [[ ! "${TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: tag '${TAG}' does not match <major>.<minor>.<patch>." >&2
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}  # the released tag's commit
+          ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
 
       - name: Create Linear release

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,22 +1,26 @@
 name: Linear release tracking
 
-# Fires on every release tag push (`<major>.<minor>.<patch>`, e.g. `3.5.2`).
-# The single job runs Linear's release action, which scans commits since the
-# previous tag for `MOB-###` references and creates a matching release under
-# the iOS Linear pipeline (Settings → Releases → zodl-ios in Linear).
+# Runs when a GitHub Release is published. The single job runs Linear's release
+# action, which scans commits since the previous release tag for `MOB-###`
+# references and creates a matching release under the iOS Linear pipeline
+# (Settings → Releases → zodl-ios in Linear).
+#
+# Why `release: published` and not `push: tags`? For tag-push events GitHub runs
+# the workflow file *as it exists on the tagged commit*. Our release tags are cut
+# from a release branch that predates this workflow, so the file isn't present
+# there and nothing fires. `release` events run the workflow from the default
+# branch (main) instead, so this file is always used regardless of what the tag
+# points at — while still releasing exactly the tag's commit range.
 #
 # Requires the LINEAR_ACCESS_KEY repo secret, generated against the iOS
 # pipeline in Linear's UI.
 
 on:
-  push:
-    tags:
-      # GitHub Actions tag filters are glob patterns (minimatch), not regex.
-      # `+` is a literal `+` in glob — the previous `[0-9]+.[0-9]+.[0-9]+`
-      # was being interpreted as "digit + literal `+` + literal `.` + …"
-      # and so only ever matched strings like `3+.5+.2+`, never real
-      # release tags like `3.5.3`. The workflow had never fired.
-      - '*.*.*'
+  release:
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
   linear-release:
@@ -25,6 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.release.tag_name }}  # the released tag's commit
           fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
 
       - name: Create Linear release

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -22,6 +22,14 @@ on:
 permissions:
   contents: read
 
+# Serialize runs for a given tag. Editing/re-publishing a release can emit
+# `release: published` more than once; this prevents overlapping Linear syncs
+# for the same release. cancel-in-progress: false so a second event waits for
+# the first to finish rather than aborting it mid-sync.
+concurrency:
+  group: linear-release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   linear-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -11,7 +11,12 @@ name: Linear release tracking
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      # GitHub Actions tag filters are glob patterns (minimatch), not regex.
+      # `+` is a literal `+` in glob — the previous `[0-9]+.[0-9]+.[0-9]+`
+      # was being interpreted as "digit + literal `+` + literal `.` + …"
+      # and so only ever matched strings like `3+.5+.2+`, never real
+      # release tags like `3.5.3`. The workflow had never fired.
+      - '*.*.*'
 
 jobs:
   linear-release:


### PR DESCRIPTION
## What
Make Linear release tracking actually fire on iOS by running the Linear action **inline off the version-tag push**, with a manual `workflow_dispatch` escape hatch.

## Why
The workflow had never run. Originally `push: tags` used the invalid assumption that the file was on the tagged commit — for `push: tags`, GitHub uses the workflow file **as it exists on the tagged commit**, and our release tags are cut from a release branch that predated this workflow, so it wasn't there (`3.6.0` produced zero runs).

I first switched this to `release: published`, but verified that **won't work on iOS**: iOS publishes **no GitHub Releases** (0 in repo history) and has **no GitHub App token**, so a release made with the default `GITHUB_TOKEN` wouldn't cascade to this workflow anyway. That path would need new infrastructure (a GitHub App) to function.

So this runs the Linear action **inline** instead — needs only the existing `LINEAR_ACCESS_KEY`, no GitHub Release and no App token. The tagged-commit limitation is handled the same way Android's `create-release.yml` handles it: a `workflow_dispatch` escape hatch that runs from `main` for any tag, plus the fact that release branches cut from `main` after this merges will carry the file and fire automatically.

(Also corrects the earlier premise: GitHub tag filters aren't minimatch globs — `+` means "one or more", so `[0-9]+.[0-9]+.[0-9]+` was valid all along. Thanks @chlup.)

## Changes
- Trigger on `push: tags: ['[0-9]+.[0-9]+.[0-9]+']` **and** `workflow_dispatch` (with a `tag` input).
- Resolve + validate the tag (`^[0-9]+\.[0-9]+\.[0-9]+$`), checkout it with `fetch-depth: 0`, run `linear/linear-release-action`.
- `permissions: contents: read`; `concurrency` guard keyed on the tag.

## How it runs going forward
- Normal: push `3.7.0` → workflow fires automatically (file is on the tagged commit once release branches are cut from `main` after this merges).
- Old/transition tags: `gh workflow run linear-release.yml -f tag=3.6.0` (runs from `main`).

## Note vs Android
Android (zodl-android#2337) uses `release: published` because it already creates GitHub Releases and has a GitHub App token (the cascade is proven). iOS lacks both, so it uses this simpler inline approach. If you later set up a release-bot GitHub App on iOS, we can converge both to the same model.