### PR TITLE
[#MOB-1450] Reconcile Address Book encryption key against the current seed

### DIFF
--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -1360,6 +1360,7 @@
 		34B967672F8CC48B00823B20 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 34B967662F8CC48B00823B20 /* Atomics */; };
 		34B967692F8CC49100823B20 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 34B967682F8CC49100823B20 /* Atomics */; };
 		34D06C912FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D06C902FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift */; };
+		34F6DA972FEEDD8E004C654E /* AddressBookEncryptionKeyReconcileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F6DA962FEEDD8E004C654E /* AddressBookEncryptionKeyReconcileTests.swift */; };
 		37BTC00000000000000INT04 /* BackgroundTaskClientInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BTC00000000000000INT01 /* BackgroundTaskClientInterface.swift */; };
 		37BTC00000000000000INT05 /* BackgroundTaskClientInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BTC00000000000000INT01 /* BackgroundTaskClientInterface.swift */; };
 		37BTC00000000000000INT06 /* BackgroundTaskClientInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BTC00000000000000INT01 /* BackgroundTaskClientInterface.swift */; };
@@ -2050,6 +2051,7 @@
 		34AA77032F857D4100D244E2 /* fonts_swift5_swiftui.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = fonts_swift5_swiftui.stencil; sourceTree = "<group>"; };
 		34AA77052F857D4100D244E2 /* assets_swift5_swiftui.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = assets_swift5_swiftui.stencil; sourceTree = "<group>"; };
 		34D06C902FD2CF0B00BB10EE /* DecommissionedServerMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecommissionedServerMigrationTests.swift; sourceTree = "<group>"; };
+		34F6DA962FEEDD8E004C654E /* AddressBookEncryptionKeyReconcileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEncryptionKeyReconcileTests.swift; sourceTree = "<group>"; };
 		37BTC00000000000000INT01 /* BackgroundTaskClientInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskClientInterface.swift; sourceTree = "<group>"; };
 		37BTC00000000000000LIV01 /* BackgroundTaskClientLiveKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskClientLiveKey.swift; sourceTree = "<group>"; };
 		37BTC00000000000000TST01 /* BackgroundTaskClientTestKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskClientTestKey.swift; sourceTree = "<group>"; };
@@ -4353,6 +4355,7 @@
 				348EC4CB2FD7FD96008495FB /* TransactionGuardTests.swift */,
 				9EF8135B27ECC25E0075AF48 /* UserPreferencesStorageTests.swift */,
 				9E39112D283F91600073DD9A /* ZatoshiTests.swift */,
+				34F6DA962FEEDD8E004C654E /* AddressBookEncryptionKeyReconcileTests.swift */,
 			);
 			path = UtilTests;
 			sourceTree = "<group>";
@@ -5020,6 +5023,7 @@
 				348EC4D12FD7FD96008495FB /* AutoServerSelectionClientTests.swift in Sources */,
 				921B3D95249329CD65C36E1B /* LoggerTests.swift in Sources */,
 				63B448CA6B0B3D800DE8CB2B /* SecItemClientTests.swift in Sources */,
+				34F6DA972FEEDD8E004C654E /* AddressBookEncryptionKeyReconcileTests.swift in Sources */,
 				2D502ADD8B5CBB60D72B642B /* UserPreferencesStorageTests.swift in Sources */,
 				BFE03A2F84B2F8B97831CD9F /* ZatoshiTests.swift in Sources */,
 				A9BE701F099CD0D1379F63AE /* ZatoshiStringRepresentationCommaTests.swift in Sources */,

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -206,10 +206,15 @@ struct WalletStorage {
             guard let data = try encode(object: keys) else {
                 throw KeychainError.encoding
             }
-            
-            try setData(data, forKey: Constants.zcashStoredAdressBookEncryptionKeys)
-        } catch KeychainError.duplicate {
-            throw WalletStorageError.alreadyImported
+
+            do {
+                try setData(data, forKey: Constants.zcashStoredAdressBookEncryptionKeys)
+            } catch KeychainError.duplicate {
+                // The slot already holds keys; overwrite instead of failing so a key derived
+                // from a previous wallet seed can be replaced with the current seed's key. A
+                // stale key must never survive into a new wallet (MOB-1450).
+                try updateData(data, forKey: Constants.zcashStoredAdressBookEncryptionKeys)
+            }
         } catch {
             throw WalletStorageError.storageError(error)
         }

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
@@ -110,3 +110,17 @@ struct WalletStorageClient {
     var importVotingHotkey: @Sendable (_ phrase: String, _ accountId: AccountUUID) throws -> Void
     var exportVotingHotkey: @Sendable (_ accountId: AccountUUID) throws -> StoredVotingHotkey
 }
