### PR TITLE
[Tests] Add Equatable to SendForm and SwapAndPay State/Action

### DIFF
--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -18,7 +18,7 @@ struct SendForm {
     }
     
     @ObservableState
-    struct State {
+    struct State: Equatable {
         var cancelId = UUID()
         
         var addMemoState: Bool
@@ -196,7 +196,7 @@ struct SendForm {
         }
     }
 
-    enum Action: BindableAction {
+    enum Action: BindableAction, Equatable {
         case addNewContactTapped(RedactableString)
         case addressBookTapped
         case addressUpdated(RedactableString)

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -20,7 +20,7 @@ struct SwapAndPay {
     }
     
     @ObservableState
-    struct State {
+    struct State: Equatable {
         var SwapAssetsCancelId = UUID()
         var ABCancelId = UUID()
         var QRCancelId = UUID()
@@ -194,7 +194,7 @@ struct SwapAndPay {
         }
     }
 
-    enum Action: BindableAction {
+    enum Action: BindableAction, Equatable {
         case alert(PresentationAction<Action>)
         case assetSelectRequested
         case assetTapped(SwapAsset)


### PR DESCRIPTION
## Summary

Adds `Equatable` conformance to the `State` and `Action` types of `SendForm` and `SwapAndPay`. This unblocks using TCA's `TestStore` for these features, which requires `Equatable` state and actions to assert state changes.

- `SendForm.State` / `SendForm.Action`
- `SwapAndPay.State` / `SwapAndPay.Action`

No behavioral changes — these are conformance-only additions to support test coverage uplift.

## Test plan

- [ ] Build passes (conformances compile cleanly)
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)