### PR TITLE
Add ZODL app-name convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Zodl (formerly Zashi) is an iOS Zcash wallet built with SwiftUI and The Composable Architecture (TCA). It uses the Zcash Swift SDK (`ZcashLightClientKit`) for blockchain operations.
+ZODL (formerly Zashi) is an iOS Zcash wallet built with SwiftUI and The Composable Architecture (TCA). It uses the Zcash Swift SDK (`ZcashLightClientKit`) for blockchain operations.
+
+## App name
+
+The app's name is always written **ZODL** — all uppercase. Whenever generated text refers to the app by name — UI strings (`Localizable.xcstrings`), code, comments, documentation, commit messages, PR titles/descriptions, etc. — it MUST be `ZODL`, never `Zodl` (nor `zodl`/`ZODl`). This rule is about the app name as a word; it does NOT change fixed technical identifiers such as the `zodl_internal` module, the `zodl-ios` repository, scheme names, or bundle IDs. The former name "Zashi" is unaffected.
 
 ## Build & Development
 


### PR DESCRIPTION
## What

Adds a project convention to `CLAUDE.md`: the app name must always be written **ZODL** (all uppercase) in any generated text — UI strings (`Localizable.xcstrings`), code, comments, documentation, and commit/PR text — never `Zodl` (nor `zodl`/`ZODl`).

## Notes

- Scope excludes fixed technical identifiers: the `zodl_internal` module, the `zodl-ios` repository, scheme names, and bundle IDs.
- The former name "Zashi" is unaffected.
- Also fixes the single lowercase `Zodl` in the Project Overview line so the file isn't self-contradictory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
