### PR TITLE
[MOB-1460] Ironwood migration screens: Entry + Network Privacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Added
 - [MOB-1459] Groundwork for the Orchard → Ironwood migration: data models and the stubbed migration SDK interface. No user-visible changes yet.
+- [MOB-1460] Ironwood migration screens: entry (mode choice) and network privacy (Tor opt-in). Not reachable in the app yet.
 
 ## 3.7.2 build 1
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -18685,6 +18685,397 @@
           }
         }
       }
+    },
+    "migrationEntry.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move to Ironwood"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrar a Ironwood"
+          }
+        }
+      }
+    },
+    "migrationEntry.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The latest Zcash network upgrade requires moving your %1$@ (%2$@) from the Orchard pool to the new Ironwood pool. Your funds are safe."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La última actualización de la red Zcash requiere mover tus %1$@ (%2$@) del pool Orchard al nuevo pool Ironwood. Tus fondos están seguros."
+          }
+        }
+      }
+    },
+    "migrationEntry.descNoFiat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The latest Zcash network upgrade requires moving your %1$@ from the Orchard pool to the new Ironwood pool. Your funds are safe."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La última actualización de la red Zcash requiere mover tus %1$@ del pool Orchard al nuevo pool Ironwood. Tus fondos están seguros."
+          }
+        }
+      }
+    },
+    "migrationEntry.findOutMore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find out more"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más información"
+          }
+        }
+      }
+    },
+    "migrationEntry.privacyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate with Privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrar con privacidad"
+          }
+        }
+      }
+    },
+    "migrationEntry.privacyDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Split transfers over time · Scheduled in background · Maximum privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias divididas en el tiempo · Programadas en segundo plano · Máxima privacidad"
+          }
+        }
+      }
+    },
+    "migrationEntry.immediateTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Immediately"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrar inmediatamente"
+          }
+        }
+      }
+    },
+    "migrationEntry.immediateDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single transfer · Sends now · Less privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia única · Se envía ahora · Menos privacidad"
+          }
+        }
+      }
+    },
+    "migrationEntry.disclaimerTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy Disclaimer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso de privacidad"
+          }
+        }
+      }
+    },
+    "migrationEntry.disclaimerDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your full balance will be revealed on-chain — crossing the pool boundary exposes the transaction amount. We recommend selecting Migrate with Privacy instead."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo completo quedará expuesto en cadena (on-chain): cruzar el límite entre pools revela el monto de la transacción. Te recomendamos seleccionar Migrar con privacidad."
+          }
+        }
+      }
+    },
+    "migrationEntry.footerNote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pool-crossing transfer amounts are visible on-chain."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los montos de las transferencias entre pools son visibles en cadena (on-chain)."
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network Privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidad de red"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Tor to route this transfer privately through the Tor network. This prevents your IP address from being linked to the transfer."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activa Tor para enrutar esta transferencia de forma privada a través de la red Tor. Esto evita que tu dirección IP quede vinculada a la transferencia."
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.vpnNote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can use a trusted VPN if Tor is unavailable in your region."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes usar una VPN confiable si Tor no está disponible en tu región."
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.whatNext" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What Happens Next"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qué sucede a continuación"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withTorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "With Tor"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Con Tor"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withTorImmediate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP hidden · Transfer unlinkable to your device"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP oculta · Transferencia no vinculable a tu dispositivo"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withTorScheduled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP hidden · All %1$lld transfers unlinkable to your device"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP oculta · Las %1$lld transferencias no son vinculables a tu dispositivo"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withoutTorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Without Tor or VPN"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin Tor ni VPN"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withoutTorImmediate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP visible to network operators"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP visible para los operadores de red"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withoutTorScheduled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers still de-correlated in time · IP visible to network operators"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transferencias siguen desvinculadas en el tiempo · IP visible para los operadores de red"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.toggleTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route via Tor"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enrutar mediante Tor"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.toggleDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Tor for transaction submission."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa Tor para el envío de transacciones."
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
@@ -1,0 +1,71 @@
+//
+//  MigrationEntryStore.swift
+//  zodl
+//
+//  "Move to Ironwood" entry screen (MOB-1460, Figma S1 · 2867:10445 / 2867:5641 / 2867:5731). Lets
+//  the user pick between migrating with privacy (scheduled, split transfers) or immediately (single
+//  transfer, less privacy). The delegate is emitted but consumed by nobody yet — chaining into the
+//  rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationEntry {
+    @ObservableState
+    struct State: Equatable {
+        var selectedMode = MigrationMode.privateScheduled
+        /// Placeholder; real balance data lands in MOB-1466.
+        var orchardBalance = Zatoshi.zero
+        /// e.g. `"$4,832.86"`; `nil` omits the parenthesized fiat amount.
+        var fiatText: String?
+
+        var isDisclaimerVisible: Bool {
+            selectedMode == .immediate
+        }
+
+        init(
+            selectedMode: MigrationMode = .privateScheduled,
+            orchardBalance: Zatoshi = Zatoshi.zero,
+            fiatText: String? = nil
+        ) {
+            self.selectedMode = selectedMode
+            self.orchardBalance = orchardBalance
+            self.fiatText = fiatText
+        }
+    }
+
+    enum Action: Equatable {
+        case delegate(Delegate)
+        /// Inert for now; the "Find out more" destination (O-7) is undecided.
+        case findOutMoreTapped
+        case modeTapped(MigrationMode)
+        case nextTapped
+
+        enum Delegate: Equatable {
+            case chose(MigrationMode)
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .delegate:
+                return .none
+
+            case .findOutMoreTapped:
+                return .none
+
+            case .modeTapped(let mode):
+                state.selectedMode = mode
+                return .none
+
+            case .nextTapped:
+                return .send(.delegate(.chose(state.selectedMode)))
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
@@ -1,0 +1,256 @@
+//
+//  MigrationEntryView.swift
+//  zodl
+//
+//  "Move to Ironwood" entry screen (MOB-1460, Figma S1 · 2867:10445 privacy selected /
+//  2867:5641 + 2867:5731 immediate selected). Visually complete per Figma; the delegate emitted by
+//  `nextTapped` is consumed by nobody yet — chaining into the rest of the migration flow lands in
+//  MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationEntryView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationEntry>
+
+    init(store: StoreOf<MigrationEntry>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        MigrationPairedIcons()
+                            .padding(.bottom, 16)
+
+                        Text(localizable: .migrationEntryTitle)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        description
+                            .padding(.bottom, 12)
+
+                        Button {
+                            store.send(.findOutMoreTapped)
+                        } label: {
+                            Text(localizable: .migrationEntryFindOutMore)
+                                .zFont(.medium, size: 14, style: Design.Text.primary)
+                                .underline()
+                        }
+                        .padding(.bottom, 24)
+
+                        optionCards
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                if store.isDisclaimerVisible {
+                    disclaimer
+                        .padding(.top, 16)
+                }
+
+                footerNote
+                    .padding(.top, 16)
+
+                ZashiButton(String(localizable: .generalNext)) {
+                    store.send(.nextTapped)
+                }
+                .padding(.top, 16)
+                .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Description
+
+    @ViewBuilder private var description: some View {
+        let amountText = "\(store.orchardBalance.decimalString()) ZEC"
+
+        if let fiatText = store.fiatText {
+            let markdown = String(localizable: .migrationEntryDesc(
+                "^[\(amountText)](style: 'boldPrimary')",
+                fiatText
+            ))
+
+            if let attrText = try? AttributedString(markdown: markdown, including: \.zashiApp) {
+                ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } else {
+            let markdown = String(localizable: .migrationEntryDescNoFiat(
+                "^[\(amountText)](style: 'boldPrimary')"
+            ))
+
+            if let attrText = try? AttributedString(markdown: markdown, including: \.zashiApp) {
+                ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    // MARK: - Option cards
+
+    @ViewBuilder private var optionCards: some View {
+        VStack(spacing: 12) {
+            optionCard(
+                mode: .privateScheduled,
+                title: String(localizable: .migrationEntryPrivacyTitle),
+                subtitle: String(localizable: .migrationEntryPrivacyDesc)
+            )
+
+            optionCard(
+                mode: .immediate,
+                title: String(localizable: .migrationEntryImmediateTitle),
+                subtitle: String(localizable: .migrationEntryImmediateDesc)
+            )
+        }
+    }
+
+    @ViewBuilder private func optionCard(mode: MigrationMode, title: String, subtitle: String) -> some View {
+        let isSelected = store.selectedMode == mode
+        let isWarning = isSelected && mode == .immediate
+
+        Button {
+            store.send(.modeTapped(mode))
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                radioIndicator(isSelected: isSelected, isWarning: isWarning)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .zFont(.semiBold, size: 16, style: isWarning ? Design.Utility.WarningYellow._600 : Design.Text.primary)
+
+                    Text(subtitle)
+                        .zFont(size: 14, style: Design.Text.tertiary)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+            .background {
+                RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                    .fill(isSelected ? Design.Surfaces.bgPrimary.color(colorScheme) : Design.Surfaces.bgSecondary.color(colorScheme))
+                    .overlay {
+                        if isSelected {
+                            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                                .stroke(
+                                    isWarning ? Design.Utility.WarningYellow._500.color(colorScheme) : Design.Checkboxes.onBg.color(colorScheme),
+                                    lineWidth: 2
+                                )
+                        }
+                    }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder private func radioIndicator(isSelected: Bool, isWarning: Bool) -> some View {
+        ZStack {
+            Circle()
+                .fill(
+                    isSelected
+                        ? (isWarning ? Design.Utility.WarningYellow._500.color(colorScheme) : Design.Checkboxes.onBg.color(colorScheme))
+                        : Design.Checkboxes.offBg.color(colorScheme)
+                )
+                .overlay {
+                    if !isSelected {
+                        Circle()
+                            .stroke(Design.Checkboxes.offStroke.color(colorScheme))
+                    }
+                }
+
+            if isSelected {
+                Circle()
+                    .fill(isWarning ? .white : Design.Checkboxes.onFg.color(colorScheme))
+                    .frame(width: 8, height: 8)
+            }
+        }
+        .frame(width: 20, height: 20)
+    }
+
+    // MARK: - Disclaimer
+
+    @ViewBuilder private var disclaimer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 0) {
+                Text(localizable: .migrationEntryDisclaimerTitle)
+                    .zFont(.medium, size: 14, style: Design.Utility.WarningYellow._600)
+
+                Spacer()
+
+                Asset.Assets.infoOutline.image
+                    .zImage(size: 16, style: Design.Utility.WarningYellow._500)
+            }
+
+            Text(localizable: .migrationEntryDisclaimerDesc)
+                .zFont(size: 12, style: Design.Utility.WarningYellow._700)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .fill(Design.Utility.WarningYellow._50.color(colorScheme))
+        }
+    }
+
+    // MARK: - Footer note
+
+    @ViewBuilder private var footerNote: some View {
+        HStack(spacing: 8) {
+            Asset.Assets.infoOutline.image
+                .zImage(size: 16, style: Design.Text.tertiary)
+
+            Text(localizable: .migrationEntryFooterNote)
+                .zFont(size: 12, style: Design.Text.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Privacy selected") {
+    NavigationView {
+        MigrationEntryView(
+            store: StoreOf<MigrationEntry>(
+                initialState: MigrationEntry.State(
+                    selectedMode: .privateScheduled,
+                    orchardBalance: Zatoshi(1_245_800_000),
+                    fiatText: "$4,832.86"
+                )
+            ) {
+                MigrationEntry()
+            }
+        )
+    }
+}
+
+#Preview("Immediate selected") {
+    NavigationView {
+        MigrationEntryView(
+            store: StoreOf<MigrationEntry>(
+                initialState: MigrationEntry.State(
+                    selectedMode: .immediate,
+                    orchardBalance: Zatoshi(1_245_800_000),
+                    fiatText: "$4,832.86"
+                )
+            ) {
+                MigrationEntry()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift
@@ -1,0 +1,62 @@
+//
+//  MigrationNetworkPrivacyStore.swift
+//  zodl
+//
+//  "Network Privacy" screen (MOB-1460, Figma S5 · 2867:5801 immediate / 2867:10835 scheduled).
+//  Lets the user opt in to routing migration transfer submission via Tor. The delegate is emitted
+//  but consumed by nobody yet — chaining into the rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct MigrationNetworkPrivacy {
+    @ObservableState
+    struct State: Equatable {
+        enum Variant: Equatable {
+            case immediate
+            case scheduled(transferCount: Int)
+        }
+
+        var variant = Variant.scheduled(transferCount: 5)
+        /// No pre-selection bias, per product rule.
+        var isTorOn = false
+
+        init(
+            variant: Variant = .scheduled(transferCount: 5),
+            isTorOn: Bool = false
+        ) {
+            self.variant = variant
+            self.isTorOn = isTorOn
+        }
+    }
+
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        case delegate(Delegate)
+        case nextTapped
+
+        enum Delegate: Equatable {
+            case confirmed(NetworkPrivacyOptions)
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+
+            case .delegate:
+                return .none
+
+            case .nextTapped:
+                return .send(.delegate(.confirmed(NetworkPrivacyOptions(useTor: state.isTorOn, submissionEndpoint: nil))))
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyView.swift
+++ b/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyView.swift
@@ -1,0 +1,191 @@
+//
+//  MigrationNetworkPrivacyView.swift
+//  zodl
+//
+//  "Network Privacy" screen (MOB-1460, Figma S5 · 2867:5801 immediate / 2867:10835 scheduled).
+//  Visually complete per Figma; the delegate emitted by `nextTapped` is consumed by nobody yet —
+//  chaining into the rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct MigrationNetworkPrivacyView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationNetworkPrivacy>
+
+    init(store: StoreOf<MigrationNetworkPrivacy>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        torBadge
+                            .padding(.bottom, 16)
+
+                        Text(localizable: .migrationNetworkPrivacyTitle)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(localizable: .migrationNetworkPrivacyDesc)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 12)
+
+                        Text(localizable: .migrationNetworkPrivacyVpnNote)
+                            .zFont(size: 12, style: Design.Text.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        Text(localizable: .migrationNetworkPrivacyWhatNext)
+                            .zFont(.semiBold, size: 16, style: Design.Text.primary)
+                            .padding(.bottom, 12)
+
+                        outcomeRows
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                Spacer(minLength: 16)
+
+                toggleCard
+                    .padding(.bottom, 16)
+
+                ZashiButton(String(localizable: .generalNext)) {
+                    store.send(.nextTapped)
+                }
+                .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Tor badge
+
+    @ViewBuilder private var torBadge: some View {
+        Circle()
+            .fill(Design.Surfaces.bgAlt.color(colorScheme))
+            .frame(width: 48, height: 48)
+            .overlay {
+                Asset.Assets.Partners.torLogo.image
+                    .zImage(width: 28, height: 19, color: .white)
+            }
+    }
+
+    // MARK: - Outcome rows
+
+    @ViewBuilder private var outcomeRows: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            outcomeRow(
+                icon: Asset.Assets.Icons.shieldTick.image,
+                title: String(localizable: .migrationNetworkPrivacyWithTorTitle),
+                caption: withTorCaption
+            )
+
+            outcomeRow(
+                icon: Asset.Assets.Icons.shieldOff.image,
+                title: String(localizable: .migrationNetworkPrivacyWithoutTorTitle),
+                caption: withoutTorCaption
+            )
+        }
+    }
+
+    private var withTorCaption: String {
+        switch store.variant {
+        case .immediate:
+            return String(localizable: .migrationNetworkPrivacyWithTorImmediate)
+        case .scheduled(let transferCount):
+            return String(localizable: .migrationNetworkPrivacyWithTorScheduled(transferCount))
+        }
+    }
+
+    private var withoutTorCaption: String {
+        switch store.variant {
+        case .immediate:
+            return String(localizable: .migrationNetworkPrivacyWithoutTorImmediate)
+        case .scheduled:
+            return String(localizable: .migrationNetworkPrivacyWithoutTorScheduled)
+        }
+    }
+
+    @ViewBuilder private func outcomeRow(icon: Image, title: String, caption: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            icon
+                .zImage(size: 20, style: Design.Text.primary)
+                .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .zFont(.medium, size: 14, style: Design.Text.primary)
+
+                Text(caption)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Toggle card
+
+    @ViewBuilder private var toggleCard: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(localizable: .migrationNetworkPrivacyToggleTitle)
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                Text(localizable: .migrationNetworkPrivacyToggleDesc)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            Toggle("", isOn: $store.isTorOn)
+                .labelsHidden()
+        }
+        .padding(20)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .fill(Design.Surfaces.bgPrimary.color(colorScheme))
+                .overlay {
+                    RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                        .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+                }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Immediate") {
+    NavigationView {
+        MigrationNetworkPrivacyView(
+            store: StoreOf<MigrationNetworkPrivacy>(
+                initialState: MigrationNetworkPrivacy.State(variant: .immediate)
+            ) {
+                MigrationNetworkPrivacy()
+            }
+        )
+    }
+}
+
+#Preview("Scheduled") {
+    NavigationView {
+        MigrationNetworkPrivacyView(
+            store: StoreOf<MigrationNetworkPrivacy>(
+                initialState: MigrationNetworkPrivacy.State(variant: .scheduled(transferCount: 5), isTorOn: true)
+            ) {
+                MigrationNetworkPrivacy()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationPairedIcons.swift
+++ b/secant/Sources/Features/Migration/MigrationPairedIcons.swift
@@ -1,0 +1,45 @@
+//
+//  MigrationPairedIcons.swift
+//  zodl
+//
+//  Shared header view for migration screens (MOB-1460): the ZODL account badge overlapped by a
+//  circular Ironwood ("coins-swap") mark. Used by MigrationEntry now and reused by later migration
+//  screens.
+//
+
+import SwiftUI
+
+struct MigrationPairedIcons: View {
+    @Environment(\.colorScheme) private var colorScheme
+    var size: CGFloat = 48
+
+    var body: some View {
+        HStack(spacing: -(size * 0.18)) {
+            Asset.Assets.zashiLogoWithBackground.image
+                .resizable()
+                .scaledToFit()
+                .frame(width: size, height: size)
+                .clipShape(Circle())
+
+            ZStack {
+                Circle()
+                    .fill(Design.Surfaces.bgTertiary.color(colorScheme))
+
+                Asset.Assets.Icons.coinsSwap.image
+                    .zImage(size: size * 0.5, style: Design.Text.primary)
+            }
+            .frame(width: size, height: size)
+            .overlay {
+                Circle()
+                    .stroke(Design.Surfaces.bgPrimary.color(colorScheme), lineWidth: 2)
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    MigrationPairedIcons()
+        .padding()
+}

--- a/zodlTests/MigrationTests/MigrationEntryTests.swift
+++ b/zodlTests/MigrationTests/MigrationEntryTests.swift
@@ -1,0 +1,89 @@
+//
+//  MigrationEntryTests.swift
+//  zodlTests
+//
+//  Covers the MigrationEntry reducer (Features/Migration/MigrationEntry/MigrationEntryStore.swift)
+//  for MOB-1460: mode selection, the disclaimer-visibility derivation, and the `nextTapped` delegate
+//  contract. No SDK calls, no navigation — chaining lands in MOB-1466. No shared/global state ->
+//  no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite struct MigrationEntryTests {
+    @MainActor @Test func defaultStateIsPrivateScheduledWithNoDisclaimer() async {
+        let state = MigrationEntry.State()
+
+        #expect(state.selectedMode == MigrationMode.privateScheduled)
+        #expect(state.isDisclaimerVisible == false)
+    }
+
+    @MainActor @Test func modeTappedImmediateSelectsModeAndRevealsDisclaimer() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.modeTapped(.immediate)) {
+            $0.selectedMode = .immediate
+        }
+
+        #expect(store.state.isDisclaimerVisible)
+    }
+
+    @MainActor @Test func modeTappedPrivateScheduledSelectsModeAndHidesDisclaimer() async {
+        let store = TestStore(initialState: MigrationEntry.State(selectedMode: .immediate)) {
+            MigrationEntry()
+        }
+
+        await store.send(.modeTapped(.privateScheduled)) {
+            $0.selectedMode = .privateScheduled
+        }
+
+        #expect(store.state.isDisclaimerVisible == false)
+    }
+
+    @MainActor @Test func modeTappedWithAlreadySelectedModeIsANoOp() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.modeTapped(.privateScheduled))
+    }
+
+    @MainActor @Test func nextTappedEmitsDelegateChoseWithPrivateScheduledMode() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.nextTapped)
+        await store.receive(.delegate(.chose(.privateScheduled)))
+    }
+
+    @MainActor @Test func nextTappedEmitsDelegateChoseWithImmediateMode() async {
+        let store = TestStore(initialState: MigrationEntry.State(selectedMode: .immediate)) {
+            MigrationEntry()
+        }
+
+        await store.send(.nextTapped)
+        await store.receive(.delegate(.chose(.immediate)))
+    }
+
+    @MainActor @Test func findOutMoreTappedProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.findOutMoreTapped)
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.delegate(.chose(.immediate)))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationNetworkPrivacyTests.swift
+++ b/zodlTests/MigrationTests/MigrationNetworkPrivacyTests.swift
@@ -1,0 +1,69 @@
+//
+//  MigrationNetworkPrivacyTests.swift
+//  zodlTests
+//
+//  Covers the MigrationNetworkPrivacy reducer
+//  (Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift) for MOB-1460: the
+//  `isTorOn` binding and the `nextTapped` delegate contract. No SDK calls, no navigation — chaining
+//  lands in MOB-1466. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite struct MigrationNetworkPrivacyTests {
+    @MainActor @Test func defaultStateHasTorOffAndScheduledVariant() async {
+        let state = MigrationNetworkPrivacy.State()
+
+        #expect(state.isTorOn == false)
+        #expect(state.variant == .scheduled(transferCount: 5))
+    }
+
+    @MainActor @Test func isTorOnBindingTogglesOn() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State()) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.binding(.set(\.isTorOn, true))) {
+            $0.isTorOn = true
+        }
+    }
+
+    @MainActor @Test func isTorOnBindingTogglesOff() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State(isTorOn: true)) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.binding(.set(\.isTorOn, false))) {
+            $0.isTorOn = false
+        }
+    }
+
+    @MainActor @Test func nextTappedEmitsDelegateConfirmedWithTorOnAndNilEndpoint() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State(isTorOn: true)) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.nextTapped)
+        await store.receive(.delegate(.confirmed(NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))))
+    }
+
+    @MainActor @Test func nextTappedEmitsDelegateConfirmedWithTorOffAndNilEndpoint() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State(isTorOn: false)) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.nextTapped)
+        await store.receive(.delegate(.confirmed(NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil))))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State()) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.delegate(.confirmed(NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil))))
+    }
+}


