### PR TITLE
[MOB-1459] Migration models + SDK migration stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Added
+- [MOB-1459] Groundwork for the Orchard → Ironwood migration: data models and the stubbed migration SDK interface. No user-visible changes yet.
+
 ## 3.7.2 build 1
 
 ### Added

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
@@ -116,5 +116,48 @@ struct SDKSynchronizerClient: Sendable {
     var enhanceTransactionBy: @Sendable (String) async throws -> Void
 
     var getTreeState: @Sendable (_ height: UInt64) async throws -> Data
+
+    // MARK: - Migration (Orchard → Ironwood) — stubs until the SDK API exists (MOB-1455)
+    //
+    // Swift mirror of `interface OrchardMigrationSdk` (`MigrationSdk.kt`). Names are qualified
+    // to fit this client's flat namespace (e.g. `stateStream` is already taken by
+    // `SynchronizerState`). Markers: `[draft]` = Kotlin draft 1:1, `[ext]` = proposed SDK
+    // extension not present in the Kotlin draft.
+
+    // State — Kotlin: getMigrationState / (Flow suggestion) / getMigrationProgress
+    var getMigrationState: @Sendable () -> MigrationState = { .notStarted }                                   // [draft]
+    var migrationStateStream: @Sendable () -> AnyPublisher<MigrationState, Never> = { Empty().eraseToAnyPublisher() }  // [ext]
+    var getMigrationProgress: @Sendable () -> MigrationProgress? = { nil }                                    // [draft]
+    // Note splitting
+    var isNoteSplitNeeded: @Sendable () -> Bool = { false }                                                   // [draft]
+    var prepareNoteSplit: @Sendable () async -> NoteSplitProposal = { NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero) }  // [draft]
+    var submitNoteSplit: @Sendable (NoteSplitProposal) async -> TransferResult = { _ in TransferResult.success(txId: "") }     // [draft]
+    // Proposal
+    var selectMigrationMode: @Sendable (MigrationMode) -> Void = { _ in }                                     // [ext]
+    var proposeMigrationTransfers: @Sendable () async -> MigrationSchedule = {  // [draft]
+        MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+    }
+    var signAndStoreMigrationSchedule: @Sendable (MigrationSchedule) async -> Void = { _ in }                 // [draft]
+    // Background execution — Kotlin: isSyncRequiredBeforeNextTransfer / executeNextPendingTransfer
+    var isSyncRequiredBeforeNextMigrationTransfer: @Sendable () -> Bool = { false }                           // [draft]
+    var executeNextPendingMigrationTransfer: @Sendable (NetworkPrivacyOptions) async -> TransferResult? = { _ in nil }  // [draft]
+    // On-launch reconciliation — Kotlin: hasOverdueTransfers / hasInvalidTransfers
+    var hasOverdueMigrationTransfers: @Sendable () -> Bool = { false }                                        // [draft]
+    var hasInvalidMigrationTransfers: @Sendable () -> Bool = { false }                                        // [draft]
+    // Recovery
+    var restartCurrentMigrationStep: @Sendable () async -> MigrationSchedule = {  // [draft]
+        MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+    }
+    var rescheduleStalledMigrationTransfer: @Sendable () async -> Void = { }                                  // [ext]
+    var recreateInvalidMigrationTransfer: @Sendable () async -> Void = { }                                    // [ext]
+    // Progress UI
+    var migrationSummary: @Sendable () -> MigrationSummary = { MigrationSummary.zero }                        // [ext]
+    var migrationTransfers: @Sendable () -> [MigrationTransferRow] = { [] }                                   // [ext]
+    // Keystone (PCZT)
+    var proposeNoteSplitPCZT: @Sendable () async -> Pczt = { Pczt() }                                         // [ext]
+    var proposeMigrationPCZTs: @Sendable (MigrationSchedule) async -> [Pczt] = { _ in [] }                    // [ext]
+    var storeSignedMigrationTransactions: @Sendable ([Pczt]) async -> Void = { _ in }                         // [ext]
+    // Lifecycle — Kotlin: initializePostUpgrade
+    var initializeMigrationPostUpgrade: @Sendable () -> Void = { }                                            // [draft]
 }
 

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -293,9 +293,10 @@ extension SDKSynchronizerClient: DependencyKey {
             // Migration (Orchard → Ironwood) — STUB: the SDK API does not exist yet (MOB-1455).
             // These compile the app against the expected contract and do nothing. When the real
             // SDK lands, replace these closures here — broadcast-capable ones (`submitNoteSplit`,
-            // `executeNextPendingMigrationTransfer`, `storeSignedMigrationTransactions`) must then
-            // acquire the transaction guard inside this LiveKey (same pattern as
-            // `createAndSubmitProposedTransactions`), never at call sites.
+            // `executeNextPendingMigrationTransfer`) must then acquire the transaction guard
+            // inside this LiveKey (same pattern as `createAndSubmitProposedTransactions`),
+            // never at call sites. `storeSignedMigrationTransactions` only stores locally —
+            // it is not a broadcast and must stay unguarded.
             getMigrationState: { .notStarted },
             migrationStateStream: { Just(MigrationState.notStarted).eraseToAnyPublisher() },
             getMigrationProgress: { nil },

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -289,7 +289,35 @@ extension SDKSynchronizerClient: DependencyKey {
                 return try await transactionGuard.withSubmission {
                     try await synchronizer.getTreeState(height: height)
                 }
-            }
+            },
+            // Migration (Orchard → Ironwood) — STUB: the SDK API does not exist yet (MOB-1455).
+            // These compile the app against the expected contract and do nothing. When the real
+            // SDK lands, replace these closures here — broadcast-capable ones (`submitNoteSplit`,
+            // `executeNextPendingMigrationTransfer`, `storeSignedMigrationTransactions`) must then
+            // acquire the transaction guard inside this LiveKey (same pattern as
+            // `createAndSubmitProposedTransactions`), never at call sites.
+            getMigrationState: { .notStarted },
+            migrationStateStream: { Just(MigrationState.notStarted).eraseToAnyPublisher() },
+            getMigrationProgress: { nil },
+            isNoteSplitNeeded: { false },
+            prepareNoteSplit: { NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero) },
+            submitNoteSplit: { _ in TransferResult.success(txId: "") },
+            selectMigrationMode: { _ in },
+            proposeMigrationTransfers: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },
+            signAndStoreMigrationSchedule: { _ in },
+            isSyncRequiredBeforeNextMigrationTransfer: { false },
+            executeNextPendingMigrationTransfer: { _ in nil },
+            hasOverdueMigrationTransfers: { false },
+            hasInvalidMigrationTransfers: { false },
+            restartCurrentMigrationStep: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },
+            rescheduleStalledMigrationTransfer: { },
+            recreateInvalidMigrationTransfer: { },
+            migrationSummary: { MigrationSummary.zero },
+            migrationTransfers: { [] },
+            proposeNoteSplitPCZT: { Pczt() },
+            proposeMigrationPCZTs: { _ in [] },
+            storeSignedMigrationTransactions: { _ in },
+            initializeMigrationPostUpgrade: { }
         )
     }
 }

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
@@ -77,7 +77,41 @@ extension SDKSynchronizerClient: TestDependencyKey {
         updateTransparentAddressTransactions: unimplemented("\(Self.self).updateTransparentAddressTransactions", placeholder: .notFound),
         fetchUTXOsByAddress: unimplemented("\(Self.self).fetchUTXOsByAddress", placeholder: .notFound),
         enhanceTransactionBy: unimplemented("\(Self.self).enhanceTransactionBy"),
-        getTreeState: unimplemented("\(Self.self).getTreeState", placeholder: Data())
+        getTreeState: unimplemented("\(Self.self).getTreeState", placeholder: Data()),
+        getMigrationState: unimplemented("\(Self.self).getMigrationState", placeholder: .notStarted),
+        migrationStateStream: unimplemented("\(Self.self).migrationStateStream", placeholder: Empty().eraseToAnyPublisher()),
+        getMigrationProgress: unimplemented("\(Self.self).getMigrationProgress", placeholder: nil),
+        isNoteSplitNeeded: unimplemented("\(Self.self).isNoteSplitNeeded", placeholder: false),
+        prepareNoteSplit: unimplemented(
+            "\(Self.self).prepareNoteSplit",
+            placeholder: NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero)
+        ),
+        submitNoteSplit: unimplemented("\(Self.self).submitNoteSplit", placeholder: .success(txId: "")),
+        selectMigrationMode: unimplemented("\(Self.self).selectMigrationMode", placeholder: {}()),
+        proposeMigrationTransfers: unimplemented(
+            "\(Self.self).proposeMigrationTransfers",
+            placeholder: MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+        ),
+        signAndStoreMigrationSchedule: unimplemented("\(Self.self).signAndStoreMigrationSchedule", placeholder: {}()),
+        isSyncRequiredBeforeNextMigrationTransfer: unimplemented(
+            "\(Self.self).isSyncRequiredBeforeNextMigrationTransfer",
+            placeholder: false
+        ),
+        executeNextPendingMigrationTransfer: unimplemented("\(Self.self).executeNextPendingMigrationTransfer", placeholder: nil),
+        hasOverdueMigrationTransfers: unimplemented("\(Self.self).hasOverdueMigrationTransfers", placeholder: false),
+        hasInvalidMigrationTransfers: unimplemented("\(Self.self).hasInvalidMigrationTransfers", placeholder: false),
+        restartCurrentMigrationStep: unimplemented(
+            "\(Self.self).restartCurrentMigrationStep",
+            placeholder: MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+        ),
+        rescheduleStalledMigrationTransfer: unimplemented("\(Self.self).rescheduleStalledMigrationTransfer", placeholder: {}()),
+        recreateInvalidMigrationTransfer: unimplemented("\(Self.self).recreateInvalidMigrationTransfer", placeholder: {}()),
+        migrationSummary: unimplemented("\(Self.self).migrationSummary", placeholder: .zero),
+        migrationTransfers: unimplemented("\(Self.self).migrationTransfers", placeholder: []),
+        proposeNoteSplitPCZT: unimplemented("\(Self.self).proposeNoteSplitPCZT", placeholder: Pczt()),
+        proposeMigrationPCZTs: unimplemented("\(Self.self).proposeMigrationPCZTs", placeholder: []),
+        storeSignedMigrationTransactions: unimplemented("\(Self.self).storeSignedMigrationTransactions", placeholder: {}()),
+        initializeMigrationPostUpgrade: unimplemented("\(Self.self).initializeMigrationPostUpgrade", placeholder: {}())
     )
 }
 
