### PR TITLE
[MOB-1446] Fix fastlane scripts and add notifications

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,7 @@ require "shellwords"
 $LOAD_PATH.unshift(File.expand_path("lib", __dir__))
 require_relative "lib/zodl/preflight"
 require_relative "lib/zodl/build_paths"
+require_relative "lib/zodl/notify"
 
 # Refuse to run outside bundler so the pinned gem versions in Gemfile.lock are
 # always used. The Scripts/*.sh wrappers invoke `bundle exec fastlane`.
@@ -47,6 +48,8 @@ lane :release do |options|
   dry_run   = truthy(options[:dry_run])
 
   variants = Zodl::Variants.expand(options.fetch(:variant))
+  # Context for the `error` hook below, which only receives the raised exception.
+  @notify_context = { variants: variants, version: version, build: build }
 
   UI.message("Fetching latest refs from origin…")
   # Fail closed: the preflight reconciles against origin, so a failed fetch must abort
@@ -82,6 +85,7 @@ lane :release do |options|
   end
 
   if dry_run
+    Zodl::Notify.post(event: :dry_run_ok, variants: variants, version: version, build: build)
     UI.success("Dry run complete — preflight passed for: #{variants.join(', ')}. No build performed.")
     next
   end
@@ -118,6 +122,7 @@ lane :release do |options|
     end
   end
 
+  Zodl::Notify.post(event: :success, variants: variants, version: version, build: build)
   UI.success("Done: #{variants.join(', ')} #{version} (#{build}) from #{ref} @ #{sha[0, 8]}")
 end
 
@@ -139,6 +144,25 @@ lane :bump do |options|
   end
 
   UI.success("Bumped to #{version} (#{build}) and committed.")
+end
+
+# Notify on a failed release. The success and dry-run paths post inline (where
+# the full context is in scope); this hook catches every other abort/exception.
+# Posting is failure-safe and never changes the exit status — fastlane still
+# re-raises after this block. `bump` is intentionally not covered.
+error do |lane, exception|
+  next unless lane.to_s == "release"
+  # A declined confirmation prompt is a deliberate user stop, not a failure.
+  next if exception.message.to_s.start_with?("Aborted")
+
+  context = @notify_context || {}
+  Zodl::Notify.post(
+    event: :failure,
+    variants: context[:variants] || [],
+    version: context[:version],
+    build: context[:build],
+    reason: exception.message
+  )
 end
 
 # --- helpers -------------------------------------------------------------

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,7 @@ require "shellwords"
 # files require each other by name; requiring preflight pulls in the other three.
 $LOAD_PATH.unshift(File.expand_path("lib", __dir__))
 require_relative "lib/zodl/preflight"
+require_relative "lib/zodl/build_paths"
 
 # Refuse to run outside bundler so the pinned gem versions in Gemfile.lock are
 # always used. The Scripts/*.sh wrappers invoke `bundle exec fastlane`.
@@ -17,11 +18,22 @@ unless ENV["BUNDLE_GEMFILE"]
   UI.user_error!("Run through bundler: use ./Scripts/release.sh or ./Scripts/bump.sh (they call `bundle exec fastlane`).")
 end
 
-PROJECT = "secant.xcodeproj"
+PROJECT = Zodl::BuildPaths::PROJECT
 TEST_SCHEME = "zodl-internal"        # only scheme wired to the zodlTests target
 TEST_DEVICE = "iPhone 17 Pro"
 PARTNER_KEYS_REL = "secant/Resources/PartnerKeys.plist"
 FASTLANE_DIR = __dir__
