### PR TITLE
[MOB-1461] Ironwood migration screen: Note Split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Added
 - [MOB-1459] Groundwork for the Orchard → Ironwood migration: data models and the stubbed migration SDK interface. No user-visible changes yet.
+- [MOB-1460] Ironwood migration screens: entry (mode choice) and network privacy (Tor opt-in). Not reachable in the app yet.
 
 ## 3.7.2 build 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Added
 - [MOB-1459] Groundwork for the Orchard → Ironwood migration: data models and the stubbed migration SDK interface. No user-visible changes yet.
 - [MOB-1460] Ironwood migration screens: entry (mode choice) and network privacy (Tor opt-in). Not reachable in the app yet.
+- [MOB-1461] Ironwood migration screen: note split (explainer, progress, confirmation, failure). Not reachable in the app yet.
 
 ## 3.7.2 build 1
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -19076,6 +19076,210 @@
           }
         }
       }
+    },
+    "migrationNoteSplit.explainerTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Split Your Wallet Funds"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Divide los fondos de tu monedero"
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.explainerDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This sends a transaction to yourself, breaking your balance into smaller notes. Each Ironwood migration transfer then settles independently — no waiting for change."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto envía una transacción a ti mismo, dividiendo tu saldo en notas más pequeñas. Cada transferencia de migración a Ironwood se liquida entonces de forma independiente, sin esperar el cambio."
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.splittingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splitting Funds…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dividiendo fondos…"
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.splittingDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splitting your balance into transfer-sized notes. This is a send-to-self — your ZEC stays in Orchard."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dividiendo tu saldo en notas del tamaño de una transferencia. Esto es un envío a ti mismo: tu ZEC permanece en Orchard."
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.confirmedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Split Confirmed!"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡División confirmada!"
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.confirmedDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your balance is now split into transfer-sized notes, ready to migrate."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo ya está dividido en notas del tamaño de una transferencia, listas para migrar."
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.inProgressTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transaction in Progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transacción en curso"
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.inProgressBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep your phone on and the app open until this step completes."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantén el teléfono encendido y la app abierta hasta que termine este paso."
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.failedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transaction Failed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transacción fallida"
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.failedBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The transaction couldn't be broadcast. Your ZEC is safe — tap below to try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo transmitir la transacción. Tu ZEC está seguro: toca abajo para volver a intentarlo."
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.continue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar"
+          }
+        }
+      }
+    },
+    "migrationNoteSplit.retry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reintentar"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -18685,6 +18685,397 @@
           }
         }
       }