@@ -134,7 +168,29 @@ extension SDKSynchronizerClient {
         updateTransparentAddressTransactions: { _ in .notFound },
         fetchUTXOsByAddress: { _, _ in .notFound },
         enhanceTransactionBy: { _ in },
-        getTreeState: { _ in Data() }
+        getTreeState: { _ in Data() },
+        getMigrationState: { .notStarted },
+        migrationStateStream: { Empty().eraseToAnyPublisher() },
+        getMigrationProgress: { nil },
+        isNoteSplitNeeded: { false },
+        prepareNoteSplit: { NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero) },
+        submitNoteSplit: { _ in TransferResult.success(txId: "") },
+        selectMigrationMode: { _ in },
+        proposeMigrationTransfers: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },
+        signAndStoreMigrationSchedule: { _ in },
+        isSyncRequiredBeforeNextMigrationTransfer: { false },
+        executeNextPendingMigrationTransfer: { _ in nil },
+        hasOverdueMigrationTransfers: { false },
+        hasInvalidMigrationTransfers: { false },
+        restartCurrentMigrationStep: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },
+        rescheduleStalledMigrationTransfer: { },
+        recreateInvalidMigrationTransfer: { },
+        migrationSummary: { MigrationSummary.zero },
+        migrationTransfers: { [] },
+        proposeNoteSplitPCZT: { Pczt() },
+        proposeMigrationPCZTs: { _ in [] },
+        storeSignedMigrationTransactions: { _ in },
+        initializeMigrationPostUpgrade: { }
     )
 
     static let mock = Self.mocked()
