### PR TITLE
[MOB-1450] Reconcile Address Book encryption key against the current seed

### DIFF
--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -206,10 +206,15 @@ struct WalletStorage {
             guard let data = try encode(object: keys) else {
                 throw KeychainError.encoding
             }
-            
-            try setData(data, forKey: Constants.zcashStoredAdressBookEncryptionKeys)
-        } catch KeychainError.duplicate {
-            throw WalletStorageError.alreadyImported
+
+            do {
+                try setData(data, forKey: Constants.zcashStoredAdressBookEncryptionKeys)
+            } catch KeychainError.duplicate {
+                // The slot already holds keys; overwrite instead of failing so a key derived
+                // from a previous wallet seed can be replaced with the current seed's key. A
+                // stale key must never survive into a new wallet (MOB-1450).
+                try updateData(data, forKey: Constants.zcashStoredAdressBookEncryptionKeys)
+            }
         } catch {
             throw WalletStorageError.storageError(error)
         }

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -257,14 +257,19 @@ struct WalletStorage {
                 throw KeychainError.encoding
             }
             
-            try setData(data, forKey: Constants.accountMetadataFilename(account: account))
-        } catch KeychainError.duplicate {
-            throw WalletStorageError.alreadyImported
+            do {
+                try setData(data, forKey: Constants.accountMetadataFilename(account: account))
+            } catch KeychainError.duplicate {
+                // The slot already holds keys; overwrite instead of failing so a key derived
+                // from a previous wallet seed can be replaced with the current seed's key. A
+                // stale key must never survive into a new wallet (MOB-1450).
+                try updateData(data, forKey: Constants.accountMetadataFilename(account: account))
+            }
         } catch {
             throw WalletStorageError.storageError(error)
         }
     }
