### PR TITLE
[MOB-1464] Ironwood migration screens: status, recovery, complete, banner states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1460] Ironwood migration screens: entry (mode choice) and network privacy (Tor opt-in). Not reachable in the app yet.
 - [MOB-1461] Ironwood migration screen: note split (explainer, progress, confirmation, failure). Not reachable in the app yet.
 - [MOB-1462] Ironwood migration screens: background delivery and notifications permissions. Not reachable in the app yet.
+- [MOB-1463] Ironwood migration screens: transfer plan, transfer review, sending states, and migration scheduled. Not reachable in the app yet.
 
 ## 3.7.2 build 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1461] Ironwood migration screen: note split (explainer, progress, confirmation, failure). Not reachable in the app yet.
 - [MOB-1462] Ironwood migration screens: background delivery and notifications permissions. Not reachable in the app yet.
 - [MOB-1463] Ironwood migration screens: transfer plan, transfer review, sending states, and migration scheduled. Not reachable in the app yet.
+- [MOB-1464] Ironwood migration screens: progress status, plan recovery, migration complete, and the home widget states. Not reachable in the app yet.
 
 ## 3.7.2 build 1
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -19671,6 +19671,448 @@
           }
         }
       }
+    },
+    "migrationPlan.titleConfirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm Transfer Plan"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar plan de transferencia"
+          }
+        }
+      }
+    },
+    "migrationPlan.titleManual" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer Plan"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plan de transferencia"
+          }
+        }
+      }
+    },
+    "migrationPlan.descScheduled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your balance is split into %1$lld transfers over ~%2$lld hours. Approve once and we'll handle the rest — just keep the app running in the background. Amounts are randomized for privacy. If we miss a window, ZODL will prompt you on next open."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo se divide en %1$lld transferencias a lo largo de ~%2$lld horas. Aprueba una vez y nosotros nos encargamos del resto — solo mantén la app ejecutándose en segundo plano. Los montos son aleatorios por privacidad. Si nos perdemos una ventana, ZODL te lo indicará la próxima vez que abras la app."
+          }
+        }
+      }
+    },
+    "migrationPlan.descManual" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We recommend following the plan below. Your balance will be split into %1$lld transfers over ~%2$lld hours. Amounts are randomized for privacy. Confirm to send the first transfer now."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Te recomendamos seguir el siguiente plan. Tu saldo se dividirá en %1$lld transferencias a lo largo de ~%2$lld horas. Los montos son aleatorios por privacidad. Confirma para enviar la primera transferencia ahora."
+          }
+        }
+      }
+    },
+    "migrationPlan.descRecreated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your remaining Orchard balance splits into %1$lld transfers over ~%2$lld hours. Approve once and we'll handle the rest — just keep the app running in the background. If we miss a window, ZODL will prompt you on next open."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo restante en Orchard se divide en %1$lld transferencias a lo largo de ~%2$lld horas. Aprueba una vez y nosotros nos encargamos del resto — solo mantén la app ejecutándose en segundo plano. Si nos perdemos una ventana, ZODL te lo indicará la próxima vez que abras la app."
+          }
+        }
+      }
+    },
+    "migrationPlan.transferN" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld"
+          }
+        }
+      }
+    },
+    "migrationPlan.etaHours" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%1$lld hours"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%1$lld horas"
+          }
+        }
+      }
+    },
+    "migrationPlan.etaFirst" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~10 mins"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~10 min"
+          }
+        }
+      }
+    },
+    "migrationPlan.sentAgo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent %1$lldh ago"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviado hace %1$lldh"
+          }
+        }
+      }
+    },
+    "migrationPlan.readyNow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ready now"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo ahora"
+          }
+        }
+      }
+    },
+    "migrationReview.titleImmediate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review Transfer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisar transferencia"
+          }
+        }
+      }
+    },
+    "migrationReview.titleManual" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review Transfer %1$lld of %2$lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisar transferencia %1$lld de %2$lld"
+          }
+        }
+      }
+    },
+    "migrationReview.descImmediate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your full Orchard balance will be transferred to Ironwood in a single on-chain transfer. Once confirmed, this transfer cannot be cancelled."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo completo de Orchard se transferirá a Ironwood en una única transferencia en cadena. Una vez confirmada, esta transferencia no se puede cancelar."
+          }
+        }
+      }
+    },
+    "migrationReview.descManual" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This transfer sends part of your Orchard balance to Ironwood as part of your scheduled migration.\n\nReview and confirm to send the transaction. Once confirmed, this cannot be undone."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta transferencia envía parte de tu saldo de Orchard a Ironwood como parte de tu migración programada.\n\nRevisa y confirma para enviar la transacción. Una vez confirmada, esto no se puede deshacer."
+          }
+        }
+      }
+    },
+    "migrationSending.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviando…"
+          }
+        }
+      }
+    },
+    "migrationSending.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your ZEC is being sent to Ironwood…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu ZEC se está enviando a Ironwood…"
+          }
+        }
+      }
+    },
+    "migrationSending.sentTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent!"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Enviado!"
+          }
+        }
+      }
+    },
+    "migrationSending.sentSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your ZEC were successfully sent to Ironwood."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu ZEC se envió correctamente a Ironwood."
+          }
+        }
+      }
+    },
+    "migrationScheduled.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Scheduled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migración programada"
+          }
+        }
+      }
+    },
+    "migrationScheduled.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your ZEC will be migrated to the Ironwood pool based on the schedule you approved."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu ZEC se migrará al pool de Ironwood según el cronograma que aprobaste."
+          }
+        }
+      }
+    },
+    "migrationScheduled.rowTotal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total to transfer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total a transferir"
+          }
+        }
+      }
+    },
+    "migrationScheduled.rowPool" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pool"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pool"
+          }
+        }
+      }
+    },
+    "migrationScheduled.rowPoolValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orchard → Ironwood"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orchard → Ironwood"
+          }
+        }
+      }
+    },
+    "migrationScheduled.rowTransfers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias"
+          }
+        }
+      }
+    },
+    "migrationScheduled.rowTransfersValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld"
+          }
+        }
+      }
+    },
+    "migrationScheduled.rowDuration" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duración"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -20113,6 +20113,737 @@
           }
         }
       }
