### PR TITLE
ci: fix Linear release tracking for iOS

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -83,7 +83,8 @@ jobs:
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          prev=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -1)
+          prev=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | awk -v t="$TAG" 'found{print; exit} $0==t{found=1}')
           echo "tag=${prev}" >> "$GITHUB_OUTPUT"
 
       - name: Create Linear release

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -78,7 +78,17 @@ jobs:
           ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
 
+      - name: Find previous tag
+        id: prev
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          prev=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -1)
+          echo "tag=${prev}" >> "$GITHUB_OUTPUT"
+
       - name: Create Linear release
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ steps.tag.outputs.tag }}
+          base_ref: ${{ steps.prev.outputs.tag }}


### PR DESCRIPTION
## Summary

- Passes `version` to the Linear action so releases are named `3.7.0` instead of a commit hash
- Passes `base_ref` (auto-detected previous git tag) so the action scans all commits since the last release, not just HEAD
- Root cause of 3.7.0 producing an empty release: iOS has no GitHub Releases for the action to look up boundaries, so it fell back to scanning 1 commit

## Test plan
- Merge and manually trigger for 3.7.0: `gh workflow run linear-release.yml -f tag=3.7.0`
- Verify Linear shows a `3.7.0` release with MOB tickets attached