-    
+
     func exportUserMetadataEncryptionKeys(account: Account) throws -> UserMetadataEncryptionKeys {
         let reqData: Data?
         

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -181,11 +181,20 @@ struct WalletStorage {
     func resetZashi() throws {
         try deleteData(forKey: Constants.zcashStoredWallet)
         try? deleteData(forKey: Constants.zcashStoredAdressBookEncryptionKeys)
-        try? deleteData(forKey: "\(Constants.zcashStoredUserMetadataEncryptionKeys)_zashi")
-        try? deleteData(forKey: "\(Constants.zcashStoredUserMetadataEncryptionKeys)_keystone")
+        // Metadata-encryption-key and shielding-reminder entries are stored per account under
+        // "<base>_<accountName>" (accountMetadataFilename / zcashStoredShieldingReminder). The
+        // account name comes from a localizable string — it became "Zodl" after the ZODL rebrand
+        // (was "Zashi"), and the two builders even disagree on casing ("_zodl" vs "_Zodl") — so a
+        // hardcoded "_zashi"/"_keystone" suffix misses the live key and leaks a stale metadata
+        // encryption key into the next wallet (MOB-1450 class). Enumerate and wipe every per-account
+        // entry, mirroring the voting-hotkey handling below.
+        for key in keychainKeys(withPrefix: "\(Constants.zcashStoredUserMetadataEncryptionKeys)_") {
+            try? deleteData(forKey: key)
+        }
         try? deleteData(forKey: Constants.zcashStoredWalletBackupReminder)
-        try? deleteData(forKey: "\(Constants.zcashStoredShieldingReminder)_zashi")
-        try? deleteData(forKey: "\(Constants.zcashStoredShieldingReminder)_keystone")
+        for key in keychainKeys(withPrefix: "\(Constants.zcashStoredShieldingReminder)_") {
+            try? deleteData(forKey: key)
+        }
         try? deleteData(forKey: Constants.zcashStoredWalletBackupAcknowledged)
         try? deleteData(forKey: Constants.zcashStoredShieldingAcknowledged)
         try? deleteData(forKey: Constants.zcashStoredTorSetupFlag)

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
@@ -110,3 +110,17 @@ struct WalletStorageClient {
     var importVotingHotkey: @Sendable (_ phrase: String, _ accountId: AccountUUID) throws -> Void
     var exportVotingHotkey: @Sendable (_ accountId: AccountUUID) throws -> StoredVotingHotkey
 }
+
+extension WalletStorageClient {
+    /// Ensures the stored Address Book encryption keys match `expected` — the keys derived from
+    /// the CURRENT wallet seed. A key derived from a previous seed must never survive into a new
+    /// wallet, otherwise that wallet can read and write another wallet's encrypted contacts file
+    /// in the shared iCloud container (MOB-1450). Overwrites a stale or absent key.
+    func reconcileAddressBookEncryptionKeys(_ expected: AddressBookEncryptionKeys) throws {
+        let current = try? exportAddressBookEncryptionKeys()
+        guard current != expected else {
+            return
+        }
+        try importAddressBookEncryptionKeys(expected)
+    }
+}

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
@@ -123,4 +123,16 @@ extension WalletStorageClient {
         }
         try importAddressBookEncryptionKeys(expected)
     }
+
+    /// Ensures the stored User Metadata encryption keys for `account` match `expected` — the keys
+    /// derived from the CURRENT wallet seed. A key derived from a previous seed must never survive
+    /// into a new wallet, otherwise that wallet can read and write another wallet's encrypted
+    /// metadata file in the shared iCloud container (MOB-1450). Overwrites a stale or absent key.
+    func reconcileUserMetadataEncryptionKeys(_ expected: UserMetadataEncryptionKeys, account: Account) throws {
+        let current = try? exportUserMetadataEncryptionKeys(account)
+        guard current != expected else {
+            return
+        }
+        try importUserMetadataEncryptionKeys(expected, account)
+    }
 }

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -398,23 +398,27 @@ extension Root {
                 // key left over from a previous wallet (e.g. a stale keychain entry that survived a
                 // wipe) would otherwise let this wallet read and write another wallet's encrypted
                 // contacts file in the shared iCloud container.
-                if let zashiAccount = walletAccounts.first(where: { $0.vendor == .zcash }),
-                   let storedWallet = try? walletStorage.exportWallet(),
-                   let seedBytes = try? mnemonic.toSeed(storedWallet.seedPhrase.value()) {
-                    var expectedKeys = AddressBookEncryptionKeys.empty
-                    try? expectedKeys.cacheFor(
-                        seed: seedBytes,
-                        account: zashiAccount.account,
-                        network: zcashSDKEnvironment.network().networkType
-                    )
-                    // Never overwrite a real key with an empty set if derivation produced nothing.
-                    if !expectedKeys.keys.isEmpty {
-                        try? walletStorage.reconcileAddressBookEncryptionKeys(expectedKeys)
-                    }
-                }
-
                 return .merge(
-                    .send(.loadContacts),
+                    // Reconcile inside the effect — seed derivation (PBKDF2) and keychain access
+                    // block — then load contacts, preserving the "reconcile before decrypt"
+                    // ordering without blocking the store's actor.
+                    .run { send in
+                        if let zashiAccount = walletAccounts.first(where: { $0.vendor == .zcash }),
+                           let storedWallet = try? walletStorage.exportWallet(),
+                           let seedBytes = try? mnemonic.toSeed(storedWallet.seedPhrase.value()) {
+                            var expectedKeys = AddressBookEncryptionKeys.empty
+                            try? expectedKeys.cacheFor(
+                                seed: seedBytes,
+                                account: zashiAccount.account,
+                                network: zcashSDKEnvironment.network().networkType
+                            )
+                            // Never overwrite a real key with an empty set if derivation produced nothing.
+                            if !expectedKeys.keys.isEmpty {
+                                try? walletStorage.reconcileAddressBookEncryptionKeys(expectedKeys)
+                            }
+                        }
+                        await send(.loadContacts)
+                    },
                     .send(.loadUserMetadata),
                     .send(.loadSwapAPIAccess)
                 )

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -391,11 +391,14 @@ extension Root {
                 }
 
                 // MOB-1450: ensure the Address Book encryption key matches the CURRENT seed
-                // before contacts load. The cached key is the source of contact decryption, so a
-                // key left over from a previous wallet (e.g. a stale keychain entry that survived
-                // a wipe) would otherwise let this wallet read and write another wallet's encrypted
+                // before contacts load. The address book is tied to the Zashi (seed-based, .zcash)
+                // account — every AddressBook operation resolves against it — so we select that
+                // account by vendor and reconcile its key. Keystone (hardware) accounts have no
+                // in-app seed and no separate address book, so they are intentionally skipped. A
+                // key left over from a previous wallet (e.g. a stale keychain entry that survived a
+                // wipe) would otherwise let this wallet read and write another wallet's encrypted
                 // contacts file in the shared iCloud container.
-                if let zashiAccount = state.zashiWalletAccount,
+                if let zashiAccount = walletAccounts.first(where: { $0.vendor == .zcash }),
                    let storedWallet = try? walletStorage.exportWallet(),
                    let seedBytes = try? mnemonic.toSeed(storedWallet.seedPhrase.value()) {
                     var expectedKeys = AddressBookEncryptionKeys.empty

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -348,8 +348,9 @@ extension Root {
                             let walletAccounts = try await sdkSynchronizer.walletAccounts()
                             await send(.initialization(.loadedWalletAccounts(walletAccounts)))
                             // MOB-1450: the user-metadata key reconcile and the metadata load are driven
-                            // by .loadedWalletAccounts (via .concatenate) so the load can't race the
-                            // reconcile and decrypt/write metadata with a stale key from a previous seed.
+                            // by .loadedWalletAccounts (which reconciles inline, then sends .loadUserMetadata)
+                            // so the load can't race the reconcile and decrypt/write metadata with a stale
+                            // key from a previous seed.
 
                             try await sdkSynchronizer.start(false)
 
@@ -427,14 +428,43 @@ extension Root {
                         }
                         await send(.loadContacts)
                     },
-                    // MOB-1450: reconcile the user-metadata key BEFORE metadata loads — the same
-                    // "reconcile before decrypt" guarantee the Address Book .run above gives contacts.
-                    // .concatenate waits for the reconcile effect to finish before .loadUserMetadata, so
-                    // metadata is never decrypted or written back with a stale key from a previous seed.
-                    .concatenate(
-                        .send(.resolveMetadataEncryptionKeys),
-                        .send(.loadUserMetadata)
-                    ),
+                    // MOB-1450: reconcile each account's user-metadata key BEFORE metadata loads — the
+                    // same "reconcile before decrypt" guarantee the Address Book .run above gives
+                    // contacts. The reconcile runs inline inside this .run (seed derivation + keychain
+                    // access block), and .loadUserMetadata is sent only after it completes, so metadata
+                    // is never decrypted or written back with a stale key from a previous seed.
+                    //
+                    // This must NOT be expressed as
+                    // .concatenate(.send(.resolveMetadataEncryptionKeys), .send(.loadUserMetadata)):
+                    // .resolveMetadataEncryptionKeys returns its OWN async .run that does the reconcile,
+                    // and .concatenate sequences only the delivery of the actions, not the completion of
+                    // that effect — so .loadUserMetadata would race the reconcile and could decrypt with
+                    // a stale key. (.resolveMetadataEncryptionKeys is still used by the account-switch
+                    // and disconnect paths, which sequence their own load afterwards.)
+                    .run { send in
+                        if let storedWallet = try? walletStorage.exportWallet(),
+                           let seedBytes = try? mnemonic.toSeed(storedWallet.seedPhrase.value()) {
+                            for account in walletAccounts {
+                                var expectedKeys = UserMetadataEncryptionKeys.empty
+                                try? expectedKeys.cacheFor(
+                                    seed: seedBytes,
+                                    account: account.account,
+                                    network: zcashSDKEnvironment.network().networkType
+                                )
+                                // Never overwrite a real key with an empty set if derivation produced nothing.
+                                guard !expectedKeys.keys.isEmpty else { continue }
+                                do {
+                                    try walletStorage.reconcileUserMetadataEncryptionKeys(expectedKeys, account: account.account)
+                                } catch {
+                                    // A failed reconcile leaves a possibly-stale key in place, so the
+                                    // security fix would silently not apply — log it (UI-level error
+                                    // handling still tracked by #1408) rather than dropping it.
+                                    LoggerProxy.error("MOB-1450: user-metadata key reconcile failed: \(error)")
+                                }
+                            }
+                        }
+                        await send(.loadUserMetadata)
+                    },
                     .send(.loadSwapAPIAccess)
                 )
 

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -347,8 +347,9 @@ extension Root {
 
                             let walletAccounts = try await sdkSynchronizer.walletAccounts()
                             await send(.initialization(.loadedWalletAccounts(walletAccounts)))
-                            await send(.resolveMetadataEncryptionKeys)
-                            await send(.loadUserMetadata)
+                            // MOB-1450: the user-metadata key reconcile and the metadata load are driven
+                            // by .loadedWalletAccounts (via .concatenate) so the load can't race the
+                            // reconcile and decrypt/write metadata with a stale key from a previous seed.
 
                             try await sdkSynchronizer.start(false)
 
@@ -419,7 +420,14 @@ extension Root {
                         }
                         await send(.loadContacts)
                     },
-                    .send(.loadUserMetadata),
+                    // MOB-1450: reconcile the user-metadata key BEFORE metadata loads — the same
+                    // "reconcile before decrypt" guarantee the Address Book .run above gives contacts.
+                    // .concatenate waits for the reconcile effect to finish before .loadUserMetadata, so
+                    // metadata is never decrypted or written back with a stale key from a previous seed.
+                    .concatenate(
+                        .send(.resolveMetadataEncryptionKeys),
+                        .send(.loadUserMetadata)
+                    ),
                     .send(.loadSwapAPIAccess)
                 )
 

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -481,7 +481,7 @@ extension Root {
                     
                     return .run { [walletAccounts = state.walletAccounts] send in
                         do {
-                            
+                            var metadataKeyChanged = false
                             for account in walletAccounts {
                                 // MOB-1450: reconcile each account's user-metadata encryption key
                                 // against the CURRENT seed before metadata loads. The cached key
@@ -508,8 +508,14 @@ extension Root {
                                     LoggerProxy.error("MOB-1450: user-metadata key reconcile failed: \(error)")
                                 }
                                 if changed {
-                                    await send(.loadUserMetadata)
+                                    metadataKeyChanged = true
                                 }
+                            }
+                            // Reload metadata once if any account's key changed — not once per
+                            // account. `.loadUserMetadata` always targets the single selected
+                            // account, so repeated sends would only duplicate the load + reset.
+                            if metadataKeyChanged {
+                                await send(.loadUserMetadata)
                             }
                         }
                     }

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -352,36 +352,9 @@ extension Root {
 
                             try await sdkSynchronizer.start(false)
 
-                            var selectedAccount: WalletAccount?
-                            
-                            for account in walletAccounts {
-                                if account.vendor == .zcash {
-                                    selectedAccount = account
-                                }
-                            }
-
                             exchangeRate.refreshExchangeRateUSD()
 
-                            if let account = selectedAccount {
-                                let addressBookEncryptionKeys = try? walletStorage.exportAddressBookEncryptionKeys()
-                                if addressBookEncryptionKeys == nil {
-                                    do {
-                                        var keys = AddressBookEncryptionKeys.empty
-                                        try keys.cacheFor(
-                                            seed: seedBytes,
-                                            account: account.account,
-                                            network: zcashSDKEnvironment.network().networkType
-                                        )
-                                        try walletStorage.importAddressBookEncryptionKeys(keys)
-                                    } catch {
-                                        // TODO: [#1408] error handling https://github.com/Electric-Coin-Company/zashi-ios/issues/1408
-                                    }
-                                }
-
-                                await send(.initialization(.initializationSuccessfullyDone))
-                            } else {
-                                await send(.initialization(.initializationSuccessfullyDone))
-                            }
+                            await send(.initialization(.initializationSuccessfullyDone))
                         } catch {
                             await send(.initialization(.initializationFailed(error.toZcashError())))
                         }
@@ -416,6 +389,27 @@ extension Root {
                         }
                     }
                 }