### PR DESCRIPTION
## Summary

First two migration screens ([MOB-1460](https://linear.app/zodl/issue/MOB-1460)), built visually complete from Figma with fully-shaped TCA stores whose delegates nothing consumes yet — chaining lands with MOB-1466. Not reachable in the app; `#Preview` per variant for eyeballing.

Stacked PR #2 of the Ironwood migration series: targets `michal/MOB-1459-models-migration-sdk-stub` (PR #1876).

## Screens

- **S1 · MigrationEntry — "Move to Ironwood"** ([Figma, privacy selected](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2867-10445) · [immediate selected](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2867-5641)): paired-icons header (shared `MigrationPairedIcons` view), description with the **bolded amount injected into one localized format string** (markdown-attribute idiom used elsewhere in the repo), two radio option cards (TorSetup pattern; black-accent privacy card, WarningYellow-accent immediate card), privacy-disclaimer callout when Immediately is selected, on-chain footer note, `ZashiButton` Next.
- **S5 · MigrationNetworkPrivacy — "Network Privacy"** ([immediate](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2867-5801) · [scheduled](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2867-10835)): Tor badge on `bgAlt`, what-happens-next rows (`shieldTick`/`shieldOff`), variant-dependent copy (immediate vs scheduled with transfer count), route-via-Tor toggle card (native Toggle, default **off** — no pre-selection bias), Next.

All colors are existing Design tokens (the design's orange = `Design.Utility.WarningYellow` ramp — hexes verified against `Colors.xcassets`: `._500` #EF6820, `._600` #E04F16, `._700` #B93815, `._50` #FEF6EE). No design-system gaps.

## Strings

23 new keys in `Localizable.xcstrings` (EN + ES, purely additive splice — zero existing bytes touched). CTA reuses `general.next`.

## Tests / verification

- `MigrationEntryTests` + `MigrationNetworkPrivacyTests` (Swift Testing TestStore: selection logic, disclaimer visibility, delegate payloads incl. `NetworkPrivacyOptions(useTor:)` mirroring the toggle).
- `xcodebuild test` on `zodl-internal` (iPhone 17 Pro sim): all four migration suites pass (the two new + MOB-1459's).
- Added Swift lines ≤ 150 chars (long lines exist only as single-line localized sentence values inside the xcstrings JSON, matching Xcode's own formatting).
- Preview render via Xcode MCP was attempted but blocked by unapproved Swift macros in the Xcode UI — please eyeball the four `#Preview`s during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)