+
+extension WalletStorageClient {
+    /// Ensures the stored Address Book encryption keys match `expected` — the keys derived from
+    /// the CURRENT wallet seed. A key derived from a previous seed must never survive into a new
+    /// wallet, otherwise that wallet can read and write another wallet's encrypted contacts file
+    /// in the shared iCloud container (MOB-1450). Overwrites a stale or absent key.
+    func reconcileAddressBookEncryptionKeys(_ expected: AddressBookEncryptionKeys) throws {
+        let current = try? exportAddressBookEncryptionKeys()
+        guard current != expected else {
+            return
+        }
+        try importAddressBookEncryptionKeys(expected)
+    }
+}

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -352,36 +352,9 @@ extension Root {
 
                             try await sdkSynchronizer.start(false)
 
-                            var selectedAccount: WalletAccount?
-                            
-                            for account in walletAccounts {
-                                if account.vendor == .zcash {
-                                    selectedAccount = account
-                                }
-                            }
-
                             exchangeRate.refreshExchangeRateUSD()
 
-                            if let account = selectedAccount {
-                                let addressBookEncryptionKeys = try? walletStorage.exportAddressBookEncryptionKeys()
-                                if addressBookEncryptionKeys == nil {
-                                    do {
-                                        var keys = AddressBookEncryptionKeys.empty
-                                        try keys.cacheFor(
-                                            seed: seedBytes,
-                                            account: account.account,
-                                            network: zcashSDKEnvironment.network().networkType
-                                        )
-                                        try walletStorage.importAddressBookEncryptionKeys(keys)
-                                    } catch {
-                                        // TODO: [#1408] error handling https://github.com/Electric-Coin-Company/zashi-ios/issues/1408
-                                    }
-                                }
-
-                                await send(.initialization(.initializationSuccessfullyDone))
-                            } else {
-                                await send(.initialization(.initializationSuccessfullyDone))
-                            }
+                            await send(.initialization(.initializationSuccessfullyDone))
                         } catch {
                             await send(.initialization(.initializationFailed(error.toZcashError())))
                         }
@@ -416,6 +389,27 @@ extension Root {
                         }
                     }
                 }