+
+                // MOB-1450: ensure the Address Book encryption key matches the CURRENT seed
+                // before contacts load. The cached key is the source of contact decryption, so a
+                // key left over from a previous wallet (e.g. a stale keychain entry that survived
+                // a wipe) would otherwise let this wallet read and write another wallet's encrypted
+                // contacts file in the shared iCloud container.
+                if let zashiAccount = state.zashiWalletAccount,
+                   let storedWallet = try? walletStorage.exportWallet(),
+                   let seedBytes = try? mnemonic.toSeed(storedWallet.seedPhrase.value()) {
+                    var expectedKeys = AddressBookEncryptionKeys.empty
+                    try? expectedKeys.cacheFor(
+                        seed: seedBytes,
+                        account: zashiAccount.account,
+                        network: zcashSDKEnvironment.network().networkType
+                    )
+                    // Never overwrite a real key with an empty set if derivation produced nothing.
+                    if !expectedKeys.keys.isEmpty {
+                        try? walletStorage.reconcileAddressBookEncryptionKeys(expectedKeys)
+                    }
+                }
+
                 return .merge(
                     .send(.loadContacts),
                     .send(.loadUserMetadata),

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -438,20 +438,25 @@ extension Root {
                         do {
                             
                             for account in walletAccounts {
-                                let userMetadataEncryptionKeys = try? walletStorage.exportUserMetadataEncryptionKeys(account.account)
-                                if userMetadataEncryptionKeys == nil {
-                                    do {
-                                        var keys = UserMetadataEncryptionKeys.empty
-                                        try keys.cacheFor(
-                                            seed: seedBytes,
-                                            account: account.account,
-                                            network: zcashSDKEnvironment.network().networkType
-                                        )
-                                        try walletStorage.importUserMetadataEncryptionKeys(keys, account.account)
-                                        await send(.loadUserMetadata)
-                                    } catch {
-                                        // TODO: [#1408] error handling https://github.com/Electric-Coin-Company/zashi-ios/issues/1408
-                                    }
+                                // MOB-1450: reconcile each account's user-metadata encryption key
+                                // against the CURRENT seed before metadata loads. The cached key
+                                // decrypts the metadata file synced through the shared iCloud
+                                // container, so a key left over from a previous wallet seed must
+                                // never survive into a new wallet — otherwise this wallet could read
+                                // and write another wallet's encrypted metadata. Overwrite a stale or
+                                // absent key (replaces the old "derive only when the slot is nil").
+                                var keys = UserMetadataEncryptionKeys.empty
+                                try? keys.cacheFor(
+                                    seed: seedBytes,
+                                    account: account.account,
+                                    network: zcashSDKEnvironment.network().networkType
+                                )
+                                // Never overwrite a real key with an empty set if derivation produced nothing.
+                                guard !keys.keys.isEmpty else { continue }
+                                let changed = (try? walletStorage.exportUserMetadataEncryptionKeys(account.account)) != keys
+                                try? walletStorage.reconcileUserMetadataEncryptionKeys(keys, account: account.account)
+                                if changed {
+                                    await send(.loadUserMetadata)
                                 }
                             }
                         }

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -439,8 +439,14 @@ extension Root {
                     // .resolveMetadataEncryptionKeys returns its OWN async .run that does the reconcile,
                     // and .concatenate sequences only the delivery of the actions, not the completion of
                     // that effect — so .loadUserMetadata would race the reconcile and could decrypt with
-                    // a stale key. (.resolveMetadataEncryptionKeys is still used by the account-switch
-                    // and disconnect paths, which sequence their own load afterwards.)
+                    // a stale key. (.resolveMetadataEncryptionKeys is still used by the account-switch,
+                    // hardware-wallet-import, and disconnect paths in RootCoordinator, which do NOT
+                    // strictly order their load after the reconcile — they use the same
+                    // .concatenate(.send, .send) / sequential-`await send` shape called out as unsafe
+                    // above. That race is benign on those paths: they run within a single wallet/seed,
+                    // so the stored key already matches the current seed and the reconcile is a no-op —
+                    // only create/restore (startup, handled here) can leave a stale key from a DIFFERENT
+                    // seed. Ordering those paths too is defense-in-depth, tracked as a MOB-1450 follow-up.)
                     .run { send in
                         if let storedWallet = try? walletStorage.exportWallet(),
                            let seedBytes = try? mnemonic.toSeed(storedWallet.seedPhrase.value()) {

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -415,7 +415,14 @@ extension Root {
                             )
                             // Never overwrite a real key with an empty set if derivation produced nothing.
                             if !expectedKeys.keys.isEmpty {
-                                try? walletStorage.reconcileAddressBookEncryptionKeys(expectedKeys)
+                                do {
+                                    try walletStorage.reconcileAddressBookEncryptionKeys(expectedKeys)
+                                } catch {
+                                    // A failed reconcile leaves a possibly-stale key in place, so the
+                                    // security fix would silently not apply — log it (UI-level error
+                                    // handling still tracked by #1408) rather than dropping it.
+                                    LoggerProxy.error("MOB-1450: Address Book key reconcile failed: \(error)")
+                                }
                             }
                         }
                         await send(.loadContacts)
@@ -462,16 +469,25 @@ extension Root {
                                 // Never overwrite a real key with an empty set if derivation produced nothing.
                                 guard !keys.keys.isEmpty else { continue }
                                 let changed = (try? walletStorage.exportUserMetadataEncryptionKeys(account.account)) != keys
-                                try? walletStorage.reconcileUserMetadataEncryptionKeys(keys, account: account.account)
+                                do {
+                                    try walletStorage.reconcileUserMetadataEncryptionKeys(keys, account: account.account)
+                                } catch {
+                                    // A failed reconcile leaves a possibly-stale key in place, so the
+                                    // security fix would silently not apply — log it (UI-level error
+                                    // handling still tracked by #1408) rather than dropping it.
+                                    LoggerProxy.error("MOB-1450: user-metadata key reconcile failed: \(error)")
+                                }
                                 if changed {
                                     await send(.loadUserMetadata)
                                 }
                             }
                         }
                     }
-                } catch { }
+                } catch {
+                    LoggerProxy.error("MOB-1450: resolving user-metadata encryption keys failed: \(error)")
+                }
                 return .none
-                
+
             case .initialization(.checkBackupPhraseValidation):
                 do {
                     let _ = try walletStorage.exportWallet()

--- a/zodlTests/UtilTests/AddressBookEncryptionKeyReconcileTests.swift
+++ b/zodlTests/UtilTests/AddressBookEncryptionKeyReconcileTests.swift
@@ -1,0 +1,129 @@
+//
+//  AddressBookEncryptionKeyReconcileTests.swift
+//  zodlTests
+//
+//  Regression coverage for MOB-1450: an Address Book encryption key derived from a
+//  previous wallet seed must never be reused by a wallet with a different seed. The
+//  cached key is the source of contact decryption, so it must always be reconciled
+//  against the current seed (and the keychain slot must be overwritable).
+//
+
+import Foundation
+import os
+import Security
+import Testing
+@testable import zodl_internal
+
+@Suite("Address Book encryption key reconcile (MOB-1450)")
+struct AddressBookEncryptionKeyReconcileTests {
+    // MARK: importAddressBookEncryptionKeys upsert
+
+    @Test func reimportingAddressBookEncryptionKeysOverwritesPreviousKeys() throws {
+        let client = Self.makeWalletStorageClient()
+        let keysA = try Self.addressBookKeys(byte: 0xAA)
+        let keysB = try Self.addressBookKeys(byte: 0xBB)
+
+        try client.importAddressBookEncryptionKeys(keysA)
+        // Re-importing different keys must overwrite, not throw `alreadyImported`.
+        try client.importAddressBookEncryptionKeys(keysB)
+
+        #expect(try client.exportAddressBookEncryptionKeys() == keysB)
+    }
+
+    // MARK: reconcile against the current seed
+
+    @Test func reconcileOverwritesStaleKeysFromADifferentSeed() throws {
+        let client = Self.makeWalletStorageClient()
+        let stale = try Self.addressBookKeys(byte: 0xAA)
+        let current = try Self.addressBookKeys(byte: 0xBB)
+
+        // A key left over from a previous wallet seed is present in the keychain.
+        try client.importAddressBookEncryptionKeys(stale)
+
+        try client.reconcileAddressBookEncryptionKeys(current)
+
+        #expect(try client.exportAddressBookEncryptionKeys() == current)
+    }
+
+    @Test func reconcileStoresKeysWhenNoneExist() throws {
+        let client = Self.makeWalletStorageClient()
+        let current = try Self.addressBookKeys(byte: 0xCC)
+
+        try client.reconcileAddressBookEncryptionKeys(current)
+
+        #expect(try client.exportAddressBookEncryptionKeys() == current)
+    }
+
+    @Test func reconcileKeepsKeysThatAlreadyMatchTheCurrentSeed() throws {
+        let client = Self.makeWalletStorageClient()
+        let current = try Self.addressBookKeys(byte: 0xDD)
+
+        try client.importAddressBookEncryptionKeys(current)
+        try client.reconcileAddressBookEncryptionKeys(current)
+
+        #expect(try client.exportAddressBookEncryptionKeys() == current)
+    }
+
+    // MARK: Helpers
+
+    static func makeWalletStorageClient() -> WalletStorageClient {
+        WalletStorageClient.live(walletStorage: WalletStorage(secItem: InMemoryKeychain().makeClient()))
+    }
+
+    /// Builds an `AddressBookEncryptionKeys` (single account, index 0) with a deterministic
+    /// 32-byte key via the model's `Codable` form, so no SDK seed derivation is needed.
+    static func addressBookKeys(byte: UInt8) throws -> AddressBookEncryptionKeys {
+        let raw = Data(repeating: byte, count: 32)
+        let json = try JSONSerialization.data(withJSONObject: ["keys": ["0": raw.base64EncodedString()]])
+        return try JSONDecoder().decode(AddressBookEncryptionKeys.self, from: json)
+    }
+}
+
+/// Minimal in-memory keychain backing for `SecItemClient`, keyed by `kSecAttrService`.
+/// Mirrors the real add/update/copyMatching/delete semantics (duplicate detection,
+/// not-found) so `WalletStorage` upsert/read behaviour is exercised for real.
+private final class InMemoryKeychain: Sendable {
+    private let store = OSAllocatedUnfairLock<[String: Data]>(initialState: [:])
+
+    func makeClient() -> SecItemClient {
+        SecItemClient(
+            copyMatching: { query, result in
+                guard let service = InMemoryKeychain.service(query) else { return errSecParam }
+                guard let data = self.store.withLock({ $0[service] }) else { return errSecItemNotFound }
+                result = data as AnyObject
+                return errSecSuccess
+            },
+            add: { query, _ in
+                guard let service = InMemoryKeychain.service(query),
+                      let data = InMemoryKeychain.value(from: query) else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] == nil else { return errSecDuplicateItem }
+                    items[service] = data
+                    return errSecSuccess
+                }
+            },
+            update: { query, attributes in
+                guard let service = InMemoryKeychain.service(query),
+                      let data = InMemoryKeychain.value(from: attributes) else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] != nil else { return errSecItemNotFound }
+                    items[service] = data
+                    return errSecSuccess
+                }
+            },
+            delete: { query in
+                guard let service = InMemoryKeychain.service(query) else { return errSecParam }
+                self.store.withLock { $0[service] = nil }
+                return errSecSuccess
+            }
+        )
+    }
+
+    private static func service(_ query: CFDictionary) -> String? {
+        (query as? [String: Any])?[kSecAttrService as String] as? String
+    }
+
+    private static func value(from dict: CFDictionary) -> Data? {
+        (dict as? [String: Any])?[kSecValueData as String] as? Data
+    }
+}