@@ -314,7 +370,31 @@ extension SDKSynchronizerClient {
             updateTransparentAddressTransactions: updateTransparentAddressTransactions,
             fetchUTXOsByAddress: fetchUTXOsByAddress,
             enhanceTransactionBy: enhanceTransactionBy,
-            getTreeState: getTreeState
+            getTreeState: getTreeState,
+            // Migration (Orchard → Ironwood) — inert values; customize via the interface when a
+            // preview/test needs real migration behavior.
+            getMigrationState: { .notStarted },
+            migrationStateStream: { Empty().eraseToAnyPublisher() },
+            getMigrationProgress: { nil },
+            isNoteSplitNeeded: { false },
+            prepareNoteSplit: { NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero) },
+            submitNoteSplit: { _ in TransferResult.success(txId: "") },
+            selectMigrationMode: { _ in },
+            proposeMigrationTransfers: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },
+            signAndStoreMigrationSchedule: { _ in },
+            isSyncRequiredBeforeNextMigrationTransfer: { false },
+            executeNextPendingMigrationTransfer: { _ in nil },
+            hasOverdueMigrationTransfers: { false },
+            hasInvalidMigrationTransfers: { false },
+            restartCurrentMigrationStep: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },
+            rescheduleStalledMigrationTransfer: { },
+            recreateInvalidMigrationTransfer: { },
+            migrationSummary: { MigrationSummary.zero },
+            migrationTransfers: { [] },
+            proposeNoteSplitPCZT: { Pczt() },
+            proposeMigrationPCZTs: { _ in [] },
+            storeSignedMigrationTransactions: { _ in },
+            initializeMigrationPostUpgrade: { }
         )
     }
 }

