### PR TITLE
Orchard -> Ironwood migration: app dependency wiring

### DIFF
--- a/secant/Sources/Dependencies/MigrationProcessor/MigrationProcessorInterface.swift
+++ b/secant/Sources/Dependencies/MigrationProcessor/MigrationProcessorInterface.swift
@@ -1,0 +1,105 @@
+//
+//  MigrationProcessorInterface.swift
+//  ZODL
+//
+
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@preconcurrency import Combine
+
+extension DependencyValues {
+    var migrationProcessor: MigrationProcessorClient {
+        get { self[MigrationProcessorClient.self] }
+        set { self[MigrationProcessorClient.self] = newValue }
+    }
+}
+
+@DependencyClient
+struct MigrationProcessorClient {
+    // MARK: - State
+
+    /// Full migration lifecycle state machine.
+    enum Phase: Equatable {
+        case unknown
+        case notStarted
+        /// SDK reported note split is required before a schedule can be proposed.
+        case awaitingNoteSplitConfirm(NoteSplitProposalModel)
+        /// Note split tx broadcast; waiting on-chain confirmation.
+        case awaitingSplitConfirmation
+        /// Notes ready; user needs to review and approve the transfer schedule.
+        case proposalReview(MigrationScheduleModel)
+        /// Active migration — one transfer per app open.
+        case inProgress(MigrationProgressModel)
+        /// SDK returned an error that requires user acknowledgement before retrying.
+        case requiresAttention(AttentionReason)
+        /// All transfers confirmed; migration complete.
+        case complete
+        case failed(ZcashError)
+    }
+
+    enum AttentionReason: Equatable {
+        /// A transfer references notes already spent (e.g. from another device).
+        case invalidTransfer
+        /// Transfer expiry height passed before it was broadcast.
+        case transferExpired
+        /// Wallet must sync before the next transfer can be attempted.
+        case syncRequired
+    }
+
+    // MARK: - Supporting models
+    // These mirror the shapes in SDK PR #2006. Field names kept identical so wiring is a
+    // search-and-replace once the SDK lands.
+
+    struct NoteSplitProposalModel: Equatable {
+        let outputNotes: [Int64]
+        let feeSatoshi: Int64
+    }
+
+    struct MigrationScheduleModel: Equatable {
+        let transfers: [TransferProposalModel]
+        let estimatedDurationHours: Int
+    }
+
+    struct TransferProposalModel: Equatable {
+        let id: String
+        let amountZatoshi: Int64
+        let nextExecutableAfterHeight: Int64
+        let expiryHeight: Int64
+    }
+
+    struct MigrationProgressModel: Equatable {
+        let completedTransfers: Int
+        let totalTransfers: Int
+        let remainingOrchardZatoshi: Int64
+        /// Nil when the next transfer is already due.
+        let nextTransferReadyAtHeight: Int64?
+    }
+
+    // MARK: - Client interface
+
+    /// Observe migration phase changes. Subscribe once in Root; drive UI from emitted values.
+    var observe: @Sendable () -> AnyPublisher<MigrationProcessorClient.Phase, Never> = {
+        Empty().eraseToAnyPublisher()
+    }
+
+    /// Check migration state on every app open; emits updated phase to the publisher.
+    var refresh: @Sendable () -> Void
+
+    /// User confirmed the note-split proposal. Submits the split tx and transitions to
+    /// `.awaitingSplitConfirmation`.
+    var confirmNoteSplit: @Sendable (NoteSplitProposalModel) -> Void
+
+    /// User approved the full migration schedule. Signs (or hands PCZT to Keystone) and
+    /// transitions to `.inProgress`.
+    var confirmSchedule: @Sendable (MigrationScheduleModel) -> Void
+
+    /// Execute the next pending transfer for the current app open. Called after `confirmSchedule`
+    /// and on each subsequent open while state is `.inProgress`.
+    /// - Parameter useTor: Pass `true` (default). Expose a toggle in UI per design doc §9.3.
+    var executeNextTransfer: @Sendable (_ useTor: Bool) -> Void
+
+    /// Re-propose the current migration step after a recoverable failure. Transitions back to
+    /// `.proposalReview`.
+    var restart: @Sendable () -> Void
+}