--- a/zodlTests/UtilTests/UserMetadataEncryptionKeyReconcileTests.swift
+++ b/zodlTests/UtilTests/UserMetadataEncryptionKeyReconcileTests.swift
@@ -1,0 +1,141 @@
+//
+//  UserMetadataEncryptionKeyReconcileTests.swift
+//  zodlTests
+//
+//  Regression coverage for MOB-1450 (defense-in-depth): a User Metadata encryption key
+//  derived from a previous wallet seed must never be reused by a wallet with a different
+//  seed. The metadata file is synced through a shared iCloud container, so a stale key
+//  would let a new wallet read and write another wallet's encrypted metadata. The cached
+//  key must be reconciled against the current seed, and the keychain slot must be
+//  overwritable.
+//
+
+import Foundation
+import os
+import Security
+import Testing
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite("User metadata encryption key reconcile (MOB-1450)")
+struct UserMetadataEncryptionKeyReconcileTests {
+    // MARK: importUserMetadataEncryptionKeys upsert
+
+    @Test func reimportingUserMetadataEncryptionKeysOverwritesPreviousKeys() throws {
+        let client = Self.makeWalletStorageClient()
+        let account = try Self.account()
+        let keysA = Self.metadataKeys(byte: 0xAA)
+        let keysB = Self.metadataKeys(byte: 0xBB)
+
+        try client.importUserMetadataEncryptionKeys(keysA, account)
+        // Re-importing different keys must overwrite, not throw `alreadyImported`.
+        try client.importUserMetadataEncryptionKeys(keysB, account)
+
+        #expect(try client.exportUserMetadataEncryptionKeys(account) == keysB)
+    }
+
+    // MARK: reconcile against the current seed
+
+    @Test func reconcileOverwritesStaleKeysFromADifferentSeed() throws {
+        let client = Self.makeWalletStorageClient()
+        let account = try Self.account()
+        let stale = Self.metadataKeys(byte: 0xAA)
+        let current = Self.metadataKeys(byte: 0xBB)
+
+        // A key left over from a previous wallet seed is present in the keychain.
+        try client.importUserMetadataEncryptionKeys(stale, account)
+
+        try client.reconcileUserMetadataEncryptionKeys(current, account: account)
+
+        #expect(try client.exportUserMetadataEncryptionKeys(account) == current)
+    }
+
+    @Test func reconcileStoresKeysWhenNoneExist() throws {
+        let client = Self.makeWalletStorageClient()
+        let account = try Self.account()
+        let current = Self.metadataKeys(byte: 0xCC)
+
+        try client.reconcileUserMetadataEncryptionKeys(current, account: account)
+
+        #expect(try client.exportUserMetadataEncryptionKeys(account) == current)
+    }
+
+    @Test func reconcileKeepsKeysThatAlreadyMatchTheCurrentSeed() throws {
+        let client = Self.makeWalletStorageClient()
+        let account = try Self.account()
+        let current = Self.metadataKeys(byte: 0xDD)
+
+        try client.importUserMetadataEncryptionKeys(current, account)
+        try client.reconcileUserMetadataEncryptionKeys(current, account: account)
+
+        #expect(try client.exportUserMetadataEncryptionKeys(account) == current)
+    }
+
+    // MARK: Helpers
+
+    static func makeWalletStorageClient() -> WalletStorageClient {
+        WalletStorageClient.live(walletStorage: WalletStorage(secItem: InMemoryKeychain().makeClient()))
+    }
+
+    /// Builds a minimal SDK `Account` via its `Codable` form (the memberwise init is
+    /// SDK-internal). Only `id` is required; `name` drives the keychain slot.
+    static func account(name: String = "zashi") throws -> Account {
+        let json = #"{"id":{"id":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]},"name":"\#(name)"}"#
+        return try JSONDecoder().decode(Account.self, from: Data(json.utf8))
+    }
+
+    /// Deterministic single-account user-metadata keys (index 0, one 32-byte key), built via
+    /// the model's in-memory initializers so no SDK seed derivation is needed.
+    static func metadataKeys(byte: UInt8) -> UserMetadataEncryptionKeys {
+        UserMetadataEncryptionKeys(keys: [0: UserMetadataKeys(privateKeys: [Data(repeating: byte, count: 32)])])
+    }
+}
+
+/// Minimal in-memory keychain backing for `SecItemClient`, keyed by `kSecAttrService`.
+/// Mirrors the real add/update/copyMatching/delete semantics (duplicate detection,
+/// not-found) so `WalletStorage` upsert/read behaviour is exercised for real.
+private final class InMemoryKeychain: Sendable {
+    private let store = OSAllocatedUnfairLock<[String: Data]>(initialState: [:])
+
+    func makeClient() -> SecItemClient {
+        SecItemClient(
+            copyMatching: { query, result in
+                guard let service = InMemoryKeychain.service(query) else { return errSecParam }
+                guard let data = self.store.withLock({ $0[service] }) else { return errSecItemNotFound }
+                result = data as AnyObject
+                return errSecSuccess
+            },
+            add: { query, _ in
+                guard let service = InMemoryKeychain.service(query),
+                      let data = InMemoryKeychain.value(from: query) else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] == nil else { return errSecDuplicateItem }
+                    items[service] = data
+                    return errSecSuccess
+                }
+            },
+            update: { query, attributes in
+                guard let service = InMemoryKeychain.service(query),
+                      let data = InMemoryKeychain.value(from: attributes) else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] != nil else { return errSecItemNotFound }
+                    items[service] = data
+                    return errSecSuccess
+                }
+            },
+            delete: { query in
+                guard let service = InMemoryKeychain.service(query) else { return errSecParam }
+                self.store.withLock { $0[service] = nil }
+                return errSecSuccess
+            }
+        )
+    }
+
+    private static func service(_ query: CFDictionary) -> String? {
+        (query as? [String: Any])?[kSecAttrService as String] as? String
+    }
+
+    private static func value(from dict: CFDictionary) -> Data? {
+        (dict as? [String: Any])?[kSecValueData as String] as? Data
+    }
+}

