### PR TITLE
Fix flaky Swap routing tests (account isolation + poll deadline)

### DIFF
--- a/zodlTests/SendTests/MultiServerSubmitRoutingTests.swift
+++ b/zodlTests/SendTests/MultiServerSubmitRoutingTests.swift
@@ -645,10 +645,13 @@ import ComposableArchitecture
 
 @MainActor
 private func waitForStore(
-    // Generous deadline: the polling runs on the main actor, which the rest of the test suite
-    // contends for during a full parallel run. The poll exits as soon as the condition holds,
-    // so a healthy test never waits this long.
-    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    // Generous deadline: these live stores deliver `.send`/`.run` effects through the cooperative
+    // pool and `DispatchQueue.main`, both of which are heavily contended during a full parallel run
+    // (the whole test target runs concurrently on a CPU-limited CI runner). The poll pumps the main
+    // queue (via `Task.sleep`) and exits as soon as the condition holds, so a healthy test never
+    // waits anywhere near this long — the deadline only guards against extreme scheduler starvation,
+    // which is what made the 15s deadline flake on CI.
+    timeoutNanoseconds: UInt64 = 60_000_000_000,
     sourceLocation: SourceLocation = #_sourceLocation,
     condition: @escaping @MainActor () -> Bool
 ) async {

--- a/zodlTests/SendTests/MultiServerSubmitRoutingTests.swift
+++ b/zodlTests/SendTests/MultiServerSubmitRoutingTests.swift
@@ -311,75 +311,97 @@ import ComposableArchitecture
     }
 
     @Test func missingProposalRoutesToFailureNotPending() async {
-        // No proposal means nothing was created or submitted, so there is no transaction the
-        // "pending" screen could be waiting for — this must land on the failure screen.
-        var initialState = SwapAndPayCoordFlow.State()
-        initialState.swapAndPayState.address = "ztestaddr"
-        initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+        // Isolate shared account storage (see partialSubmissionRoutesToFailureSupportState). This test
+        // reaches failure via the missing-proposal guard regardless of the account, but it still writes
+        // `selectedWalletAccount`, so isolating keeps it from clobbering suites running in parallel.
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            // No proposal means nothing was created or submitted, so there is no transaction the
+            // "pending" screen could be waiting for — this must land on the failure screen.
+            var initialState = SwapAndPayCoordFlow.State()
+            initialState.swapAndPayState.address = "ztestaddr"
+            initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
 
-        let store = Store(initialState: initialState) {
-            SwapAndPayCoordFlow()
-        } withDependencies: {
-            $0.mainQueue = .immediate
-        }
+            let store = Store(initialState: initialState) {
+                SwapAndPayCoordFlow()
+            } withDependencies: {
+                $0.mainQueue = .immediate
+            }
 
-        store.send(.swapRequested)
-        await waitForStore {
-            if case .sendResultFailure = store.state.path.last { return true }
-            return false
+            store.send(.swapRequested)
+            await waitForStore {
+                if case .sendResultFailure = store.state.path.last { return true }
+                return false
+            }
         }
     }
 
     @Test func partialSubmissionRoutesToFailureSupportState() async throws {
-        let firstTxId = Data([0xAA]).toHexStringTxId()
-        let secondTxId = Data([0xBB]).toHexStringTxId()
-        let statuses = ["accepted by endpoint 1", "all servers unreachable"]
-        let store = makeStore(result: .partial(txIds: [firstTxId, secondTxId], statuses: statuses))
+        // Pin the process-global `@Shared(.inMemory(.selectedWalletAccount))` storage to a fresh,
+        // isolated `InMemoryStorage` for the duration of the test. Without this, a suite running in
+        // parallel that mutates `selectedWalletAccount` can clobber it before `.swapRequested` reads
+        // it; the reducer's `guard let ... state.selectedWalletAccount` then bails, navigation never
+        // reaches `.sendResultFailure`, and `waitForStore` times out (a flaky CI failure). Mirrors the
+        // isolation already used by `MultiServerSubmitFlexaRoutingTests`.
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let firstTxId = Data([0xAA]).toHexStringTxId()
+            let secondTxId = Data([0xBB]).toHexStringTxId()
+            let statuses = ["accepted by endpoint 1", "all servers unreachable"]
+            let store = makeStore(result: .partial(txIds: [firstTxId, secondTxId], statuses: statuses))
 
-        store.send(.swapRequested)
-        await waitForStore {
-            if case .sendResultFailure = store.state.path.last { return true }
-            return false
+            store.send(.swapRequested)
+            await waitForStore {
+                if case .sendResultFailure = store.state.path.last { return true }
+                return false
+            }
+
+            guard case let .sendResultFailure(resultState) = store.state.path.last else {
+                Issue.record("Expected Swap/Pay partial submission to route to failure")
+                return
+            }
+
+            #expect(store.state.txIdToExpand == firstTxId)
+            #expect(store.state.partialFailureTxIds == [firstTxId, secondTxId])
+            #expect(store.state.partialFailureStatuses == statuses)
+            #expect(store.state.failedCode == -999)
+            #expect(store.state.failedDescription == statuses.joined(separator: ", "))
+            #expect(resultState.txIdToExpand == firstTxId)
+            #expect(resultState.partialFailureTxIds == [firstTxId, secondTxId])
+            #expect(resultState.partialFailureStatuses == statuses)
+            #expect(resultState.failedDescription == statuses.joined(separator: ", "))
         }
-
-        guard case let .sendResultFailure(resultState) = store.state.path.last else {
-            Issue.record("Expected Swap/Pay partial submission to route to failure")
-            return
-        }
-
-        #expect(store.state.txIdToExpand == firstTxId)
-        #expect(store.state.partialFailureTxIds == [firstTxId, secondTxId])
-        #expect(store.state.partialFailureStatuses == statuses)
-        #expect(store.state.failedCode == -999)
-        #expect(store.state.failedDescription == statuses.joined(separator: ", "))
-        #expect(resultState.txIdToExpand == firstTxId)
-        #expect(resultState.partialFailureTxIds == [firstTxId, secondTxId])
-        #expect(resultState.partialFailureStatuses == statuses)
-        #expect(resultState.failedDescription == statuses.joined(separator: ", "))
     }
 
     @Test func timeoutSubmissionRoutesToPendingWithTimeoutCopy() async throws {
-        let txId = Data([0xAA]).toHexStringTxId()
-        let store = makeStore(
-            result: .grpcFailure(txIds: [txId], reason: .timeout),
-            txIdExists: true
-        )
+        // Isolate shared account storage (see partialSubmissionRoutesToFailureSupportState).
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let txId = Data([0xAA]).toHexStringTxId()
+            let store = makeStore(
+                result: .grpcFailure(txIds: [txId], reason: .timeout),
+                txIdExists: true
+            )
 
-        store.send(.swapRequested)
-        await waitForStore {
-            if case .sendResultPending = store.state.path.last { return true }
-            return false
+            store.send(.swapRequested)
+            await waitForStore {
+                if case .sendResultPending = store.state.path.last { return true }
+                return false
+            }
+
+            guard case let .sendResultPending(resultState) = store.state.path.last else {
+                Issue.record("Expected Swap/Pay timeout submission to route to pending")
+                return
+            }
+
+            #expect(store.state.txIdToExpand == txId)
+            #expect(store.state.pendingDescription == String(localizable: .sendPendingTimeoutInfo))
+            #expect(resultState.txIdToExpand == txId)
+            #expect(resultState.pendingDescription == String(localizable: .sendPendingTimeoutInfo))
         }
-
-        guard case let .sendResultPending(resultState) = store.state.path.last else {
-            Issue.record("Expected Swap/Pay timeout submission to route to pending")
-            return
-        }
-
-        #expect(store.state.txIdToExpand == txId)
-        #expect(store.state.pendingDescription == String(localizable: .sendPendingTimeoutInfo))
-        #expect(resultState.txIdToExpand == txId)
-        #expect(resultState.pendingDescription == String(localizable: .sendPendingTimeoutInfo))
     }
 
     @Test func keystonePendingKeepsPendingDescription() async throws {


### PR DESCRIPTION
## Problem

CI intermittently failed in `MultiServerSubmitSwapRoutingTests`. There turned out to be **two independent flakes**, fixed in two commits — both are flaky tests, not product bugs.

---

## Flake 1 — `partialSubmissionRoutesToFailureSupportState()` (shared account clobbering)

### Root cause

The test drives a live store through `.swapRequested`, whose reducer bails silently when the wallet account is missing:

```swift
guard let zip32AccountIndex = state.selectedWalletAccount?.zip32AccountIndex else {
    return .none   // never navigates to .sendResultFailure
}
```

`selectedWalletAccount` is process-global `@Shared(.inMemory(.selectedWalletAccount))`. During the full parallel test run, another suite mutates that global storage between the test setting it and the reducer reading it → the reducer bails → navigation never reaches `.sendResultFailure` → `waitForStore` times out, producing the observed `Expectation failed: condition()`.

This is the same flake the **Flexa** suite in the same file already documents and fixes with an isolated `InMemoryStorage`; the Swap suite simply hadn't adopted it.

### Fix

Wrap the three Swap-suite tests that touch the shared account in the established isolation, pinning `@Shared(.inMemory(...))` to a fresh per-test `InMemoryStorage` so no parallel suite can clobber it:

```swift
await withDependencies {
    $0.defaultInMemoryStorage = InMemoryStorage()
} operation: { … }
```

- `partialSubmissionRoutesToFailureSupportState` — the actual failure
- `timeoutSubmissionRoutesToPendingWithTimeoutCopy` — identical latent twin (same `makeStore` → account-guard path)
- `missingProposalRoutesToFailureNotPending` — robust to clobbering itself, but writes the global account, so isolating stops it clobbering *other* parallel suites

---

## Flake 2 — `missingProposalRoutesToFailureNotPending()` (poll deadline too short)

After the isolation above landed, CI still failed — this time on `missingProposalRoutesToFailureNotPending()`, again with `Expectation failed: condition()` (a `waitForStore` timeout).

### Root cause

This is a **different** root cause: the missing-proposal path returns at the `guard let proposal …` check *before* the reducer ever reads `selectedWalletAccount`, so account isolation never applied to it. Its problem is timing.

These coordinator tests can't use `TestStore` (`SwapAndPayCoordFlow.State` isn't `Equatable`), so they drive a live `Store` and poll with `waitForStore`. A live store delivers its `.send` / `.run` effects through the Swift-concurrency cooperative pool and `DispatchQueue.main`. When the whole test target runs concurrently on a CPU-limited CI runner, those hops are badly starved, and the **15s** poll deadline was simply too short — the chain (`.swapRequested → .sendFailed → .updateResult(.failure)`) hadn't navigated to `.sendResultFailure` before the deadline. In isolation the same test completes in ~0.1s.

### Fix

Raise `waitForStore`'s default deadline **15s → 60s**. The poll already pumps the main queue (via `Task.sleep`) and exits the instant the condition holds, so healthy tests are unaffected — the larger deadline only adds headroom against extreme scheduler starvation.

> Note: `await store.send(...).finish()` is **not** a viable alternative here. It deadlocks: TCA's `.send` effects deliver asynchronously via `DispatchQueue.main`, which creates a keep-alive task that `.finish()` waits on forever while it blocks the actor that would otherwise pump that queue. The polling approach is correct precisely because it pumps the main queue and never awaits keep-alive tasks.

---

## Verification

- All Swap-suite tests pass locally in isolation (~0.1s each), with no hang.
- **CI `unit_tests` is green** on the final commit (`339c2a42`).

## Follow-up (not in this PR)

`MultiServerSubmitShieldingTests.partialSubmissionReportsFailure` has the same latent account-clobbering vulnerability (writes the global account without isolation). Its timing window is much smaller, so it's far less likely to flake — left untouched here to keep this change focused, can be hardened the same way if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