+    },
+    "migrationEntry.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move to Ironwood"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrar a Ironwood"
+          }
+        }
+      }
+    },
+    "migrationEntry.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The latest Zcash network upgrade requires moving your %1$@ (%2$@) from the Orchard pool to the new Ironwood pool. Your funds are safe."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La última actualización de la red Zcash requiere mover tus %1$@ (%2$@) del pool Orchard al nuevo pool Ironwood. Tus fondos están seguros."
+          }
+        }
+      }
+    },
+    "migrationEntry.descNoFiat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The latest Zcash network upgrade requires moving your %1$@ from the Orchard pool to the new Ironwood pool. Your funds are safe."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La última actualización de la red Zcash requiere mover tus %1$@ del pool Orchard al nuevo pool Ironwood. Tus fondos están seguros."
+          }
+        }
+      }
+    },
+    "migrationEntry.findOutMore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find out more"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más información"
+          }
+        }
+      }
+    },
+    "migrationEntry.privacyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate with Privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrar con privacidad"
+          }
+        }
+      }
+    },
+    "migrationEntry.privacyDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Split transfers over time · Scheduled in background · Maximum privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias divididas en el tiempo · Programadas en segundo plano · Máxima privacidad"
+          }
+        }
+      }
+    },
+    "migrationEntry.immediateTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrate Immediately"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrar inmediatamente"
+          }
+        }
+      }
+    },
+    "migrationEntry.immediateDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single transfer · Sends now · Less privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia única · Se envía ahora · Menos privacidad"
+          }
+        }
+      }
+    },
+    "migrationEntry.disclaimerTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy Disclaimer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso de privacidad"
+          }
+        }
+      }
+    },
+    "migrationEntry.disclaimerDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your full balance will be revealed on-chain — crossing the pool boundary exposes the transaction amount. We recommend selecting Migrate with Privacy instead."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo completo quedará expuesto en cadena (on-chain): cruzar el límite entre pools revela el monto de la transacción. Te recomendamos seleccionar Migrar con privacidad."
+          }
+        }
+      }
+    },
+    "migrationEntry.footerNote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pool-crossing transfer amounts are visible on-chain."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los montos de las transferencias entre pools son visibles en cadena (on-chain)."
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network Privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidad de red"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Tor to route this transfer privately through the Tor network. This prevents your IP address from being linked to the transfer."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activa Tor para enrutar esta transferencia de forma privada a través de la red Tor. Esto evita que tu dirección IP quede vinculada a la transferencia."
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.vpnNote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can use a trusted VPN if Tor is unavailable in your region."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes usar una VPN confiable si Tor no está disponible en tu región."
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.whatNext" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What Happens Next"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qué sucede a continuación"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withTorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "With Tor"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Con Tor"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withTorImmediate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP hidden · Transfer unlinkable to your device"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP oculta · Transferencia no vinculable a tu dispositivo"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withTorScheduled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP hidden · All %1$lld transfers unlinkable to your device"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP oculta · Las %1$lld transferencias no son vinculables a tu dispositivo"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withoutTorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Without Tor or VPN"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin Tor ni VPN"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withoutTorImmediate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP visible to network operators"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP visible para los operadores de red"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.withoutTorScheduled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers still de-correlated in time · IP visible to network operators"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transferencias siguen desvinculadas en el tiempo · IP visible para los operadores de red"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.toggleTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route via Tor"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enrutar mediante Tor"
+          }
+        }
+      }
+    },
+    "migrationNetworkPrivacy.toggleDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Tor for transaction submission."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa Tor para el envío de transacciones."
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
@@ -1,0 +1,71 @@
+//
+//  MigrationEntryStore.swift
+//  zodl
+//
+//  "Move to Ironwood" entry screen (MOB-1460, Figma S1 · 2867:10445 / 2867:5641 / 2867:5731). Lets
+//  the user pick between migrating with privacy (scheduled, split transfers) or immediately (single
+//  transfer, less privacy). The delegate is emitted but consumed by nobody yet — chaining into the
+//  rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationEntry {
+    @ObservableState
+    struct State: Equatable {
+        var selectedMode = MigrationMode.privateScheduled
+        /// Placeholder; real balance data lands in MOB-1466.
+        var orchardBalance = Zatoshi.zero
+        /// e.g. `"$4,832.86"`; `nil` omits the parenthesized fiat amount.
+        var fiatText: String?
+
+        var isDisclaimerVisible: Bool {
+            selectedMode == .immediate
+        }
+
+        init(
+            selectedMode: MigrationMode = .privateScheduled,
+            orchardBalance: Zatoshi = Zatoshi.zero,
+            fiatText: String? = nil
+        ) {
+            self.selectedMode = selectedMode
+            self.orchardBalance = orchardBalance
+            self.fiatText = fiatText
+        }
+    }
+
+    enum Action: Equatable {
+        case delegate(Delegate)
+        /// Inert for now; the "Find out more" destination (O-7) is undecided.
+        case findOutMoreTapped
+        case modeTapped(MigrationMode)
+        case nextTapped
+
+        enum Delegate: Equatable {
+            case chose(MigrationMode)
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .delegate:
+                return .none
+
+            case .findOutMoreTapped:
+                return .none
+
+            case .modeTapped(let mode):
+                state.selectedMode = mode
+                return .none
+
+            case .nextTapped:
+                return .send(.delegate(.chose(state.selectedMode)))
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
@@ -1,0 +1,256 @@
+//
+//  MigrationEntryView.swift
+//  zodl
+//
+//  "Move to Ironwood" entry screen (MOB-1460, Figma S1 · 2867:10445 privacy selected /
+//  2867:5641 + 2867:5731 immediate selected). Visually complete per Figma; the delegate emitted by
+//  `nextTapped` is consumed by nobody yet — chaining into the rest of the migration flow lands in
+//  MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationEntryView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationEntry>
+
+    init(store: StoreOf<MigrationEntry>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        MigrationPairedIcons()
+                            .padding(.bottom, 16)
+
+                        Text(localizable: .migrationEntryTitle)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        description
+                            .padding(.bottom, 12)
+
+                        Button {
+                            store.send(.findOutMoreTapped)
+                        } label: {
+                            Text(localizable: .migrationEntryFindOutMore)
+                                .zFont(.medium, size: 14, style: Design.Text.primary)
+                                .underline()
+                        }
+                        .padding(.bottom, 24)
+
+                        optionCards
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                if store.isDisclaimerVisible {
+                    disclaimer
+                        .padding(.top, 16)
+                }
+
+                footerNote
+                    .padding(.top, 16)
+
+                ZashiButton(String(localizable: .generalNext)) {
+                    store.send(.nextTapped)
+                }
+                .padding(.top, 16)
+                .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Description
+
+    @ViewBuilder private var description: some View {
+        let amountText = "\(store.orchardBalance.decimalString()) ZEC"
+
+        if let fiatText = store.fiatText {
+            let markdown = String(localizable: .migrationEntryDesc(
+                "^[\(amountText)](style: 'boldPrimary')",
+                fiatText
+            ))
+
+            if let attrText = try? AttributedString(markdown: markdown, including: \.zashiApp) {
+                ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } else {
+            let markdown = String(localizable: .migrationEntryDescNoFiat(
+                "^[\(amountText)](style: 'boldPrimary')"
+            ))
+
+            if let attrText = try? AttributedString(markdown: markdown, including: \.zashiApp) {
+                ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    // MARK: - Option cards
+
+    @ViewBuilder private var optionCards: some View {
+        VStack(spacing: 12) {
+            optionCard(
+                mode: .privateScheduled,
+                title: String(localizable: .migrationEntryPrivacyTitle),
+                subtitle: String(localizable: .migrationEntryPrivacyDesc)
+            )
+
+            optionCard(
+                mode: .immediate,
+                title: String(localizable: .migrationEntryImmediateTitle),
+                subtitle: String(localizable: .migrationEntryImmediateDesc)
+            )
+        }
+    }
+
+    @ViewBuilder private func optionCard(mode: MigrationMode, title: String, subtitle: String) -> some View {
+        let isSelected = store.selectedMode == mode
+        let isWarning = isSelected && mode == .immediate
+
+        Button {
+            store.send(.modeTapped(mode))
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                radioIndicator(isSelected: isSelected, isWarning: isWarning)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .zFont(.semiBold, size: 16, style: isWarning ? Design.Utility.WarningYellow._600 : Design.Text.primary)
+
+                    Text(subtitle)
+                        .zFont(size: 14, style: Design.Text.tertiary)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+            .background {
+                RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                    .fill(isSelected ? Design.Surfaces.bgPrimary.color(colorScheme) : Design.Surfaces.bgSecondary.color(colorScheme))
+                    .overlay {
+                        if isSelected {
+                            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                                .stroke(
+                                    isWarning ? Design.Utility.WarningYellow._500.color(colorScheme) : Design.Checkboxes.onBg.color(colorScheme),
+                                    lineWidth: 2
+                                )
+                        }
+                    }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder private func radioIndicator(isSelected: Bool, isWarning: Bool) -> some View {
+        ZStack {
+            Circle()
+                .fill(
+                    isSelected
+                        ? (isWarning ? Design.Utility.WarningYellow._500.color(colorScheme) : Design.Checkboxes.onBg.color(colorScheme))
+                        : Design.Checkboxes.offBg.color(colorScheme)
+                )
+                .overlay {
+                    if !isSelected {
+                        Circle()
+                            .stroke(Design.Checkboxes.offStroke.color(colorScheme))
+                    }
+                }
+
+            if isSelected {
+                Circle()
+                    .fill(isWarning ? .white : Design.Checkboxes.onFg.color(colorScheme))
+                    .frame(width: 8, height: 8)
+            }
+        }
+        .frame(width: 20, height: 20)
+    }
+
+    // MARK: - Disclaimer
+
+    @ViewBuilder private var disclaimer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 0) {
+                Text(localizable: .migrationEntryDisclaimerTitle)
+                    .zFont(.medium, size: 14, style: Design.Utility.WarningYellow._600)
+
+                Spacer()
+
+                Asset.Assets.infoOutline.image
+                    .zImage(size: 16, style: Design.Utility.WarningYellow._500)
+            }
+
+            Text(localizable: .migrationEntryDisclaimerDesc)
+                .zFont(size: 12, style: Design.Utility.WarningYellow._700)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .fill(Design.Utility.WarningYellow._50.color(colorScheme))
+        }
+    }
+
+    // MARK: - Footer note
+
+    @ViewBuilder private var footerNote: some View {
+        HStack(spacing: 8) {
+            Asset.Assets.infoOutline.image
+                .zImage(size: 16, style: Design.Text.tertiary)
+
+            Text(localizable: .migrationEntryFooterNote)
+                .zFont(size: 12, style: Design.Text.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Privacy selected") {
+    NavigationView {
+        MigrationEntryView(
+            store: StoreOf<MigrationEntry>(
+                initialState: MigrationEntry.State(
+                    selectedMode: .privateScheduled,
+                    orchardBalance: Zatoshi(1_245_800_000),
+                    fiatText: "$4,832.86"
+                )
+            ) {
+                MigrationEntry()
+            }
+        )
+    }
+}
+
+#Preview("Immediate selected") {
+    NavigationView {
+        MigrationEntryView(
+            store: StoreOf<MigrationEntry>(
+                initialState: MigrationEntry.State(
+                    selectedMode: .immediate,
+                    orchardBalance: Zatoshi(1_245_800_000),
+                    fiatText: "$4,832.86"
+                )
+            ) {
+                MigrationEntry()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift
@@ -1,0 +1,62 @@
+//
+//  MigrationNetworkPrivacyStore.swift
+//  zodl
+//
+//  "Network Privacy" screen (MOB-1460, Figma S5 · 2867:5801 immediate / 2867:10835 scheduled).
+//  Lets the user opt in to routing migration transfer submission via Tor. The delegate is emitted
+//  but consumed by nobody yet — chaining into the rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct MigrationNetworkPrivacy {
+    @ObservableState
+    struct State: Equatable {
+        enum Variant: Equatable {
+            case immediate
+            case scheduled(transferCount: Int)
+        }
+
+        var variant = Variant.scheduled(transferCount: 5)
+        /// No pre-selection bias, per product rule.
+        var isTorOn = false
+
+        init(
+            variant: Variant = .scheduled(transferCount: 5),
+            isTorOn: Bool = false
+        ) {
+            self.variant = variant
+            self.isTorOn = isTorOn
+        }
+    }
+
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        case delegate(Delegate)
+        case nextTapped
+
+        enum Delegate: Equatable {
+            case confirmed(NetworkPrivacyOptions)
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+
+            case .delegate:
+                return .none
+
+            case .nextTapped:
+                return .send(.delegate(.confirmed(NetworkPrivacyOptions(useTor: state.isTorOn, submissionEndpoint: nil))))
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyView.swift
+++ b/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyView.swift
@@ -1,0 +1,191 @@
+//
+//  MigrationNetworkPrivacyView.swift
+//  zodl
+//
+//  "Network Privacy" screen (MOB-1460, Figma S5 · 2867:5801 immediate / 2867:10835 scheduled).
+//  Visually complete per Figma; the delegate emitted by `nextTapped` is consumed by nobody yet —
+//  chaining into the rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct MigrationNetworkPrivacyView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationNetworkPrivacy>
+
+    init(store: StoreOf<MigrationNetworkPrivacy>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        torBadge
+                            .padding(.bottom, 16)
+
+                        Text(localizable: .migrationNetworkPrivacyTitle)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(localizable: .migrationNetworkPrivacyDesc)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 12)
+
+                        Text(localizable: .migrationNetworkPrivacyVpnNote)
+                            .zFont(size: 12, style: Design.Text.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        Text(localizable: .migrationNetworkPrivacyWhatNext)
+                            .zFont(.semiBold, size: 16, style: Design.Text.primary)
+                            .padding(.bottom, 12)
+
+                        outcomeRows
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                Spacer(minLength: 16)
+
+                toggleCard
+                    .padding(.bottom, 16)
+
+                ZashiButton(String(localizable: .generalNext)) {
+                    store.send(.nextTapped)
+                }
+                .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Tor badge
+
+    @ViewBuilder private var torBadge: some View {
+        Circle()
+            .fill(Design.Surfaces.bgAlt.color(colorScheme))
+            .frame(width: 48, height: 48)
+            .overlay {
+                Asset.Assets.Partners.torLogo.image
+                    .zImage(width: 28, height: 19, color: .white)
+            }
+    }
+
+    // MARK: - Outcome rows
+
+    @ViewBuilder private var outcomeRows: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            outcomeRow(
+                icon: Asset.Assets.Icons.shieldTick.image,
+                title: String(localizable: .migrationNetworkPrivacyWithTorTitle),
+                caption: withTorCaption
+            )
+
+            outcomeRow(
+                icon: Asset.Assets.Icons.shieldOff.image,
+                title: String(localizable: .migrationNetworkPrivacyWithoutTorTitle),
+                caption: withoutTorCaption
+            )
+        }
+    }
+
+    private var withTorCaption: String {
+        switch store.variant {
+        case .immediate:
+            return String(localizable: .migrationNetworkPrivacyWithTorImmediate)
+        case .scheduled(let transferCount):
+            return String(localizable: .migrationNetworkPrivacyWithTorScheduled(transferCount))
+        }
+    }
+
+    private var withoutTorCaption: String {
+        switch store.variant {
+        case .immediate:
+            return String(localizable: .migrationNetworkPrivacyWithoutTorImmediate)
+        case .scheduled:
+            return String(localizable: .migrationNetworkPrivacyWithoutTorScheduled)
+        }
+    }
+
+    @ViewBuilder private func outcomeRow(icon: Image, title: String, caption: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            icon
+                .zImage(size: 20, style: Design.Text.primary)
+                .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .zFont(.medium, size: 14, style: Design.Text.primary)
+
+                Text(caption)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Toggle card
+
+    @ViewBuilder private var toggleCard: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(localizable: .migrationNetworkPrivacyToggleTitle)
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                Text(localizable: .migrationNetworkPrivacyToggleDesc)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            Toggle("", isOn: $store.isTorOn)
+                .labelsHidden()
+        }
+        .padding(20)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .fill(Design.Surfaces.bgPrimary.color(colorScheme))
+                .overlay {
+                    RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                        .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+                }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Immediate") {
+    NavigationView {
+        MigrationNetworkPrivacyView(
+            store: StoreOf<MigrationNetworkPrivacy>(
+                initialState: MigrationNetworkPrivacy.State(variant: .immediate)
+            ) {
+                MigrationNetworkPrivacy()
+            }
+        )
+    }
+}
+
+#Preview("Scheduled") {
+    NavigationView {
+        MigrationNetworkPrivacyView(
+            store: StoreOf<MigrationNetworkPrivacy>(
+                initialState: MigrationNetworkPrivacy.State(variant: .scheduled(transferCount: 5), isTorOn: true)
+            ) {
+                MigrationNetworkPrivacy()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
@@ -1,0 +1,113 @@
+//
+//  MigrationNoteSplitStore.swift
+//  zodl
+//
+//  "Split Your Wallet Funds" screen (MOB-1461, Figma S2 · 2867:10535 explainer / 2867:10741
+//  progress / 2867:10645 success / 2670:15570 failure sheet). One screen, three phases (explainer
+//  -> splitting -> confirmed) plus a failure bottom sheet presented over the splitting phase.
+//  Visual-only: SDK-driven actions (`splitConfirmed`, `splitResult`) are declared but inert, and the
+//  screen never transitions phases itself — wiring that up against the SDK is MOB-1466's job. The
+//  `continueTapped` delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationNoteSplit {
+    @ObservableState
+    struct State: Equatable {
+        enum Phase: Equatable {
+            case explainer
+            case splitting
+            case confirmed
+        }
+
+        var phase = Phase.explainer
+        /// Placeholder; real proposal data lands in MOB-1466.
+        var amount = Zatoshi.zero
+        var fee = Zatoshi.zero
+        /// Shown from the splitting phase on.
+        var txId = ""
+        /// Failure sheet presented over the splitting phase.
+        var isFailurePresented = false
+
+        init(
+            phase: Phase = .explainer,
+            amount: Zatoshi = Zatoshi.zero,
+            fee: Zatoshi = Zatoshi.zero,
+            txId: String = "",
+            isFailurePresented: Bool = false
+        ) {
+            self.phase = phase
+            self.amount = amount
+            self.fee = fee
+            self.txId = txId
+            self.isFailurePresented = isFailurePresented
+        }
+    }
+
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        /// Failure sheet: dismiss (stay on screen).
+        case cancelTapped
+        /// Explainer CTA — inert now; MOB-1466 submits the split.
+        case confirmTapped
+        /// Confirmed CTA.
+        case continueTapped
+        case copyTxIdTapped
+        case delegate(Delegate)
+        /// Failure sheet: dismiss — inert re-submit (MOB-1466).
+        case retryTapped
+        /// Declared for MOB-1466 (SDK-driven) — inert.
+        case splitConfirmed
+        /// Declared for MOB-1466 (SDK-driven) — inert.
+        case splitResult(TransferResult)
+
+        enum Delegate: Equatable {
+            case continued
+        }
+    }
+
+    @Dependency(\.pasteboard) var pasteboard
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+
+            case .cancelTapped:
+                state.isFailurePresented = false
+                return .none
+
+            case .confirmTapped:
+                return .none
+
+            case .continueTapped:
+                return .send(.delegate(.continued))
+
+            case .copyTxIdTapped:
+                pasteboard.setString(state.txId.redacted)
+                return .none
+
+            case .delegate:
+                return .none
+
+            case .retryTapped:
+                state.isFailurePresented = false
+                return .none
+
+            case .splitConfirmed:
+                return .none
+
+            case .splitResult:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
@@ -31,6 +31,7 @@ struct MigrationNoteSplit {
         var txId = ""
         /// Failure sheet presented over the splitting phase.
         var isFailurePresented = false
+        @Shared(.inMemory(.toast)) var toast: Toast.Edge? = nil
 
         init(
             phase: Phase = .explainer,
@@ -93,6 +94,7 @@ struct MigrationNoteSplit {
 
             case .copyTxIdTapped:
                 pasteboard.setString(state.txId.redacted)
+                state.$toast.withLock { $0 = .top(String(localizable: .generalCopiedToTheClipboard)) }
                 return .none
 
             case .delegate:

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
@@ -1,0 +1,347 @@
+//
+//  MigrationNoteSplitView.swift
+//  zodl
+//
+//  "Split Your Wallet Funds" screen (MOB-1461, Figma S2 · 2867:10535 explainer / 2867:10741
+//  progress / 2867:10645 success / 2670:15570 failure sheet). Visually complete per Figma; phase
+//  transitions and the SDK-driven split submission are declared but inert — wiring them up lands in
+//  MOB-1466. The `continueTapped` delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationNoteSplitView: View {
+    private enum RowAppereance {
+        case bottom
+        case full
+        case middle
+        case top
+
+        var corners: UIRectCorner {
+            switch self {
+            case .bottom:
+                return [.bottomLeft, .bottomRight]
+            case .full:
+                return [.allCorners]
+            case .middle:
+                return []
+            case .top:
+                return [.topLeft, .topRight]
+            }
+        }
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationNoteSplit>
+
+    init(store: StoreOf<MigrationNoteSplit>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        MigrationPairedIcons(badge: headerBadge)
+                            .padding(.bottom, 16)
+
+                        Text(title)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(description)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        detailRows
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                footer
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+            .zashiSheet(isPresented: $store.isFailurePresented) {
+                failureSheetContent
+            }
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Header badge
+
+    private var headerBadge: MigrationPairedIcons.Badge {
+        switch store.phase {
+        case .explainer:
+            return .coinsSwap
+        case .splitting:
+            return .spinner
+        case .confirmed:
+            return .successCheck
+        }
+    }
+
+    // MARK: - Title + description
+
+    private var title: String {
+        switch store.phase {
+        case .explainer:
+            return String(localizable: .migrationNoteSplitExplainerTitle)
+        case .splitting:
+            return String(localizable: .migrationNoteSplitSplittingTitle)
+        case .confirmed:
+            return String(localizable: .migrationNoteSplitConfirmedTitle)
+        }
+    }
+
+    private var description: String {
+        switch store.phase {
+        case .explainer:
+            return String(localizable: .migrationNoteSplitExplainerDesc)
+        case .splitting:
+            return String(localizable: .migrationNoteSplitSplittingDesc)
+        case .confirmed:
+            return String(localizable: .migrationNoteSplitConfirmedDesc)
+        }
+    }
+
+    // MARK: - Detail rows
+
+    private var isTxIdRowVisible: Bool {
+        store.phase != .explainer
+    }
+
+    @ViewBuilder private var detailRows: some View {
+        VStack(spacing: 0) {
+            if isTxIdRowVisible {
+                detailRow(
+                    title: String(localizable: .transactionListTransactionId),
+                    value: store.txId.truncateMiddle,
+                    isAddressFont: true,
+                    icon: Asset.Assets.copy.image,
+                    rowAppereance: .top
+                )
+                .onTapGesture {
+                    store.send(.copyTxIdTapped)
+                }
+            }
+
+            detailRow(
+                title: String(localizable: .sendAmount),
+                value: "\(store.amount.decimalString()) ZEC",
+                rowAppereance: isTxIdRowVisible ? .middle : .top
+            )
+
+            detailRow(
+                title: String(localizable: .sendFeeSummary),
+                value: "\(store.fee.decimalString()) ZEC",
+                rowAppereance: .bottom
+            )
+        }
+    }
+
+    @ViewBuilder private func detailRow(
+        title: String,
+        value: String,
+        isAddressFont: Bool = false,
+        icon: Image? = nil,
+        rowAppereance: RowAppereance = .full
+    ) -> some View {
+        HStack(spacing: 0) {
+            Text(title)
+                .zFont(size: 14, style: Design.Text.tertiary)
+
+            Spacer()
+
+            Text(value)
+                .zFont(.medium, fontFamily: isAddressFont ? .robotoMono : .inter, size: 14, style: Design.Text.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+
+            if let icon {
+                icon
+                    .zImage(size: 20, style: Design.Text.primary)
+                    .padding(.leading, 6)
+            }
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 20)
+        .background {
+            CustomRoundedRectangle(corners: rowAppereance.corners, radius: 12)
+                .fill(Design.Surfaces.bgSecondary.color(colorScheme))
+        }
+        .padding(.bottom, rowAppereance == .full || rowAppereance == .bottom ? 0 : 1)
+    }
+
+    // MARK: - Footer
+
+    @ViewBuilder private var footer: some View {
+        switch store.phase {
+        case .explainer:
+            ZashiButton(String(localizable: .generalConfirm)) {
+                store.send(.confirmTapped)
+            }
+            .padding(.top, 16)
+            .padding(.bottom, 24)
+
+        case .splitting:
+            VStack(spacing: 16) {
+                inProgressInfoCard
+
+                ZashiButton(
+                    String(localizable: .migrationNoteSplitSplittingTitle),
+                    type: .secondary,
+                    accessoryView: ProgressView()
+                ) { }
+                .disabled(true)
+            }
+            .padding(.top, 16)
+            .padding(.bottom, 24)
+
+        case .confirmed:
+            ZashiButton(String(localizable: .migrationNoteSplitContinue)) {
+                store.send(.continueTapped)
+            }
+            .padding(.top, 16)
+            .padding(.bottom, 24)
+        }
+    }
+
+    @ViewBuilder private var inProgressInfoCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 0) {
+                Text(localizable: .migrationNoteSplitInProgressTitle)
+                    .zFont(.semiBold, size: 14, style: Design.Text.primary)
+
+                Spacer()
+
+                Asset.Assets.infoOutline.image
+                    .zImage(size: 16, style: Design.Text.tertiary)
+            }
+
+            Text(localizable: .migrationNoteSplitInProgressBody)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .fill(Design.Surfaces.bgSecondary.color(colorScheme))
+        }
+    }
+
+    // MARK: - Failure sheet
+
+    @ViewBuilder private var failureSheetContent: some View {
+        VStack(spacing: 0) {
+            Asset.Assets.Icons.alertOutline.image
+                .zImage(size: 20, style: Design.Utility.ErrorRed._500)
+                .background {
+                    Circle()
+                        .fill(Design.Utility.ErrorRed._100.color(colorScheme))
+                        .frame(width: 44, height: 44)
+                }
+                .padding(.top, 48)
+
+            Text(localizable: .migrationNoteSplitFailedTitle)
+                .zFont(.semiBold, size: 20, style: Design.Text.primary)
+                .multilineTextAlignment(.center)
+                .padding(.top, 16)
+                .padding(.bottom, 12)
+
+            Text(localizable: .migrationNoteSplitFailedBody)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.center)
+                .lineSpacing(2)
+                .padding(.bottom, 32)
+
+            ZashiButton(String(localizable: .generalCancel), type: .secondary) {
+                store.send(.cancelTapped)
+            }
+            .padding(.bottom, 12)
+
+            ZashiButton(String(localizable: .migrationNoteSplitRetry)) {
+                store.send(.retryTapped)
+            }
+            .padding(.bottom, Design.Spacing.sheetBottomSpace)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Explainer") {
+    NavigationView {
+        MigrationNoteSplitView(
+            store: StoreOf<MigrationNoteSplit>(
+                initialState: MigrationNoteSplit.State(
+                    phase: .explainer,
+                    amount: Zatoshi(1_245_800_000),
+                    fee: Zatoshi(100_000)
+                )
+            ) {
+                MigrationNoteSplit()
+            }
+        )
+    }
+}
+
+#Preview("Splitting") {
+    NavigationView {
+        MigrationNoteSplitView(
+            store: StoreOf<MigrationNoteSplit>(
+                initialState: MigrationNoteSplit.State(
+                    phase: .splitting,
+                    amount: Zatoshi(1_245_800_000),
+                    fee: Zatoshi(100_000),
+                    txId: "e87f1234567890abcdef6f28b"
+                )
+            ) {
+                MigrationNoteSplit()
+            }
+        )
+    }
+}
+
+#Preview("Confirmed") {
+    NavigationView {
+        MigrationNoteSplitView(
+            store: StoreOf<MigrationNoteSplit>(
+                initialState: MigrationNoteSplit.State(
+                    phase: .confirmed,
+                    amount: Zatoshi(1_245_800_000),
+                    fee: Zatoshi(100_000),
+                    txId: "e87f1234567890abcdef6f28b"
+                )
+            ) {
+                MigrationNoteSplit()
+            }
+        )
+    }
+}
+
+#Preview("Splitting + failure sheet") {
+    NavigationView {
+        MigrationNoteSplitView(
+            store: StoreOf<MigrationNoteSplit>(
+                initialState: MigrationNoteSplit.State(
+                    phase: .splitting,
+                    amount: Zatoshi(1_245_800_000),
+                    fee: Zatoshi(100_000),
+                    txId: "e87f1234567890abcdef6f28b",
+                    isFailurePresented: true
+                )
+            ) {
+                MigrationNoteSplit()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationPairedIcons.swift
+++ b/secant/Sources/Features/Migration/MigrationPairedIcons.swift
@@ -3,15 +3,26 @@
 //  zodl
 //
 //  Shared header view for migration screens (MOB-1460): the ZODL account badge overlapped by a
-//  circular Ironwood ("coins-swap") mark. Used by MigrationEntry now and reused by later migration
-//  screens.
+//  circular Ironwood ("coins-swap") mark. Used by MigrationEntry and reused by later migration
+//  screens. MOB-1461 parameterizes the trailing badge so MigrationNoteSplit can swap it per phase
+//  (spinner while splitting, success check once confirmed) while MigrationEntry keeps the default.
 //
 
 import SwiftUI
 
 struct MigrationPairedIcons: View {
+    enum Badge: Equatable {
+        /// Default — current appearance (bgTertiary circle + coinsSwap glyph).
+        case coinsSwap
+        /// bgTertiary circle + `ProgressView()`.
+        case spinner
+        /// Light-green circle + `Icons.checkVerifiedFilled` in `SuccessGreen._500`.
+        case successCheck
+    }
+
     @Environment(\.colorScheme) private var colorScheme
     var size: CGFloat = 48
+    var badge: Badge = .coinsSwap
 
     var body: some View {
         HStack(spacing: -(size * 0.18)) {
@@ -23,10 +34,18 @@ struct MigrationPairedIcons: View {
 
             ZStack {
                 Circle()
-                    .fill(Design.Surfaces.bgTertiary.color(colorScheme))
+                    .fill(badgeCircleColor.color(colorScheme))
 
-                Asset.Assets.Icons.coinsSwap.image
-                    .zImage(size: size * 0.5, style: Design.Text.primary)
+                switch badge {
+                case .coinsSwap:
+                    Asset.Assets.Icons.coinsSwap.image
+                        .zImage(size: size * 0.5, style: Design.Text.primary)
+                case .spinner:
+                    ProgressView()
+                case .successCheck:
+                    Asset.Assets.Icons.checkVerifiedFilled.image
+                        .zImage(size: size * 0.5, style: Design.Utility.SuccessGreen._500)
+                }
             }
             .frame(width: size, height: size)
             .overlay {
@@ -35,11 +54,30 @@ struct MigrationPairedIcons: View {
             }
         }
     }
+
+    private var badgeCircleColor: Colorable {
+        switch badge {
+        case .coinsSwap, .spinner:
+            return Design.Surfaces.bgTertiary
+        case .successCheck:
+            return Design.Utility.SuccessGreen._100
+        }
+    }
 }
 
 // MARK: - Previews
 
-#Preview {
+#Preview("Coins swap") {
     MigrationPairedIcons()
+        .padding()
+}
+
+#Preview("Spinner") {
+    MigrationPairedIcons(badge: .spinner)
+        .padding()
+}
+
+#Preview("Success check") {
+    MigrationPairedIcons(badge: .successCheck)
         .padding()
 }

--- a/secant/Sources/Features/Migration/MigrationPairedIcons.swift
+++ b/secant/Sources/Features/Migration/MigrationPairedIcons.swift
@@ -1,0 +1,45 @@
+//
+//  MigrationPairedIcons.swift
+//  zodl
+//
+//  Shared header view for migration screens (MOB-1460): the ZODL account badge overlapped by a
+//  circular Ironwood ("coins-swap") mark. Used by MigrationEntry now and reused by later migration
+//  screens.
+//
+
+import SwiftUI
+
+struct MigrationPairedIcons: View {
+    @Environment(\.colorScheme) private var colorScheme
+    var size: CGFloat = 48
+
+    var body: some View {
+        HStack(spacing: -(size * 0.18)) {
+            Asset.Assets.zashiLogoWithBackground.image
+                .resizable()
+                .scaledToFit()
+                .frame(width: size, height: size)
+                .clipShape(Circle())
+
+            ZStack {
+                Circle()
+                    .fill(Design.Surfaces.bgTertiary.color(colorScheme))
+
+                Asset.Assets.Icons.coinsSwap.image
+                    .zImage(size: size * 0.5, style: Design.Text.primary)
+            }
+            .frame(width: size, height: size)
+            .overlay {
+                Circle()
+                    .stroke(Design.Surfaces.bgPrimary.color(colorScheme), lineWidth: 2)
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    MigrationPairedIcons()
+        .padding()
+}

--- a/zodlTests/MigrationTests/MigrationEntryTests.swift
+++ b/zodlTests/MigrationTests/MigrationEntryTests.swift
@@ -1,0 +1,89 @@
+//
+//  MigrationEntryTests.swift
+//  zodlTests
+//
+//  Covers the MigrationEntry reducer (Features/Migration/MigrationEntry/MigrationEntryStore.swift)
+//  for MOB-1460: mode selection, the disclaimer-visibility derivation, and the `nextTapped` delegate
+//  contract. No SDK calls, no navigation — chaining lands in MOB-1466. No shared/global state ->
+//  no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite struct MigrationEntryTests {
+    @MainActor @Test func defaultStateIsPrivateScheduledWithNoDisclaimer() async {
+        let state = MigrationEntry.State()
+
+        #expect(state.selectedMode == MigrationMode.privateScheduled)
+        #expect(state.isDisclaimerVisible == false)
+    }
+
+    @MainActor @Test func modeTappedImmediateSelectsModeAndRevealsDisclaimer() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.modeTapped(.immediate)) {
+            $0.selectedMode = .immediate
+        }
+
+        #expect(store.state.isDisclaimerVisible)
+    }
+
+    @MainActor @Test func modeTappedPrivateScheduledSelectsModeAndHidesDisclaimer() async {
+        let store = TestStore(initialState: MigrationEntry.State(selectedMode: .immediate)) {
+            MigrationEntry()
+        }
+
+        await store.send(.modeTapped(.privateScheduled)) {
+            $0.selectedMode = .privateScheduled
+        }
+
+        #expect(store.state.isDisclaimerVisible == false)
+    }
+
+    @MainActor @Test func modeTappedWithAlreadySelectedModeIsANoOp() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.modeTapped(.privateScheduled))
+    }
+
+    @MainActor @Test func nextTappedEmitsDelegateChoseWithPrivateScheduledMode() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.nextTapped)
+        await store.receive(.delegate(.chose(.privateScheduled)))
+    }
+
+    @MainActor @Test func nextTappedEmitsDelegateChoseWithImmediateMode() async {
+        let store = TestStore(initialState: MigrationEntry.State(selectedMode: .immediate)) {
+            MigrationEntry()
+        }
+
+        await store.send(.nextTapped)
+        await store.receive(.delegate(.chose(.immediate)))
+    }
+
+    @MainActor @Test func findOutMoreTappedProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.findOutMoreTapped)
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        }
+
+        await store.send(.delegate(.chose(.immediate)))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationNetworkPrivacyTests.swift
+++ b/zodlTests/MigrationTests/MigrationNetworkPrivacyTests.swift
@@ -1,0 +1,69 @@
+//
+//  MigrationNetworkPrivacyTests.swift
+//  zodlTests
+//
+//  Covers the MigrationNetworkPrivacy reducer
+//  (Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift) for MOB-1460: the
+//  `isTorOn` binding and the `nextTapped` delegate contract. No SDK calls, no navigation — chaining
+//  lands in MOB-1466. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite struct MigrationNetworkPrivacyTests {
+    @MainActor @Test func defaultStateHasTorOffAndScheduledVariant() async {
+        let state = MigrationNetworkPrivacy.State()
+
+        #expect(state.isTorOn == false)
+        #expect(state.variant == .scheduled(transferCount: 5))
+    }
+
+    @MainActor @Test func isTorOnBindingTogglesOn() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State()) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.binding(.set(\.isTorOn, true))) {
+            $0.isTorOn = true
+        }
+    }
+
+    @MainActor @Test func isTorOnBindingTogglesOff() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State(isTorOn: true)) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.binding(.set(\.isTorOn, false))) {
+            $0.isTorOn = false
+        }
+    }
+
+    @MainActor @Test func nextTappedEmitsDelegateConfirmedWithTorOnAndNilEndpoint() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State(isTorOn: true)) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.nextTapped)
+        await store.receive(.delegate(.confirmed(NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))))
+    }
+
+    @MainActor @Test func nextTappedEmitsDelegateConfirmedWithTorOffAndNilEndpoint() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State(isTorOn: false)) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.nextTapped)
+        await store.receive(.delegate(.confirmed(NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil))))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationNetworkPrivacy.State()) {
+            MigrationNetworkPrivacy()
+        }
+
+        await store.send(.delegate(.confirmed(NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil))))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
+++ b/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
@@ -6,7 +6,8 @@
 //  (Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift) for MOB-1461: the default
 //  phase/state, the txid pasteboard copy, the failure sheet dismissal (cancel/retry), and the
 //  `continueTapped` delegate contract. Phase transitions and SDK calls are inert/declared-only —