--- a/zodlTests/UtilTests/WalletResetKeychainCleanupTests.swift
+++ b/zodlTests/UtilTests/WalletResetKeychainCleanupTests.swift
@@ -1,0 +1,118 @@
+//
+//  WalletResetKeychainCleanupTests.swift
+//  zodlTests
+//
+//  Regression coverage: `WalletStorage.resetZashi()` must delete the per-account
+//  metadata-encryption-key and shielding-reminder keychain entries for the CURRENT
+//  account name. Those keys are stored under "<base>_<accountName>", and the account
+//  name comes from a localizable string ("Zodl" after the ZODL rebrand). A hardcoded
+//  "_zashi" suffix in resetZashi orphaned the live key, leaking a stale metadata
+//  encryption key into the next wallet — the same class of bug as MOB-1450.
+//
+
+import Foundation
+import os
+import Security
+import Testing
+@testable import zodl_internal
+
+@Suite("Wallet reset keychain cleanup")
+struct WalletResetKeychainCleanupTests {
+    @Test func resetZashiDeletesCurrentAccountMetadataAndShieldingKeys() throws {
+        let keychain = EnumerableInMemoryKeychain()
+        let storage = WalletStorage(secItem: keychain.makeClient())
+
+        let zashiName = WalletAccount.Vendor.zcash.name()       // "Zodl"
+        let keystoneName = WalletAccount.Vendor.keystone.name() // "Keystone"
+
+        // Metadata encryption keys live at `accountMetadataFilename` = "<base>_<name.lowercased()>".
+        // Seed the entries exactly as production stores them for both vendors.
+        let metadataZashi = "\(WalletStorage.Constants.zcashStoredUserMetadataEncryptionKeys)_\(zashiName.lowercased())"
+        let metadataKeystone = "\(WalletStorage.Constants.zcashStoredUserMetadataEncryptionKeys)_\(keystoneName.lowercased())"
+        keychain.seed(service: metadataZashi, data: Data([0x01]))
+        keychain.seed(service: metadataKeystone, data: Data([0x02]))
+
+        // Shielding reminders are written via the real API; `SmartBannerStore` passes
+        // `vendor.name()` as-is (NOT lowercased), e.g. "zcashStoredShieldingReminder_Zodl".
+        try storage.importShieldingReminder(ReminedMeTimestamp(timestamp: 0, occurence: 1), accountName: zashiName)
+        try storage.importShieldingReminder(ReminedMeTimestamp(timestamp: 0, occurence: 1), accountName: keystoneName)
+
+        try storage.resetZashi()
+
+        // The seed-derived metadata encryption key must NOT survive a wallet reset
+        // (a surviving key leaks into the next wallet — MOB-1450 class).
+        #expect(!keychain.contains(service: metadataZashi))
+        #expect(!keychain.contains(service: metadataKeystone))
+        // Shielding reminders for every account must be cleared too.
+        #expect(storage.exportShieldingReminder(accountName: zashiName) == nil)
+        #expect(storage.exportShieldingReminder(accountName: keystoneName) == nil)
+    }
+}
+
+/// In-memory `SecItemClient` backing keyed by `kSecAttrService`. Supports both single-item
+/// lookups and the `kSecMatchLimitAll` enumeration that `WalletStorage.keychainKeys(withPrefix:)`
+/// relies on, so `resetZashi`'s prefix-based wipe is exercised for real. Exposes `seed`/`contains`
+/// for assertions.
+private final class EnumerableInMemoryKeychain: Sendable {
+    private let store = OSAllocatedUnfairLock<[String: Data]>(initialState: [:])
+
+    func seed(service: String, data: Data) {
+        store.withLock { $0[service] = data }
+    }
+
+    func contains(service: String) -> Bool {
+        store.withLock { $0[service] != nil }
+    }
+
+    func makeClient() -> SecItemClient {
+        SecItemClient(
+            copyMatching: { query, result in
+                let dict = query as? [String: Any]
+                // Enumeration query (kSecMatchLimitAll) → return every service as attributes.
+                if let limit = dict?[kSecMatchLimit as String] as? String, limit == (kSecMatchLimitAll as String) {
+                    let services = self.store.withLock { Array($0.keys) }
+                    guard !services.isEmpty else { return errSecItemNotFound }
+                    let items: [[String: Any]] = services.map { [kSecAttrService as String: $0] }
+                    result = items as AnyObject
+                    return errSecSuccess
+                }
+                // Single-item lookup by service.
+                guard let service = EnumerableInMemoryKeychain.service(dict) else { return errSecParam }
+                guard let data = self.store.withLock({ $0[service] }) else { return errSecItemNotFound }
+                result = data as AnyObject
+                return errSecSuccess
+            },
+            add: { query, _ in
+                guard let dict = query as? [String: Any],
+                      let service = EnumerableInMemoryKeychain.service(dict),
+                      let data = dict[kSecValueData as String] as? Data else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] == nil else { return errSecDuplicateItem }
+                    items[service] = data
+                    return errSecSuccess
+                }
+            },
+            update: { query, attributes in
+                guard let service = EnumerableInMemoryKeychain.service(query as? [String: Any]),
+                      let data = (attributes as? [String: Any])?[kSecValueData as String] as? Data else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] != nil else { return errSecItemNotFound }
+                    items[service] = data
+                    return errSecSuccess
+                }
+            },
+            delete: { query in
+                guard let service = EnumerableInMemoryKeychain.service(query as? [String: Any]) else { return errSecParam }
+                return self.store.withLock { items in
+                    guard items[service] != nil else { return errSecItemNotFound }
+                    items[service] = nil
+                    return errSecSuccess
+                }
+            }
+        )
+    }
+
+    private static func service(_ dict: [String: Any]?) -> String? {
+        dict?[kSecAttrService as String] as? String
+    }
+}