+
+                // MOB-1450: ensure the Address Book encryption key matches the CURRENT seed
+                // before contacts load. The cached key is the source of contact decryption, so a
+                // key left over from a previous wallet (e.g. a stale keychain entry that survived
+                // a wipe) would otherwise let this wallet read and write another wallet's encrypted
+                // contacts file in the shared iCloud container.
+                if let zashiAccount = state.zashiWalletAccount,
+                   let storedWallet = try? walletStorage.exportWallet(),
+                   let seedBytes = try? mnemonic.toSeed(storedWallet.seedPhrase.value()) {
+                    var expectedKeys = AddressBookEncryptionKeys.empty
+                    try? expectedKeys.cacheFor(
+                        seed: seedBytes,
+                        account: zashiAccount.account,
+                        network: zcashSDKEnvironment.network().networkType
+                    )
+                    // Never overwrite a real key with an empty set if derivation produced nothing.
+                    if !expectedKeys.keys.isEmpty {
+                        try? walletStorage.reconcileAddressBookEncryptionKeys(expectedKeys)
+                    }
+                }
+
                 return .merge(
                     .send(.loadContacts),
                     .send(.loadUserMetadata),

--- a/zodlTests/UtilTests/AddressBookEncryptionKeyReconcileTests.swift
+++ b/zodlTests/UtilTests/AddressBookEncryptionKeyReconcileTests.swift
@@ -1,0 +1,129 @@
+//
+//  AddressBookEncryptionKeyReconcileTests.swift
+//  zodlTests
+//
+//  Regression coverage for MOB-1450: an Address Book encryption key derived from a
+//  previous wallet seed must never be reused by a wallet with a different seed. The
+//  cached key is the source of contact decryption, so it must always be reconciled
+//  against the current seed (and the keychain slot must be overwritable).
+//
+
+import Foundation
+import os
+import Security
+import Testing
+@testable import zodl_internal
+
+@Suite("Address Book encryption key reconcile (MOB-1450)")
+struct AddressBookEncryptionKeyReconcileTests {
+    // MARK: importAddressBookEncryptionKeys upsert
+
+    @Test func reimportingAddressBookEncryptionKeysOverwritesPreviousKeys() throws {
+        let client = Self.makeWalletStorageClient()
+        let keysA = try Self.addressBookKeys(byte: 0xAA)
+        let keysB = try Self.addressBookKeys(byte: 0xBB)
+
+        try client.importAddressBookEncryptionKeys(keysA)
+        // Re-importing different keys must overwrite, not throw `alreadyImported`.
+        try client.importAddressBookEncryptionKeys(keysB)
+
+        #expect(try client.exportAddressBookEncryptionKeys() == keysB)
+    }
+
+    // MARK: reconcile against the current seed
+
+    @Test func reconcileOverwritesStaleKeysFromADifferentSeed() throws {
+        let client = Self.makeWalletStorageClient()
+        let stale = try Self.addressBookKeys(byte: 0xAA)
+        let current = try Self.addressBookKeys(byte: 0xBB)
+
+        // A key left over from a previous wallet seed is present in the keychain.
+        try client.importAddressBookEncryptionKeys(stale)
+
+        try client.reconcileAddressBookEncryptionKeys(current)
+
+        #expect(try client.exportAddressBookEncryptionKeys() == current)
+    }
+
+    @Test func reconcileStoresKeysWhenNoneExist() throws {
+        let client = Self.makeWalletStorageClient()
+        let current = try Self.addressBookKeys(byte: 0xCC)
+
+        try client.reconcileAddressBookEncryptionKeys(current)
+
+        #expect(try client.exportAddressBookEncryptionKeys() == current)
+    }
+
+    @Test func reconcileKeepsKeysThatAlreadyMatchTheCurrentSeed() throws {
+        let client = Self.makeWalletStorageClient()
+        let current = try Self.addressBookKeys(byte: 0xDD)
+
+        try client.importAddressBookEncryptionKeys(current)
+        try client.reconcileAddressBookEncryptionKeys(current)
+
+        #expect(try client.exportAddressBookEncryptionKeys() == current)
+    }
+
+    // MARK: Helpers
+
+    static func makeWalletStorageClient() -> WalletStorageClient {
+        WalletStorageClient.live(walletStorage: WalletStorage(secItem: InMemoryKeychain().makeClient()))
+    }
+
+    /// Builds an `AddressBookEncryptionKeys` (single account, index 0) with a deterministic
+    /// 32-byte key via the model's `Codable` form, so no SDK seed derivation is needed.
+    static func addressBookKeys(byte: UInt8) throws -> AddressBookEncryptionKeys {
+        let raw = Data(repeating: byte, count: 32)
+        let json = try JSONSerialization.data(withJSONObject: ["keys": ["0": raw.base64EncodedString()]])
+        return try JSONDecoder().decode(AddressBookEncryptionKeys.self, from: json)
+    }
+}
+
+/// Minimal in-memory keychain backing for `SecItemClient`, keyed by `kSecAttrService`.
+/// Mirrors the real add/update/copyMatching/delete semantics (duplicate detection,
+/// not-found) so `WalletStorage` upsert/read behaviour is exercised for real.
+private final class InMemoryKeychain: Sendable {
+    private let store = OSAllocatedUnfairLock<[String: Data]>(initialState: [:])
+
+    func makeClient() -> SecItemClient {
+        SecItemClient(
+            copyMatching: { query, result in
+                guard let service = InMemoryKeychain.service(query) else { return errSecParam }
+                guard let data = self.store.withLock({ $0[service] }) else { return errSecItemNotFound }
+                result = data as AnyObject
+                return errSecSuccess
+            },
+            add: { query, _ in
+                guard let service = InMemoryKeychain.service(query),
+                      let data = InMemoryKeychain.value(from: query) else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] == nil else { return errSecDuplicateItem }
+                    items[service] = data
+                    return errSecSuccess
+                }
+            },
+            update: { query, attributes in
+                guard let service = InMemoryKeychain.service(query),
+                      let data = InMemoryKeychain.value(from: attributes) else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] != nil else { return errSecItemNotFound }
+                    items[service] = data
+                    return errSecSuccess
+                }
+            },
+            delete: { query in
+                guard let service = InMemoryKeychain.service(query) else { return errSecParam }
+                self.store.withLock { $0[service] = nil }
+                return errSecSuccess
+            }
+        )
+    }
+
+    private static func service(_ query: CFDictionary) -> String? {
+        (query as? [String: Any])?[kSecAttrService as String] as? String
+    }
+
+    private static func value(from dict: CFDictionary) -> Data? {
+        (dict as? [String: Any])?[kSecValueData as String] as? Data
+    }
+}