-//  wiring them up is MOB-1466's job. No shared/global state -> no `.serialized`.
+//  wiring them up is MOB-1466's job. The copy action writes the shared toast (`@Shared` in-memory
+//  state) -> `.serialized` per the repo rule for suites mutating process-global state.
 //
 
 import Testing
@@ -15,7 +16,7 @@ import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite struct MigrationNoteSplitTests {
+@Suite(.serialized) struct MigrationNoteSplitTests {
     @MainActor @Test func defaultStateIsExplainerWithNoFailureSheet() async {
         let state = MigrationNoteSplit.State()
 

--- a/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
+++ b/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
@@ -1,0 +1,108 @@
+//
+//  MigrationNoteSplitTests.swift
+//  zodlTests
+//
+//  Covers the MigrationNoteSplit reducer
+//  (Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift) for MOB-1461: the default
+//  phase/state, the txid pasteboard copy, the failure sheet dismissal (cancel/retry), and the
+//  `continueTapped` delegate contract. Phase transitions and SDK calls are inert/declared-only —
+//  wiring them up is MOB-1466's job. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationNoteSplitTests {
+    @MainActor @Test func defaultStateIsExplainerWithNoFailureSheet() async {
+        let state = MigrationNoteSplit.State()
+
+        #expect(state.phase == MigrationNoteSplit.State.Phase.explainer)
+        #expect(state.amount == Zatoshi.zero)
+        #expect(state.fee == Zatoshi.zero)
+        #expect(state.txId == "")
+        #expect(state.isFailurePresented == false)
+    }
+
+    @MainActor @Test func copyTxIdTappedCopiesTxIdToPasteboard() async {
+        let copied = LockIsolated<RedactableString?>(nil)
+        let store = TestStore(
+            initialState: MigrationNoteSplit.State(phase: .splitting, txId: "e87f1234567890abcdef6f28b")
+        ) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.pasteboard.setString = { copied.setValue($0) }
+        }
+
+        await store.send(.copyTxIdTapped)
+
+        #expect(copied.value == "e87f1234567890abcdef6f28b".redacted)
+    }
+
+    @MainActor @Test func cancelTappedDismissesFailureSheet() async {
+        let store = TestStore(
+            initialState: MigrationNoteSplit.State(phase: .splitting, isFailurePresented: true)
+        ) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.cancelTapped) {
+            $0.isFailurePresented = false
+        }
+    }
+
+    @MainActor @Test func retryTappedDismissesFailureSheet() async {
+        let store = TestStore(
+            initialState: MigrationNoteSplit.State(phase: .splitting, isFailurePresented: true)
+        ) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.retryTapped) {
+            $0.isFailurePresented = false
+        }
+    }
+
+    @MainActor @Test func continueTappedEmitsDelegateContinued() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .confirmed)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.continueTapped)
+        await store.receive(.delegate(.continued))
+    }
+
+    @MainActor @Test func confirmTappedProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State()) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.confirmTapped)
+    }
+
+    @MainActor @Test func splitConfirmedProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitConfirmed)
+    }
+
+    @MainActor @Test func splitResultInvalidNoteProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.invalidNote))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State()) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.delegate(.continued))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
+++ b/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
@@ -35,10 +35,12 @@ import ComposableArchitecture
         } withDependencies: {
             $0.pasteboard.setString = { copied.setValue($0) }
         }