--- a/secant/Sources/Models/Migration/MigrationModels.swift
+++ b/secant/Sources/Models/Migration/MigrationModels.swift
@@ -95,6 +95,15 @@ struct MigrationProgress: Equatable, Sendable, Codable {
 /// Aggregate summary of the migration for progress UI. Not part of the Kotlin draft.
 /// [ext]
 struct MigrationSummary: Equatable, Sendable, Codable {
+    /// All-zero convenience value, e.g. before any migration data has loaded.
+    static let zero = MigrationSummary(
+        transferred: Zatoshi.zero,
+        dust: Zatoshi.zero,
+        transfersSent: 0,
+        transfersTotal: 0,
+        estimatedDurationHours: 0
+    )
+
     var transferred: Zatoshi
     var dust: Zatoshi
     var transfersSent: Int
@@ -114,15 +123,6 @@ struct MigrationSummary: Equatable, Sendable, Codable {
         self.transfersTotal = transfersTotal
         self.estimatedDurationHours = estimatedDurationHours
     }
-
-    /// All-zero convenience value, e.g. before any migration data has loaded.
-    static let zero = MigrationSummary(
-        transferred: Zatoshi.zero,
-        dust: Zatoshi.zero,
-        transfersSent: 0,
-        transfersTotal: 0,
-        estimatedDurationHours: 0
-    )
 }
 
 /// A single row in the migration transfers list UI. Not part of the Kotlin draft.

--- a/secant/Sources/Models/Migration/MigrationModels.swift
+++ b/secant/Sources/Models/Migration/MigrationModels.swift
@@ -1,0 +1,194 @@
+//
+//  MigrationModels.swift
+//  Zashi
+//
+//  Value models for the Orchard -> Ironwood migration (MOB-1459). All types are
+//  `Equatable, Sendable, Codable` since they will be persisted via `@Shared(.appStorage)`
+//  later. Each type's doc comment maps it to its `MigrationSdk.kt` counterpart and carries a
+//  `[draft]` (Kotlin draft 1:1) or `[ext]` (proposed SDK extension) marker.
+//
+
+@preconcurrency import ZcashLightClientKit
+
+/// Network/privacy configuration for migration transfer submission.
+/// Kotlin: `NetworkPrivacyOptions` — [draft]
+struct NetworkPrivacyOptions: Equatable, Sendable, Codable {
+    var useTor: Bool
+    /// `nil` = same LWD server as sync.
+    var submissionEndpoint: String?
+
+    init(useTor: Bool, submissionEndpoint: String?) {
+        self.useTor = useTor
+        self.submissionEndpoint = submissionEndpoint
+    }
+}
+
+/// Proposal to split existing Orchard notes so migration transfers have suitable note sizes.
+/// Kotlin: `NoteSplitProposal` — [draft]
+struct NoteSplitProposal: Equatable, Sendable, Codable {
+    var outputNotes: [Zatoshi]
+    var fee: Zatoshi
+
+    init(outputNotes: [Zatoshi], fee: Zatoshi) {
+        self.outputNotes = outputNotes
+        self.fee = fee
+    }
+}
+
+/// A single scheduled migration transfer.
+/// Kotlin: `TransferProposal` — [draft]
+struct TransferProposal: Equatable, Sendable, Codable, Identifiable {
+    var id: String
+    var amount: Zatoshi
+    var anchorHeight: BlockHeight
+    var nextExecutableAfterHeight: BlockHeight
+    var expiryHeight: BlockHeight
+
+    init(
+        id: String,
+        amount: Zatoshi,
+        anchorHeight: BlockHeight,
+        nextExecutableAfterHeight: BlockHeight,
+        expiryHeight: BlockHeight
+    ) {
+        self.id = id
+        self.amount = amount
+        self.anchorHeight = anchorHeight
+        self.nextExecutableAfterHeight = nextExecutableAfterHeight
+        self.expiryHeight = expiryHeight
+    }
+}
+
+/// The full set of proposed migration transfers plus a duration estimate.
+/// Kotlin: `MigrationSchedule` — [draft]
+struct MigrationSchedule: Equatable, Sendable, Codable {
+    var transfers: [TransferProposal]
+    var estimatedDurationHours: Int
+
+    init(transfers: [TransferProposal], estimatedDurationHours: Int) {
+        self.transfers = transfers
+        self.estimatedDurationHours = estimatedDurationHours
+    }
+}
+
+/// Snapshot of in-progress migration execution.
+/// Kotlin: `MigrationProgress` — [draft]
+struct MigrationProgress: Equatable, Sendable, Codable {
+    var completedTransfers: Int
+    var totalTransfers: Int
+    var remainingOrchard: Zatoshi
+    var nextTransferReadyAtHeight: BlockHeight?
+
+    init(
+        completedTransfers: Int,
+        totalTransfers: Int,
+        remainingOrchard: Zatoshi,
+        nextTransferReadyAtHeight: BlockHeight?
+    ) {
+        self.completedTransfers = completedTransfers
+        self.totalTransfers = totalTransfers
+        self.remainingOrchard = remainingOrchard
+        self.nextTransferReadyAtHeight = nextTransferReadyAtHeight
+    }
+}
+
+/// Aggregate summary of the migration for progress UI. Not part of the Kotlin draft.
+/// [ext]
+struct MigrationSummary: Equatable, Sendable, Codable {
+    var transferred: Zatoshi
+    var dust: Zatoshi
+    var transfersSent: Int
+    var transfersTotal: Int
+    var estimatedDurationHours: Int
+
+    init(
+        transferred: Zatoshi,
+        dust: Zatoshi,
+        transfersSent: Int,
+        transfersTotal: Int,
+        estimatedDurationHours: Int
+    ) {
+        self.transferred = transferred
+        self.dust = dust
+        self.transfersSent = transfersSent
+        self.transfersTotal = transfersTotal
+        self.estimatedDurationHours = estimatedDurationHours
+    }
+
+    /// All-zero convenience value, e.g. before any migration data has loaded.
+    static let zero = MigrationSummary(
+        transferred: Zatoshi.zero,
+        dust: Zatoshi.zero,
+        transfersSent: 0,
+        transfersTotal: 0,
+        estimatedDurationHours: 0
+    )
+}
+
+/// A single row in the migration transfers list UI. Not part of the Kotlin draft.
+/// [ext]
+struct MigrationTransferRow: Equatable, Sendable, Codable, Identifiable {
+    enum Status: Equatable, Sendable, Codable {
+        case sent
+        case active
+        case overdue
+        case pending
+        case invalid
+        case expired
+    }
+
+    var id: String
+    /// 0-based position in the schedule.
+    var index: Int
+    var amount: Zatoshi
+    var status: Status
+    /// 0 = ready now; meaningful for pending rows.
+    var hoursFromNow: Int
+
+    init(id: String, index: Int, amount: Zatoshi, status: Status, hoursFromNow: Int) {
+        self.id = id
+        self.index = index
+        self.amount = amount
+        self.status = status
+        self.hoursFromNow = hoursFromNow
+    }
+}
+
+/// Reasons the migration flow needs the user's attention.
+enum AttentionReason: Equatable, Sendable, Codable {
+    /// Kotlin: `AttentionReason.InvalidTransfer` — [draft]
+    case invalidTransfer(transferId: String)
+    /// Kotlin: `AttentionReason.TransferExpired` — [draft]
+    case transferExpired
+    /// Kotlin: `AttentionReason.SyncRequiredBeforeNext` — [draft]
+    case syncRequiredBeforeNext
+    /// 1-based. Not part of the Kotlin draft. [ext]
+    case transferStalled(transferNumber: Int)
+}
+
+/// Overall migration state machine.
+/// Kotlin: `MigrationState` — [draft]
+enum MigrationState: Equatable, Sendable, Codable {
+    case notStarted
+    case splitPendingConfirmation
+    case readyToPropose
+    case inProgress(MigrationProgress)
+    case requiresAttention(AttentionReason)
+    case complete
+}
+
+/// Outcome of submitting a single migration transfer (or note split).
+/// Kotlin: `TransferResult` — [draft]
+enum TransferResult: Equatable, Sendable, Codable {
+    case success(txId: String)
+    case networkError(retryable: Bool)
+    case invalidNote
+    case expired
+}
+
+/// User's chosen migration privacy/timing mode. Not part of the Kotlin draft.
+/// [ext]
+enum MigrationMode: String, Equatable, Sendable, Codable {
+    case immediate
+    case privateScheduled
+}

--- a/zodlTests/MigrationTests/MigrationModelsTests.swift
+++ b/zodlTests/MigrationTests/MigrationModelsTests.swift
@@ -1,0 +1,158 @@
+//
+//  MigrationModelsTests.swift
+//  zodlTests
+//
+//  Covers Codable round-trips and basic invariants for the Orchard -> Ironwood migration
+//  value models (Models/Migration/MigrationModels.swift). No shared/global state -> no
+//  `.serialized`.
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationModelsTests {
+    @Test func migrationModeCodableRoundTrip() throws {
+        for mode in [MigrationMode.immediate, MigrationMode.privateScheduled] {
+            let data = try JSONEncoder().encode(mode)
+            #expect(try JSONDecoder().decode(MigrationMode.self, from: data) == mode)
+        }
+    }
+
+    @Test func networkPrivacyOptionsCodableRoundTripWithNilEndpoint() throws {
+        let original = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(NetworkPrivacyOptions.self, from: data) == original)
+    }
+
+    @Test func networkPrivacyOptionsCodableRoundTripWithNonNilEndpoint() throws {
+        let original = NetworkPrivacyOptions(useTor: false, submissionEndpoint: "https://example.com:9067")
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(NetworkPrivacyOptions.self, from: data) == original)
+    }
+
+    @Test func transferResultCodableRoundTripAllCases() throws {
+        let cases: [TransferResult] = [
+            TransferResult.success(txId: "abc123"),
+            TransferResult.networkError(retryable: true),
+            TransferResult.invalidNote,
+            TransferResult.expired
+        ]
+
+        for original in cases {
+            let data = try JSONEncoder().encode(original)
+            #expect(try JSONDecoder().decode(TransferResult.self, from: data) == original)
+        }
+    }
+
+    @Test func attentionReasonCodableRoundTripAllCases() throws {
+        let cases: [AttentionReason] = [
+            AttentionReason.invalidTransfer(transferId: "transfer-1"),
+            AttentionReason.transferExpired,
+            AttentionReason.syncRequiredBeforeNext,
+            AttentionReason.transferStalled(transferNumber: 3)
+        ]
+
+        for original in cases {
+            let data = try JSONEncoder().encode(original)
+            #expect(try JSONDecoder().decode(AttentionReason.self, from: data) == original)
+        }
+    }
+
+    @Test func migrationStateCodableRoundTripAllCases() throws {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 123_456
+        )
+
+        let cases: [MigrationState] = [
+            MigrationState.notStarted,
+            MigrationState.splitPendingConfirmation,
+            MigrationState.readyToPropose,
+            MigrationState.inProgress(progress),
+            MigrationState.requiresAttention(AttentionReason.transferExpired),
+            MigrationState.complete
+        ]
+
+        for original in cases {
+            let data = try JSONEncoder().encode(original)
+            #expect(try JSONDecoder().decode(MigrationState.self, from: data) == original)
+        }
+    }
+
+    @Test func migrationScheduleCodableRoundTripWithNonTrivialTransferGraph() throws {
+        let transfers = [
+            TransferProposal(
+                id: "transfer-1",
+                amount: Zatoshi(500),
+                anchorHeight: 100,
+                nextExecutableAfterHeight: 110,
+                expiryHeight: 200
+            ),
+            TransferProposal(
+                id: "transfer-2",
+                amount: Zatoshi(1_500),
+                anchorHeight: 110,
+                nextExecutableAfterHeight: 220,
+                expiryHeight: 310
+            ),
+            TransferProposal(
+                id: "transfer-3",
+                amount: Zatoshi(2_500),
+                anchorHeight: 220,
+                nextExecutableAfterHeight: 330,
+                expiryHeight: 420
+            )
+        ]
+        let original = MigrationSchedule(transfers: transfers, estimatedDurationHours: 72)
+
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(MigrationSchedule.self, from: data) == original)
+    }
+
+    @Test func migrationTransferRowCodableRoundTripEachStatus() throws {
+        let statuses: [MigrationTransferRow.Status] = [
+            MigrationTransferRow.Status.sent,
+            MigrationTransferRow.Status.active,
+            MigrationTransferRow.Status.overdue,
+            MigrationTransferRow.Status.pending,
+            MigrationTransferRow.Status.invalid,
+            MigrationTransferRow.Status.expired
+        ]
+
+        for (index, status) in statuses.enumerated() {
+            let original = MigrationTransferRow(
+                id: "row-\(index)",
+                index: index,
+                amount: Zatoshi(Int64(100 * (index + 1))),
+                status: status,
+                hoursFromNow: index
+            )
+            let data = try JSONEncoder().encode(original)
+            #expect(try JSONDecoder().decode(MigrationTransferRow.self, from: data) == original)
+        }
+    }
+
+    @Test func migrationSummaryZeroIsAllZero() {
+        let zero = MigrationSummary.zero
+        #expect(zero.transferred == Zatoshi.zero)
+        #expect(zero.dust == Zatoshi.zero)
+        #expect(zero.transfersSent == 0)
+        #expect(zero.transfersTotal == 0)
+        #expect(zero.estimatedDurationHours == 0)
+    }
+
+    @Test func transferProposalIdDrivesIdentifiable() {
+        let proposal = TransferProposal(
+            id: "transfer-42",
+            amount: Zatoshi(999),
+            anchorHeight: 10,
+            nextExecutableAfterHeight: 20,
+            expiryHeight: 30
+        )
+        #expect(proposal.id == "transfer-42")
+    }
+}