### PR DESCRIPTION
## What & why

The Address Book is an encrypted file synced through a shared iCloud container (`iCloud.com.electriccoinco.zashi`); its encryption key is derived from the wallet seed. The key was cached in the keychain and **only (re)derived when the keychain slot was empty**, with no check that the cached key belonged to the current seed. A key left over from a previous wallet — e.g. a stale keychain entry that survived a wipe — was therefore **reused by a new wallet with a different seed**, letting it read *and write* that other wallet's encrypted contacts file in the shared container.

Fixes MOB-1450 — https://linear.app/zodl/issue/MOB-1450

## Fix

Reconcile the cached key against the **current seed** on init, before contacts load, and overwrite a stale/absent key:

- `WalletStorage.importAddressBookEncryptionKeys` now **upserts** (update on duplicate) instead of throwing `alreadyImported`, so a new seed's key can replace a stale one.
- New `WalletStorageClient.reconcileAddressBookEncryptionKeys(_:)` overwrites the slot only when the stored keys don't match the current-seed keys (no-op otherwise).
- `Root` `.loadedWalletAccounts` reconciles for the Zashi account **before** `.send(.loadContacts)`, guarded by `!expectedKeys.keys.isEmpty` so a failed derivation can never wipe a real key. Replaces the old `if addressBookEncryptionKeys == nil` derivation block.