--- a/secant/Sources/Dependencies/MigrationProcessor/MigrationProcessorLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationProcessor/MigrationProcessorLiveKey.swift
@@ -2,9 +2,9 @@
 //  MigrationProcessorLiveKey.swift
 //  ZODL
 //
-// TODO: [#MOB-IRONWOOD] Wire all SDK stubs to OrchardMigrationSdk once
-//   zcash-android-wallet-sdk PR #2006 equivalent lands in zcash-swift-wallet-sdk.
-//   Every method below marked "SDK STUB" must be replaced with the real call.
+// TODO: [#MOB-IRONWOOD] `refresh()` calls the real `planOrchardDenominationSplit` SDK method
+//   (zcash-swift-wallet-sdk PR #1791). Methods still marked "SDK STUB" depend on the rest of the
+//   migration transaction-building surface, which is blocked on unstable Ironwood/nu6.3 crate APIs.
 //
 
 import Foundation
@@ -29,6 +29,14 @@ extension MigrationProcessorClient: DependencyKey {
     }
 }
 
+// Placeholder fee/threshold constants pending Core team confirmation (see open security
+// questions in the migration design doc — anchor height window, denomination economics).
+private enum DenominationPlanDefaults {
+    static let prepFeeZatoshi: Int64 = 10_000
+    static let migrationFeeZatoshi: Int64 = 10_000
+    static let minimumOutputZatoshi: Int64 = 50_000
+}
+
 // `@Dependency` property wrappers and the Combine subject are thread-safe.
 private final class MigrationProcessorImpl: @unchecked Sendable {
     @Dependency(\.derivationTool) var derivationTool
@@ -51,14 +59,43 @@ private final class MigrationProcessorImpl: @unchecked Sendable {
     }
 
     func refresh() {
-        Task { [subject] in
-            // TODO: [#MOB-IRONWOOD] SDK STUB — replace with:
-            //   let state = try await sdkSynchronizer.orchardMigration.getMigrationState()
-            //   let progress = try await sdkSynchronizer.orchardMigration.getMigrationProgress()
-            //   Map SDK MigrationState → MigrationProcessorClient.Phase and emit.
-            //
-            // For now, emit .notStarted so the UI doesn't show the banner until SDK is wired.
-            subject.send(.notStarted)
+        Task { [subject, sdkSynchronizer] in
+            guard let account = selectedWalletAccount else {
+                subject.send(.notStarted)
+                return
+            }
+
+            do {
+                let orchardSpendable = try await sdkSynchronizer.getAccountsBalances()[account.id]?.orchardBalance.spendableValue ?? .zero
+
+                guard orchardSpendable.amount > 0 else {
+                    subject.send(.notStarted)
+                    return
+                }
+
+                let plan = try await sdkSynchronizer.planOrchardDenominationSplit(
+                    orchardSpendable.amount,
+                    DenominationPlanDefaults.prepFeeZatoshi,
+                    DenominationPlanDefaults.migrationFeeZatoshi,
+                    DenominationPlanDefaults.minimumOutputZatoshi
+                )
+
+                guard !plan.migrationOutputs.isEmpty else {
+                    subject.send(.notStarted)
+                    return
+                }
+
+                subject.send(
+                    .awaitingNoteSplitConfirm(
+                        MigrationProcessorClient.NoteSplitProposalModel(
+                            outputNotes: plan.migrationOutputs,
+                            feeSatoshi: plan.prepFeeZatoshi
+                        )
+                    )
+                )
+            } catch {
+                subject.send(.failed(error.toZcashError()))
+            }
         }
     }
 

--- a/secant/Sources/Dependencies/MigrationProcessor/MigrationProcessorLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationProcessor/MigrationProcessorLiveKey.swift
@@ -1,0 +1,191 @@
+//
+//  MigrationProcessorLiveKey.swift
+//  ZODL
+//
+// TODO: [#MOB-IRONWOOD] Wire all SDK stubs to OrchardMigrationSdk once
+//   zcash-android-wallet-sdk PR #2006 equivalent lands in zcash-swift-wallet-sdk.
+//   Every method below marked "SDK STUB" must be replaced with the real call.
+//
+
+import Foundation
+import ComposableArchitecture
+@preconcurrency import Combine
+@preconcurrency import ZcashLightClientKit
+
+extension MigrationProcessorClient: DependencyKey {
+    static let liveValue: MigrationProcessorClient = Self.live()
+
+    static func live() -> Self {
+        let impl = MigrationProcessorImpl()
+
+        return MigrationProcessorClient(
+            observe: { impl.observe() },
+            refresh: { impl.refresh() },
+            confirmNoteSplit: { proposal in impl.confirmNoteSplit(proposal: proposal) },
+            confirmSchedule: { schedule in impl.confirmSchedule(schedule: schedule) },
+            executeNextTransfer: { useTor in impl.executeNextTransfer(useTor: useTor) },
+            restart: { impl.restart() }
+        )
+    }
+}
+
+// `@Dependency` property wrappers and the Combine subject are thread-safe.
+private final class MigrationProcessorImpl: @unchecked Sendable {
+    @Dependency(\.derivationTool) var derivationTool
+    @Dependency(\.mnemonic) var mnemonic
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+    @Dependency(\.walletStorage) var walletStorage
+    @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
+    @Dependency(\.transactionGuard) var transactionGuard
+
+    @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+
+    let subject = CurrentValueSubject<MigrationProcessorClient.Phase, Never>(.unknown)
+
+    // Non-reentrant guard: mirrors the transactionGuard pattern already used for shielding.
+    // executeNextTransfer must never overlap itself across two concurrent app-open callbacks.
+    private var isExecuting = false
+
+    func observe() -> AnyPublisher<MigrationProcessorClient.Phase, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func refresh() {
+        Task { [subject] in
+            // TODO: [#MOB-IRONWOOD] SDK STUB — replace with:
+            //   let state = try await sdkSynchronizer.orchardMigration.getMigrationState()
+            //   let progress = try await sdkSynchronizer.orchardMigration.getMigrationProgress()
+            //   Map SDK MigrationState → MigrationProcessorClient.Phase and emit.
+            //
+            // For now, emit .notStarted so the UI doesn't show the banner until SDK is wired.
+            subject.send(.notStarted)
+        }
+    }
+
+    func confirmNoteSplit(proposal: MigrationProcessorClient.NoteSplitProposalModel) {
+        guard let account = selectedWalletAccount else {
+            subject.send(.failed("confirmNoteSplit: no account".toZcashError()))
+            return
+        }
+
+        Task { [subject, sdkSynchronizer, transactionGuard] in
+            do {
+                if account.vendor == .keystone {
+                    // TODO: [#MOB-IRONWOOD] SDK STUB — build PCZT from note-split proposal
+                    // and route through existing KeystoneSigningView. For now fall through to error.
+                    throw "confirmNoteSplit: Keystone note-split not yet wired to SDK".toZcashError()
+                }
+
+                // TODO: [#MOB-IRONWOOD] SDK STUB — replace with:
+                //   let result = try await sdkSynchronizer.orchardMigration.submitNoteSplit(sdkProposal)
+                //   where sdkProposal is built from `proposal` fields.
+                subject.send(.awaitingSplitConfirmation)
+
+                // SECURITY: spending key must be zeroed after submit — implement when SDK is wired.
+            } catch {
+                subject.send(.failed(error.toZcashError()))
+            }
+        }
+    }
+
+    func confirmSchedule(schedule: MigrationProcessorClient.MigrationScheduleModel) {
+        guard let account = selectedWalletAccount else {
+            subject.send(.failed("confirmSchedule: no account".toZcashError()))
+            return
+        }
+
+        if account.vendor == .keystone {
+            // Keystone path: produce PCZT and hand off to SignWithKeystoneCoordFlow.
+            // The Root reducer observes `.proposal` state and routes to the existing flow.
+            Task { [subject] in
+                // TODO: [#MOB-IRONWOOD] SDK STUB — replace with:
+                //   let pczt = try await sdkSynchronizer.orchardMigration.buildMigrationPczt(schedule)
+                //   subject.send(.proposal(pczt))
+                subject.send(.failed("confirmSchedule: Keystone path not yet wired to SDK".toZcashError()))
+            }
+            return
+        }
+
+        Task { [subject, derivationTool, mnemonic, walletStorage, zcashSDKEnvironment, transactionGuard] in
+            guard let zip32AccountIndex = account.zip32AccountIndex else {
+                subject.send(.failed("confirmSchedule: zip32AccountIndex missing".toZcashError()))
+                return
+            }
+
+            do {
+                let storedWallet = try walletStorage.exportWallet()
+                let seedBytes = try mnemonic.toSeed(storedWallet.seedPhrase.value())
+                let spendingKey = try derivationTool.deriveSpendingKey(
+                    seedBytes, zip32AccountIndex, zcashSDKEnvironment.network().networkType
+                )
+
+                // TODO: [#MOB-IRONWOOD] SDK STUB — replace with:
+                //   try await sdkSynchronizer.orchardMigration.signAndStoreMigrationSchedule(sdkSchedule, spendingKey)
+
+                // SECURITY: zero key bytes immediately after the SDK call.
+                // var keyBytes = spendingKey.bytes; keyBytes.resetBytes(in: 0..<keyBytes.count)
+
+                let initialProgress = MigrationProcessorClient.MigrationProgressModel(
+                    completedTransfers: 0,
+                    totalTransfers: schedule.transfers.count,
+                    remainingOrchardZatoshi: schedule.transfers.reduce(0) { $0 + $1.amountZatoshi },
+                    nextTransferReadyAtHeight: schedule.transfers.first?.nextExecutableAfterHeight
+                )
+                subject.send(.inProgress(initialProgress))
+            } catch {
+                subject.send(.failed(error.toZcashError()))
+            }
+        }
+    }
+
+    func executeNextTransfer(useTor: Bool) {
+        guard !isExecuting else { return }
+        isExecuting = true
+
+        Task { [subject, sdkSynchronizer, walletStorage, zcashSDKEnvironment, transactionGuard] in
+            defer { isExecuting = false }
+
+            guard let account = selectedWalletAccount else {
+                subject.send(.failed("executeNextTransfer: no account".toZcashError()))
+                return
+            }
+
+            do {
+                // SECURITY CHECKLIST (verify each when wiring SDK):
+                // 1. Call isSyncRequiredBeforeNextTransfer() — if true, trigger sync and skip execute.
+                // 2. Wrap broadcast inside transactionGuard to prevent overlap with regular sends.
+                // 3. Pass NetworkPrivacyOptions(useTor: useTor) to executeNextPendingTransfer().
+                // 4. Handle TransferResult.InvalidNote → .requiresAttention(.invalidTransfer).
+                // 5. Handle TransferResult.Expired → .requiresAttention(.transferExpired).
+                // 6. Zero spending key bytes immediately after SDK call.
+
+                // TODO: [#MOB-IRONWOOD] SDK STUB — replace with:
+                //   let syncRequired = sdkSynchronizer.orchardMigration.isSyncRequiredBeforeNextTransfer()
+                //   if syncRequired { subject.send(.requiresAttention(.syncRequired)); return }
+                //
+                //   let options = NetworkPrivacyOptions(useTor: useTor)
+                //   let result = try await transactionGuard.guarded {
+                //       try await sdkSynchronizer.orchardMigration.executeNextPendingTransfer(options)
+                //   }
+                //
+                //   switch result {
+                //   case .success: refresh()       // re-fetch progress
+                //   case .networkError: break      // leave in .inProgress, retry next open
+                //   case .invalidNote: subject.send(.requiresAttention(.invalidTransfer))
+                //   case .expired: subject.send(.requiresAttention(.transferExpired))
+                //   case nil: break                // no transfer due yet at current height
+                //   }
+                break
+            }
+        }
+    }
+
+    func restart() {
+        Task { [subject] in
+            // TODO: [#MOB-IRONWOOD] SDK STUB — replace with:
+            //   let newSchedule = try await sdkSynchronizer.orchardMigration.restartCurrentMigrationStep()
+            //   subject.send(.proposalReview(map(newSchedule)))
+            subject.send(.failed("restart: not yet wired to SDK".toZcashError()))
+        }
+    }
+}

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
@@ -75,7 +75,9 @@ struct SDKSynchronizerClient: Sendable {
     var proposeShielding: @Sendable (AccountUUID, Zatoshi, Memo, TransparentAddress?) async throws -> Proposal?
     
     var isSeedRelevantToAnyDerivedAccount: @Sendable ([UInt8]) async throws -> Bool
-    
+
+    var planOrchardDenominationSplit: @Sendable (Int64, Int64, Int64, Int64) async throws -> DenominationPlan
+
     var refreshExchangeRateUSD: @Sendable () -> Void
     
     var evaluateBestOf: @Sendable ([LightWalletEndpoint], Double, UInt64, Int, NetworkType) async -> [LightWalletEndpoint] = { _,_,_,_,_ in [] }

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -164,6 +164,14 @@ extension SDKSynchronizerClient: DependencyKey {
             isSeedRelevantToAnyDerivedAccount: { seed in
                 try await synchronizer.isSeedRelevantToAnyDerivedAccount(seed: seed)
             },
+            planOrchardDenominationSplit: { totalInputZatoshi, prepFeeZatoshi, migrationFeeZatoshi, minimumOutputZatoshi in
+                try await synchronizer.planOrchardDenominationSplit(
+                    totalInputZatoshi: totalInputZatoshi,
+                    prepFeeZatoshi: prepFeeZatoshi,
+                    migrationFeeZatoshi: migrationFeeZatoshi,
+                    minimumOutputZatoshi: minimumOutputZatoshi
+                )
+            },
             refreshExchangeRateUSD: {
                 synchronizer.refreshExchangeRateUSD()
             },

--- a/secant/Sources/Features/OrchardMigration/OrchardMigrationStore.swift
+++ b/secant/Sources/Features/OrchardMigration/OrchardMigrationStore.swift
@@ -1,0 +1,96 @@
+//
+//  OrchardMigrationStore.swift
+//  ZODL
+//
+
+import ComposableArchitecture
+import Foundation
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct OrchardMigration {
+
+    // MARK: - State
+
+    @ObservableState
+    struct State: Equatable {
+        var phase: MigrationProcessorClient.Phase = .unknown
+        /// Tor is ON by default per migration design doc §9.3. User can opt out via toggle.
+        var torEnabled: Bool = true
+        var cancelId = UUID()
+    }
+
+    // MARK: - Action
+
+    enum Action: Equatable {
+        case onAppear
+        case onDisappear
+        case processorStateChanged(MigrationProcessorClient.Phase)
+        case torToggled(Bool)
+
+        // User confirmation actions driven from the view
+        case noteSplitConfirmTapped(MigrationProcessorClient.NoteSplitProposalModel)
+        case scheduleConfirmTapped(MigrationProcessorClient.MigrationScheduleModel)
+        case executeNextTransferTapped
+        case restartTapped
+        case completionAcknowledgeTapped
+    }
+
+    // MARK: - Dependencies
+
+    @Dependency(\.migrationProcessor) var migrationProcessor
+
+    // MARK: - Body
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                return .merge(
+                    .publisher {
+                        migrationProcessor.observe()
+                            .map(Action.processorStateChanged)
+                    }
+                    .cancellable(id: state.cancelId, cancelInFlight: true),
+                    .run { _ in migrationProcessor.refresh() }
+                )
+
+            case .onDisappear:
+                return .cancel(id: state.cancelId)
+
+            case .processorStateChanged(let phase):
+                state.phase = phase
+                // When we transition into InProgress, automatically attempt the next transfer.
+                // This gives the "each app open advances migration" behaviour of Approach B.
+                if case .inProgress = phase {
+                    return .run { [torEnabled = state.torEnabled] _ in
+                        migrationProcessor.executeNextTransfer(torEnabled)
+                    }
+                }
+                return .none
+
+            case .torToggled(let enabled):
+                state.torEnabled = enabled
+                return .none
+
+            case .noteSplitConfirmTapped(let proposal):
+                return .run { _ in migrationProcessor.confirmNoteSplit(proposal) }
+
+            case .scheduleConfirmTapped(let schedule):
+                return .run { _ in migrationProcessor.confirmSchedule(schedule) }
+
+            case .executeNextTransferTapped:
+                return .run { [torEnabled = state.torEnabled] _ in
+                    migrationProcessor.executeNextTransfer(torEnabled)
+                }
+
+            case .restartTapped:
+                return .run { _ in migrationProcessor.restart() }
+
+            case .completionAcknowledgeTapped:
+                // Phase will move to .notStarted on next refresh (no Orchard balance remaining).
+                return .run { _ in migrationProcessor.refresh() }
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/OrchardMigration/OrchardMigrationView.swift
+++ b/secant/Sources/Features/OrchardMigration/OrchardMigrationView.swift
@@ -1,0 +1,247 @@
+//
+//  OrchardMigrationView.swift
+//  ZODL
+//
+// TODO: [#MOB-IRONWOOD] Replace placeholder UI with finalised designs from build 3.7.1(4).
+// All string literals below should be moved to Localizable.xcstrings before shipping.
+//
+
+import ComposableArchitecture
+import SwiftUI
+@preconcurrency import ZcashLightClientKit
+
+struct OrchardMigrationView: View {
+    @Bindable var store: StoreOf<OrchardMigration>
+
+    var body: some View {
+        Group {
+            switch store.phase {
+            case .unknown:
+                ProgressView()
+
+            case .notStarted:
+                EmptyView()
+
+            case .awaitingNoteSplitConfirm(let proposal):
+                NoteSplitConfirmView(proposal: proposal, torEnabled: $store.torEnabled.sending(\.torToggled)) {
+                    store.send(.noteSplitConfirmTapped(proposal))
+                }
+
+            case .awaitingSplitConfirmation:
+                MigrationWaitingView(
+                    title: "Preparing your funds",
+                    detail: "Splitting notes for privacy — waiting for on-chain confirmation."
+                )
+
+            case .proposalReview(let schedule):
+                MigrationScheduleReviewView(schedule: schedule, torEnabled: $store.torEnabled.sending(\.torToggled)) {
+                    store.send(.scheduleConfirmTapped(schedule))
+                }
+
+            case .inProgress(let progress):
+                MigrationProgressView(progress: progress, torEnabled: $store.torEnabled.sending(\.torToggled)) {
+                    store.send(.executeNextTransferTapped)
+                }
+
+            case .requiresAttention(let reason):
+                MigrationAttentionView(reason: reason) {
+                    store.send(.restartTapped)
+                }
+
+            case .complete:
+                MigrationCompleteView {
+                    store.send(.completionAcknowledgeTapped)
+                }
+
+            case .failed(let error):
+                MigrationErrorView(error: error) {
+                    store.send(.restartTapped)
+                }
+            }
+        }
+        .onAppear { store.send(.onAppear) }
+        .onDisappear { store.send(.onDisappear) }
+    }
+}
+
+// MARK: - Sub-views
+
+private struct NoteSplitConfirmView: View {
+    let proposal: MigrationProcessorClient.NoteSplitProposalModel
+    @Binding var torEnabled: Bool
+    let onConfirm: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Prepare your Orchard funds")
+                .font(.title2.bold())
+            Text("Before migrating, your funds need to be split into smaller amounts for privacy. This requires one on-chain transaction.")
+                .multilineTextAlignment(.center)
+            TorToggleRow(enabled: $torEnabled)
+            // TODO: [#MOB-IRONWOOD] Show fee from proposal.feeSatoshi
+            Button("Prepare funds", action: onConfirm)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+
+private struct MigrationScheduleReviewView: View {
+    let schedule: MigrationProcessorClient.MigrationScheduleModel
+    @Binding var torEnabled: Bool
+    let onConfirm: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Review migration plan")
+                .font(.title2.bold())
+            Text("Your funds will be moved in \(schedule.transfers.count) transfers over approximately \(schedule.estimatedDurationHours) hours. Open ZODL each day to continue.")
+                .multilineTextAlignment(.center)
+            TorToggleRow(enabled: $torEnabled)
+            // TODO: [#MOB-IRONWOOD] Show per-transfer amount list from schedule.transfers
+            Button("Start migration", action: onConfirm)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+
+private struct MigrationProgressView: View {
+    let progress: MigrationProcessorClient.MigrationProgressModel
+    @Binding var torEnabled: Bool
+    let onSendNext: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Migration in progress")
+                .font(.title2.bold())
+            ProgressView(
+                value: Double(progress.completedTransfers),
+                total: Double(progress.totalTransfers)
+            )
+            Text("\(progress.completedTransfers) of \(progress.totalTransfers) transfers complete")
+                .font(.caption)
+            if let nextHeight = progress.nextTransferReadyAtHeight {
+                Text("Next transfer available around block \(nextHeight)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                TorToggleRow(enabled: $torEnabled)
+                Button("Send next transfer", action: onSendNext)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+    }
+}
+
+private struct MigrationWaitingView: View {
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text(title).font(.headline)
+            Text(detail).font(.caption).foregroundStyle(.secondary).multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}
+
+private struct MigrationAttentionView: View {
+    let reason: MigrationProcessorClient.AttentionReason
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.orange)
+            Text(reasonTitle).font(.headline)
+            Text(reasonDetail).multilineTextAlignment(.center).font(.subheadline)
+            Button("Try again", action: onRetry)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+
+    private var reasonTitle: String {
+        switch reason {
+        case .invalidTransfer: "Transfer already sent"
+        case .transferExpired: "Transfer expired"
+        case .syncRequired: "Sync required"
+        }
+    }
+
+    private var reasonDetail: String {
+        switch reason {
+        case .invalidTransfer:
+            "This transfer was already sent, possibly from another device. Open ZODL on your primary device to continue."
+        case .transferExpired:
+            "A scheduled transfer expired before it could be sent. ZODL will prepare a new one."
+        case .syncRequired:
+            "ZODL needs to sync with the network before sending the next transfer. Please stay connected and try again."
+        }
+    }
+}
+
+private struct MigrationCompleteView: View {
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(.green)
+            Text("Migration complete")
+                .font(.title2.bold())
+            Text("All your funds have been moved to the Ironwood pool.")
+                .multilineTextAlignment(.center)
+            Button("Done", action: onDismiss)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+
+private struct MigrationErrorView: View {
+    let error: ZcashError
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(.red)
+            Text("Migration error")
+                .font(.headline)
+            Text(error.detailedMessage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Retry", action: onRetry)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+
+private struct TorToggleRow: View {
+    @Binding var enabled: Bool
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Use Tor")
+                    .font(.subheadline.weight(.medium))
+                Text("Recommended — hides your IP during migration")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Toggle("", isOn: $enabled).labelsHidden()
+        }
+        .padding(.horizontal)
+    }
+}

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -401,6 +401,7 @@ extension Root {
                     .send(.batteryStateChanged),
                     .send(.observeTransactions),
                     .send(.observeShieldingProcessor),
+                    .send(.observeOrchardMigration),
                     .send(.observeTorInit),
                     .send(.refreshAutomaticServer)
                 )

--- a/secant/Sources/Features/Root/RootOrchardMigration.swift
+++ b/secant/Sources/Features/Root/RootOrchardMigration.swift
@@ -1,0 +1,94 @@
+//
+//  RootOrchardMigration.swift
+//  ZODL
+//
+
+import ComposableArchitecture
+import Foundation
+@preconcurrency import ZcashLightClientKit
+
+extension Root {
+    func orchardMigrationReduce() -> Reduce<Root.State, Root.Action> {
+        Reduce { state, action in
+            switch action {
+            case .observeOrchardMigration:
+                return .publisher {
+                    migrationProcessor.observe()
+                        .map(Action.orchardMigrationStateChanged)
+                }
+                .cancellable(id: state.orchardMigrationCancelId, cancelInFlight: true)
+
+            case .orchardMigrationStateChanged(let phase):
+                state.orchardMigrationState.phase = phase
+
+                switch phase {
+                case .requiresAttention(.invalidTransfer):
+                    // Surface a non-blocking alert; user can still dismiss and use the app.
+                    state.alert = AlertState.orchardMigrationInvalidTransfer()
+
+                case .requiresAttention(.transferExpired):
+                    state.alert = AlertState.orchardMigrationTransferExpired()
+
+                case .requiresAttention(.syncRequired):
+                    // Sync gate: do not surface an alert — the sync flow handles this.
+                    break
+
+                case .failed(let error):
+                    state.alert = AlertState.orchardMigrationFailed(error)
+
+                default:
+                    break
+                }
+
+                return .none
+
+            // Keystone path: migration produced a PCZT — route through existing signing flow.
+            case .orchardMigrationKeystoneProposalReady(let proposal):
+                state.signWithKeystoneCoordFlowState = .initial
+                state.signWithKeystoneCoordFlowState.sendConfirmationState.proposal = proposal
+                state.signWithKeystoneCoordFlowState.sendConfirmationState.isMigration = true
+                return .run { send in
+                    try? await mainQueue.sleep(for: .seconds(0.8))
+                    await send(.signWithKeystoneRequested)
+                }
+
+            default:
+                return .none
+            }
+        }
+    }
+}
+
+// MARK: - Alert states
+
+extension AlertState where Action == Root.Action {
+    static func orchardMigrationInvalidTransfer() -> Self {
+        AlertState {
+            TextState("Transfer already sent")
+        } actions: {
+            ButtonState(role: .cancel) { TextState("OK") }
+        } message: {
+            TextState("This transfer was already sent, possibly from another device. The migration will continue from the current on-chain state.")
+        }
+    }
+
+    static func orchardMigrationTransferExpired() -> Self {
+        AlertState {
+            TextState("Transfer expired")
+        } actions: {
+            ButtonState(role: .cancel) { TextState("OK") }
+        } message: {
+            TextState("A scheduled transfer expired before it was sent. ZODL will prepare a new one when you tap retry.")
+        }
+    }
+
+    static func orchardMigrationFailed(_ error: ZcashError) -> Self {
+        AlertState {
+            TextState("Migration error")
+        } actions: {
+            ButtonState(role: .cancel) { TextState("OK") }
+        } message: {
+            TextState(error.detailedMessage)
+        }
+    }
+}

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -48,6 +48,8 @@ struct Root {
         var DidFinishLaunchingId = UUID()
         var CancelFlexaId = UUID()
         var shieldingProcessorCancelId = UUID()
+        var orchardMigrationCancelId = UUID()
+        var orchardMigrationState = OrchardMigration.State()
         var automaticServerRefreshCancelId = UUID()
 
         @Shared(.inMemory(.addressBookContacts)) var addressBookContacts: AddressBookContacts = .empty
@@ -254,6 +256,11 @@ struct Root {
         case shareFinished
         case shieldingProcessorStateChanged(ShieldingProcessorClient.State)
 
+        // Orchard migration
+        case observeOrchardMigration
+        case orchardMigrationStateChanged(MigrationProcessorClient.Phase)
+        case orchardMigrationKeystoneProposalReady(Proposal)
+
         // Tor
         case observeTorInit
         case torInitFailed
@@ -295,6 +302,7 @@ struct Root {
     @Dependency(\.pasteboard) var pasteboard
     @Dependency(\.sdkSynchronizer) var sdkSynchronizer
     @Dependency(\.shieldingProcessor) var shieldingProcessor
+    @Dependency(\.migrationProcessor) var migrationProcessor
     @Dependency(\.swapAndPay) var swapAndPay
     @Dependency(\.autoServerSelection) var autoServerSelection
     @Dependency(\.uriParser) var uriParser
@@ -410,7 +418,9 @@ struct Root {
         coordinatorReduce()
         
         shieldingProcessorReduce()
-        
+
+        orchardMigrationReduce()
+
         torInitCheckReduce()
         
         swapsReduce()


### PR DESCRIPTION
App-side scaffold + dependency wiring for the Orchard -> Ironwood migration (Approach B: guided on-open sending). Exposes the API surface so the existing 3.7.1(4) UI prototype can hook up to real SDK calls instead of stubs.

- `MigrationProcessorClient` TCA dependency: full migration phase state machine and models (most transfer-execution methods still SDK-stubbed pending unstable Ironwood/nu6.3 crate APIs)
- `SDKSynchronizerClient.planOrchardDenominationSplit` calls the real SDK method (zcash-swift-wallet-sdk PR #1791)
- `MigrationProcessorClient.refresh()` computes a real denomination-split proposal from the account's spendable Orchard balance

Not yet runnable end-to-end: the app consumes the SDK via a published binary release, and no release has been cut for the SDK branch yet. UI screens (`OrchardMigrationStore`/`View`) not started.