+    },
+    "migrationStatus.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso de la migraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationStatus.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your balance is split into %1$lld transfers over ~%2$lld hours. There are %3$lld remaining transfers."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo se divide en %1$lld transferencias durante ~%2$lld horas. Quedan %3$lld transferencias pendientes."
+          }
+        }
+      }
+    },
+    "migrationStatus.resumeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resume Migration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reanudar migraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationStatus.reschedulingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Re-scheduling\u2026"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogramando\u2026"
+          }
+        }
+      }
+    },
+    "migrationStatus.resumeDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld of %2$lld was scheduled %3$lld hours ago but wasn't sent. Send now or reschedule."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La transferencia %1$lld de %2$lld se program\u00f3 hace %3$lld horas pero no se envi\u00f3. Env\u00edala ahora o reprogr\u00e1mala."
+          }
+        }
+      }
+    },
+    "migrationStatus.overdueAgo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Overdue \u00b7 %1$lldh ago"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atrasada \u00b7 hace %1$lldh"
+          }
+        }
+      }
+    },
+    "migrationStatus.sentRecently" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent recently"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviado recientemente"
+          }
+        }
+      }
+    },
+    "migrationStatus.windowMissedNote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending now will delay your wallet's sync about 10 mins. To protect your privacy, we need to decouple syncing and transaction broadcasting."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar ahora retrasar\u00e1 la sincronizaci\u00f3n de tu billetera unos 10 minutos. Para proteger tu privacidad, necesitamos desacoplar la sincronizaci\u00f3n de la transmisi\u00f3n de transacciones."
+          }
+        }
+      }
+    },
+    "migrationStatus.reschedule" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reschedule"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogramar"
+          }
+        }
+      }
+    },
+    "migrationStatus.sendNow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send now"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar ahora"
+          }
+        }
+      }
+    },
+    "migrationRecovery.titleSpent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reschedule Transfers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogramar transferencias"
+          }
+        }
+      }
+    },
+    "migrationRecovery.titleExpired" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers No Longer Valid"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias ya no v\u00e1lidas"
+          }
+        }
+      }
+    },
+    "migrationRecovery.descSpent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers %1$lld-%2$lld were pre-signed for a balance that has since changed. The migration plan needs to be re-created for the remaining amount. No funds are lost \u2014 only the pre-signed transactions are discarded."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transferencias %1$lld-%2$lld se prefirmaron para un saldo que ha cambiado desde entonces. El plan de migraci\u00f3n debe volver a crearse para el monto restante. No se pierden fondos \u2014 solo se descartan las transacciones prefirmadas."
+          }
+        }
+      }
+    },
+    "migrationRecovery.descExpired" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers %1$lld-%2$lld were pre-signed but expired before they could be sent. The migration plan needs to be re-created for the remaining amount. No funds are lost \u2014 only the pre-signed transactions are discarded."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transferencias %1$lld-%2$lld se prefirmaron pero caducaron antes de poder enviarse. El plan de migraci\u00f3n debe volver a crearse para el monto restante. No se pierden fondos \u2014 solo se descartan las transacciones prefirmadas."
+          }
+        }
+      }
+    },
+    "migrationRecovery.whatNext" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What Happens Next"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qu\u00e9 sucede a continuaci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationRecovery.bullet1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A new migration plan will be created."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se crear\u00e1 un nuevo plan de migraci\u00f3n."
+          }
+        }
+      }
+    },
+    "migrationRecovery.bullet2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers %1$lld-%2$lld will be rescheduled."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transferencias %1$lld-%2$lld se reprogramar\u00e1n."
+          }
+        }
+      }
+    },
+    "migrationRecovery.bullet3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Once you confirm the new schedule, we will send the transfers in the background."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una vez que confirmes el nuevo cronograma, enviaremos las transferencias en segundo plano."
+          }
+        }
+      }
+    },
+    "migrationComplete.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migraci\u00f3n completa"
+          }
+        }
+      }
+    },
+    "migrationComplete.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your ZEC is now in the Ironwood pool."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu ZEC ahora est\u00e1 en el fondo Ironwood."
+          }
+        }
+      }
+    },
+    "migrationComplete.rowTotal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total transferred"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total transferido"
+          }
+        }
+      }
+    },
+    "migrationComplete.rowDust" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remaining dust"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Polvo restante"
+          }
+        }
+      }
+    },
+    "migrationComplete.rowTransfers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias"
+          }
+        }
+      }
+    },
+    "migrationComplete.rowTransfersValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld sent"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld enviadas"
+          }
+        }
+      }
+    },
+    "migrationComplete.rowDuration" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationComplete.dustTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dust balance remaining"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saldo de polvo restante"
+          }
+        }
+      }
+    },
+    "migrationComplete.dustBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ stayed in Orchard \u2014 the amount is below the transfer threshold."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ permaneci\u00f3 en Orchard \u2014 el monto est\u00e1 por debajo del umbral de transferencia."
+          }
+        }
+      }
+    },
+    "migrationBanner.requiredTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Required"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migraci\u00f3n requerida"
+          }
+        }
+      }
+    },
+    "migrationBanner.requiredInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move your funds to Ironwood."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mueve tus fondos a Ironwood."
+          }
+        }
+      }
+    },
+    "migrationBanner.splittingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Split in progress\u2026"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Divisi\u00f3n en curso\u2026"
+          }
+        }
+      }
+    },
+    "migrationBanner.progressTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso de la migraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationBanner.progressInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld transfers done ~ %3$lld%% complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld transferencias hechas ~ %3$lld%% completo"
+          }
+        }
+      }
+    },
+    "migrationBanner.waitingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld waiting"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld en espera"
+          }
+        }
+      }
+    },
+    "migrationBanner.waitingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to reschedule or send now"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para reprogramar o enviar ahora"
+          }
+        }
+      }
+    },
+    "migrationBanner.updatePlanTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update migration plan"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar plan de migraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationBanner.updatePlanInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to review and approve"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para revisar y aprobar"
+          }
+        }
+      }
+    },
+    "migrationBanner.expiredTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers %1$lld-%2$lld expired"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias %1$lld-%2$lld caducadas"
+          }
+        }
+      }
+    },
+    "migrationBanner.expiredInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to create a new transfer plan"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para crear un nuevo plan de transferencia"
+          }
+        }
+      }
+    },
+    "migrationBanner.readyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld ready to send"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld lista para enviar"
+          }
+        }
+      }
+    },
+    "migrationBanner.readyInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to review and approve"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para revisar y aprobar"
+          }
+        }
+      }
+    },
+    "migrationBanner.completeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migraci\u00f3n completa"
+          }
+        }
+      }
+    },
+    "migrationBanner.completeInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to review the details"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para revisar los detalles"
+          }
+        }
+      }
+    },
+    "migration.gotIt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got it"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entendido"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
@@ -1,0 +1,64 @@
+//
+//  MigrationCompleteStore.swift
+//  zodl
+//
+//  "Migration Complete" screen (MOB-1464, Figma S12 · 2696:7267). Visually complete per Figma; all
+//  summary fields are placeholders — wiring the real data lands in MOB-1466. The `gotItTapped`
+//  delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationComplete {
+    @ObservableState
+    struct State: Equatable {
+        var totalTransferred = Zatoshi.zero
+        var dust = Zatoshi.zero
+        var transfersSent = 0
+        var transfersTotal = 0
+        var durationHours = 0
+
+        var hasDust: Bool {
+            dust.amount > 0
+        }
+
+        init(
+            totalTransferred: Zatoshi = .zero,
+            dust: Zatoshi = .zero,
+            transfersSent: Int = 0,
+            transfersTotal: Int = 0,
+            durationHours: Int = 0
+        ) {
+            self.totalTransferred = totalTransferred
+            self.dust = dust
+            self.transfersSent = transfersSent
+            self.transfersTotal = transfersTotal
+            self.durationHours = durationHours
+        }
+    }
+
+    enum Action: Equatable {
+        case delegate(Delegate)
+        case gotItTapped
+
+        enum Delegate: Equatable {
+            case done
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .gotItTapped:
+                return .send(.delegate(.done))
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteView.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteView.swift
@@ -1,0 +1,167 @@
+//
+//  MigrationCompleteView.swift
+//  zodl
+//
+//  "Migration Complete" screen (MOB-1464, Figma S12 · 2696:7267). Visually complete per Figma; all
+//  summary fields are placeholders — wiring the real data lands in MOB-1466. The `gotItTapped`
+//  delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationCompleteView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationComplete>
+
+    init(store: StoreOf<MigrationComplete>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                Spacer()
+
+                Asset.Assets.Illustrations.success1.image
+                    .resizable()
+                    .frame(width: 148, height: 148)
+
+                Text(localizable: .migrationCompleteTitle)
+                    .zFont(.semiBold, size: 28, style: Design.Text.primary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 16)
+
+                Text(localizable: .migrationCompleteSubtitle)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 8)
+
+                summaryCard
+                    .padding(.top, 24)
+
+                if store.hasDust {
+                    dustCallout
+                        .padding(.top, 16)
+                }
+
+                Spacer()
+
+                ZashiButton(String(localizable: .migrationGotIt)) {
+                    store.send(.gotItTapped)
+                }
+                .padding(.bottom, 24)
+            }
+            .padding(.vertical, 1)
+            .screenHorizontalPadding()
+            .navigationBarBackButtonHidden()
+        }
+        .applySuccessScreenBackground()
+    }
+
+    // MARK: - Summary card
+
+    @ViewBuilder private var summaryCard: some View {
+        VStack(spacing: 0) {
+            MigrationDetailRow(
+                title: String(localizable: .migrationCompleteRowTotal),
+                value: "\(store.totalTransferred.decimalString()) ZEC",
+                rowAppereance: .top
+            )
+
+            if store.hasDust {
+                MigrationDetailRow(
+                    title: String(localizable: .migrationCompleteRowDust),
+                    value: "\(store.dust.decimalString()) ZEC",
+                    rowAppereance: .middle
+                )
+            }
+
+            MigrationDetailRow(
+                title: String(localizable: .migrationCompleteRowTransfers),
+                value: String(localizable: .migrationCompleteRowTransfersValue(store.transfersSent, store.transfersTotal)),
+                rowAppereance: .middle
+            )
+
+            MigrationDetailRow(
+                title: String(localizable: .migrationCompleteRowDuration),
+                value: String(localizable: .migrationPlanEtaHours(store.durationHours)),
+                rowAppereance: .bottom
+            )
+        }
+    }
+
+    // MARK: - Dust callout
+
+    @ViewBuilder private var dustCallout: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 0) {
+                Text(localizable: .migrationCompleteDustTitle)
+                    .zFont(.semiBold, size: 14, style: Design.Text.primary)
+
+                Spacer()
+
+                Asset.Assets.infoOutline.image
+                    .zImage(size: 20, style: Design.Text.tertiary)
+            }
+
+            dustBody
+        }
+        .padding(16)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .fill(Design.Surfaces.bgSecondary.color(colorScheme))
+        }
+    }
+
+    @ViewBuilder private var dustBody: some View {
+        let amountText = "\(store.dust.decimalString()) ZEC"
+        let markdown = String(localizable: .migrationCompleteDustBody("^[\(amountText)](style: 'boldPrimary')"))
+
+        if let attrText = try? AttributedString(markdown: markdown, including: \.zashiApp) {
+            ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("With dust") {
+    NavigationView {
+        MigrationCompleteView(
+            store: StoreOf<MigrationComplete>(
+                initialState: MigrationComplete.State(
+                    totalTransferred: Zatoshi(1_245_800_000),
+                    dust: Zatoshi(31_000),
+                    transfersSent: 5,
+                    transfersTotal: 5,
+                    durationHours: 24
+                )
+            ) {
+                MigrationComplete()
+            }
+        )
+    }
+}
+
+#Preview("Clean, no dust") {
+    NavigationView {
+        MigrationCompleteView(
+            store: StoreOf<MigrationComplete>(
+                initialState: MigrationComplete.State(
+                    totalTransferred: Zatoshi(1_245_800_000),
+                    dust: .zero,
+                    transfersSent: 5,
+                    transfersTotal: 5,
+                    durationHours: 24
+                )
+            ) {
+                MigrationComplete()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationDetailRow.swift
+++ b/secant/Sources/Features/Migration/MigrationDetailRow.swift
@@ -1,0 +1,78 @@
+//
+//  MigrationDetailRow.swift
+//  zodl
+//
+//  Shared banded label/value row card for migration screens (MOB-1463): label 14 regular tertiary
+//  on the left, value 14 semibold primary on the right, bgSecondary bands with first/last corner
+//  rounding and thin 1 pt gaps between rows — the TransactionDetails row pattern
+//  (`TransactionDetailsView.RowAppereance` + `CustomRoundedRectangle`) already privately replicated
+//  in `MigrationNoteSplitView`. Used by MigrationReviewTransfer and MigrationScheduled.
+//  MigrationNoteSplitView keeps its own private copy as-is to avoid churn on its in-review PR.
+//
+
+import SwiftUI
+
+struct MigrationDetailRow: View {
+    enum RowAppereance {
+        case bottom
+        case full
+        case middle
+        case top
+
+        var corners: UIRectCorner {
+            switch self {
+            case .bottom:
+                return [.bottomLeft, .bottomRight]
+            case .full:
+                return [.allCorners]
+            case .middle:
+                return []
+            case .top:
+                return [.topLeft, .topRight]
+            }
+        }
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    let title: String
+    let value: String
+    var rowAppereance: RowAppereance = .full
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(title)
+                .zFont(size: 14, style: Design.Text.tertiary)
+
+            Spacer()
+
+            Text(value)
+                .zFont(.medium, size: 14, style: Design.Text.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 20)
+        .background {
+            CustomRoundedRectangle(corners: rowAppereance.corners, radius: 12)
+                .fill(Design.Surfaces.bgSecondary.color(colorScheme))
+        }
+        .padding(.bottom, rowAppereance == .full || rowAppereance == .bottom ? 0 : 1)
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    VStack(spacing: 0) {
+        MigrationDetailRow(title: "Amount", value: "12.458 ZEC", rowAppereance: .top)
+        MigrationDetailRow(title: "Fee", value: "0.001 ZEC", rowAppereance: .bottom)
+    }
+    .padding()
+}
+
+#Preview("Single row") {
+    MigrationDetailRow(title: "Pool", value: "Orchard → Ironwood")
+        .padding()
+}

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
@@ -1,0 +1,55 @@
+//
+//  MigrationRecoveryStore.swift
+//  zodl
+//
+//  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
+//  2696:5626 / expired 2973:5698). Visually complete per Figma; the `continueTapped` delegate is
+//  emitted but consumed by nobody yet — wiring the real plan-recreation flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct MigrationRecovery {
+    @ObservableState
+    struct State: Equatable {
+        enum Reason: Equatable {
+            case notesSpent
+            case expired
+        }
+
+        var reason = Reason.notesSpent
+        /// "Transfers {a}–{b}" range in copy.
+        var firstTransfer = 3
+        var lastTransfer = 5
+
+        init(reason: Reason = .notesSpent, firstTransfer: Int = 3, lastTransfer: Int = 5) {
+            self.reason = reason
+            self.firstTransfer = firstTransfer
+            self.lastTransfer = lastTransfer
+        }
+    }
+
+    enum Action: Equatable {
+        case continueTapped
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case recreate
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .continueTapped:
+                return .send(.delegate(.recreate))
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryView.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryView.swift
@@ -1,0 +1,153 @@
+//
+//  MigrationRecoveryView.swift
+//  zodl
+//
+//  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
+//  2696:5626 / expired 2973:5698). Visually complete per Figma; the `continueTapped` delegate is
+//  emitted but consumed by nobody yet — wiring the real plan-recreation flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct MigrationRecoveryView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationRecovery>
+
+    init(store: StoreOf<MigrationRecovery>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(title)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(description)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        Text(localizable: .migrationRecoveryWhatNext)
+                            .zFont(.medium, size: 14, style: Design.Text.primary)
+                            .padding(.bottom, 12)
+
+                        whatHappensNext
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                ZashiButton(String(localizable: .migrationNoteSplitContinue)) {
+                    store.send(.continueTapped)
+                }
+                .padding(.top, 16)
+                .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Title + description
+
+    private var title: String {
+        switch store.reason {
+        case .notesSpent:
+            return String(localizable: .migrationRecoveryTitleSpent)
+        case .expired:
+            return String(localizable: .migrationRecoveryTitleExpired)
+        }
+    }
+
+    private var description: String {
+        switch store.reason {
+        case .notesSpent:
+            return String(localizable: .migrationRecoveryDescSpent(store.firstTransfer, store.lastTransfer))
+        case .expired:
+            return String(localizable: .migrationRecoveryDescExpired(store.firstTransfer, store.lastTransfer))
+        }
+    }
+
+    // MARK: - What happens next
+
+    @ViewBuilder private var whatHappensNext: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            numberedBullet(
+                number: 1,
+                text: String(localizable: .migrationRecoveryBullet1),
+                isLast: false
+            )
+
+            numberedBullet(
+                number: 2,
+                text: String(localizable: .migrationRecoveryBullet2(store.firstTransfer, store.lastTransfer)),
+                isLast: false
+            )
+
+            numberedBullet(
+                number: 3,
+                text: String(localizable: .migrationRecoveryBullet3),
+                isLast: true
+            )
+        }
+    }
+
+    @ViewBuilder private func numberedBullet(number: Int, text: String, isLast: Bool) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 4) {
+                Circle()
+                    .fill(Design.Text.primary.color(colorScheme))
+                    .frame(width: 24, height: 24)
+                    .overlay {
+                        Text("\(number)")
+                            .zFont(.semiBold, size: 11, style: Design.Surfaces.bgPrimary)
+                    }
+
+                if !isLast {
+                    Rectangle()
+                        .fill(Design.Surfaces.strokeSecondary.color(colorScheme))
+                        .frame(width: 1.5, height: 20)
+                }
+            }
+
+            Text(text)
+                .zFont(.medium, size: 14, style: Design.Text.primary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 2)
+                .padding(.bottom, 12)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Notes spent") {
+    NavigationView {
+        MigrationRecoveryView(
+            store: StoreOf<MigrationRecovery>(
+                initialState: MigrationRecovery.State(reason: .notesSpent, firstTransfer: 3, lastTransfer: 5)
+            ) {
+                MigrationRecovery()
+            }
+        )
+    }
+}
+
+#Preview("Expired") {
+    NavigationView {
+        MigrationRecoveryView(
+            store: StoreOf<MigrationRecovery>(
+                initialState: MigrationRecovery.State(reason: .expired, firstTransfer: 3, lastTransfer: 5)
+            ) {
+                MigrationRecovery()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
@@ -1,0 +1,69 @@
+//
+//  MigrationReviewTransferStore.swift
+//  zodl
+//
+//  "Review Transfer" screen (MOB-1463, Figma S7 · immediate 2867:5924 / manual "3 of 5" 2729:8544,
+//  equivalent to frame 2712:7779 which fails to render via MCP). Final confirmation before a
+//  migration transfer is sent — either the single immediate transfer, or one step of a scheduled
+//  plan. Visual-only: `amount`/`fee` are placeholders and `sendResult` is declared but inert —
+//  submitting the transfer lands in MOB-1466. The `confirmTapped` delegate is emitted but consumed
+//  by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationReviewTransfer {
+    @ObservableState
+    struct State: Equatable {
+        enum Mode: Equatable {
+            case immediate
+            case manualStep(number: Int, total: Int)
+        }
+
+        var mode = Mode.immediate
+        /// Placeholder; real proposal data lands in MOB-1466.
+        var amount = Zatoshi.zero
+        var fee = Zatoshi.zero
+
+        init(
+            mode: Mode = .immediate,
+            amount: Zatoshi = Zatoshi.zero,
+            fee: Zatoshi = Zatoshi.zero
+        ) {
+            self.mode = mode
+            self.amount = amount
+            self.fee = fee
+        }
+    }
+
+    enum Action: Equatable {
+        /// Inert now; MOB-1466 submits the transfer.
+        case confirmTapped
+        case delegate(Delegate)
+        /// Declared for MOB-1466 (SDK-driven) — inert.
+        case sendResult(TransferResult)
+
+        enum Delegate: Equatable {
+            case confirmed
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .confirmTapped:
+                return .send(.delegate(.confirmed))
+
+            case .delegate:
+                return .none
+
+            case .sendResult:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferView.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferView.swift
@@ -1,0 +1,135 @@
+//
+//  MigrationReviewTransferView.swift
+//  zodl
+//
+//  "Review Transfer" screen (MOB-1463, Figma S7 · immediate 2867:5924 / manual "3 of 5"
+//  2729:8544). Visually complete per Figma; `sendResult` is declared but inert — submitting the
+//  transfer lands in MOB-1466. The `confirmTapped` delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationReviewTransferView: View {
+    @Perception.Bindable var store: StoreOf<MigrationReviewTransfer>
+
+    init(store: StoreOf<MigrationReviewTransfer>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        if isIconHeaderVisible {
+                            MigrationPairedIcons()
+                                .padding(.bottom, 16)
+                        }
+
+                        Text(title)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(description)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        detailRows
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                ZashiButton(String(localizable: .generalConfirm)) {
+                    store.send(.confirmTapped)
+                }
+                .padding(.top, 16)
+                .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Header
+
+    private var isIconHeaderVisible: Bool {
+        store.mode == .immediate
+    }
+
+    // MARK: - Title + description
+
+    private var title: String {
+        switch store.mode {
+        case .immediate:
+            return String(localizable: .migrationReviewTitleImmediate)
+        case .manualStep(let number, let total):
+            return String(localizable: .migrationReviewTitleManual(number, total))
+        }
+    }
+
+    private var description: String {
+        switch store.mode {
+        case .immediate:
+            return String(localizable: .migrationReviewDescImmediate)
+        case .manualStep:
+            return String(localizable: .migrationReviewDescManual)
+        }
+    }
+
+    // MARK: - Detail rows
+
+    @ViewBuilder private var detailRows: some View {
+        VStack(spacing: 0) {
+            MigrationDetailRow(
+                title: String(localizable: .sendAmount),
+                value: "\(store.amount.decimalString()) ZEC",
+                rowAppereance: .top
+            )
+
+            MigrationDetailRow(
+                title: String(localizable: .sendFeeSummary),
+                value: "\(store.fee.decimalString()) ZEC",
+                rowAppereance: .bottom
+            )
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Immediate") {
+    NavigationView {
+        MigrationReviewTransferView(
+            store: StoreOf<MigrationReviewTransfer>(
+                initialState: MigrationReviewTransfer.State(
+                    mode: .immediate,
+                    amount: Zatoshi(1_245_800_000),
+                    fee: Zatoshi(100_000)
+                )
+            ) {
+                MigrationReviewTransfer()
+            }
+        )
+    }
+}
+
+#Preview("Manual step 3 of 5") {
+    NavigationView {
+        MigrationReviewTransferView(
+            store: StoreOf<MigrationReviewTransfer>(
+                initialState: MigrationReviewTransfer.State(
+                    mode: .manualStep(number: 3, total: 5),
+                    amount: Zatoshi(243_100_000),
+                    fee: Zatoshi(100_000)
+                )
+            ) {
+                MigrationReviewTransfer()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledStore.swift
+++ b/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledStore.swift
@@ -1,0 +1,59 @@
+//
+//  MigrationScheduledStore.swift
+//  zodl
+//
+//  "Migration Scheduled" screen (MOB-1463, Figma S9 · 2630:11282). Terminal success screen shown
+//  once a scheduled migration plan has been confirmed: a summary card of what's being transferred
+//  and over how long. Visual-only: all fields are placeholders — the real summary data lands in
+//  MOB-1466. The `doneTapped` delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationScheduled {
+    @ObservableState
+    struct State: Equatable {
+        /// Placeholder; real summary data lands in MOB-1466.
+        var totalAmount = Zatoshi.zero
+        var sentCount = 0
+        var totalCount = 0
+        var durationHours = 0
+
+        init(
+            totalAmount: Zatoshi = Zatoshi.zero,
+            sentCount: Int = 0,
+            totalCount: Int = 0,
+            durationHours: Int = 0
+        ) {
+            self.totalAmount = totalAmount
+            self.sentCount = sentCount
+            self.totalCount = totalCount
+            self.durationHours = durationHours
+        }
+    }
+
+    enum Action: Equatable {
+        case delegate(Delegate)
+        case doneTapped
+
+        enum Delegate: Equatable {
+            case done
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .delegate:
+                return .none
+
+            case .doneTapped:
+                return .send(.delegate(.done))
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledView.swift
+++ b/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledView.swift
@@ -1,0 +1,106 @@
+//
+//  MigrationScheduledView.swift
+//  zodl
+//
+//  "Migration Scheduled" screen (MOB-1463, Figma S9 · 2630:11282). Visually complete per Figma;
+//  all summary fields are placeholders — wiring the real data lands in MOB-1466. The `doneTapped`
+//  delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationScheduledView: View {
+    @Perception.Bindable var store: StoreOf<MigrationScheduled>
+
+    init(store: StoreOf<MigrationScheduled>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                Spacer()
+
+                Asset.Assets.Illustrations.success1.image
+                    .resizable()
+                    .frame(width: 148, height: 148)
+
+                Text(localizable: .migrationScheduledTitle)
+                    .zFont(.semiBold, size: 28, style: Design.Text.primary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 16)
+
+                Text(localizable: .migrationScheduledSubtitle)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 8)
+
+                summaryCard
+                    .padding(.top, 24)
+
+                Spacer()
+
+                ZashiButton(String(localizable: .generalDone)) {
+                    store.send(.doneTapped)
+                }
+                .padding(.bottom, 24)
+            }
+            .padding(.vertical, 1)
+            .screenHorizontalPadding()
+            .navigationBarBackButtonHidden()
+        }
+        .applySuccessScreenBackground()
+    }
+
+    // MARK: - Summary card
+
+    @ViewBuilder private var summaryCard: some View {
+        VStack(spacing: 0) {
+            MigrationDetailRow(
+                title: String(localizable: .migrationScheduledRowTotal),
+                value: "\(store.totalAmount.decimalString()) ZEC",
+                rowAppereance: .top
+            )
+
+            MigrationDetailRow(
+                title: String(localizable: .migrationScheduledRowPool),
+                value: String(localizable: .migrationScheduledRowPoolValue),
+                rowAppereance: .middle
+            )
+
+            MigrationDetailRow(
+                title: String(localizable: .migrationScheduledRowTransfers),
+                value: String(localizable: .migrationScheduledRowTransfersValue(store.sentCount, store.totalCount)),
+                rowAppereance: .middle
+            )
+
+            MigrationDetailRow(
+                title: String(localizable: .migrationScheduledRowDuration),
+                value: String(localizable: .migrationPlanEtaHours(store.durationHours)),
+                rowAppereance: .bottom
+            )
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    NavigationView {
+        MigrationScheduledView(
+            store: StoreOf<MigrationScheduled>(
+                initialState: MigrationScheduled.State(
+                    totalAmount: Zatoshi(1_245_800_000),
+                    sentCount: 0,
+                    totalCount: 5,
+                    durationHours: 24
+                )
+            ) {
+                MigrationScheduled()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
@@ -1,0 +1,91 @@
+//
+//  MigrationSendingStore.swift
+//  zodl
+//
+//  "Sending" / "Sent" screen (MOB-1463, Figma S8 · sending 2618:6858 / sent 2618:6895). Shown while
+//  a migration transfer broadcasts, then flips to a success state. Visual-only: `txId` is a
+//  placeholder and `result` is declared but inert — resubmitting after a failure and wiring the
+//  real broadcast result land in MOB-1466. The `closeTapped` / `viewTransactionTapped` delegates
+//  are emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationSending {
+    @ObservableState
+    struct State: Equatable {
+        enum Phase: Equatable {
+            case sending
+            case success
+        }
+
+        var phase = Phase.sending
+        /// Failure sheet presented over the sending phase.
+        var isFailurePresented = false
+        /// Placeholder; real tx id lands in MOB-1466 (wires up View Transaction).
+        var txId = ""
+
+        init(
+            phase: Phase = .sending,
+            isFailurePresented: Bool = false,
+            txId: String = ""
+        ) {
+            self.phase = phase
+            self.isFailurePresented = isFailurePresented
+            self.txId = txId
+        }
+    }
+
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        /// Failure sheet: dismiss (stay on screen).
+        case cancelTapped
+        case closeTapped
+        case delegate(Delegate)
+        /// Declared for MOB-1466 (SDK-driven) — inert.
+        case result(TransferResult)
+        /// Failure sheet: dismiss — inert re-submit (MOB-1466).
+        case retryTapped
+        case viewTransactionTapped
+
+        enum Delegate: Equatable {
+            case closed
+            case viewTransaction
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+
+            case .cancelTapped:
+                state.isFailurePresented = false
+                return .none
+
+            case .closeTapped:
+                return .send(.delegate(.closed))
+
+            case .delegate:
+                return .none
+
+            case .result:
+                return .none
+
+            case .retryTapped:
+                state.isFailurePresented = false
+                return .none
+
+            case .viewTransactionTapped:
+                return .send(.delegate(.viewTransaction))
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingView.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingView.swift
@@ -1,0 +1,192 @@
+//
+//  MigrationSendingView.swift
+//  zodl
+//
+//  "Sending" / "Sent" screen (MOB-1463, Figma S8 · sending 2618:6858 / sent 2618:6895). Visually
+//  complete per Figma; `result` is declared but inert — wiring the real broadcast result and
+//  resubmission after a failure lands in MOB-1466. The `closeTapped` / `viewTransactionTapped`
+//  delegates are emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+import Lottie
+
+struct MigrationSendingView: View {
+    private enum Constants {
+        static let lottieNameLight = "sending"
+        static let lottieNameDark = "sending-dark"
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationSending>
+
+    init(store: StoreOf<MigrationSending>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            content
+                .navigationBarBackButtonHidden()
+                .zashiSheet(isPresented: $store.isFailurePresented) {
+                    failureSheetContent
+                }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder private var content: some View {
+        switch store.phase {
+        case .sending:
+            sendingContent
+                .screenHorizontalPadding()
+                .applyScreenBackground()
+
+        case .success:
+            successContent
+                .padding(.vertical, 1)
+                .screenHorizontalPadding()
+                .applySuccessScreenBackground()
+        }
+    }
+
+    // MARK: - Sending
+
+    @ViewBuilder private var sendingContent: some View {
+        VStack(spacing: 0) {
+            LottieView(
+                animation:
+                    .named(colorScheme == .light ? Constants.lottieNameLight : Constants.lottieNameDark)
+            )
+            .resizable()
+            .looping()
+            .frame(width: 170, height: 170)
+
+            Text(localizable: .migrationSendingTitle)
+                .zFont(.semiBold, size: 28, style: Design.Text.primary)
+                .padding(.top, 16)
+
+            Text(localizable: .migrationSendingSubtitle)
+                .zFont(size: 14, style: Design.Text.primary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    // MARK: - Success
+
+    @ViewBuilder private var successContent: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            Asset.Assets.Illustrations.success1.image
+                .resizable()
+                .frame(width: 148, height: 148)
+
+            Text(localizable: .migrationSendingSentTitle)
+                .zFont(.semiBold, size: 28, style: Design.Text.primary)
+                .padding(.top, 16)
+
+            Text(localizable: .migrationSendingSentSubtitle)
+                .zFont(size: 14, style: Design.Text.primary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(1.5)
+                .padding(.top, 8)
+
+            ZashiButton(
+                String(localizable: .sendViewTransaction),
+                type: .tertiary,
+                infinityWidth: false
+            ) {
+                store.send(.viewTransactionTapped)
+            }
+            .padding(.top, 16)
+
+            Spacer()
+
+            ZashiButton(String(localizable: .generalClose)) {
+                store.send(.closeTapped)
+            }
+            .padding(.bottom, 24)
+        }
+    }
+
+    // MARK: - Failure sheet
+
+    @ViewBuilder private var failureSheetContent: some View {
+        VStack(spacing: 0) {
+            Asset.Assets.Icons.alertOutline.image
+                .zImage(size: 20, style: Design.Utility.ErrorRed._500)
+                .background {
+                    Circle()
+                        .fill(Design.Utility.ErrorRed._100.color(colorScheme))
+                        .frame(width: 44, height: 44)
+                }
+                .padding(.top, 48)
+
+            Text(localizable: .migrationNoteSplitFailedTitle)
+                .zFont(.semiBold, size: 20, style: Design.Text.primary)
+                .multilineTextAlignment(.center)
+                .padding(.top, 16)
+                .padding(.bottom, 12)
+
+            Text(localizable: .migrationNoteSplitFailedBody)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.center)
+                .lineSpacing(2)
+                .padding(.bottom, 32)
+
+            ZashiButton(String(localizable: .generalCancel), type: .secondary) {
+                store.send(.cancelTapped)
+            }
+            .padding(.bottom, 12)
+
+            ZashiButton(String(localizable: .migrationNoteSplitRetry)) {
+                store.send(.retryTapped)
+            }
+            .padding(.bottom, Design.Spacing.sheetBottomSpace)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Sending") {
+    NavigationView {
+        MigrationSendingView(
+            store: StoreOf<MigrationSending>(
+                initialState: MigrationSending.State(phase: .sending)
+            ) {
+                MigrationSending()
+            }
+        )
+    }
+}
+
+#Preview("Success") {
+    NavigationView {
+        MigrationSendingView(
+            store: StoreOf<MigrationSending>(
+                initialState: MigrationSending.State(phase: .success, txId: "e87f1234567890abcdef6f28b")
+            ) {
+                MigrationSending()
+            }
+        )
+    }
+}
+
+#Preview("Sending + failure sheet") {
+    NavigationView {
+        MigrationSendingView(
+            store: StoreOf<MigrationSending>(
+                initialState: MigrationSending.State(phase: .sending, isFailurePresented: true)
+            ) {
+                MigrationSending()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
@@ -1,0 +1,89 @@
+//
+//  MigrationStatusStore.swift
+//  zodl
+//
+//  "Migration Progress" / "Resume Migration" / "Re-scheduling…" screen (MOB-1464, Figma S10 ·
+//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). Visually complete per Figma;
+//  `rows` is a placeholder and every delegate is emitted but consumed by nobody yet — wiring the
+//  real reschedule/send-now behavior and chaining into the rest of the migration flow lands in
+//  MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationStatus {
+    @ObservableState
+    struct State: Equatable {
+        enum Presentation: Equatable {
+            case progress
+            case resume
+        }
+
+        var presentation = Presentation.progress
+        /// Placeholder; real proposal data lands in MOB-1466.
+        var rows: IdentifiedArrayOf<MigrationTransferRow> = []
+        var totalDurationHours = 0
+        /// Resume header: "Transfer {n} of {m} …".
+        var stalledNumber = 0
+        var stalledHoursAgo = 0
+        /// Visual-only: skeleton captions + disabled spinner button on the resume presentation.
+        var isRescheduling = false
+
+        var remainingCount: Int {
+            rows.filter { $0.status != .sent }.count
+        }
+
+        init(
+            presentation: Presentation = .progress,
+            rows: IdentifiedArrayOf<MigrationTransferRow> = [],
+            totalDurationHours: Int = 0,
+            stalledNumber: Int = 0,
+            stalledHoursAgo: Int = 0,
+            isRescheduling: Bool = false
+        ) {
+            self.presentation = presentation
+            self.rows = rows
+            self.totalDurationHours = totalDurationHours
+            self.stalledNumber = stalledNumber
+            self.stalledHoursAgo = stalledHoursAgo
+            self.isRescheduling = isRescheduling
+        }
+    }
+
+    enum Action: Equatable {
+        /// Progress CTA and the X close.
+        case gotItTapped
+        case delegate(Delegate)
+        case rescheduleTapped
+        case sendNowTapped
+
+        enum Delegate: Equatable {
+            case done
+            case reschedule
+            case sendNow
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .gotItTapped:
+                return .send(.delegate(.done))
+
+            case .rescheduleTapped:
+                state.isRescheduling = true
+                return .send(.delegate(.reschedule))
+
+            case .sendNowTapped:
+                return .send(.delegate(.sendNow))
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
@@ -96,7 +96,10 @@ struct MigrationStatusView: View {
             return String(localizable: .migrationStatusOverdueAgo(row.hoursFromNow))
         default:
             // Pending/active rows: "~Nh" ETA per the frames (S10-progress Transfer 3 = "~6 hours").
-            return String(localizable: .migrationPlanEtaHours(row.hoursFromNow))
+            // A ready-now row renders "~10 mins", matching the Transfer Plan screen's treatment.
+            return row.hoursFromNow == 0
+                ? String(localizable: .migrationPlanEtaFirst)
+                : String(localizable: .migrationPlanEtaHours(row.hoursFromNow))
         }
     }
 

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
@@ -1,0 +1,243 @@
+//
+//  MigrationStatusView.swift
+//  zodl
+//
+//  "Migration Progress" / "Resume Migration" / "Re-scheduling…" screen (MOB-1464, Figma S10 ·
+//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). Visually complete per Figma;
+//  every delegate emitted here is consumed by nobody yet — wiring the real reschedule/send-now
+//  behavior and chaining into the rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationStatusView: View {
+    @Perception.Bindable var store: StoreOf<MigrationStatus>
+
+    init(store: StoreOf<MigrationStatus>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(title)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(description)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        MigrationTransferTimeline(
+                            rows: store.rows,
+                            caption: caption(for:),
+                            skeletonPendingCaptions: store.isRescheduling
+                        )
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                if store.presentation == .resume {
+                    footerNote
+                        .padding(.top, 16)
+                }
+
+                buttons
+                    .padding(.top, 16)
+                    .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .applyPresentationModifier(store: store)
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Title + description
+
+    private var title: String {
+        switch store.presentation {
+        case .progress:
+            return String(localizable: .migrationStatusTitle)
+        case .resume:
+            return store.isRescheduling
+                ? String(localizable: .migrationStatusReschedulingTitle)
+                : String(localizable: .migrationStatusResumeTitle)
+        }
+    }
+
+    private var description: String {
+        switch store.presentation {
+        case .progress:
+            return String(
+                localizable: .migrationStatusDesc(store.rows.count, store.totalDurationHours, store.remainingCount)
+            )
+        case .resume:
+            return String(
+                localizable: .migrationStatusResumeDesc(store.stalledNumber, store.rows.count, store.stalledHoursAgo)
+            )
+        }
+    }
+
+    // MARK: - Caption
+
+    private func caption(for row: MigrationTransferRow) -> String {
+        switch row.status {
+        case .sent:
+            return row.hoursFromNow == 0
+                ? String(localizable: .migrationStatusSentRecently)
+                : String(localizable: .migrationPlanSentAgo(row.hoursFromNow))
+        case .overdue:
+            return String(localizable: .migrationStatusOverdueAgo(row.hoursFromNow))
+        default:
+            // Pending/active rows: "~Nh" ETA per the frames (S10-progress Transfer 3 = "~6 hours").
+            return String(localizable: .migrationPlanEtaHours(row.hoursFromNow))
+        }
+    }
+
+    // MARK: - Footer note
+
+    @ViewBuilder private var footerNote: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Asset.Assets.infoOutline.image
+                .zImage(size: 16, style: Design.Text.tertiary)
+
+            Text(localizable: .migrationStatusWindowMissedNote)
+                .zFont(size: 12, style: Design.Text.tertiary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Buttons
+
+    @ViewBuilder private var buttons: some View {
+        switch store.presentation {
+        case .progress:
+            ZashiButton(String(localizable: .migrationGotIt)) {
+                store.send(.gotItTapped)
+            }
+        case .resume:
+            VStack(spacing: 8) {
+                if store.isRescheduling {
+                    ZashiButton(
+                        String(localizable: .migrationStatusReschedulingTitle),
+                        type: .tertiary,
+                        accessoryView: ProgressView()
+                    ) {
+                        store.send(.rescheduleTapped)
+                    }
+                    .disabled(true)
+                } else {
+                    ZashiButton(String(localizable: .migrationStatusReschedule), type: .ghost) {
+                        store.send(.rescheduleTapped)
+                    }
+                }
+
+                ZashiButton(String(localizable: .migrationStatusSendNow)) {
+                    store.send(.sendNowTapped)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Presentation modifier
+
+private extension View {
+    @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationStatus>) -> some View {
+        if store.presentation == .progress {
+            zashiBackV2 {
+                store.send(.gotItTapped)
+            }
+        } else {
+            zashiBack()
+        }
+    }
+}
+
+// MARK: - Mock data
+
+private extension IdentifiedArray where ID == MigrationTransferRow.ID, Element == MigrationTransferRow {
+    /// The 5-transfer set from the Figma frames (3.51220 / 2.87410 / 2.43100 / 1.99830 / 1.64240 ZEC).
+    static var previewProgressRows: Self {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .active, hoursFromNow: 6),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 18)
+        ]
+    }
+
+    /// The resume/re-scheduling frame: two sent, one overdue, two pending.
+    static var previewResumeRows: Self {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 18),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 11),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 1),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 7)
+        ]
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Progress") {
+    NavigationView {
+        MigrationStatusView(
+            store: StoreOf<MigrationStatus>(
+                initialState: MigrationStatus.State(
+                    presentation: .progress,
+                    rows: .previewProgressRows,
+                    totalDurationHours: 24
+                )
+            ) {
+                MigrationStatus()
+            }
+        )
+    }
+}
+
+#Preview("Resume") {
+    NavigationView {
+        MigrationStatusView(
+            store: StoreOf<MigrationStatus>(
+                initialState: MigrationStatus.State(
+                    presentation: .resume,
+                    rows: .previewResumeRows,
+                    totalDurationHours: 24,
+                    stalledNumber: 3,
+                    stalledHoursAgo: 5
+                )
+            ) {
+                MigrationStatus()
+            }
+        )
+    }
+}
+
+#Preview("Re-scheduling") {
+    NavigationView {
+        MigrationStatusView(
+            store: StoreOf<MigrationStatus>(
+                initialState: MigrationStatus.State(
+                    presentation: .resume,
+                    rows: .previewResumeRows,
+                    totalDurationHours: 24,
+                    stalledNumber: 3,
+                    stalledHoursAgo: 5,
+                    isRescheduling: true
+                )
+            ) {
+                MigrationStatus()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationStepBadge.swift
+++ b/secant/Sources/Features/Migration/MigrationStepBadge.swift
@@ -1,0 +1,66 @@
+//
+//  MigrationStepBadge.swift
+//  zodl
+//
+//  Small numbered/checkmark badge used by the migration transfer timelines (MOB-1463, Figma S6 ·
+//  2867:10211 / 2867:2198 / 2709:3519). Rebuilt from the prototype
+//  (`origin/michal/MOB-1451-ironwood-migration-prototype:…/MigrationStepBadge.swift`) so the
+//  Transfer Plan screen renders consistent step indicators. `.warning` isn't used yet — it's
+//  included now so this shared file is touched once; MOB-1464 reaches for it.
+//
+
+import SwiftUI
+
+struct MigrationStepBadge: View {
+    enum Style: Equatable {
+        /// Completed — green filled check.
+        case sent
+        /// The next/current step — dark filled circle with the number.
+        case active
+        /// A future step — outlined circle with the number.
+        case pending
+        /// Needs attention — amber filled exclamation. Unused until MOB-1464.
+        case warning
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    let number: Int
+    let style: Style
+
+    var body: some View {
+        ZStack {
+            switch style {
+            case .sent:
+                Circle().fill(Design.Utility.SuccessGreen._500.color(colorScheme))
+                Asset.Assets.check.image
+                    .zImage(size: 12, color: .white)
+            case .active:
+                Circle().fill(Design.Text.primary.color(colorScheme))
+                Text("\(number)")
+                    .zFont(.semiBold, size: 13, style: Design.Surfaces.bgPrimary)
+            case .pending:
+                Circle().stroke(Design.Surfaces.strokeSecondary.color(colorScheme), lineWidth: 1.5)
+                Text("\(number)")
+                    .zFont(.medium, size: 13, style: Design.Text.tertiary)
+            case .warning:
+                Circle().fill(Design.Utility.WarningYellow._500.color(colorScheme))
+                Asset.Assets.Icons.alertCircle.image
+                    .zImage(size: 12, color: .white)
+            }
+        }
+        .frame(width: 28, height: 28)
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    HStack(spacing: 12) {
+        MigrationStepBadge(number: 1, style: .sent)
+        MigrationStepBadge(number: 2, style: .active)
+        MigrationStepBadge(number: 3, style: .pending)
+        MigrationStepBadge(number: 4, style: .warning)
+    }
+    .padding()
+}

--- a/secant/Sources/Features/Migration/MigrationStepBadge.swift
+++ b/secant/Sources/Features/Migration/MigrationStepBadge.swift
@@ -5,8 +5,8 @@
 //  Small numbered/checkmark badge used by the migration transfer timelines (MOB-1463, Figma S6 ·
 //  2867:10211 / 2867:2198 / 2709:3519). Rebuilt from the prototype
 //  (`origin/michal/MOB-1451-ironwood-migration-prototype:…/MigrationStepBadge.swift`) so the
-//  Transfer Plan screen renders consistent step indicators. `.warning` isn't used yet — it's
-//  included now so this shared file is touched once; MOB-1464 reaches for it.
+//  Transfer Plan screen renders consistent step indicators. `.warning` is used by
+//  MigrationTransferTimeline for invalid/expired rows (MOB-1464).
 //
 
 import SwiftUI
@@ -19,7 +19,7 @@ struct MigrationStepBadge: View {
         case active
         /// A future step — outlined circle with the number.
         case pending
-        /// Needs attention — amber filled exclamation. Unused until MOB-1464.
+        /// Needs attention — amber filled exclamation (invalid/expired timeline rows).
         case warning
     }
 

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -1,0 +1,65 @@
+//
+//  MigrationTransferPlanStore.swift
+//  zodl
+//
+//  "Transfer Plan" screen (MOB-1463, Figma S6 · scheduled 2867:10211 / manual 2867:2198 /
+//  re-created 2709:3519). One-time review of the migration schedule before signing: a timeline of
+//  transfer rows, each showing its amount, status, and ETA. Visual-only: `rows` is a placeholder —
+//  the real proposal (and signing/storing it) lands in MOB-1466. The `confirmTapped` delegate is
+//  emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationTransferPlan {
+    @ObservableState
+    struct State: Equatable {
+        enum Variant: Equatable {
+            case scheduled
+            case manual
+            case recreated
+        }
+
+        var variant = Variant.scheduled
+        /// Placeholder; real proposal data lands in MOB-1466.
+        var rows: IdentifiedArrayOf<MigrationTransferRow> = []
+        var totalDurationHours = 0
+        @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion?
+
+        init(
+            variant: Variant = .scheduled,
+            rows: IdentifiedArrayOf<MigrationTransferRow> = [],
+            totalDurationHours: Int = 0
+        ) {
+            self.variant = variant
+            self.rows = rows
+            self.totalDurationHours = totalDurationHours
+        }
+    }
+
+    enum Action: Equatable {
+        /// Inert now; MOB-1466 signs and stores the schedule.
+        case confirmTapped
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case confirmed
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .confirmTapped:
+                return .send(.delegate(.confirmed))
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
@@ -13,7 +13,6 @@ import ComposableArchitecture
 import SwiftUI
 
 struct MigrationTransferPlanView: View {
-    @Environment(\.colorScheme) private var colorScheme
     @Perception.Bindable var store: StoreOf<MigrationTransferPlan>
 
     init(store: StoreOf<MigrationTransferPlan>) {
@@ -35,7 +34,7 @@ struct MigrationTransferPlanView: View {
                             .fixedSize(horizontal: false, vertical: true)
                             .padding(.bottom, 24)
 
-                        timelineRows
+                        MigrationTransferTimeline(rows: store.rows, caption: caption(for:))
                     }
                     .padding(.vertical, 1)
                 }
@@ -76,74 +75,7 @@ struct MigrationTransferPlanView: View {
         }
     }
 
-    // MARK: - Timeline rows
-
-    @ViewBuilder private var timelineRows: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(store.rows.enumerated()), id: \.element.id) { index, row in
-                timelineRow(row, isLast: index == store.rows.count - 1)
-            }
-        }
-    }
-
-    @ViewBuilder private func timelineRow(_ row: MigrationTransferRow, isLast: Bool) -> some View {
-        HStack(alignment: .top, spacing: 12) {
-            VStack(spacing: 4) {
-                MigrationStepBadge(number: row.index + 1, style: badgeStyle(for: row.status))
-
-                if !isLast {
-                    Rectangle()
-                        .fill(connectorColor(for: row.status).color(colorScheme))
-                        .frame(width: 1.5, height: 28)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localizable: .migrationPlanTransferN(row.index + 1)))
-                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
-
-                Text(caption(for: row))
-                    .zFont(size: 14, style: Design.Text.tertiary)
-            }
-            .padding(.top, 2)
-
-            Spacer(minLength: 8)
-
-            VStack(alignment: .trailing, spacing: 2) {
-                Text("\(row.amount.decimalString()) ZEC")
-                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
-
-                if let currencyConversion = store.currencyConversion {
-                    Text(currencyConversion.convert(row.amount))
-                        .zFont(size: 13, style: Design.Text.tertiary)
-                }
-            }
-            .padding(.top, 2)
-            .padding(.bottom, 16)
-        }
-    }
-
-    private func badgeStyle(for status: MigrationTransferRow.Status) -> MigrationStepBadge.Style {
-        switch status {
-        case .sent:
-            return .sent
-        case .active:
-            return .active
-        default:
-            return .pending
-        }
-    }
-
-    private func connectorColor(for status: MigrationTransferRow.Status) -> Colorable {
-        switch status {
-        case .sent:
-            return Design.Utility.SuccessGreen._500
-        case .active:
-            return Design.Text.primary
-        default:
-            return Design.Surfaces.strokeSecondary
-        }
-    }
+    // MARK: - Caption
 
     private func caption(for row: MigrationTransferRow) -> String {
         switch row.status {

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
@@ -1,0 +1,242 @@
+//
+//  MigrationTransferPlanView.swift
+//  zodl
+//
+//  "Transfer Plan" screen (MOB-1463, Figma S6 · scheduled 2867:10211 / manual 2867:2198 /
+//  re-created 2709:3519). Visually complete per Figma; `rows` is a placeholder and the
+//  `confirmTapped` delegate is emitted but consumed by nobody yet — wiring the real proposal and
+//  chaining into the rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationTransferPlanView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationTransferPlan>
+
+    init(store: StoreOf<MigrationTransferPlan>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(title)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(description)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        timelineRows
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                ZashiButton(String(localizable: .generalConfirm)) {
+                    store.send(.confirmTapped)
+                }
+                .padding(.top, 16)
+                .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Title + description
+
+    private var title: String {
+        switch store.variant {
+        case .scheduled, .recreated:
+            return String(localizable: .migrationPlanTitleConfirm)
+        case .manual:
+            return String(localizable: .migrationPlanTitleManual)
+        }
+    }
+
+    private var description: String {
+        let transferCount = store.rows.count
+
+        switch store.variant {
+        case .scheduled:
+            return String(localizable: .migrationPlanDescScheduled(transferCount, store.totalDurationHours))
+        case .manual:
+            return String(localizable: .migrationPlanDescManual(transferCount, store.totalDurationHours))
+        case .recreated:
+            return String(localizable: .migrationPlanDescRecreated(transferCount, store.totalDurationHours))
+        }
+    }
+
+    // MARK: - Timeline rows
+
+    @ViewBuilder private var timelineRows: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(store.rows.enumerated()), id: \.element.id) { index, row in
+                timelineRow(row, isLast: index == store.rows.count - 1)
+            }
+        }
+    }
+
+    @ViewBuilder private func timelineRow(_ row: MigrationTransferRow, isLast: Bool) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 4) {
+                MigrationStepBadge(number: row.index + 1, style: badgeStyle(for: row.status))
+
+                if !isLast {
+                    Rectangle()
+                        .fill(connectorColor(for: row.status).color(colorScheme))
+                        .frame(width: 1.5, height: 28)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localizable: .migrationPlanTransferN(row.index + 1)))
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                Text(caption(for: row))
+                    .zFont(size: 14, style: Design.Text.tertiary)
+            }
+            .padding(.top, 2)
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("\(row.amount.decimalString()) ZEC")
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                if let currencyConversion = store.currencyConversion {
+                    Text(currencyConversion.convert(row.amount))
+                        .zFont(size: 13, style: Design.Text.tertiary)
+                }
+            }
+            .padding(.top, 2)
+            .padding(.bottom, 16)
+        }
+    }
+
+    private func badgeStyle(for status: MigrationTransferRow.Status) -> MigrationStepBadge.Style {
+        switch status {
+        case .sent:
+            return .sent
+        case .active:
+            return .active
+        default:
+            return .pending
+        }
+    }
+
+    private func connectorColor(for status: MigrationTransferRow.Status) -> Colorable {
+        switch status {
+        case .sent:
+            return Design.Utility.SuccessGreen._500
+        case .active:
+            return Design.Text.primary
+        default:
+            return Design.Surfaces.strokeSecondary
+        }
+    }
+
+    private func caption(for row: MigrationTransferRow) -> String {
+        switch row.status {
+        case .sent:
+            return String(localizable: .migrationPlanSentAgo(row.hoursFromNow))
+        case .active:
+            return store.variant == .recreated
+                ? String(localizable: .migrationPlanReadyNow)
+                : eta(hoursFromNow: row.hoursFromNow)
+        default:
+            return eta(hoursFromNow: row.hoursFromNow)
+        }
+    }
+
+    private func eta(hoursFromNow: Int) -> String {
+        hoursFromNow == 0
+            ? String(localizable: .migrationPlanEtaFirst)
+            : String(localizable: .migrationPlanEtaHours(hoursFromNow))
+    }
+}
+
+// MARK: - Mock data
+
+private extension IdentifiedArray where ID == MigrationTransferRow.ID, Element == MigrationTransferRow {
+    /// The 5-transfer set from the Figma frames (3.51220 / 2.87410 / 2.43100 / 1.99830 / 1.64240 ZEC).
+    static var previewRows: Self {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .active, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .pending, hoursFromNow: 6),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 18),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 24)
+        ]
+    }
+
+    /// The re-created variant's frame: two already sent, one active, two pending.
+    static var previewRecreatedRows: Self {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 17),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .active, hoursFromNow: 0),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 6),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 12)
+        ]
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Scheduled") {
+    NavigationView {
+        MigrationTransferPlanView(
+            store: StoreOf<MigrationTransferPlan>(
+                initialState: MigrationTransferPlan.State(
+                    variant: .scheduled,
+                    rows: .previewRows,
+                    totalDurationHours: 24
+                )
+            ) {
+                MigrationTransferPlan()
+            }
+        )
+    }
+}
+
+#Preview("Manual") {
+    NavigationView {
+        MigrationTransferPlanView(
+            store: StoreOf<MigrationTransferPlan>(
+                initialState: MigrationTransferPlan.State(
+                    variant: .manual,
+                    rows: .previewRows,
+                    totalDurationHours: 24
+                )
+            ) {
+                MigrationTransferPlan()
+            }
+        )
+    }
+}
+
+#Preview("Recreated") {
+    NavigationView {
+        MigrationTransferPlanView(
+            store: StoreOf<MigrationTransferPlan>(
+                initialState: MigrationTransferPlan.State(
+                    variant: .recreated,
+                    rows: .previewRecreatedRows,
+                    totalDurationHours: 12
+                )
+            ) {
+                MigrationTransferPlan()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationTransferTimeline.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferTimeline.swift
@@ -1,0 +1,138 @@
+//
+//  MigrationTransferTimeline.swift
+//  zodl
+//
+//  Shared badge+connector+title/caption+amount/fiat timeline rows, extracted from
+//  `MigrationTransferPlanView` (MOB-1463) for MOB-1464's Status/Recovery screens — the third
+//  consumer of this row list. Screens own their own caption copy via the `caption` closure;
+//  everything else (badge mapping, connector color, amount + fiat display) lives here.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationTransferTimeline: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Shared(.inMemory(.exchangeRate)) private var currencyConversion: CurrencyConversion?
+
+    let rows: IdentifiedArrayOf<MigrationTransferRow>
+    let caption: (MigrationTransferRow) -> String
+    var skeletonPendingCaptions = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                timelineRow(row, isLast: index == rows.count - 1)
+            }
+        }
+    }
+
+    @ViewBuilder private func timelineRow(_ row: MigrationTransferRow, isLast: Bool) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 4) {
+                MigrationStepBadge(number: row.index + 1, style: badgeStyle(for: row.status))
+
+                if !isLast {
+                    Rectangle()
+                        .fill(connectorColor(for: row.status).color(colorScheme))
+                        .frame(width: 1.5, height: 28)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localizable: .migrationPlanTransferN(row.index + 1)))
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                captionOrSkeleton(for: row)
+            }
+            .padding(.top, 2)
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("\(row.amount.decimalString()) ZEC")
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                if let currencyConversion {
+                    Text(currencyConversion.convert(row.amount))
+                        .zFont(size: 13, style: Design.Text.tertiary)
+                }
+            }
+            .padding(.top, 2)
+            .padding(.bottom, 16)
+        }
+    }
+
+    @ViewBuilder private func captionOrSkeleton(for row: MigrationTransferRow) -> some View {
+        if skeletonPendingCaptions && row.status != .sent {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Design.Surfaces.bgTertiary.color(colorScheme))
+                .frame(width: 72, height: 12)
+        } else {
+            Text(caption(row))
+                .zFont(size: 14, style: Design.Text.tertiary)
+        }
+    }
+
+    private func badgeStyle(for status: MigrationTransferRow.Status) -> MigrationStepBadge.Style {
+        switch status {
+        case .sent:
+            return .sent
+        case .active, .overdue:
+            return .active
+        case .pending:
+            return .pending
+        case .invalid, .expired:
+            return .warning
+        }
+    }
+
+    private func connectorColor(for status: MigrationTransferRow.Status) -> Colorable {
+        switch badgeStyle(for: status) {
+        case .sent:
+            return Design.Utility.SuccessGreen._500
+        case .active:
+            return Design.Text.primary
+        case .pending:
+            return Design.Surfaces.strokeSecondary
+        case .warning:
+            return Design.Utility.WarningYellow._500
+        }
+    }
+}
+
+// MARK: - Previews
+
+private extension IdentifiedArray where ID == MigrationTransferRow.ID, Element == MigrationTransferRow {
+    static var previewRows: Self {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .active, hoursFromNow: 0),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .expired, hoursFromNow: 18)
+        ]
+    }
+}
+
+#Preview {
+    ScrollView {
+        MigrationTransferTimeline(
+            rows: .previewRows,
+            caption: { row in "hoursFromNow: \(row.hoursFromNow)" }
+        )
+        .padding()
+    }
+}
+
+#Preview("Skeleton pending captions") {
+    ScrollView {
+        MigrationTransferTimeline(
+            rows: .previewRows,
+            caption: { row in "hoursFromNow: \(row.hoursFromNow)" },
+            skeletonPendingCaptions: true
+        )
+        .padding()
+    }
+}