Shared code, so it fixes iOS (and macOS). **Self-healing**: on first launch after this ships a legitimate wallet re-derives the identical key (no-op); a stale-key install corrects itself.

## Testing

New Swift Testing suite `AddressBookEncryptionKeyReconcileTests` (in-memory `SecItemClient` fake), written test-first:
- re-importing different keys overwrites (upsert)
- reconcile overwrites a stale key from a different seed
- reconcile stores keys when none exist
- reconcile keeps keys that already match

Watched RED (3 failed for the right reasons) → GREEN. The 6 existing `SecItemClientTests` still pass (no keychain-layer regression). Full app build green (scheme `zodl-internal`).

## Out of scope / follow-ups (tracked on MOB-1450)

- Multi-account / Keystone reconcile (covers the Zashi/zcash account only today).
- Defense-in-depth: include the AB key in the post-wipe `areKeysPresent` check; optional non-reversible seed fingerprint validated at the encrypt/decrypt sites; consider the data-protection keychain on macOS.
- The reducer wiring itself is build-verified, not unit-tested (no Root `TestStore` tests on this branch).

## Review follow-ups (automated verified code review)

Issues surfaced by an autonomous verified code review of this branch were fixed in follow-up commits (all in `RootInitialization.swift`):

1. **User-metadata key reconcile ordering** — the metadata reconcile ran as a fire-and-forget effect while `.loadUserMetadata` was dispatched concurrently (from the init `.run` and the `.loadedWalletAccounts` `.merge`), so metadata could be decrypted — and written back to the shared iCloud container — with a stale key from a previous seed *before* the reconcile completed. An initial attempt sequenced it via `.concatenate(.send(.resolveMetadataEncryptionKeys), .send(.loadUserMetadata))` (`dc57d563`), but `.concatenate` does **not** order that work: `.send` completes the instant the action is delivered, and `.resolveMetadataEncryptionKeys` returns its *own* async `.run` that performs the reconcile, so `.loadUserMetadata` still raced it. It is now reconciled **inline inside a single `.run`** in `.loadedWalletAccounts`, with `.loadUserMetadata` sent only after the reconcile completes — the same "reconcile before decrypt" structure the Address Book path uses. This also removed the redundant double `.loadUserMetadata` dispatch on a stale-key launch. (`b7bd7fd0`)
2. **Silent reconcile failures** — the security-critical reconcile calls used `try?` with an empty `catch {}`; a keychain failure left a stale cross-wallet key in place with no signal. Failures are now logged via `LoggerProxy.error` (the repo convention); UI-level handling stays tracked by #1408. (`d9c9a8c7`)
3. **Redundant `.loadUserMetadata` dispatch** — `.resolveMetadataEncryptionKeys` sent `.loadUserMetadata` from *inside* its per-account reconcile loop, so it fired once per account whose key changed. `.loadUserMetadata` only ever loads the currently-selected account's metadata (`RootUserMetadata.swift`), so the extra dispatches were redundant — each re-ran `userMetadataProvider.load` + `readTransactionsStorage.resetZashi` for the same account. It now tracks whether any account's key changed and sends `.loadUserMetadata` once after the loop, mirroring the `.loadedWalletAccounts` path. Behaviour-preserving. (`0ae9386a`)
4. **Misleading comment on non-startup reconcile ordering** — the comment on the `.loadedWalletAccounts` user-metadata reconcile stated that `.resolveMetadataEncryptionKeys` "is still used by the account-switch and disconnect paths, which sequence their own load afterwards", implying those callers order `.loadUserMetadata` after the reconcile. They don't: the account-switch, hardware-wallet-import, and disconnect paths in `RootCoordinator` use the same `.concatenate(.send, .send)` / sequential-`await send` shape the comment itself calls unsafe, so the load is **not** strictly ordered after the reconcile there. The race is benign on those paths — they run within a single wallet/seed, so the stored key already matches the current seed and the reconcile is a no-op; only create/restore (startup) can present a stale cross-seed key — so the comment was corrected to describe that accurately. Ordering those paths too remains a defense-in-depth follow-up (MOB-1450). Comment-only, no behavioural change. (`665af8a7`)

Verified by full app build (scheme `zodl-internal`) + the reconcile/keychain suites green (15 tests: Address Book + user-metadata reconcile, wallet-reset cleanup, and `SecItemClientTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