+        store.exhaustivity = .off
 
         await store.send(.copyTxIdTapped)
 
         #expect(copied.value == "e87f1234567890abcdef6f28b".redacted)
+        #expect(store.state.toast == .top(String(localizable: .generalCopiedToTheClipboard)))
     }
 
     @MainActor @Test func cancelTappedDismissesFailureSheet() async {


### PR DESCRIPTION
## Summary

Third migration screen ([MOB-1461](https://linear.app/zodl/issue/MOB-1461)): the note-split step — one screen with three phases plus a failure bottom sheet, visually complete per Figma, logic-inert until MOB-1466. Not reachable in the app; `#Preview` per phase (incl. the failure sheet).

Stacked PR #3: targets `michal/MOB-1460-entry-network-privacy-screens` (PR #1877).

## Screens

[explainer](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2867-10535) · [progress](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2867-10741) · [success](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2867-10645) · [failure sheet](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2670-15570)

- Phase-driven header via `MigrationPairedIcons` (new `Badge` param: coinsSwap / spinner / successCheck — SuccessGreen shades pixel-verified against the frame).
- Detail rows follow the TransactionDetails banded-row pattern; Transaction ID is robotoMono, middle-truncated, tap-to-copy via the `pasteboard` dependency.
- Splitting footer: "Transaction in Progress" info card + disabled `ZashiButton` with `accessoryView: ProgressView()` (SendConfirmation idiom).
- Failure sheet via `zashiSheet`, badge mirroring the DeleteWallet sheet idiom (ErrorRed 500/100), Cancel + Retry.

## Behavior (visual-only stage)

Real & tested: tx-id copy, Cancel/Retry dismissing the sheet, Continue emitting `.delegate(.continued)`. Declared-inert (SDK-driven, MOB-1466): `confirmTapped`, `splitResult`, `splitConfirmed`, actual retry resubmission. Phases enter via initial state only.

## Strings

12 new keys (EN + ES). Generic labels reuse existing catalog keys (`transactionListTransactionId`, `sendAmount`, `sendFeeSummary`, `generalConfirm`, `generalCancel`); scoped `continue`/`retry` added deliberately — the only existing matches are an alert-scoped TextState key and an untranslated coinVote key.

## Verification

- `xcodebuild test` on `zodl-internal` (iPhone 17 Pro sim): all five migration suites pass, first run.
- Added Swift lines ≤ 150 chars; xcstrings splice purely additive (JSON parse verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)