### PR TITLE
[MOB-1435] Tighten simplified rounding to 0.2% and round USD countervalue to 2 decimals

### DIFF
--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -1577,12 +1577,13 @@ extension SwapAndPay.State {
     }
     
     var payUsdLabel: String {
+        // MOB-1435: USD countervalue is rounded to 2 decimals, matching the Send page (SendFormStore).
         guard let selectedAsset else {
-            return conversionCrossPayFormatter.string(from: NSNumber(value: 0.0)) ?? "0"
+            return Decimal(0).formatted(.number.precision(.fractionLength(2)))
         }
 
         let amountInUsd = assetAmount * selectedAsset.usdPrice
-        return conversionCrossPayFormatter.string(from: NSDecimalNumber(decimal: amountInUsd)) ?? "0"
+        return amountInUsd.formatted(.number.precision(.fractionLength(2)))
     }
 }
 

--- a/secant/Sources/Utils/Decimals.swift
+++ b/secant/Sources/Utils/Decimals.swift
@@ -13,8 +13,8 @@ extension Decimal {
     var simplified: Decimal {
         guard self != 0 else { return 0 }
 
-        /// Tolerance 0.5%
-        let tolerance: Decimal = 0.005
+        /// Tolerance 0.2% (MOB-1435: tightened from 0.5% to reduce rounding of fine-precision amounts)
+        let tolerance: Decimal = 0.002
         /// At least 2 floating points
         let minimumFractionDigits = 2
         /// At most 8 floating points

--- a/zodlTests/SwapTests/CrossPayAmountTests.swift
+++ b/zodlTests/SwapTests/CrossPayAmountTests.swift
@@ -1,0 +1,46 @@
+//
+//  CrossPayAmountTests.swift
+//  zodlTests
+//
+//  MOB-1435 — reduce rounding of fine-precision swap/pay amounts by tightening Decimal.simplified's
+//  tolerance from 0.5% to 0.2%, and render the CrossPay USD countervalue at exactly two decimals
+//  (the same system the Send page uses).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct CrossPayAmountTests {
+    // MARK: - simplified tolerance tightened to 0.2%
+
+    @Test func simplifiedTightenedToleranceRoundsReporterValues() {
+        // 0.00279422: scale-4 0.0028 is 0.207% error (> 0.2%, rejected) -> scale-5 0.00279 (0.151%).
+        #expect(decimal("0.00279422").simplified == decimal("0.00279"))
+        // 0.00111 has no shorter form within 0.2% -> stays exact (reporter's second data point).
+        #expect(decimal("0.00111").simplified == decimal("0.00111"))
+    }
+
+    @Test func simplifiedStillCollapsesWithinTolerance() {
+        // simplify is NOT disabled: it still trims when the relative error stays within 0.2%.
+        #expect(decimal("0.123456789").simplified == decimal("0.1235"))
+    }
+
+    // MARK: - USD countervalue rounded to 2 decimals (Send-page system)
+
+    @Test func usdCountervalueRoundsToTwoDecimals() {
+        // payUsdLabel formats the USD countervalue with this style (see SwapAndPayStore / SendFormStore).
+        let formatted = decimal("292.5512").formatted(.number.precision(.fractionLength(2)))
+        // Locale-robust: assert exactly two fraction digits using the current locale's separator.
+        let separator = Locale.current.decimalSeparator ?? "."
+        let parts = formatted.components(separatedBy: separator)
+        #expect(parts.count == 2)
+        #expect(parts.last?.count == 2)
+    }
+
+    // MARK: - Helpers
+
+    private func decimal(_ string: String) -> Decimal {
+        Decimal(string: string) ?? .zero
+    }
+}


### PR DESCRIPTION
## Problem

[MOB-1435](https://linear.app/zodl/issue/MOB-1435) — In CrossPay the user specifies the **destination** asset amount. Fine-precision amounts (e.g. BTC `0.00279422`) were rounded too aggressively, both for display and for the value sent to NEAR, because `Decimal.simplified` collapses to the shortest representation within a **0.5%** relative-error tolerance (`0.00279422 → 0.0028`). The CrossPay USD countervalue could also render with up to 8 decimals.

## Approach

A minimal, low-risk change — keep using `Decimal.simplified` everywhere, just make it tighter, and fix the USD countervalue formatting:

1. **Tighten the tolerance 0.5% → 0.2%** (`Utils/Decimals.swift`). `.simplified` is referenced only in the swap/pay feature (`SwapAndPayStore.swift` + `Near1Click.swift`), so balances and transaction history are unaffected.
   - `0.00279422 → 0.00279` (was `0.0028`); `0.00111` stays exact.
   - **Note:** 0.2% *reduces* but does not *eliminate* rounding — `0.00279422` still becomes `0.00279`, in both the UI and the value sent to the API. (The threshold route can't both keep `simplified` meaningful and preserve that exact value; this tighter tolerance is the chosen trade-off.)
2. **Round the CrossPay USD countervalue to 2 decimals** (`payUsdLabel`) using the Send page's system — `amountInUsd.formatted(.number.precision(.fractionLength(2)))`, matching `SendFormStore.swift`. Every other USD display already renders 2 dp via `.currency` / `.localeUsd`, so they're unchanged.

## Changes

- `secant/Sources/Utils/Decimals.swift` — `simplified` tolerance `0.005 → 0.002`.
- `secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift` — `payUsdLabel` renders 2-dp USD via `.formatted(.number.precision(.fractionLength(2)))`.
- `zodlTests/SwapTests/CrossPayAmountTests.swift` — characterizes `simplified` at 0.2% (locks `0.00279422 → 0.00279` and `0.00111 → 0.00111`, plus a value that still simplifies) and the 2-dp USD formatting.

## Testing

- Built on `main`; **3/3 new tests pass**.

## Notes

- **Targets `main`.**
- No `.simplified` usages were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
