### PR TITLE
Add Claude code skill to update whatsnew json and generate changelog for AppStore

### DIFF
--- a/.claude/skills/update-whatsnew/SKILL.md
+++ b/.claude/skills/update-whatsnew/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: update-whatsnew
+description: Prepare a Zodl release changelog. Reads the version from the zodl-production target, prepends a new release entry to every whatsNew*.json file (one per language), and prints the App Store changelog text for each language. Manual only — invoke with /update-whatsnew and paste the multi-language changelog.
+disable-model-invocation: true
+argument-hint: <paste the multi-language changelog (language blocks with Added/Changed/Fixed sections)>
+---
+
+# Update What's New + App Store changelog
+
+Turn a freeform, multi-language release changelog into two things:
+
+1. **Updated `whatsNew*.json` files** — one file per language, each with a new
+   release entry prepended to the top of its `releases` array.
+2. **App Store changelog text** — one ready-to-paste block per language, printed
+   in the chat.
+
+You do the part that needs judgment: reading the messy, multi-language input and
+splitting it into clean structured sections. A bundled script
+(`scripts/whatsnew.py`) does the mechanical part — inserting into the JSON and
+rendering the App Store text — so the file edit is always valid JSON and a
+minimal, review-friendly diff (existing entries are never reformatted).
+
+This skill is manual only. Run it when a release is being cut.
+
+## The input
+
+The changelog arrives as the command argument (substituted below) or in the
+user's message:
+
+ARGUMENTS: $ARGUMENTS
+
+It is one block per language. Each block starts with a language name
+(`English`, `Español`, …) and contains sections — a short header line ending in
+`:` (`Added:`, `Changed:`, `Fixed:`, `Removed:`, and their localized forms like
+`Añadido:`, `Cambiado:`, `Corregido:`) followed by one or more items.
+
+The shape is **not** rigid. Expect variation between releases: blank lines
+between items, an optional leading `-`, `*`, `•`, or `–` on each item, extra
+spacing. Read it for meaning rather than matching an exact pattern. If the
+changelog isn't in the argument or the message, ask the user to paste it.
+
+## Workflow
+
+### 1. Read the release version
+
+Read `MARKETING_VERSION` from the **zodl-production** target (this is what ships
+to the App Store). It takes ~20s — that's normal:
+
+```bash
+xcodebuild -project secant.xcodeproj -target zodl-production \
+  -showBuildSettings -configuration Release-AppStore 2>/dev/null \
+  | awk -F' = ' '/ MARKETING_VERSION /{print $2; exit}'
+```
+
+Fallback if `xcodebuild` is unavailable (every target is kept on the same
+version, so this is reliable in practice, just not target-specific):
+
+```bash
+grep -m1 'MARKETING_VERSION' secant.xcodeproj/project.pbxproj | sed 's/.*= *//; s/;.*//'
+```
+
+### 2. Determine date and timestamp — once, shared by all languages
+
+```bash
+date +%d-%m-%Y   # e.g. 23-06-2026  (DD-MM-YYYY — matches recent entries)
+date +%s         # e.g. 1782211565  (Unix epoch seconds)
+```
+
+Use the **same** version, date, and timestamp for every language — it's one
+release.
+
+### 3. Parse the changelog into one payload per language
+
+For each language block, build a payload JSON file (write it to a temp path such
+as `/tmp/whatsnew-<lang>.json` — using the file write tool avoids shell-escaping
+problems with quotes, apostrophes, and accents):
+
+```json
+{
+  "version": "<from step 1>",
+  "date": "<from step 2>",
+  "timestamp": <from step 2>,
+  "sections": [
+    { "title": "Added:", "bulletpoints": ["First item.", "Second item."] },
+    { "title": "Changed:", "bulletpoints": ["..."] }
+  ]
+}
+```
+
+Rules:
+
+- **Keep the section title verbatim**, including the trailing colon, in that
+  language (`Added:`, `Añadido:`, …). Never translate — the input is already
+  localized.
+- **Preserve section order** as given.
+- **One clean string per item.** Strip a leading bullet marker (`-`, `*`, `•`,
+  `–`) and surrounding whitespace. Items are normally separated by blank lines.
+- Map each language to its file (see the table below). If a block has no
+  language header and there's only one block, ask the user which language it is
+  rather than guessing.
+
+### 4. Pre-flight — dry-run every target file
+
+Before touching anything, dry-run each file so the whole operation is atomic:
+
+```bash
+python3 .claude/skills/update-whatsnew/scripts/whatsnew.py add \
+  --file <whatsNew file> --payload <temp payload> --dry-run
+```
+
+- **Exit 3 = a version entry already exists.** Per policy: **stop and warn the
+  user, and change nothing** — not this file and not the others. (This is the
+  normal guard against re-running for a version that's already in the files.)
+- **A language with no file yet** is a new language. Do **not** guess the
+  filename. Ask the user to confirm the name (suggest `whatsNew_<code>.json`
+  with the ISO 639-1 code, e.g. German → `whatsNew_de.json`), then plan to pass
+  `--create` for that file in step 5.
+
+Only continue once every dry-run is OK.
+
+### 5. Apply — prepend the entries
+
+```bash
+python3 .claude/skills/update-whatsnew/scripts/whatsnew.py add \
+  --file <whatsNew file> --payload <temp payload>
+```
+
+Add `--create` **only** for the new-language file the user confirmed in step 4.
+
+### 6. Produce the App Store text
+
+For each language:
+
+```bash
+python3 .claude/skills/update-whatsnew/scripts/whatsnew.py appstore \
+  --payload <temp payload>
+```
+
+Present each language's output in its own labeled fenced code block so the user
+can copy each one straight into App Store Connect.
+
+### 7. Report
+
+Summarize: the version, date, timestamp, and which files changed. Show the
+inserted diff (`git diff -- secant/Resources/WhatsNew/`) so the user can confirm
+only a new top entry was added and nothing else moved.
+
+## Language → file mapping
+
+| Language block | File |
+|----------------|------|
+| English | `secant/Resources/WhatsNew/whatsNew.json` |
+| Español / Spanish | `secant/Resources/WhatsNew/whatsNew_es.json` |
+| Any other language | `secant/Resources/WhatsNew/whatsNew_<ISO 639-1>.json` — **confirm the name with the user, then `--create`** |
+
+English is the only language with no suffix. Every other language uses a
+`_<code>` suffix.
+
+## Invariants (why the script exists)
+
+- **Newest entry on top; existing entries are never touched.** The script does a
+  pure textual insert after the `"releases": [` line, so a release shows up as a
+  small, obvious diff instead of a whole-file reformat.
+- **Valid JSON, correct formatting, accents preserved** (8-space-indented entry,
+  `ensure_ascii=False`). The script validates the result before writing.
+- **One release = one shared version/date/timestamp across all languages.**
+- Don't hand-edit the JSON files for this — let the script do it so every
+  release is consistent.
+
+## The helper script
+
+`scripts/whatsnew.py` (Python 3, standard library only):
+
+- `add --file F --payload P [--create] [--dry-run]` — prepend the release in `P`
+  to `F`. Exits **3** without writing if that version already exists. `--create`
+  makes a fresh `{ "releases": [] }` file for a new language. `--dry-run`
+  validates and reports without writing.
+- `appstore --payload P` — print the App Store changelog text for `P`.
+
+Payload schema is shown in step 3; `date`/`timestamp` default to today/now if
+omitted, but pass them explicitly so all languages match.

--- a/.claude/skills/update-whatsnew/evals/evals.json
+++ b/.claude/skills/update-whatsnew/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "update-whatsnew",
+  "notes": "Canonical example for the 3.7.0 release. The whatsNew files are kept newest-first; running the skill with version 3.7.0 against files topped by 3.6.0 must reproduce the expected entries below exactly, as a minimal diff (existing entries untouched).",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "/update-whatsnew\n\nEnglish\n\nAdded:\n\nWhen your server selection is set to Automatic, we now broadcast your transactions across several servers at once, so they're more likely to send reliably. You can change this in Advanced Settings.\n\nChanged:\n\nWe made a range of security and privacy improvements.\n\nFixed:\n\nWe fixed an issue where some successful transactions briefly showed a failure screen.\n\nWe fixed an issue where some received transactions could stay marked as pending.\n\nEspañol\n\nAñadido:\n\nCuando la selección de servidor está en Automático, ahora transmitimos tus transacciones a través de varios servidores a la vez, para que se envíen de forma más confiable. Puedes cambiarlo en Configuración Avanzada.\n\nCambiado:\n\nRealizamos varias mejoras de seguridad y privacidad.\n\nCorregido:\n\nCorregimos un problema por el cual algunas transacciones exitosas mostraban brevemente una pantalla de error.\n\nCorregimos un problema por el cual algunas transacciones recibidas podían quedar marcadas como pendientes.",
+      "expected_output": "whatsNew.json and whatsNew_es.json each get a new top entry for the version reported by zodl-production (date DD-MM-YYYY, timestamp now), with sections Added/Changed/Fixed (Añadido/Cambiado/Corregido) and the items as bulletpoints — a minimal diff that leaves all existing entries unchanged. Plus two App Store text blocks (EN + ES): each section title on its own line, every item prefixed with '* ', blank line between sections.",
+      "files": [],
+      "assertions": [
+        "Both files updated; the new entry is at index 0 of releases (newest-first)",
+        "version equals zodl-production MARKETING_VERSION; date is DD-MM-YYYY; timestamp is an integer epoch",
+        "Section titles are kept verbatim per language (Added:/Changed:/Fixed: and Añadido:/Cambiado:/Corregido:), not translated",
+        "The 'Fixed:'/'Corregido:' section has two bulletpoints; the others have one",
+        "Existing entries (3.6.0 and older) are byte-for-byte unchanged; output is valid JSON",
+        "App Store text: one block per language, section title line then '* ' bullets, blank line between sections",
+        "If an entry for the version already exists, nothing is written and the user is warned (stop-and-warn)"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/update-whatsnew/scripts/whatsnew.py
+++ b/.claude/skills/update-whatsnew/scripts/whatsnew.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Helper for the `update-whatsnew` skill.
+
+Handles the deterministic, error-prone parts of preparing a release changelog so
+the model only has to do the part it is good at: turning the freeform,
+multi-language changelog into structured sections. Keeping the file edit in a
+script (rather than hand-editing JSON) guarantees valid output and a minimal,
+review-friendly diff every single time.
+
+Subcommands
+-----------
+add       Prepend a new release entry to the top of a whatsNew file's `releases`
+          array. The edit is a pure textual insert: every existing line is left
+          byte-for-byte unchanged and only the new lines are added, so the
+          release diff stays clean. Aborts WITHOUT writing if an entry for the
+          same version already exists (the skill's "stop and warn" policy).
+appstore  Print the App Store changelog text for a payload (one language).
+
+Payload schema (JSON, one object per language)
+----------------------------------------------
+{
+  "version":   "3.8.0",
+  "date":      "30-06-2026",       # DD-MM-YYYY  (optional -> today, local time)
+  "timestamp": 1782211565,          # Unix epoch seconds (optional -> now)
+  "sections": [
+    {"title": "Added:",   "bulletpoints": ["First item.", "Second item."]},
+    {"title": "Changed:", "bulletpoints": ["..."]}
+  ]
+}
+
+The `title` is taken verbatim from the input for that language (e.g. "Added:" in
+English, "Añadido:" in Spanish) — this script never translates anything.
+"""
+
+import argparse
+import datetime
+import json
+import sys
+import time
+
+RELEASES_HEADER = '"releases": ['
+
+
+def fail(msg, code=2):
+    sys.stderr.write(f"error: {msg}\n")
+    sys.exit(code)
+
+
+def load_payload(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except FileNotFoundError:
+        fail(f"payload file not found: {path!r}")
+    except json.JSONDecodeError as exc:
+        fail(f"payload {path!r} is not valid JSON: {exc}")
+
+    if not payload.get("version"):
+        fail(f"payload {path!r} is missing a non-empty \"version\"")
+    sections = payload.get("sections")
+    if not isinstance(sections, list) or not sections:
+        fail(f"payload {path!r} must have a non-empty \"sections\" array")
+    for i, section in enumerate(sections):
+        if not section.get("title"):
+            fail(f"section #{i} in {path!r} is missing a \"title\"")
+        bullets = section.get("bulletpoints")
+        if not isinstance(bullets, list) or not bullets:
+            fail(f"section {section.get('title')!r} in {path!r} has no bulletpoints")
+
+    # Default date/timestamp to "today / now" so a caller can omit them, but the
+    # skill is expected to pass identical explicit values across every language
+    # of the same release.
+    if not payload.get("date"):
+        payload["date"] = datetime.datetime.now().strftime("%d-%m-%Y")
+    if payload.get("timestamp") in (None, ""):
+        payload["timestamp"] = int(time.time())
+    return payload
+
+
+def release_object(payload):
+    """Build the release dict with keys in the canonical on-disk order."""
+    return {
+        "version": payload["version"],
+        "date": payload["date"],
+        "timestamp": int(payload["timestamp"]),
+        "sections": [
+            {"title": s["title"], "bulletpoints": list(s["bulletpoints"])}
+            for s in payload["sections"]
+        ],
+    }
+
+
+def render_block(payload, indent=8):
+    """Render the release object as text, indented to match the file (8 spaces).
+
+    json.dumps(indent=4) gives 4-space steps; prefixing every line with 8 spaces
+    lands the object brace at column 8 and its fields at 12, which is exactly how
+    the existing entries are laid out. ensure_ascii=False keeps accented
+    characters literal (matching the Spanish file)."""
+    pretty = json.dumps(release_object(payload), ensure_ascii=False, indent=4)
+    pad = " " * indent
+    return [pad + line for line in pretty.split("\n")]
+
+
+def skeleton():
+    return '{\n    "releases": [\n    ]\n}\n'
+
+
+def cmd_add(args):
+    payload = load_payload(args.payload)
+    version = payload["version"]
+
+    try:
+        with open(args.file, "r", encoding="utf-8") as f:
+            text = f.read()
+        existed = True
+    except FileNotFoundError:
+        if not args.create:
+            fail(f"{args.file!r} does not exist. For a new language, confirm the "
+                 f"filename first, then pass --create.")
+        text = skeleton()
+        existed = False
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        fail(f"{args.file!r} is not valid JSON: {exc}")
+
+    releases = data.get("releases")
+    if not isinstance(releases, list):
+        fail(f"{args.file!r} has no top-level \"releases\" array")
+
+    if any(r.get("version") == version for r in releases):
+        sys.stderr.write(
+            f"version {version} already has an entry in {args.file} — not "
+            f"modifying it. (Re-run policy: stop and warn.)\n"
+        )
+        sys.exit(3)
+
+    lines = text.split("\n")
+    header_idx = next(
+        (i for i, line in enumerate(lines) if line.strip() == RELEASES_HEADER),
+        None,
+    )
+    if header_idx is None:
+        fail(f"could not find a `{RELEASES_HEADER}` line in {args.file!r}")
+
+    block_lines = render_block(payload)
+    if releases:  # not the first entry -> needs a comma before the next one
+        block_lines[-1] += ","
+
+    if args.dry_run:
+        verb = "create + add" if not existed else "add"
+        print(f"OK: would {verb} version {version} to {args.file} "
+              f"(date {payload['date']}, timestamp {payload['timestamp']}, "
+              f"{len(payload['sections'])} section(s)).")
+        return
+
+    new_text = "\n".join(lines[:header_idx + 1] + block_lines + lines[header_idx + 1:])
+
+    try:
+        json.loads(new_text)
+    except json.JSONDecodeError as exc:
+        fail(f"internal error: insertion produced invalid JSON ({exc}); "
+             f"{args.file} left unchanged")
+
+    with open(args.file, "w", encoding="utf-8") as f:
+        f.write(new_text)
+
+    verb = "Created and added" if not existed else "Added"
+    print(f"{verb} version {version} to {args.file} "
+          f"(date {payload['date']}, timestamp {payload['timestamp']}).")
+
+
+def cmd_appstore(args):
+    payload = load_payload(args.payload)
+    blocks = []
+    for section in payload["sections"]:
+        block = [section["title"]] + [f"* {bp}" for bp in section["bulletpoints"]]
+        blocks.append("\n".join(block))
+    print("\n\n".join(blocks))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="update-whatsnew helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_add = sub.add_parser("add", help="prepend a release entry to a whatsNew file")
+    p_add.add_argument("--file", required=True, help="path to whatsNew*.json")
+    p_add.add_argument("--payload", required=True, help="path to the language payload JSON")
+    p_add.add_argument("--create", action="store_true",
+                       help="create the file (new language) if it does not exist")
+    p_add.add_argument("--dry-run", action="store_true",
+                       help="validate and report what would happen, but do not write")
+    p_add.set_defaults(func=cmd_add)
+
+    p_as = sub.add_parser("appstore", help="print the App Store changelog text")
+    p_as.add_argument("--payload", required=True, help="path to the language payload JSON")
+    p_as.set_defaults(func=cmd_appstore)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This skill can be used like this: `/update-whatsnew <changelog text provided by the PM>`.

This skill updates whats new json files in the project. It uses today for date, now for timestamp and it takes project version from `zodl-production` target (marketing version). And it prints the changelog which can be put to Apple AppStore.