--- a/zodlTests/MigrationTests/MigrationSDKStubTests.swift
+++ b/zodlTests/MigrationTests/MigrationSDKStubTests.swift
@@ -1,0 +1,61 @@
+//
+//  MigrationSDKStubTests.swift
+//  zodlTests
+//
+//  Covers the inert "does nothing yet" contract of the stubbed migration members on
+//  SDKSynchronizerClient (Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift). No
+//  shared/global state -> no `.serialized`.
+//
+//  Deliberately NOT testing `liveValue`/`live()` — constructing the live client builds the
+//  real synchronizer stack; unit tests never touch `liveValue` (TCA convention). The stub's
+//  "never calls the SDK" property is enforced by review + the fact the SDK API doesn't exist
+//  to call.
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct MigrationSDKStubTests {
+    @Test func noOpMigrationEndpointsAreInert() async {
+        let client = SDKSynchronizerClient.noOp
+
+        #expect(client.getMigrationState() == .notStarted)
+        #expect(client.isNoteSplitNeeded() == false)
+        #expect(client.hasOverdueMigrationTransfers() == false)
+        #expect(client.hasInvalidMigrationTransfers() == false)
+        #expect(client.getMigrationProgress() == nil)
+
+        let executedTransfer = await client.executeNextPendingMigrationTransfer(
+            NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        )
+        #expect(executedTransfer == nil)
+
+        let schedule = await client.proposeMigrationTransfers()
+        #expect(schedule.transfers.isEmpty)
+
+        #expect(client.migrationSummary() == MigrationSummary.zero)
+        #expect(client.migrationTransfers().isEmpty)
+
+        let pczts = await client.proposeMigrationPCZTs(
+            MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+        )
+        #expect(pczts.isEmpty)
+    }
+
+    @Test func mockedMigrationEndpointsAreInert() async {
+        // `mocked()` is the construction previews/tests reach for — its migration endpoints
+        // must stay inert until the real SDK API exists. (A bare `SDKSynchronizerClient()` is
+        // not constructible: the macro's memberwise init requires the non-defaulted `let`
+        // members, so the interface defaults are not independently instantiable.)
+        let client = SDKSynchronizerClient.mocked()
+
+        #expect(client.getMigrationState() == .notStarted)
+        #expect(client.isNoteSplitNeeded() == false)
+
+        let executedTransfer = await client.executeNextPendingMigrationTransfer(
+            NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        )
+        #expect(executedTransfer == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Groundwork for the Orchard → Ironwood migration ([MOB-1459](https://linear.app/zodl/issue/MOB-1459)): the value models and the expected SDK migration API as **stubbed closures on the existing `SDKSynchronizerClient`** — nothing calls the real SDK (it doesn't exist yet, see MOB-1455), and nothing in the app consumes these members yet.

Stacked PR: targets the feature umbrella branch `michal/MOB-1458-ironwood-support-feature`.

## What's inside

- **`secant/Sources/Models/Migration/MigrationModels.swift`** — 11 value types mirroring the `MigrationSdk.kt` draft (state machine, note-split proposal, schedule, progress, transfer rows, summary, mode), all `Equatable/Sendable/Codable`, each doc-commented with its `[draft]`/`[ext]` marker.
- **`SDKSynchronizerClient`** — 23 migration members appended in a dedicated MARK block. Names are qualified for the client's flat namespace (`migrationStateStream`, `executeNextPendingMigrationTransfer`, …) with the Kotlin originals recorded in doc comments.
  - `live()`: explicit inert stubs with a STUB comment — when the real SDK lands, broadcast-capable closures must acquire the transaction guard inside this LiveKey (same pattern as `createAndSubmitProposedTransactions`).
  - `testValue`: `unimplemented(...)` entries so TestStore reports un-overridden migration calls.
  - `noOp` + `mocked()`: inert entries.
- **Tests** (`zodlTests/MigrationTests/`, Swift Testing): Codable round-trips for every enum case + model invariants; inert-contract checks for `noOp`/`mocked()`.
- `CHANGELOG.md` entry under Unreleased.

## Notes for review

- `isMigrationCompleteAcknowledged`/`acknowledgeMigrationComplete` from the feature spec are deliberately absent — app-owned, arriving with MOB-1466.
- A bare `SDKSynchronizerClient()` is not constructible (the macro's memberwise init requires the non-defaulted `let` members), so the stub tests assert on `noOp`/`mocked()` instead; `liveValue` is untouched by tests per TCA convention.

## Verification

- `xcodebuild test` on `zodl-internal` (`-skipMacroValidation`, iPhone 17 Pro sim): **both new suites pass** (`MigrationModelsTests`, `MigrationSDKStubTests`), app + test targets compile.
- All added lines ≤ 150 chars; diff confined to the 7 files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)