### PR DESCRIPTION
## What & why

The Address Book is an encrypted file synced through a shared iCloud container (`iCloud.com.electriccoinco.zashi`); its encryption key is derived from the wallet seed. The key was cached in the keychain and **only (re)derived when the keychain slot was empty**, with no check that the cached key belonged to the current seed. A key left over from a previous wallet — e.g. a stale keychain entry that survived a wipe — was therefore **reused by a new wallet with a different seed**, letting it read *and write* that other wallet's encrypted contacts file in the shared container.

Fixes MOB-1450 — https://linear.app/zodl/issue/MOB-1450

## Fix

Reconcile the cached key against the **current seed** on init, before contacts load, and overwrite a stale/absent key:

- `WalletStorage.importAddressBookEncryptionKeys` now **upserts** (update on duplicate) instead of throwing `alreadyImported`, so a new seed's key can replace a stale one.
- New `WalletStorageClient.reconcileAddressBookEncryptionKeys(_:)` overwrites the slot only when the stored keys don't match the current-seed keys (no-op otherwise).
- `Root` `.loadedWalletAccounts` reconciles for the Zashi account **before** `.send(.loadContacts)`, guarded by `!expectedKeys.keys.isEmpty` so a failed derivation can never wipe a real key. Replaces the old `if addressBookEncryptionKeys == nil` derivation block.

Shared code, so it fixes iOS (and macOS). **Self-healing**: on first launch after this ships a legitimate wallet re-derives the identical key (no-op); a stale-key install corrects itself.

## Testing

New Swift Testing suite `AddressBookEncryptionKeyReconcileTests` (in-memory `SecItemClient` fake), written test-first:
- re-importing different keys overwrites (upsert)
- reconcile overwrites a stale key from a different seed
- reconcile stores keys when none exist
- reconcile keeps keys that already match

Watched RED (3 failed for the right reasons) → GREEN. The 6 existing `SecItemClientTests` still pass (no keychain-layer regression). Full app build green (scheme `zodl-internal`).

## Out of scope / follow-ups (tracked on MOB-1450)

- Multi-account / Keystone reconcile (covers the Zashi/zcash account only today).
- Defense-in-depth: include the AB key in the post-wipe `areKeysPresent` check; optional non-reversible seed fingerprint validated at the encrypt/decrypt sites; consider the data-protection keychain on macOS.
- The reducer wiring itself is build-verified, not unit-tested (no Root `TestStore` tests on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
