### PR TITLE
CI: skip all tests on draft PRs

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -2,6 +2,11 @@ name: E2E Smoke Tests
 
 on:
   pull_request:
+    # Include ready_for_review so flipping a draft PR to "Ready for review"
+    # re-triggers CI. The default activity types are opened/synchronize/
+    # reopened only, so without this the draft-skipped jobs below would never
+    # run until the next push.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - '.github/pull_request_template.md'
@@ -26,6 +31,10 @@ jobs:
   # via actions/upload-artifact. The previous matrix design ran
   # xcodebuild + SPM resolve in each phase job, paying ~7 min twice.
   build:
+    # Skip draft PRs — the e2e/smoke suite is expensive (up to 75-min runs
+    # that spend real mainnet funds). Manual `workflow_dispatch` runs carry
+    # no pull_request context, so the guard lets them through.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: macos-26
     timeout-minutes: 25
     permissions:
@@ -190,6 +199,8 @@ jobs:
 
   e2e-ios:
     needs: build
+    # Same draft-PR guard as `build` — keep it explicit on the expensive job.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: macos-26
     # Cold-cache phase 2 runs spend ~25-30 min on the
     # restore-existing-wallet sync alone (chain-tip catchup from the

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,11 @@ name: Pull Request
 
 on:
   pull_request:
+    # Include ready_for_review so flipping a draft PR to "Ready for review"
+    # re-triggers CI. The default activity types are opened/synchronize/
+    # reopened only, so without this the draft-skipped job below would never
+    # run until the next push.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - '.github/pull_request_template.md'
@@ -20,6 +25,9 @@ env:
 
 jobs:
   unit_tests:
+    # Skip draft PRs — no tests run until a PR is marked ready for review
+    # (matches the e2e/smoke suite guard in e2e-smoke.yml).
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: macos-26
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## What

Stop running CI tests on **draft** PRs. Previously every PR workflow — the unit tests and the e2e/smoke suite — ran on draft PRs too.

## Changes

- **Draft guard** on every PR test job, skipping it while the PR is a draft:
  ```yaml
  if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
  ```
  Applied to `unit_tests` (`pull-request.yml`) and `build` + `e2e-ios` (`e2e-smoke.yml`). The `github.event_name != 'pull_request'` clause keeps manual `workflow_dispatch` runs of the e2e suite working (they have no PR context).
- **`ready_for_review` added to the `pull_request` trigger types** in both workflows. The default activity types (`opened`/`synchronize`/`reopened`) don't include `ready_for_review`, so without this, flipping a draft PR to "Ready for review" wouldn't re-fire CI and the tests would stay skipped until the next push.

## Behavior

| PR state | Tests |
|---|---|
| Draft | none run |
| Flipped to "Ready for review" | all run (unit, build, e2e/smoke) |
| Opened non-draft | all run |
| Manual e2e dispatch | runs |

`linear-release.yml` is untouched — it's not a test and isn't triggered by PRs (runs on tag push / manual dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