--- a/secant/Sources/Features/SmartBanner/SmartBannerContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerContent.swift
@@ -31,6 +31,7 @@ extension SmartBannerView {
             case .priority75: torSetupContent()
             case .priority8: currencyConversionContent()
             case .priority9: autoShieldingContent()
+            case .priorityMigration: migrationContent()
             default: EmptyView()
             }
         }

--- a/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
@@ -1,0 +1,139 @@
+//
+//  SmartBannerMigrationContent.swift
+//  zodl
+//
+//  Ironwood migration content for the SmartBanner's `priorityMigration` case (MOB-1464). Visual-only:
+//  the case can never be requested by the running evaluator chain yet — wiring the real
+//  triggering/evaluators/routing is MOB-1466's job. `MigrationBannerVariant` is a pure, testable
+//  mapping (see MigrationBannerVariantTests); `migrationContent()` mirrors `shieldingContent()`'s
+//  structure.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+enum MigrationBannerVariant: Equatable {
+    case required
+    case splitting
+    case inProgress(done: Int, total: Int)
+    case transferWaiting(number: Int)
+    case updatePlan
+    case transfersExpired(first: Int, last: Int)
+    case transferReady(number: Int)
+    case complete
+
+    var title: String {
+        switch self {
+        case .required, .splitting:
+            return String(localizable: .migrationBannerRequiredTitle)
+        case .inProgress:
+            return String(localizable: .migrationBannerProgressTitle)
+        case .transferWaiting(let number):
+            return String(localizable: .migrationBannerWaitingTitle(number))
+        case .updatePlan:
+            return String(localizable: .migrationBannerUpdatePlanTitle)
+        case .transfersExpired(let first, let last):
+            return String(localizable: .migrationBannerExpiredTitle(first, last))
+        case .transferReady(let number):
+            return String(localizable: .migrationBannerReadyTitle(number))
+        case .complete:
+            return String(localizable: .migrationBannerCompleteTitle)
+        }
+    }
+
+    var info: String {
+        switch self {
+        case .required:
+            return String(localizable: .migrationBannerRequiredInfo)
+        case .splitting:
+            return String(localizable: .migrationBannerSplittingInfo)
+        case .inProgress(let done, let total):
+            return String(localizable: .migrationBannerProgressInfo(done, total, percent ?? 0))
+        case .transferWaiting:
+            return String(localizable: .migrationBannerWaitingInfo)
+        case .updatePlan:
+            return String(localizable: .migrationBannerUpdatePlanInfo)
+        case .transfersExpired:
+            return String(localizable: .migrationBannerExpiredInfo)
+        case .transferReady:
+            return String(localizable: .migrationBannerReadyInfo)
+        case .complete:
+            return String(localizable: .migrationBannerCompleteInfo)
+        }
+    }
+
+    /// "More" everywhere except `transferReady`, which reads "Review".
+    var buttonLabel: String {
+        switch self {
+        case .transferReady:
+            return String(localizable: .sendReview)
+        default:
+            return String(localizable: .generalMore)
+        }
+    }
+
+    var percent: Int? {
+        guard case let .inProgress(done, total) = self else {
+            return nil
+        }
+        return Int((Double(done) / Double(max(total, 1)) * 100).rounded())
+    }
+}
+
+extension SmartBannerView {
+    @ViewBuilder func migrationContent() -> some View {
+        HStack(spacing: 0) {
+            migrationIcon()
+                .padding(.trailing, 12)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(store.migrationBannerVariant.title)
+                    .zFont(.medium, size: 14, color: titleStyle())
+
+                Text(store.migrationBannerVariant.info)
+                    .zFont(.medium, size: 12, color: infoStyle())
+            }
+
+            Spacer()
+
+            ZashiButton(
+                store.migrationBannerVariant.buttonLabel,
+                type: .ghost,
+                infinityWidth: false
+            ) {
+                store.send(.smartBannerContentTapped)
+            }
+        }
+    }
+
+    @ViewBuilder private func migrationIcon() -> some View {
+        switch store.migrationBannerVariant {
+        case .required, .splitting:
+            Asset.Assets.Icons.coinsSwap.image
+                .zImage(size: 20, color: titleStyle())
+        case .inProgress:
+            migrationProgressRing()
+        case .transferWaiting, .updatePlan, .transfersExpired, .transferReady:
+            Asset.Assets.Icons.alertCircle.image
+                .zImage(size: 20, color: titleStyle())
+        case .complete:
+            Asset.Assets.Icons.checkVerified.image
+                .zImage(size: 20, color: titleStyle())
+        }
+    }
+
+    @ViewBuilder private func migrationProgressRing() -> some View {
+        let percent = store.migrationBannerVariant.percent ?? 0
+
+        ZStack {
+            Circle()
+                .stroke(titleStyle().opacity(0.3), lineWidth: 2)
+
+            Circle()
+                .trim(from: 0, to: CGFloat(percent) / 100)
+                .stroke(titleStyle(), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: 20, height: 20)
+    }
+}

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -35,9 +35,13 @@ struct SmartBanner {
             case priority75 // tor
             case priority8 // currency conversion
             case priority9 // auto-shielding
+            case priorityMigration = -1 // ironwood migration (MOB-1464; not triggered yet — MOB-1466)
 
             func next() -> PriorityContent {
-                PriorityContent.init(rawValue: self.rawValue - 1) ?? .priority9
+                // `priorityMigration` (-1) sits outside the walk-down chain — it is only ever
+                // triggered explicitly, so walking below `priority1` wraps to `priority9` as before.
+                guard rawValue > 0 else { return .priority9 }
+                return PriorityContent(rawValue: rawValue - 1) ?? .priority9
             }
         }
         
