### PR TITLE
[MOB-385] Show actionable error message for anchor computation failure on send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## 3.7.0 build 1
 
+### Fixed
+- When a send fails because the wallet's chain state changed between tapping review and confirm (due to syncing catching up, a reorg, or the app resuming from background), a clear actionable message is now shown instead of the generic error copy.
+
 ### Changed
 - Sending, swapping, shielding, and Flexa payments now broadcast your transaction to multiple servers at once when you're in Automatic server mode (Manual mode still uses the server you selected), so a single slow or unreachable server is less likely to make a submission fail. If a server times out before confirming, you now see a clear message that your transaction may still have been broadcast, rather than an outright failure.
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -12030,13 +12030,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your wallet was still syncing when you tried to send. Please wait for sync to complete and try again."
+            "value" : "Your wallet's chain state changed while preparing this transaction. Please wait for sync to complete and try again."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tu cartera aún estaba sincronizando cuando intentaste enviar. Por favor, espera a que la sincronización termine e intenta de nuevo."
+            "value" : "El estado de la cadena cambió mientras se preparaba la transacción. Por favor, espera a que la sincronización termine e intenta de nuevo."
           }
         }
       }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -12024,6 +12024,23 @@
         }
       }
     },
+    "send.failureAnchorInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet was still syncing when you tried to send. Please wait for sync to complete and try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu cartera aún estaba sincronizando cuando intentaste enviar. Por favor, espera a que la sincronización termine e intenta de nuevo."
+          }
+        }
+      }
+    },
     "send.failureInfo" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -663,9 +663,17 @@ extension SendConfirmation.State {
         : String(localizable: .swapAndPayPendingPayTitle)
     }
     
+    var isAnchorError: Bool {
+        failedDescription?.localizedCaseInsensitiveContains("Unable to compute anchor") == true
+    }
+
     var failureInfo: String {
         if !partialFailureTxIds.isEmpty {
             return String(localizable: .sendPartialFailureInfo)
+        }
+
+        if isAnchorError {
+            return String(localizable: .sendFailureAnchorInfo)
         }
 
         return isShielding

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -43,6 +43,7 @@ struct SendConfirmation {
         var currencyAmount: RedactableString
         var failedCode: Int?
         var failedDescription: String?
+        var isAnchorError = false
         var failedPcztMsg: String?
         @Shared(.inMemory(.featureFlags)) var featureFlags: FeatureFlags = .initial
         var feeRequired: Zatoshi
@@ -332,6 +333,14 @@ struct SendConfirmation {
 
             case let .sendFailed(error, isTxIdPresentInTheDB):
                 state.failedDescription = error?.localizedDescription ?? ""
+                // MOB-385: rustCreateToAddress is the typed SDK case for Rust creation failures.
+                // The anchor string comes from Rust (zcash_client_sqlite) — no typed sub-code exists yet.
+                // If the SDK ever adds one, replace the string check with it and drop the comment.
+                if case let .rustCreateToAddress(rustError) = error {
+                    state.isAnchorError = rustError.localizedCaseInsensitiveContains("Unable to compute anchor")
+                } else {
+                    state.isAnchorError = false
+                }
                 state.isSending = false
                 let diffTime = Date().timeIntervalSince1970 - state.sendingScreenOnAppearTimestamp
                 let waitTimeToPresentScreen = diffTime > 2.0 ? 0.01 : 2.0 - diffTime
@@ -663,9 +672,6 @@ extension SendConfirmation.State {
         : String(localizable: .swapAndPayPendingPayTitle)
     }
     
-    var isAnchorError: Bool {
-        failedDescription?.localizedCaseInsensitiveContains("Unable to compute anchor") == true
-    }
 
     var failureInfo: String {
         if !partialFailureTxIds.isEmpty {


### PR DESCRIPTION
## What
When `createProposedTransactions` fails with an anchor computation error, users now see a specific, actionable message instead of the generic send failure copy.

## Why
The wallet selects an anchor block at proposal time. If the chain advances before the user taps confirm, the anchor may no longer exist in the commitment tree — causing a cryptic `Unable to compute anchor for block height BlockHeight(X)` error. Previously this surfaced as "There was an error attempting to send coins" with no guidance.

This can occur naturally due to:
- The chain advancing by a few blocks while the user is on the review screen
- A reorg rolling back the chain past the selected anchor height
- The app resuming after being backgrounded with a stale anchor reference

In all cases the funds are safe — the transaction was never broadcast.

## Changes
- `isAnchorError` is now a stored `Bool` on `State`, set in the `sendFailed` reducer by pattern-matching `ZcashError.rustCreateToAddress` directly — the typed SDK case for Rust creation failures — then checking the Rust error string on that case only
- Shows: *"Your wallet's chain state changed while preparing this transaction. Please wait for sync to complete and try again."*
- Spanish (`es`) translation updated to match revised English copy
- Report button and underlying root cause are preserved unchanged