+TEAM_ID = "RLPRR8CPQG"               # Apple Developer team (matches DEVELOPMENT_TEAM in the project)
+
+# Swift macros (TCA, swift-dependencies, swift-perception, swift-case-paths) and
+# SPM build-tool plugins (SwiftGen, SwiftLint, XCStringsTool) must be trusted
+# before use. A fresh build worktree carries no prior approval and this
+# non-interactive CLI build (fastlane → xcodebuild) can't show the trust prompt,
+# so without these flags xcodebuild fails at ComputeTargetDependencyGraph with
+# "Macro … must be enabled before it can be used". Both the test run and the
+# archive go through the same xcodebuild CLI, so both need them — keep the flags
+# here so the two invocations can't drift apart.
+SKIP_VALIDATION_XCARGS = "-skipPackagePluginValidation -skipMacroValidation"
 
 # Don't auto-generate fastlane/README.md on every run; it is maintained by hand.
 skip_docs
@@ -44,6 +56,9 @@ lane :release do |options|
   branch_version = Zodl::Version.from_branch(ref)
   project_version = marketing_version_at(repo_root, sha)
   api_key = asc_api_key
+  # Resolve+verify the signing key path now (cwd is still the real repo), so it's
+  # an absolute path into the real fastlane dir before we chdir into the worktree.
+  auth_xcargs = asc_auth_xcargs(repo_root)
 
   variants.each do |variant|
     cfg = Zodl::Variants.config(variant)
@@ -73,6 +88,10 @@ lane :release do |options|
 
   UI.user_error!("Aborted.") unless truthy(options[:yes]) || UI.confirm("Proceed with the build above?")
 
+  # Create/refresh the App Store distribution profiles up front, so a signing or
+  # API-permission problem fails now instead of after the ~15-minute build.
+  ensure_appstore_profiles(variants, api_key)
+
   worktree = File.join(Dir.tmpdir, "zodl-release-#{sha[0, 8]}")
   begin
     UI.message("Creating a clean build worktree at #{sha[0, 8]}…")
@@ -80,12 +99,16 @@ lane :release do |options|
     FileUtils.cp(File.join(repo_root, PARTNER_KEYS_REL), File.join(worktree, PARTNER_KEYS_REL))
 
     Dir.chdir(worktree) do
+      # Absolute paths, anchored to the worktree: fastlane runs each action inside
+      # `Dir.chdir("..")`, which from here lands in the worktree's PARENT, so any
+      # RELATIVE path passed to run_tests/build_app would resolve there and break.
+      paths = Zodl::BuildPaths.resolve(worktree)
       UI.message("Resolving Swift packages…")
       run("xcodebuild -project #{PROJECT} -scheme #{TEST_SCHEME} -resolvePackageDependencies", must_succeed: true)
-      run_unit_tests unless truthy(options[:skip_tests])
+      run_unit_tests(paths) unless truthy(options[:skip_tests])
       variants.each do |variant|
         UI.message("Building and uploading #{variant}…")
-        build_and_upload(variant, version, build, api_key)
+        build_and_upload(variant, version, build, api_key, paths, auth_xcargs)
       end
     end
   ensure
@@ -143,6 +166,25 @@ def asc_api_key
     issuer_id: ENV.fetch("ASC_ISSUER_ID"),
     key_filepath: File.expand_path(ENV.fetch("ASC_KEY_FILEPATH"), FASTLANE_DIR)
   )
+end
+
+# xcodebuild flags that authenticate automatic signing (-allowProvisioningUpdates)
+# with the App Store Connect API key. gym/build_app has no api_key option, so
+# without these the export step can't reach App Store Connect to create the
+# distribution profile the entitlements need (Associated Domains, iCloud) and
+# falls back to Xcode's stored GUI accounts — failing on a stale one. Same key as
+# asc_api_key. The path is anchored on the absolute repo_root (NOT the cwd-relative
+# FASTLANE_DIR): build_app runs inside Dir.chdir(worktree), so FASTLANE_DIR would
+# resolve into the worktree — which has no .p8 — and xcodebuild would reject the
+# path as non-existent. Checked here so we fail fast, not minutes into the build.
+def asc_auth_xcargs(repo_root)
+  key_path = File.expand_path(ENV.fetch("ASC_KEY_FILEPATH"), File.join(repo_root, "fastlane"))
+  UI.user_error!("ASC API key not found at #{key_path} — set ASC_KEY_FILEPATH in fastlane/.env") unless File.exist?(key_path)
+  [
+    "-authenticationKeyPath #{key_path.shellescape}",
+    "-authenticationKeyID #{ENV.fetch('ASC_KEY_ID').shellescape}",
+    "-authenticationKeyIssuerID #{ENV.fetch('ASC_ISSUER_ID').shellescape}"
+  ].join(" ")
 end
 
 # Latest build number for an app+version on App Store Connect (TestFlight train).