@@ -60,6 +64,7 @@ struct SmartBanner {
         var lastKnownErrorMessage = ""
         var lastKnownSyncPercentage = -1.0
         var messageToBeShared: String?
+        var migrationBannerVariant = MigrationBannerVariant.required
         var priorityContent: PriorityContent? = nil
         var priorityContentRequested: PriorityContent? = nil
         var remindMeShieldedPhaseCounter = 0

--- a/zodlTests/MigrationTests/MigrationBannerVariantTests.swift
+++ b/zodlTests/MigrationTests/MigrationBannerVariantTests.swift
@@ -1,0 +1,112 @@
+//
+//  MigrationBannerVariantTests.swift
+//  zodlTests
+//
+//  Covers the pure `MigrationBannerVariant` mappings
+//  (Features/SmartBanner/SmartBannerMigrationContent.swift) for MOB-1464: title/info/buttonLabel
+//  text per variant (including argument interpolation) and the `percent` rounding for `inProgress`.
+//  No reducer, no shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct MigrationBannerVariantTests {
+    @Test func requiredTitleAndInfo() {
+        let variant = MigrationBannerVariant.required
+
+        #expect(variant.title == String(localizable: .migrationBannerRequiredTitle))
+        #expect(variant.info == String(localizable: .migrationBannerRequiredInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func splittingTitleAndInfo() {
+        let variant = MigrationBannerVariant.splitting
+
+        #expect(variant.title == String(localizable: .migrationBannerRequiredTitle))
+        #expect(variant.info == String(localizable: .migrationBannerSplittingInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func inProgressTitleAndInfoInterpolatesDoneTotalAndPercent() {
+        let variant = MigrationBannerVariant.inProgress(done: 2, total: 5)
+
+        #expect(variant.title == String(localizable: .migrationBannerProgressTitle))
+        #expect(variant.info == String(localizable: .migrationBannerProgressInfo(2, 5, 40)))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == 40)
+    }
+
+    @Test func inProgressPercentRoundsToNearestInteger() {
+        #expect(MigrationBannerVariant.inProgress(done: 2, total: 5).percent == 40)
+        #expect(MigrationBannerVariant.inProgress(done: 1, total: 3).percent == 33)
+        #expect(MigrationBannerVariant.inProgress(done: 2, total: 3).percent == 67)
+        #expect(MigrationBannerVariant.inProgress(done: 0, total: 0).percent == 0)
+    }
+
+    @Test func transferWaitingTitleInterpolatesNumber() {
+        let variant = MigrationBannerVariant.transferWaiting(number: 3)
+
+        #expect(variant.title == String(localizable: .migrationBannerWaitingTitle(3)))
+        #expect(variant.info == String(localizable: .migrationBannerWaitingInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func updatePlanTitleAndInfo() {
+        let variant = MigrationBannerVariant.updatePlan
+
+        #expect(variant.title == String(localizable: .migrationBannerUpdatePlanTitle))
+        #expect(variant.info == String(localizable: .migrationBannerUpdatePlanInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func transfersExpiredTitleInterpolatesFirstAndLast() {
+        let variant = MigrationBannerVariant.transfersExpired(first: 3, last: 5)
+
+        #expect(variant.title == String(localizable: .migrationBannerExpiredTitle(3, 5)))
+        #expect(variant.info == String(localizable: .migrationBannerExpiredInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func transferReadyTitleInterpolatesNumberAndUsesReviewButtonLabel() {
+        let variant = MigrationBannerVariant.transferReady(number: 4)
+
+        #expect(variant.title == String(localizable: .migrationBannerReadyTitle(4)))
+        #expect(variant.info == String(localizable: .migrationBannerReadyInfo))
+        #expect(variant.buttonLabel == String(localizable: .sendReview))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func completeTitleAndInfo() {
+        let variant = MigrationBannerVariant.complete
+
+        #expect(variant.title == String(localizable: .migrationBannerCompleteTitle))
+        #expect(variant.info == String(localizable: .migrationBannerCompleteInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func onlyTransferReadyUsesTheReviewButtonLabel() {
+        let allOtherVariants: [MigrationBannerVariant] = [
+            .required,
+            .splitting,
+            .inProgress(done: 1, total: 2),
+            .transferWaiting(number: 1),
+            .updatePlan,
+            .transfersExpired(first: 1, last: 2),
+            .complete
+        ]
+
+        for variant in allOtherVariants {
+            #expect(variant.buttonLabel == String(localizable: .generalMore))
+        }
+
+        #expect(MigrationBannerVariant.transferReady(number: 1).buttonLabel == String(localizable: .sendReview))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCompleteTests.swift
+++ b/zodlTests/MigrationTests/MigrationCompleteTests.swift
@@ -1,0 +1,57 @@
+//
+//  MigrationCompleteTests.swift
+//  zodlTests
+//
+//  Covers the MigrationComplete reducer
+//  (Features/Migration/MigrationComplete/MigrationCompleteStore.swift) for MOB-1464: the `hasDust`
+//  derivation at zero/nonzero dust, and the `gotItTapped` delegate contract. Visual-only screen —
+//  no SDK calls, no navigation. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationCompleteTests {
+    @MainActor @Test func defaultStateIsAllZeroWithNoDust() async {
+        let state = MigrationComplete.State()
+
+        #expect(state.totalTransferred == Zatoshi.zero)
+        #expect(state.dust == Zatoshi.zero)
+        #expect(state.transfersSent == 0)
+        #expect(state.transfersTotal == 0)
+        #expect(state.durationHours == 0)
+        #expect(state.hasDust == false)
+    }
+
+    @MainActor @Test func hasDustIsFalseWhenDustIsZero() async {
+        let state = MigrationComplete.State(dust: Zatoshi.zero)
+
+        #expect(state.hasDust == false)
+    }
+
+    @MainActor @Test func hasDustIsTrueWhenDustIsNonzero() async {
+        let state = MigrationComplete.State(dust: Zatoshi(31_000))
+
+        #expect(state.hasDust)
+    }
+
+    @MainActor @Test func gotItTappedEmitsDelegateDone() async {
+        let store = TestStore(initialState: MigrationComplete.State()) {
+            MigrationComplete()
+        }
+
+        await store.send(.gotItTapped)
+        await store.receive(.delegate(.done))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationComplete.State()) {
+            MigrationComplete()
+        }
+
+        await store.send(.delegate(.done))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationRecoveryTests.swift
+++ b/zodlTests/MigrationTests/MigrationRecoveryTests.swift
@@ -1,0 +1,56 @@
+//
+//  MigrationRecoveryTests.swift
+//  zodlTests
+//
+//  Covers the MigrationRecovery reducer
+//  (Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift) for MOB-1464: the default
+//  `.notesSpent` reason and the `continueTapped` delegate contract. Visual-only screen — no SDK
+//  calls, no navigation. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite struct MigrationRecoveryTests {
+    @MainActor @Test func defaultStateIsNotesSpentReasonWithDefaultTransferRange() async {
+        let state = MigrationRecovery.State()
+
+        #expect(state.reason == MigrationRecovery.State.Reason.notesSpent)
+        #expect(state.firstTransfer == 3)
+        #expect(state.lastTransfer == 5)
+    }
+
+    @MainActor @Test func expiredReasonIsPreservedInState() async {
+        let state = MigrationRecovery.State(reason: .expired)
+
+        #expect(state.reason == .expired)
+    }
+
+    @MainActor @Test func continueTappedEmitsDelegateRecreate() async {
+        let store = TestStore(initialState: MigrationRecovery.State()) {
+            MigrationRecovery()
+        }
+
+        await store.send(.continueTapped)
+        await store.receive(.delegate(.recreate))
+    }
+
+    @MainActor @Test func continueTappedEmitsDelegateRecreateForExpiredReason() async {
+        let store = TestStore(initialState: MigrationRecovery.State(reason: .expired)) {
+            MigrationRecovery()
+        }
+
+        await store.send(.continueTapped)
+        await store.receive(.delegate(.recreate))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationRecovery.State()) {
+            MigrationRecovery()
+        }
+
+        await store.send(.delegate(.recreate))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationReviewTransferTests.swift
+++ b/zodlTests/MigrationTests/MigrationReviewTransferTests.swift
@@ -1,0 +1,67 @@
+//
+//  MigrationReviewTransferTests.swift
+//  zodlTests
+//
+//  Covers the MigrationReviewTransfer reducer
+//  (Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift) for MOB-1463:
+//  the default `mode`, the `confirmTapped` delegate contract, and that `sendResult` is a no-op for
+//  now — submitting the transfer is MOB-1466's job. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationReviewTransferTests {
+    @MainActor @Test func defaultStateIsImmediateModeWithZeroAmounts() async {
+        let state = MigrationReviewTransfer.State()
+
+        #expect(state.mode == MigrationReviewTransfer.State.Mode.immediate)
+        #expect(state.amount == Zatoshi.zero)
+        #expect(state.fee == Zatoshi.zero)
+    }
+
+    @MainActor @Test func confirmTappedEmitsDelegateConfirmed() async {
+        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
+            MigrationReviewTransfer()
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+    }
+
+    @MainActor @Test func confirmTappedEmitsDelegateConfirmedForManualStepMode() async {
+        let store = TestStore(
+            initialState: MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5))
+        ) {
+            MigrationReviewTransfer()
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+    }
+
+    @MainActor @Test func manualStepModeIsPreservedInState() async {
+        let state = MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5))
+
+        #expect(state.mode == .manualStep(number: 3, total: 5))
+    }
+
+    @MainActor @Test func sendResultExpiredProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
+            MigrationReviewTransfer()
+        }
+
+        await store.send(.sendResult(.expired))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
+            MigrationReviewTransfer()
+        }
+
+        await store.send(.delegate(.confirmed))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationScheduledTests.swift
+++ b/zodlTests/MigrationTests/MigrationScheduledTests.swift
@@ -1,0 +1,44 @@
+//
+//  MigrationScheduledTests.swift
+//  zodlTests
+//
+//  Covers the MigrationScheduled reducer
+//  (Features/Migration/MigrationScheduled/MigrationScheduledStore.swift) for MOB-1463: the default
+//  state and the `doneTapped` delegate contract. This is the terminal success screen for the
+//  migration flow — no SDK calls, no navigation — chaining lands in MOB-1466. No shared/global
+//  state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationScheduledTests {
+    @MainActor @Test func defaultStateIsAllZero() async {
+        let state = MigrationScheduled.State()
+
+        #expect(state.totalAmount == Zatoshi.zero)
+        #expect(state.sentCount == 0)
+        #expect(state.totalCount == 0)
+        #expect(state.durationHours == 0)
+    }
+
+    @MainActor @Test func doneTappedEmitsDelegateDone() async {
+        let store = TestStore(initialState: MigrationScheduled.State()) {
+            MigrationScheduled()
+        }
+
+        await store.send(.doneTapped)
+        await store.receive(.delegate(.done))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationScheduled.State()) {
+            MigrationScheduled()
+        }
+
+        await store.send(.delegate(.done))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationSendingTests.swift
+++ b/zodlTests/MigrationTests/MigrationSendingTests.swift
@@ -1,0 +1,80 @@
+//
+//  MigrationSendingTests.swift
+//  zodlTests
+//
+//  Covers the MigrationSending reducer
+//  (Features/Migration/MigrationSending/MigrationSendingStore.swift) for MOB-1463: the default
+//  phase/state, the `closeTapped` / `viewTransactionTapped` delegate contracts, the failure sheet
+//  dismissal (cancel/retry), and that `result` is a no-op for now — resubmitting the transfer is
+//  MOB-1466's job. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationSendingTests {
+    @MainActor @Test func defaultStateIsSendingPhaseWithNoFailureSheet() async {
+        let state = MigrationSending.State()
+
+        #expect(state.phase == MigrationSending.State.Phase.sending)
+        #expect(state.isFailurePresented == false)
+        #expect(state.txId == "")
+    }
+
+    @MainActor @Test func closeTappedEmitsDelegateClosed() async {
+        let store = TestStore(initialState: MigrationSending.State(phase: .success)) {
+            MigrationSending()
+        }
+
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.closed))
+    }
+
+    @MainActor @Test func viewTransactionTappedEmitsDelegateViewTransaction() async {
+        let store = TestStore(initialState: MigrationSending.State(phase: .success, txId: "e87f1234567890abcdef6f28b")) {
+            MigrationSending()
+        }
+
+        await store.send(.viewTransactionTapped)
+        await store.receive(.delegate(.viewTransaction))
+    }
+
+    @MainActor @Test func cancelTappedDismissesFailureSheet() async {
+        let store = TestStore(initialState: MigrationSending.State(isFailurePresented: true)) {
+            MigrationSending()
+        }
+
+        await store.send(.cancelTapped) {
+            $0.isFailurePresented = false
+        }
+    }
+
+    @MainActor @Test func retryTappedDismissesFailureSheet() async {
+        let store = TestStore(initialState: MigrationSending.State(isFailurePresented: true)) {
+            MigrationSending()
+        }
+
+        await store.send(.retryTapped) {
+            $0.isFailurePresented = false
+        }
+    }
+
+    @MainActor @Test func resultNetworkErrorRetryableProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationSending.State()) {
+            MigrationSending()
+        }
+
+        await store.send(.result(.networkError(retryable: true)))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationSending.State()) {
+            MigrationSending()
+        }
+
+        await store.send(.delegate(.closed))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationStatusTests.swift
+++ b/zodlTests/MigrationTests/MigrationStatusTests.swift
@@ -1,0 +1,88 @@
+//
+//  MigrationStatusTests.swift
+//  zodlTests
+//
+//  Covers the MigrationStatus reducer (Features/Migration/MigrationStatus/MigrationStatusStore.swift)
+//  for MOB-1464: the default `.progress` presentation, the `gotItTapped`/`sendNowTapped`/
+//  `rescheduleTapped` delegate contracts, and the `remainingCount` derivation over a mixed row set.
+//  Visual-only screen — no SDK calls, no navigation. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationStatusTests {
+    @MainActor @Test func defaultStateIsProgressPresentationWithNoRows() async {
+        let state = MigrationStatus.State()
+
+        #expect(state.presentation == MigrationStatus.State.Presentation.progress)
+        #expect(state.rows.isEmpty)
+        #expect(state.totalDurationHours == 0)
+        #expect(state.stalledNumber == 0)
+        #expect(state.stalledHoursAgo == 0)
+        #expect(state.isRescheduling == false)
+    }
+
+    @MainActor @Test func gotItTappedEmitsDelegateDone() async {
+        let store = TestStore(initialState: MigrationStatus.State()) {
+            MigrationStatus()
+        }
+
+        await store.send(.gotItTapped)
+        await store.receive(.delegate(.done))
+    }
+
+    @MainActor @Test func sendNowTappedEmitsDelegateSendNow() async {
+        let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
+            MigrationStatus()
+        }
+
+        await store.send(.sendNowTapped)
+        await store.receive(.delegate(.sendNow))
+    }
+
+    @MainActor @Test func rescheduleTappedSetsIsReschedulingAndEmitsDelegateReschedule() async {
+        let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
+            MigrationStatus()
+        }
+
+        await store.send(.rescheduleTapped) {
+            $0.isRescheduling = true
+        }
+        await store.receive(.delegate(.reschedule))
+    }
+
+    @MainActor @Test func remainingCountCountsAllRowsNotYetSent() async {
+        var state = MigrationStatus.State()
+        state.rows = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 18),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(2_000), status: .sent, hoursFromNow: 11),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(3_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(4_000), status: .pending, hoursFromNow: 1),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(5_000), status: .pending, hoursFromNow: 7)
+        ]
+
+        #expect(state.remainingCount == 3)
+    }
+
+    @MainActor @Test func remainingCountIsZeroWhenAllRowsSent() async {
+        var state = MigrationStatus.State()
+        state.rows = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 18),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(2_000), status: .sent, hoursFromNow: 11)
+        ]
+
+        #expect(state.remainingCount == 0)
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationStatus.State()) {
+            MigrationStatus()
+        }
+
+        await store.send(.delegate(.done))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
@@ -1,0 +1,57 @@
+//
+//  MigrationTransferPlanTests.swift
+//  zodlTests
+//
+//  Covers the MigrationTransferPlan reducer
+//  (Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift) for MOB-1463: the
+//  default `variant`, and the `confirmTapped` delegate contract. Signing and storing the schedule
+//  is inert for now — wiring it up is MOB-1466's job. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationTransferPlanTests {
+    @MainActor @Test func defaultStateIsScheduledVariantWithNoRows() async {
+        let state = MigrationTransferPlan.State()
+
+        #expect(state.variant == MigrationTransferPlan.State.Variant.scheduled)
+        #expect(state.rows.isEmpty)
+        #expect(state.totalDurationHours == 0)
+    }
+
+    @MainActor @Test func confirmTappedEmitsDelegateConfirmed() async {
+        let store = TestStore(initialState: MigrationTransferPlan.State()) {
+            MigrationTransferPlan()
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+    }
+
+    @MainActor @Test func confirmTappedEmitsDelegateConfirmedForManualVariant() async {
+        let store = TestStore(initialState: MigrationTransferPlan.State(variant: .manual)) {
+            MigrationTransferPlan()
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+    }
+
+    @MainActor @Test func recreatedVariantIsPreservedInState() async {
+        let state = MigrationTransferPlan.State(variant: .recreated)
+
+        #expect(state.variant == .recreated)
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationTransferPlan.State()) {
+            MigrationTransferPlan()
+        }
+
+        await store.send(.delegate(.confirmed))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
@@ -5,7 +5,8 @@
 //  Covers the MigrationTransferPlan reducer
 //  (Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift) for MOB-1463: the
 //  default `variant`, and the `confirmTapped` delegate contract. Signing and storing the schedule
-//  is inert for now — wiring it up is MOB-1466's job. No shared/global state -> no `.serialized`.
+//  is inert for now — wiring it up is MOB-1466's job. State carries the shared exchange rate but
+//  only reads it — nothing here mutates process-global state -> no `.serialized`.
 //
 
 import Testing


### PR DESCRIPTION
## Summary

The final screen ticket ([MOB-1464](https://linear.app/zodl/issue/MOB-1464)): the three remaining screens plus the Home SmartBanner migration states — visually complete per Figma, logic-inert until MOB-1466. Not reachable in the app.

Stacked PR #6: targets `michal/MOB-1463-plan-review-sending-scheduled` (PR #1882).

## Screens

[S10 progress](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2709-3350) · [S10 resume](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2696-7133) · [S10 re-scheduling](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2840-3656) · [S11 spent](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2696-5626) · [S11 expired](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2973-5698) · [S12 complete](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2696-7267) · [banner progress](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2780-4422) · [banner waiting](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=2696-6960)

- **MigrationTransferTimeline** extracted from the plan view (third consumer) — screens own caption copy via a closure; skeleton mode powers the re-scheduling state. Plan view refactored with zero visual change (its suite + previews guard it).
- **MigrationStatus** — progress (✕ close via the established `zashiBackV2` idiom) / resume / re-scheduling states.
- **MigrationRecovery** — spent/expired variants, numbered what-happens-next list.
- **MigrationComplete** — conditional dust row + callout with markdown-bolded amount.
- **SmartBanner `priorityMigration`** — compile-safe, never triggered (evaluators untouched); `MigrationBannerVariant` provides pure, tested title/info/button/percent mappings for all 8 states; in-progress renders a small percent ring.

## ⚠️ One behavioral fix beyond the spec

Adding `priorityMigration = -1` silently changed `PriorityContent.next()`'s wraparound (`priority1.next()` would resolve to `.priorityMigration` instead of `.priority9`), breaking the existing `SmartBannerTests` expectation. `next()` now guards `rawValue > 0`, preserving the original chain exactly; `SmartBannerTests` is included in this PR's verification run and passes.

## Strings

43 new keys (EN + ES). Reused: `migrationPlan.sentAgo/etaHours`, `migrationNoteSplit.continue`, `general.more`, `send.review`. Added `migration.gotIt` + `migrationStatus.reschedule`/`sendNow` (no generic equivalents existed).

## Notes for review

- "Sent 18 min ago" from the frame is unrepresentable with hour-granular `MigrationTransferRow.hoursFromNow` — renders "Sent recently" at 0h; sub-hour granularity joins the SDK-contract questions for MOB-1466.
- Banner `complete`/attention icons are closest-existing picks (`checkVerified`, `alertCircle`).
- No SmartBanner `#Preview` — its store starts three live dependency subscriptions on appear (why none of the SmartBanner files have previews today); the MOB-1465 gallery will cover the variants.

## Verification

- `xcodebuild test` on `zodl-internal` (iPhone 17 Pro sim): **16 suites pass** — all 15 migration suites + `SmartBannerTests`.
- Added Swift lines ≤ 150 chars; xcstrings splice purely additive (JSON-parse verified); diff confined to 17 files (+2098/−70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)