@@ -232,32 +274,60 @@ def signing_identity_ok?
   out.include?("Apple Distribution") || out.include?("iPhone Distribution")
 end
 
-def run_unit_tests
+def run_unit_tests(paths)
   run_tests(
-    project: PROJECT,
+    project: paths[:project],
     scheme: TEST_SCHEME,
     devices: [TEST_DEVICE],
     only_testing: ["zodlTests"],
-    derived_data_path: "build/DerivedData",
+    derived_data_path: paths[:derived_data],
     code_coverage: false,
     clean: false,
-    xcargs: "CODE_SIGNING_ALLOWED=NO -skipPackagePluginValidation -skipMacroValidation"
+    xcargs: "CODE_SIGNING_ALLOWED=NO #{SKIP_VALIDATION_XCARGS}"
   )
 end
 
-def build_and_upload(variant, version, build, api_key)
+# App Store distribution profile name per variant. Used both to create the profile
+# (get_provisioning_profile) and to reference it in gym's export options.
+def appstore_profile_name(variant)
+  "ZODL #{variant} App Store"
+end
+
+# Create or refresh an App Store distribution profile for each variant via the ASC
+# API key. force: true regenerates it so it always carries the App ID's current
+# capabilities (Associated Domains, iCloud) — exportArchive requires a profile with
+# those, and -allowProvisioningUpdates does not mint one. Installed into
+# ~/Library/MobileDevice/Provisioning Profiles for the export step to pick up.
+def ensure_appstore_profiles(variants, api_key)
+  variants.each do |variant|
+    cfg = Zodl::Variants.config(variant)
+    get_provisioning_profile(
+      api_key: api_key,
+      app_identifier: cfg[:app_identifier],
+      provisioning_name: appstore_profile_name(variant),
+      force: true
+    )
+  end
+end
+
+def build_and_upload(variant, version, build, api_key, paths, auth_xcargs)
   cfg = Zodl::Variants.config(variant)
 
   ipa = build_app(
-    project: PROJECT,
+    project: paths[:project],
     scheme: cfg[:scheme],
     configuration: cfg[:configuration],
     export_method: "app-store",
-    output_directory: "build",
+    output_directory: paths[:output_dir],
     output_name: "#{variant}-#{version}-#{build}.ipa",
     clean: true,
-    derived_data_path: "build/DerivedData",
-    xcargs: "CURRENT_PROJECT_VERSION=#{build} -allowProvisioningUpdates"
+    derived_data_path: paths[:derived_data],
+    xcargs: "CURRENT_PROJECT_VERSION=#{build} -allowProvisioningUpdates #{auth_xcargs} #{SKIP_VALIDATION_XCARGS}",
+    export_options: {
+      signingStyle: "manual",
+      teamID: TEAM_ID,
+      provisioningProfiles: { cfg[:app_identifier] => appstore_profile_name(variant) }
+    }
   )
 
   upload_to_testflight(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -44,6 +44,17 @@ own App Store Connect app), an unpushed ref, a missing/invalid `PartnerKeys.plis
 the wrong Xcode, or no distribution signing identity. Run with `--dry-run` to see
 it without building.
 
+## Notifications
+
+A finished `release` posts a native macOS notification with a sound, so you can
+step away during the build/upload: **Ping** on success (and on a passing
+`--dry-run`), **Basso** on failure. It uses the built-in `osascript`
+(`display notification`) — nothing extra is installed. (`bump` does not notify.)
+
+The first notification may prompt you to allow notifications for your terminal app
+(Terminal, iTerm, …) in System Settings → Notifications — allow it once. Set
+`ZODL_NOTIFY=0` to silence them (they are also skipped automatically when `CI` is set).
+
 ## Tests
 
     bundle exec rake test                 # Ruby preflight logic (minitest)

--- a/fastlane/lib/zodl/build_paths.rb
+++ b/fastlane/lib/zodl/build_paths.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Zodl
+  # Absolute paths for a build performed inside a throwaway worktree.
+  #
+  # fastlane runs every top-level action wrapped in `Dir.chdir("..")` — it assumes
+  # it was invoked from the `fastlane/` folder and steps up to the project root
+  # (see fastlane runner.rb: "go up from the fastlane folder, to the project
+  # folder"). The release lane instead `Dir.chdir`es into a worktree under
+  # $TMPDIR, so that per-action `..` lands in the worktree's PARENT. Any RELATIVE
+  # path handed to an action (project, derived-data, output dir) then resolves
+  # there — outside the worktree — and fails (e.g. "Project file not found at
+  # '.../T/secant.xcodeproj'"). Anchoring every action path to the absolute
+  # worktree root makes them independent of fastlane's cwd.
+  module BuildPaths
+    PROJECT = "secant.xcodeproj"
+
+    module_function
+
+    # worktree must be an absolute path (the release lane builds it from
+    # Dir.tmpdir, which is absolute).
+    def resolve(worktree)
+      build = File.join(worktree, "build")
+      {
+        project: File.join(worktree, PROJECT),
+        output_dir: build,
+        derived_data: File.join(build, "DerivedData")
+      }.freeze
+    end
+  end
+end

--- a/fastlane/lib/zodl/notify.rb
+++ b/fastlane/lib/zodl/notify.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module Zodl
+  # Posts a macOS desktop notification (banner + sound) when a release finishes.
+  #
+  # Delivery uses the built-in `osascript` / AppleScript `display notification`
+  # command — a first-party macOS facility — so there is no third-party notifier
+  # binary to fall out of date (`terminal-notifier`, the usual gem for this, has
+  # had no release since 2016).
+  #
+  # Every entry point is failure-safe by contract: posting a notification must
+  # never change the release lane's outcome, so a missing or broken notifier and
+  # any delivery error are swallowed. Notifications are skipped under CI and when
+  # `ZODL_NOTIFY` is set to a falsey value.
+  module Notify
+    SUCCESS_SOUND = "Ping"
+    FAILURE_SOUND = "Basso"
+    DISABLED_VALUES = ["0", "false", "no", "off"].freeze
+
+    module_function
+
+    # Builds the notification fields for `event`. Pure (no I/O), so the wording
+    # and sound selection are unit-testable.
+    #
+    #   event   :success | :dry_run_ok | :failure
+    #   reason  failure detail (only its first line is shown); used by :failure
+    #
+    # Returns { title:, subtitle:, message:, sound: }.
+    def payload(event:, variants: [], version: nil, build: nil, reason: nil)
+      subtitle = describe(variants, version, build)
+      case event
+      when :success
+        { title: "ZODL release ✅", subtitle: subtitle, message: "Uploaded to TestFlight", sound: SUCCESS_SOUND }
+      when :dry_run_ok
+        { title: "ZODL dry run ✅", subtitle: subtitle, message: "Preflight passed", sound: SUCCESS_SOUND }
+      when :failure
+        { title: "ZODL release ❌", subtitle: subtitle, message: first_line(reason) || "Release failed", sound: FAILURE_SOUND }
+      else
+        raise ArgumentError, "unknown notification event: #{event.inspect}"
+      end
+    end
+
+    # Posts a notification for `event`. Failure-safe: returns false (never raises)
+    # when notifications are disabled or delivery fails, and true when a
+    # notification was handed to the notifier. `runner` is injectable so tests can
+    # capture the payload without showing a real banner.
+    def post(event:, variants: [], version: nil, build: nil, reason: nil, runner: nil)
+      return false unless enabled?
+
+      fields = payload(event: event, variants: variants, version: version, build: build, reason: reason)
+      (runner || method(:deliver)).call(fields)
+      true
+    rescue StandardError
+      false
+    end
+
+    # Notifications make sense only on an interactive Mac. Skip them under CI and
+    # when explicitly disabled via ZODL_NOTIFY.
+    def enabled?
+      return false if present?(ENV["CI"])
+
+      !DISABLED_VALUES.include?(ENV["ZODL_NOTIFY"].to_s.strip.downcase)
+    end
+
+    # --- internals ---------------------------------------------------------
+
+    def describe(variants, version, build)
+      names = Array(variants).join(", ")
+      ver = [version, build && "(#{build})"].compact.join(" ")
+      [names, ver].reject { |part| part.to_s.empty? }.join(" ")
+    end
+
+    def first_line(text)
+      line = text.to_s.lines.first.to_s.strip
+      line.empty? ? nil : line
+    end
+
+    def present?(value)
+      !value.to_s.strip.empty?
+    end
+
+    # Hands the notification to macOS via osascript. Open3 in array form (no
+    # shell) keeps osascript's own output out of the lane log and avoids any
+    # shell interpolation; the values are escaped as AppleScript string literals.
+    def deliver(fields)
+      script = +"display notification #{quote(fields[:message])} with title #{quote(fields[:title])}"
+      script << " subtitle #{quote(fields[:subtitle])}" if present?(fields[:subtitle])
+      script << " sound name #{quote(fields[:sound])}" if present?(fields[:sound])
+      Open3.capture3("/usr/bin/osascript", "-e", script)
+    end
+
+    # An AppleScript string literal: double-quoted, with \ and " backslash-escaped.
+    def quote(value)
+      %("#{value.to_s.gsub(/[\\"]/) { |char| "\\#{char}" }}")
+    end
+  end
+end

--- a/fastlane/spec/build_paths_test.rb
+++ b/fastlane/spec/build_paths_test.rb
@@ -1,0 +1,46 @@
+require "minitest/autorun"
+require "tmpdir"
+require "zodl/build_paths"
+
+class ZodlBuildPathsTest < Minitest::Test
+  def test_all_paths_are_absolute
+    Dir.mktmpdir do |worktree|
+      Zodl::BuildPaths.resolve(worktree).each do |key, path|
+        assert File.absolute_path?(path), "#{key} (#{path}) must be absolute"
+      end
+    end
+  end
+
+  def test_paths_are_anchored_inside_the_worktree
+    Dir.mktmpdir do |worktree|
+      paths = Zodl::BuildPaths.resolve(worktree)
+      assert_equal File.join(worktree, "secant.xcodeproj"), paths[:project]
+      assert_equal File.join(worktree, "build"), paths[:output_dir]
+      assert_equal File.join(worktree, "build", "DerivedData"), paths[:derived_data]
+    end
+  end
+
+  # Reproduces the original failure. fastlane wraps every top-level action in
+  # `Dir.chdir("..")` (runner.rb: "go up from the fastlane folder, to the project
+  # folder"). The release lane runs inside a worktree under $TMPDIR, so that `..`
+  # lands in the worktree's PARENT. A RELATIVE project path resolves there and is
+  # not found (the "Project file not found" crash); the absolute path BuildPaths
+  # returns resolves regardless of fastlane's cwd.
+  def test_project_path_survives_fastlanes_per_action_chdir_up
+    Dir.mktmpdir do |parent|
+      worktree = File.join(parent, "zodl-release-deadbeef")
+      Dir.mkdir(worktree)
+      Dir.mkdir(File.join(worktree, "secant.xcodeproj")) # stand-in project inside the worktree
+      project = Zodl::BuildPaths.resolve(worktree)[:project]
+
+      Dir.chdir(worktree) do
+        Dir.chdir("..") do # exactly what fastlane's runner does around each action
+          refute File.exist?(File.expand_path("secant.xcodeproj")),
+                 "a bare relative project path must NOT resolve from the worktree's parent — this was the bug"
+          assert File.exist?(File.expand_path(project)),
+                 "the absolute project path must resolve regardless of fastlane's chdir"
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/notify_test.rb
+++ b/fastlane/spec/notify_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "zodl/notify"
+
+class ZodlNotifyTest < Minitest::Test
+  # These tests drive notification gating through ENV, so snapshot and force a
+  # known enabled state. CI sets CI=true, which would otherwise disable
+  # notifications and make the delivery assertions fail when run on a runner.
+  def setup
+    @saved_ci = ENV["CI"]
+    @saved_flag = ENV["ZODL_NOTIFY"]
+    ENV.delete("CI")
+    ENV.delete("ZODL_NOTIFY")
+  end
+
+  def teardown
+    restore("CI", @saved_ci)
+    restore("ZODL_NOTIFY", @saved_flag)
+  end
+
+  # --- payload -----------------------------------------------------------
+
+  def test_payload_success_uses_ping_and_testflight_message
+    fields = Zodl::Notify.payload(event: :success, variants: ["appstore"], version: "3.8.0", build: 3)
+    assert_equal "ZODL release ✅", fields[:title]
+    assert_equal "appstore 3.8.0 (3)", fields[:subtitle]
+    assert_equal "Uploaded to TestFlight", fields[:message]
+    assert_equal "Ping", fields[:sound]
+  end
+
+  def test_payload_dry_run_uses_ping_and_preflight_message
+    fields = Zodl::Notify.payload(event: :dry_run_ok, variants: ["appstore"], version: "3.8.0", build: 3)
+    assert_equal "ZODL dry run ✅", fields[:title]
+    assert_equal "Preflight passed", fields[:message]
+    assert_equal "Ping", fields[:sound]
+  end
+
+  def test_payload_failure_uses_basso_and_first_line_of_reason
+    fields = Zodl::Notify.payload(
+      event: :failure, variants: ["appstore"], version: "3.8.0", build: 3,
+      reason: "Preflight failed for appstore — aborting.\nsecond line ignored"
+    )
+    assert_equal "ZODL release ❌", fields[:title]
+    assert_equal "Preflight failed for appstore — aborting.", fields[:message]
+    assert_equal "Basso", fields[:sound]
+  end
+
+  def test_payload_failure_without_reason_has_fallback_message
+    fields = Zodl::Notify.payload(event: :failure)
+    assert_equal "Release failed", fields[:message]
+    assert_equal "", fields[:subtitle]
+  end
+
+  def test_payload_joins_multiple_variants
+    fields = Zodl::Notify.payload(event: :success, variants: ["internal", "testnet"], version: "3.8.0", build: 4)
+    assert_equal "internal, testnet 3.8.0 (4)", fields[:subtitle]
+  end
+
+  def test_payload_rejects_unknown_event
+    assert_raises(ArgumentError) { Zodl::Notify.payload(event: :bogus) }
+  end
+
+  # --- enabled? ----------------------------------------------------------
+
+  def test_enabled_by_default
+    assert Zodl::Notify.enabled?
+  end
+
+  def test_disabled_under_ci
+    ENV["CI"] = "true"
+    refute Zodl::Notify.enabled?
+  end
+
+  def test_disabled_when_flag_is_falsey
+    ["0", "false", "no", "off", "OFF", " false "].each do |value|
+      ENV["ZODL_NOTIFY"] = value
+      refute Zodl::Notify.enabled?, "expected disabled for ZODL_NOTIFY=#{value.inspect}"
+    end
+  end
+
+  def test_enabled_when_flag_is_truthy
+    ENV["ZODL_NOTIFY"] = "1"
+    assert Zodl::Notify.enabled?
+  end
+
+  # --- post (failure-safe, injectable runner) ----------------------------
+
+  def test_post_invokes_runner_with_payload
+    captured = nil
+    result = Zodl::Notify.post(
+      event: :success, variants: ["appstore"], version: "3.8.0", build: 3,
+      runner: ->(fields) { captured = fields }
+    )
+    assert result
+    assert_equal "ZODL release ✅", captured[:title]
+    assert_equal "Ping", captured[:sound]
+  end
+
+  def test_post_skips_delivery_when_disabled
+    ENV["ZODL_NOTIFY"] = "0"
+    called = false
+    result = Zodl::Notify.post(event: :success, runner: ->(_fields) { called = true })
+    refute result
+    refute called
+  end
+
+  def test_post_swallows_runner_errors
+    result = Zodl::Notify.post(event: :failure, reason: "boom", runner: ->(_fields) { raise "notifier exploded" })
+    refute result
+  end
+
+  private
+
+  def restore(key, value)
+    value.nil? ? ENV.delete(key) : ENV[key] = value
+  end
+end


### PR DESCRIPTION
Changes to the local fastlane release automation (`Scripts/release.sh` → `fastlane release`).

## 1. Make the worktree build actually build, sign, and export

The release lane `Dir.chdir`s into a throwaway worktree under `$TMPDIR`, and fastlane wraps every action in `Dir.chdir("..")`, which broke paths and cwd-relative key resolution in several ways:

- **Absolute action paths** — new `Zodl::BuildPaths` helper anchors the `project` / `derived-data` / `output` paths to the worktree root, since fastlane's per-action `chdir("..")` otherwise resolved relative paths into the worktree's *parent* ("Project file not found at `…/T/secant.xcodeproj`"). Regression test included.
- **Macro/plugin trust on archive** — hoisted `-skipPackagePluginValidation -skipMacroValidation` into a shared `SKIP_VALIDATION_XCARGS` so the archive gets them too (not just the test run); a fresh worktree carries no prior macro approval.
- **App Store Connect auth for signing** — pass `-authenticationKeyPath/ID/IssuerID` (the same key as the upload) via xcargs so `-allowProvisioningUpdates` can reach ASC during archive/export. The `.p8` is resolved to an **absolute** path against `repo_root` and verified up front (it previously resolved into the worktree, where the gitignored key never exists).
- **Distribution profiles** — create/refresh an App Store profile per variant via `get_provisioning_profile` (`force: true`) before the build, and export with explicit manual signing (`export_options.provisioningProfiles`), so an export requiring the Associated Domains + iCloud entitlements no longer fails.

## 2. Desktop notifications when a release finishes

The `release` lane now posts a **native macOS notification with a sound** on completion, so you can step away during the build/upload:

| Outcome | Banner | Sound |
|---|---|---|
| Success (uploaded) | `ZODL release ✅` · `appstore 3.8.0 (3)` · `Uploaded to TestFlight` | **Ping** |
| `--dry-run` passed | `ZODL dry run ✅` · … · `Preflight passed` | **Ping** |
| Failure | `ZODL release ❌` · … · *first line of the error* | **Basso** |

- **Built-in `osascript`** (`display notification`) — nothing extra is installed. (`terminal-notifier`, the usual gem, has had no release since 2016; `osascript` ships with macOS.)
- Isolated in a **failure-safe `Zodl::Notify`** module: a broken or unavailable notifier can never change the lane's outcome, and notifying never alters the exit status.
- Skipped under **`CI`** and when **`ZODL_NOTIFY`** is falsey (`0`/`false`/`no`/`off`). `bump` is intentionally not covered. Declining the confirmation prompt (`Aborted.`) does not notify.
- The first notification may prompt you to allow notifications for your terminal app (one-time, OS-level) — documented in `fastlane/README.md`.

## Tests & verification

`bundle exec rake test` → **44 runs, 0 failures**. Adds `notify_test.rb` (payload wording/sound per event, `enabled?` gating, and `post` failure-safety via an injected notifier, so the suite never fires a real banner). The `bats` wrapper tests are unaffected.

End-to-end: a real `fastlane release` run with a bogus `--ref` fails at `resolve_sha` (after `@notify_context` is set) and the global `error` hook fires the failure notification; the success / dry-run / failure events were each delivered via `osascript` (Ping / Ping / Basso). Whether the banner renders depends on the terminal app's one-time notification permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
