### PR TITLE
[MOB-1465] DEBUG gallery for Ironwood migration screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1461] Ironwood migration screen: note split (explainer, progress, confirmation, failure). Not reachable in the app yet.
 - [MOB-1462] Ironwood migration screens: background delivery and notifications permissions. Not reachable in the app yet.
 - [MOB-1463] Ironwood migration screens: transfer plan, transfer review, sending states, and migration scheduled. Not reachable in the app yet.
+- [MOB-1464] Ironwood migration screens: progress status, plan recovery, migration complete, and the home widget states. Not reachable in the app yet.
 
 ## 3.7.2 build 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1462] Ironwood migration screens: background delivery and notifications permissions. Not reachable in the app yet.
 - [MOB-1463] Ironwood migration screens: transfer plan, transfer review, sending states, and migration scheduled. Not reachable in the app yet.
 - [MOB-1464] Ironwood migration screens: progress status, plan recovery, migration complete, and the home widget states. Not reachable in the app yet.
+- [MOB-1465] Internal DEBUG-only gallery of all Ironwood migration screens (long-press the balance on Home). Not present in release builds.
 
 ## 3.7.2 build 1
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -20113,6 +20113,737 @@
           }
         }
       }
+    },
+    "migrationStatus.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso de la migraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationStatus.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your balance is split into %1$lld transfers over ~%2$lld hours. There are %3$lld remaining transfers."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo se divide en %1$lld transferencias durante ~%2$lld horas. Quedan %3$lld transferencias pendientes."
+          }
+        }
+      }
+    },
+    "migrationStatus.resumeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resume Migration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reanudar migraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationStatus.reschedulingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Re-scheduling\u2026"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogramando\u2026"
+          }
+        }
+      }
+    },
+    "migrationStatus.resumeDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld of %2$lld was scheduled %3$lld hours ago but wasn't sent. Send now or reschedule."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La transferencia %1$lld de %2$lld se program\u00f3 hace %3$lld horas pero no se envi\u00f3. Env\u00edala ahora o reprogr\u00e1mala."
+          }
+        }
+      }
+    },
+    "migrationStatus.overdueAgo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Overdue \u00b7 %1$lldh ago"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atrasada \u00b7 hace %1$lldh"
+          }
+        }
+      }
+    },
+    "migrationStatus.sentRecently" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent recently"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviado recientemente"
+          }
+        }
+      }
+    },
+    "migrationStatus.windowMissedNote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending now will delay your wallet's sync about 10 mins. To protect your privacy, we need to decouple syncing and transaction broadcasting."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar ahora retrasar\u00e1 la sincronizaci\u00f3n de tu billetera unos 10 minutos. Para proteger tu privacidad, necesitamos desacoplar la sincronizaci\u00f3n de la transmisi\u00f3n de transacciones."
+          }
+        }
+      }
+    },
+    "migrationStatus.reschedule" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reschedule"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogramar"
+          }
+        }
+      }
+    },
+    "migrationStatus.sendNow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send now"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar ahora"
+          }
+        }
+      }
+    },
+    "migrationRecovery.titleSpent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reschedule Transfers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogramar transferencias"
+          }
+        }
+      }
+    },
+    "migrationRecovery.titleExpired" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers No Longer Valid"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias ya no v\u00e1lidas"
+          }
+        }
+      }
+    },
+    "migrationRecovery.descSpent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers %1$lld-%2$lld were pre-signed for a balance that has since changed. The migration plan needs to be re-created for the remaining amount. No funds are lost \u2014 only the pre-signed transactions are discarded."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transferencias %1$lld-%2$lld se prefirmaron para un saldo que ha cambiado desde entonces. El plan de migraci\u00f3n debe volver a crearse para el monto restante. No se pierden fondos \u2014 solo se descartan las transacciones prefirmadas."
+          }
+        }
+      }
+    },
+    "migrationRecovery.descExpired" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers %1$lld-%2$lld were pre-signed but expired before they could be sent. The migration plan needs to be re-created for the remaining amount. No funds are lost \u2014 only the pre-signed transactions are discarded."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transferencias %1$lld-%2$lld se prefirmaron pero caducaron antes de poder enviarse. El plan de migraci\u00f3n debe volver a crearse para el monto restante. No se pierden fondos \u2014 solo se descartan las transacciones prefirmadas."
+          }
+        }
+      }
+    },
+    "migrationRecovery.whatNext" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What Happens Next"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qu\u00e9 sucede a continuaci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationRecovery.bullet1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A new migration plan will be created."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se crear\u00e1 un nuevo plan de migraci\u00f3n."
+          }
+        }
+      }
+    },
+    "migrationRecovery.bullet2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers %1$lld-%2$lld will be rescheduled."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transferencias %1$lld-%2$lld se reprogramar\u00e1n."
+          }
+        }
+      }
+    },
+    "migrationRecovery.bullet3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Once you confirm the new schedule, we will send the transfers in the background."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una vez que confirmes el nuevo cronograma, enviaremos las transferencias en segundo plano."
+          }
+        }
+      }
+    },
+    "migrationComplete.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migraci\u00f3n completa"
+          }
+        }
+      }
+    },
+    "migrationComplete.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your ZEC is now in the Ironwood pool."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu ZEC ahora est\u00e1 en el fondo Ironwood."
+          }
+        }
+      }
+    },
+    "migrationComplete.rowTotal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total transferred"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total transferido"
+          }
+        }
+      }
+    },
+    "migrationComplete.rowDust" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remaining dust"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Polvo restante"
+          }
+        }
+      }
+    },
+    "migrationComplete.rowTransfers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias"
+          }
+        }
+      }
+    },
+    "migrationComplete.rowTransfersValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld sent"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld enviadas"
+          }
+        }
+      }
+    },
+    "migrationComplete.rowDuration" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationComplete.dustTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dust balance remaining"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saldo de polvo restante"
+          }
+        }
+      }
+    },
+    "migrationComplete.dustBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ stayed in Orchard \u2014 the amount is below the transfer threshold."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ permaneci\u00f3 en Orchard \u2014 el monto est\u00e1 por debajo del umbral de transferencia."
+          }
+        }
+      }
+    },
+    "migrationBanner.requiredTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Required"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migraci\u00f3n requerida"
+          }
+        }
+      }
+    },
+    "migrationBanner.requiredInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move your funds to Ironwood."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mueve tus fondos a Ironwood."
+          }
+        }
+      }
+    },
+    "migrationBanner.splittingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Split in progress\u2026"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Divisi\u00f3n en curso\u2026"
+          }
+        }
+      }
+    },
+    "migrationBanner.progressTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration Progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso de la migraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationBanner.progressInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld transfers done ~ %3$lld%% complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld transferencias hechas ~ %3$lld%% completo"
+          }
+        }
+      }
+    },
+    "migrationBanner.waitingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld waiting"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld en espera"
+          }
+        }
+      }
+    },
+    "migrationBanner.waitingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to reschedule or send now"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para reprogramar o enviar ahora"
+          }
+        }
+      }
+    },
+    "migrationBanner.updatePlanTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update migration plan"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar plan de migraci\u00f3n"
+          }
+        }
+      }
+    },
+    "migrationBanner.updatePlanInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to review and approve"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para revisar y aprobar"
+          }
+        }
+      }
+    },
+    "migrationBanner.expiredTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfers %1$lld-%2$lld expired"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias %1$lld-%2$lld caducadas"
+          }
+        }
+      }
+    },
+    "migrationBanner.expiredInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to create a new transfer plan"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para crear un nuevo plan de transferencia"
+          }
+        }
+      }
+    },
+    "migrationBanner.readyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld ready to send"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld lista para enviar"
+          }
+        }
+      }
+    },
+    "migrationBanner.readyInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to review and approve"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para revisar y aprobar"
+          }
+        }
+      }
+    },
+    "migrationBanner.completeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migraci\u00f3n completa"
+          }
+        }
+      }
+    },
+    "migrationBanner.completeInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to review the details"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para revisar los detalles"
+          }
+        }
+      }
+    },
+    "migration.gotIt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got it"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entendido"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/secant/Sources/Features/Home/HomeView.swift
+++ b/secant/Sources/Features/Home/HomeView.swift
@@ -11,6 +11,10 @@ struct HomeView: View {
     @Shared(.appStorage(.sensitiveContent)) var isSensitiveContentHidden = false
     @Shared(.inMemory(.walletStatus)) var walletStatus: WalletStatus = .none
 
+    #if DEBUG
+    @State private var isMigrationGalleryPresented = false
+    #endif
+
     init(store: StoreOf<Home>, tokenName: String) {
         self.store = store
         self.tokenName = tokenName
@@ -29,6 +33,12 @@ struct HomeView: View {
                     shortened: true
                 )
                 .padding(.top, 1)
+                #if DEBUG
+                .onLongPressGesture(minimumDuration: 0.6) { isMigrationGalleryPresented = true }
+                .sheet(isPresented: $isMigrationGalleryPresented) {
+                    MigrationDebugGalleryView()
+                }
+                #endif
 
                 HStack {
                     button(

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
@@ -1,0 +1,64 @@
+//
+//  MigrationCompleteStore.swift
+//  zodl
+//
+//  "Migration Complete" screen (MOB-1464, Figma S12 · 2696:7267). Visually complete per Figma; all
+//  summary fields are placeholders — wiring the real data lands in MOB-1466. The `gotItTapped`
+//  delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationComplete {
+    @ObservableState
+    struct State: Equatable {
+        var totalTransferred = Zatoshi.zero
+        var dust = Zatoshi.zero
+        var transfersSent = 0
+        var transfersTotal = 0
+        var durationHours = 0
+
+        var hasDust: Bool {
+            dust.amount > 0
+        }
+
+        init(
+            totalTransferred: Zatoshi = .zero,
+            dust: Zatoshi = .zero,
+            transfersSent: Int = 0,
+            transfersTotal: Int = 0,
+            durationHours: Int = 0
+        ) {
+            self.totalTransferred = totalTransferred
+            self.dust = dust
+            self.transfersSent = transfersSent
+            self.transfersTotal = transfersTotal
+            self.durationHours = durationHours
+        }
+    }
+
+    enum Action: Equatable {
+        case delegate(Delegate)
+        case gotItTapped
+
+        enum Delegate: Equatable {
+            case done
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .gotItTapped:
+                return .send(.delegate(.done))
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteView.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteView.swift
@@ -1,0 +1,167 @@
+//
+//  MigrationCompleteView.swift
+//  zodl
+//
+//  "Migration Complete" screen (MOB-1464, Figma S12 · 2696:7267). Visually complete per Figma; all
+//  summary fields are placeholders — wiring the real data lands in MOB-1466. The `gotItTapped`
+//  delegate is emitted but consumed by nobody yet.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationCompleteView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationComplete>
+
+    init(store: StoreOf<MigrationComplete>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                Spacer()
+
+                Asset.Assets.Illustrations.success1.image
+                    .resizable()
+                    .frame(width: 148, height: 148)
+
+                Text(localizable: .migrationCompleteTitle)
+                    .zFont(.semiBold, size: 28, style: Design.Text.primary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 16)
+
+                Text(localizable: .migrationCompleteSubtitle)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 8)
+
+                summaryCard
+                    .padding(.top, 24)
+
+                if store.hasDust {
+                    dustCallout
+                        .padding(.top, 16)
+                }
+
+                Spacer()
+
+                ZashiButton(String(localizable: .migrationGotIt)) {
+                    store.send(.gotItTapped)
+                }
+                .padding(.bottom, 24)
+            }
+            .padding(.vertical, 1)
+            .screenHorizontalPadding()
+            .navigationBarBackButtonHidden()
+        }
+        .applySuccessScreenBackground()
+    }
+
+    // MARK: - Summary card
+
+    @ViewBuilder private var summaryCard: some View {
+        VStack(spacing: 0) {
+            MigrationDetailRow(
+                title: String(localizable: .migrationCompleteRowTotal),
+                value: "\(store.totalTransferred.decimalString()) ZEC",
+                rowAppereance: .top
+            )
+
+            if store.hasDust {
+                MigrationDetailRow(
+                    title: String(localizable: .migrationCompleteRowDust),
+                    value: "\(store.dust.decimalString()) ZEC",
+                    rowAppereance: .middle
+                )
+            }
+
+            MigrationDetailRow(
+                title: String(localizable: .migrationCompleteRowTransfers),
+                value: String(localizable: .migrationCompleteRowTransfersValue(store.transfersSent, store.transfersTotal)),
+                rowAppereance: .middle
+            )
+
+            MigrationDetailRow(
+                title: String(localizable: .migrationCompleteRowDuration),
+                value: String(localizable: .migrationPlanEtaHours(store.durationHours)),
+                rowAppereance: .bottom
+            )
+        }
+    }
+
+    // MARK: - Dust callout
+
+    @ViewBuilder private var dustCallout: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 0) {
+                Text(localizable: .migrationCompleteDustTitle)
+                    .zFont(.semiBold, size: 14, style: Design.Text.primary)
+
+                Spacer()
+
+                Asset.Assets.infoOutline.image
+                    .zImage(size: 20, style: Design.Text.tertiary)
+            }
+
+            dustBody
+        }
+        .padding(16)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .fill(Design.Surfaces.bgSecondary.color(colorScheme))
+        }
+    }
+
+    @ViewBuilder private var dustBody: some View {
+        let amountText = "\(store.dust.decimalString()) ZEC"
+        let markdown = String(localizable: .migrationCompleteDustBody("^[\(amountText)](style: 'boldPrimary')"))
+
+        if let attrText = try? AttributedString(markdown: markdown, including: \.zashiApp) {
+            ZashiText(withAttributedString: attrText, colorScheme: colorScheme)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("With dust") {
+    NavigationView {
+        MigrationCompleteView(
+            store: StoreOf<MigrationComplete>(
+                initialState: MigrationComplete.State(
+                    totalTransferred: Zatoshi(1_245_800_000),
+                    dust: Zatoshi(31_000),
+                    transfersSent: 5,
+                    transfersTotal: 5,
+                    durationHours: 24
+                )
+            ) {
+                MigrationComplete()
+            }
+        )
+    }
+}
+
+#Preview("Clean, no dust") {
+    NavigationView {
+        MigrationCompleteView(
+            store: StoreOf<MigrationComplete>(
+                initialState: MigrationComplete.State(
+                    totalTransferred: Zatoshi(1_245_800_000),
+                    dust: .zero,
+                    transfersSent: 5,
+                    transfersTotal: 5,
+                    durationHours: 24
+                )
+            ) {
+                MigrationComplete()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
@@ -146,7 +146,7 @@ struct MigrationEntryView: View {
                     .overlay {
                         if isSelected {
                             RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                                .stroke(
+                                .strokeBorder(
                                     isWarning ? Design.Utility.WarningYellow._500.color(colorScheme) : Design.Checkboxes.onBg.color(colorScheme),
                                     lineWidth: 2
                                 )

--- a/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyView.swift
+++ b/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyView.swift
@@ -158,7 +158,7 @@ struct MigrationNetworkPrivacyView: View {
                 .fill(Design.Surfaces.bgPrimary.color(colorScheme))
                 .overlay {
                     RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                        .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+                        .strokeBorder(Design.Surfaces.strokeSecondary.color(colorScheme))
                 }
         }
     }

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
@@ -197,7 +197,7 @@ struct MigrationNoteSplitView: View {
                 ZashiButton(
                     String(localizable: .migrationNoteSplitSplittingTitle),
                     type: .secondary,
-                    accessoryView: ProgressView()
+                    prefixView: ProgressView()
                 ) { }
                 .disabled(true)
             }

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
@@ -1,0 +1,55 @@
+//
+//  MigrationRecoveryStore.swift
+//  zodl
+//
+//  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
+//  2696:5626 / expired 2973:5698). Visually complete per Figma; the `continueTapped` delegate is
+//  emitted but consumed by nobody yet — wiring the real plan-recreation flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct MigrationRecovery {
+    @ObservableState
+    struct State: Equatable {
+        enum Reason: Equatable {
+            case notesSpent
+            case expired
+        }
+
+        var reason = Reason.notesSpent
+        /// "Transfers {a}–{b}" range in copy.
+        var firstTransfer = 3
+        var lastTransfer = 5
+
+        init(reason: Reason = .notesSpent, firstTransfer: Int = 3, lastTransfer: Int = 5) {
+            self.reason = reason
+            self.firstTransfer = firstTransfer
+            self.lastTransfer = lastTransfer
+        }
+    }
+
+    enum Action: Equatable {
+        case continueTapped
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case recreate
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .continueTapped:
+                return .send(.delegate(.recreate))
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryView.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryView.swift
@@ -1,0 +1,153 @@
+//
+//  MigrationRecoveryView.swift
+//  zodl
+//
+//  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
+//  2696:5626 / expired 2973:5698). Visually complete per Figma; the `continueTapped` delegate is
+//  emitted but consumed by nobody yet — wiring the real plan-recreation flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct MigrationRecoveryView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Perception.Bindable var store: StoreOf<MigrationRecovery>
+
+    init(store: StoreOf<MigrationRecovery>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(title)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(description)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        Text(localizable: .migrationRecoveryWhatNext)
+                            .zFont(.medium, size: 14, style: Design.Text.primary)
+                            .padding(.bottom, 12)
+
+                        whatHappensNext
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                ZashiButton(String(localizable: .migrationNoteSplitContinue)) {
+                    store.send(.continueTapped)
+                }
+                .padding(.top, 16)
+                .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .zashiBack()
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Title + description
+
+    private var title: String {
+        switch store.reason {
+        case .notesSpent:
+            return String(localizable: .migrationRecoveryTitleSpent)
+        case .expired:
+            return String(localizable: .migrationRecoveryTitleExpired)
+        }
+    }
+
+    private var description: String {
+        switch store.reason {
+        case .notesSpent:
+            return String(localizable: .migrationRecoveryDescSpent(store.firstTransfer, store.lastTransfer))
+        case .expired:
+            return String(localizable: .migrationRecoveryDescExpired(store.firstTransfer, store.lastTransfer))
+        }
+    }
+
+    // MARK: - What happens next
+
+    @ViewBuilder private var whatHappensNext: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            numberedBullet(
+                number: 1,
+                text: String(localizable: .migrationRecoveryBullet1),
+                isLast: false
+            )
+
+            numberedBullet(
+                number: 2,
+                text: String(localizable: .migrationRecoveryBullet2(store.firstTransfer, store.lastTransfer)),
+                isLast: false
+            )
+
+            numberedBullet(
+                number: 3,
+                text: String(localizable: .migrationRecoveryBullet3),
+                isLast: true
+            )
+        }
+    }
+
+    @ViewBuilder private func numberedBullet(number: Int, text: String, isLast: Bool) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 4) {
+                Circle()
+                    .fill(Design.Text.primary.color(colorScheme))
+                    .frame(width: 24, height: 24)
+                    .overlay {
+                        Text("\(number)")
+                            .zFont(.semiBold, size: 11, style: Design.Surfaces.bgPrimary)
+                    }
+
+                if !isLast {
+                    Rectangle()
+                        .fill(Design.Surfaces.strokeSecondary.color(colorScheme))
+                        .frame(width: 1.5, height: 20)
+                }
+            }
+
+            Text(text)
+                .zFont(.medium, size: 14, style: Design.Text.primary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 2)
+                .padding(.bottom, 12)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Notes spent") {
+    NavigationView {
+        MigrationRecoveryView(
+            store: StoreOf<MigrationRecovery>(
+                initialState: MigrationRecovery.State(reason: .notesSpent, firstTransfer: 3, lastTransfer: 5)
+            ) {
+                MigrationRecovery()
+            }
+        )
+    }
+}
+
+#Preview("Expired") {
+    NavigationView {
+        MigrationRecoveryView(
+            store: StoreOf<MigrationRecovery>(
+                initialState: MigrationRecovery.State(reason: .expired, firstTransfer: 3, lastTransfer: 5)
+            ) {
+                MigrationRecovery()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
@@ -1,0 +1,89 @@
+//
+//  MigrationStatusStore.swift
+//  zodl
+//
+//  "Migration Progress" / "Resume Migration" / "Re-scheduling…" screen (MOB-1464, Figma S10 ·
+//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). Visually complete per Figma;
+//  `rows` is a placeholder and every delegate is emitted but consumed by nobody yet — wiring the
+//  real reschedule/send-now behavior and chaining into the rest of the migration flow lands in
+//  MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationStatus {
+    @ObservableState
+    struct State: Equatable {
+        enum Presentation: Equatable {
+            case progress
+            case resume
+        }
+
+        var presentation = Presentation.progress
+        /// Placeholder; real proposal data lands in MOB-1466.
+        var rows: IdentifiedArrayOf<MigrationTransferRow> = []
+        var totalDurationHours = 0
+        /// Resume header: "Transfer {n} of {m} …".
+        var stalledNumber = 0
+        var stalledHoursAgo = 0
+        /// Visual-only: skeleton captions + disabled spinner button on the resume presentation.
+        var isRescheduling = false
+
+        var remainingCount: Int {
+            rows.filter { $0.status != .sent }.count
+        }
+
+        init(
+            presentation: Presentation = .progress,
+            rows: IdentifiedArrayOf<MigrationTransferRow> = [],
+            totalDurationHours: Int = 0,
+            stalledNumber: Int = 0,
+            stalledHoursAgo: Int = 0,
+            isRescheduling: Bool = false
+        ) {
+            self.presentation = presentation
+            self.rows = rows
+            self.totalDurationHours = totalDurationHours
+            self.stalledNumber = stalledNumber
+            self.stalledHoursAgo = stalledHoursAgo
+            self.isRescheduling = isRescheduling
+        }
+    }
+
+    enum Action: Equatable {
+        /// Progress CTA and the X close.
+        case gotItTapped
+        case delegate(Delegate)
+        case rescheduleTapped
+        case sendNowTapped
+
+        enum Delegate: Equatable {
+            case done
+            case reschedule
+            case sendNow
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .gotItTapped:
+                return .send(.delegate(.done))
+
+            case .rescheduleTapped:
+                state.isRescheduling = true
+                return .send(.delegate(.reschedule))
+
+            case .sendNowTapped:
+                return .send(.delegate(.sendNow))
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
@@ -96,7 +96,10 @@ struct MigrationStatusView: View {
             return String(localizable: .migrationStatusOverdueAgo(row.hoursFromNow))
         default:
             // Pending/active rows: "~Nh" ETA per the frames (S10-progress Transfer 3 = "~6 hours").
-            return String(localizable: .migrationPlanEtaHours(row.hoursFromNow))
+            // A ready-now row renders "~10 mins", matching the Transfer Plan screen's treatment.
+            return row.hoursFromNow == 0
+                ? String(localizable: .migrationPlanEtaFirst)
+                : String(localizable: .migrationPlanEtaHours(row.hoursFromNow))
         }
     }
 

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
@@ -131,13 +131,13 @@ struct MigrationStatusView: View {
                     ZashiButton(
                         String(localizable: .migrationStatusReschedulingTitle),
                         type: .tertiary,
-                        accessoryView: ProgressView()
+                        prefixView: ProgressView()
                     ) {
                         store.send(.rescheduleTapped)
                     }
                     .disabled(true)
                 } else {
-                    ZashiButton(String(localizable: .migrationStatusReschedule), type: .ghost) {
+                    ZashiButton(String(localizable: .migrationStatusReschedule), type: .secondary) {
                         store.send(.rescheduleTapped)
                     }
                 }

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
@@ -1,0 +1,243 @@
+//
+//  MigrationStatusView.swift
+//  zodl
+//
+//  "Migration Progress" / "Resume Migration" / "Re-scheduling…" screen (MOB-1464, Figma S10 ·
+//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). Visually complete per Figma;
+//  every delegate emitted here is consumed by nobody yet — wiring the real reschedule/send-now
+//  behavior and chaining into the rest of the migration flow lands in MOB-1466.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationStatusView: View {
+    @Perception.Bindable var store: StoreOf<MigrationStatus>
+
+    init(store: StoreOf<MigrationStatus>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(title)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .padding(.bottom, 8)
+
+                        Text(description)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.bottom, 24)
+
+                        MigrationTransferTimeline(
+                            rows: store.rows,
+                            caption: caption(for:),
+                            skeletonPendingCaptions: store.isRescheduling
+                        )
+                    }
+                    .padding(.vertical, 1)
+                }
+
+                if store.presentation == .resume {
+                    footerNote
+                        .padding(.top, 16)
+                }
+
+                buttons
+                    .padding(.top, 16)
+                    .padding(.bottom, 24)
+            }
+            .screenHorizontalPadding()
+            .applyPresentationModifier(store: store)
+        }
+        .applyScreenBackground()
+    }
+
+    // MARK: - Title + description
+
+    private var title: String {
+        switch store.presentation {
+        case .progress:
+            return String(localizable: .migrationStatusTitle)
+        case .resume:
+            return store.isRescheduling
+                ? String(localizable: .migrationStatusReschedulingTitle)
+                : String(localizable: .migrationStatusResumeTitle)
+        }
+    }
+
+    private var description: String {
+        switch store.presentation {
+        case .progress:
+            return String(
+                localizable: .migrationStatusDesc(store.rows.count, store.totalDurationHours, store.remainingCount)
+            )
+        case .resume:
+            return String(
+                localizable: .migrationStatusResumeDesc(store.stalledNumber, store.rows.count, store.stalledHoursAgo)
+            )
+        }
+    }
+
+    // MARK: - Caption
+
+    private func caption(for row: MigrationTransferRow) -> String {
+        switch row.status {
+        case .sent:
+            return row.hoursFromNow == 0
+                ? String(localizable: .migrationStatusSentRecently)
+                : String(localizable: .migrationPlanSentAgo(row.hoursFromNow))
+        case .overdue:
+            return String(localizable: .migrationStatusOverdueAgo(row.hoursFromNow))
+        default:
+            // Pending/active rows: "~Nh" ETA per the frames (S10-progress Transfer 3 = "~6 hours").
+            return String(localizable: .migrationPlanEtaHours(row.hoursFromNow))
+        }
+    }
+
+    // MARK: - Footer note
+
+    @ViewBuilder private var footerNote: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Asset.Assets.infoOutline.image
+                .zImage(size: 16, style: Design.Text.tertiary)
+
+            Text(localizable: .migrationStatusWindowMissedNote)
+                .zFont(size: 12, style: Design.Text.tertiary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Buttons
+
+    @ViewBuilder private var buttons: some View {
+        switch store.presentation {
+        case .progress:
+            ZashiButton(String(localizable: .migrationGotIt)) {
+                store.send(.gotItTapped)
+            }
+        case .resume:
+            VStack(spacing: 8) {
+                if store.isRescheduling {
+                    ZashiButton(
+                        String(localizable: .migrationStatusReschedulingTitle),
+                        type: .tertiary,
+                        accessoryView: ProgressView()
+                    ) {
+                        store.send(.rescheduleTapped)
+                    }
+                    .disabled(true)
+                } else {
+                    ZashiButton(String(localizable: .migrationStatusReschedule), type: .ghost) {
+                        store.send(.rescheduleTapped)
+                    }
+                }
+
+                ZashiButton(String(localizable: .migrationStatusSendNow)) {
+                    store.send(.sendNowTapped)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Presentation modifier
+
+private extension View {
+    @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationStatus>) -> some View {
+        if store.presentation == .progress {
+            zashiBackV2 {
+                store.send(.gotItTapped)
+            }
+        } else {
+            zashiBack()
+        }
+    }
+}
+
+// MARK: - Mock data
+
+private extension IdentifiedArray where ID == MigrationTransferRow.ID, Element == MigrationTransferRow {
+    /// The 5-transfer set from the Figma frames (3.51220 / 2.87410 / 2.43100 / 1.99830 / 1.64240 ZEC).
+    static var previewProgressRows: Self {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .active, hoursFromNow: 6),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 18)
+        ]
+    }
+
+    /// The resume/re-scheduling frame: two sent, one overdue, two pending.
+    static var previewResumeRows: Self {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 18),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 11),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 1),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 7)
+        ]
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Progress") {
+    NavigationView {
+        MigrationStatusView(
+            store: StoreOf<MigrationStatus>(
+                initialState: MigrationStatus.State(
+                    presentation: .progress,
+                    rows: .previewProgressRows,
+                    totalDurationHours: 24
+                )
+            ) {
+                MigrationStatus()
+            }
+        )
+    }
+}
+
+#Preview("Resume") {
+    NavigationView {
+        MigrationStatusView(
+            store: StoreOf<MigrationStatus>(
+                initialState: MigrationStatus.State(
+                    presentation: .resume,
+                    rows: .previewResumeRows,
+                    totalDurationHours: 24,
+                    stalledNumber: 3,
+                    stalledHoursAgo: 5
+                )
+            ) {
+                MigrationStatus()
+            }
+        )
+    }
+}
+
+#Preview("Re-scheduling") {
+    NavigationView {
+        MigrationStatusView(
+            store: StoreOf<MigrationStatus>(
+                initialState: MigrationStatus.State(
+                    presentation: .resume,
+                    rows: .previewResumeRows,
+                    totalDurationHours: 24,
+                    stalledNumber: 3,
+                    stalledHoursAgo: 5,
+                    isRescheduling: true
+                )
+            ) {
+                MigrationStatus()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationStepBadge.swift
+++ b/secant/Sources/Features/Migration/MigrationStepBadge.swift
@@ -5,8 +5,8 @@
 //  Small numbered/checkmark badge used by the migration transfer timelines (MOB-1463, Figma S6 ·
 //  2867:10211 / 2867:2198 / 2709:3519). Rebuilt from the prototype
 //  (`origin/michal/MOB-1451-ironwood-migration-prototype:…/MigrationStepBadge.swift`) so the
-//  Transfer Plan screen renders consistent step indicators. `.warning` isn't used yet — it's
-//  included now so this shared file is touched once; MOB-1464 reaches for it.
+//  Transfer Plan screen renders consistent step indicators. `.warning` is used by
+//  MigrationTransferTimeline for invalid/expired rows (MOB-1464).
 //
 
 import SwiftUI
@@ -19,7 +19,7 @@ struct MigrationStepBadge: View {
         case active
         /// A future step — outlined circle with the number.
         case pending
-        /// Needs attention — amber filled exclamation. Unused until MOB-1464.
+        /// Needs attention — amber filled exclamation (invalid/expired timeline rows).
         case warning
     }
 

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
@@ -13,7 +13,6 @@ import ComposableArchitecture
 import SwiftUI
 
 struct MigrationTransferPlanView: View {
-    @Environment(\.colorScheme) private var colorScheme
     @Perception.Bindable var store: StoreOf<MigrationTransferPlan>
 
     init(store: StoreOf<MigrationTransferPlan>) {
@@ -35,7 +34,7 @@ struct MigrationTransferPlanView: View {
                             .fixedSize(horizontal: false, vertical: true)
                             .padding(.bottom, 24)
 
-                        timelineRows
+                        MigrationTransferTimeline(rows: store.rows, caption: caption(for:))
                     }
                     .padding(.vertical, 1)
                 }
@@ -76,74 +75,7 @@ struct MigrationTransferPlanView: View {
         }
     }
 
-    // MARK: - Timeline rows
-
-    @ViewBuilder private var timelineRows: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(store.rows.enumerated()), id: \.element.id) { index, row in
-                timelineRow(row, isLast: index == store.rows.count - 1)
-            }
-        }
-    }
-
-    @ViewBuilder private func timelineRow(_ row: MigrationTransferRow, isLast: Bool) -> some View {
-        HStack(alignment: .top, spacing: 12) {
-            VStack(spacing: 4) {
-                MigrationStepBadge(number: row.index + 1, style: badgeStyle(for: row.status))
-
-                if !isLast {
-                    Rectangle()
-                        .fill(connectorColor(for: row.status).color(colorScheme))
-                        .frame(width: 1.5, height: 28)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localizable: .migrationPlanTransferN(row.index + 1)))
-                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
-
-                Text(caption(for: row))
-                    .zFont(size: 14, style: Design.Text.tertiary)
-            }
-            .padding(.top, 2)
-
-            Spacer(minLength: 8)
-
-            VStack(alignment: .trailing, spacing: 2) {
-                Text("\(row.amount.decimalString()) ZEC")
-                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
-
-                if let currencyConversion = store.currencyConversion {
-                    Text(currencyConversion.convert(row.amount))
-                        .zFont(size: 13, style: Design.Text.tertiary)
-                }
-            }
-            .padding(.top, 2)
-            .padding(.bottom, 16)
-        }
-    }
-
-    private func badgeStyle(for status: MigrationTransferRow.Status) -> MigrationStepBadge.Style {
-        switch status {
-        case .sent:
-            return .sent
-        case .active:
-            return .active
-        default:
-            return .pending
-        }
-    }
-
-    private func connectorColor(for status: MigrationTransferRow.Status) -> Colorable {
-        switch status {
-        case .sent:
-            return Design.Utility.SuccessGreen._500
-        case .active:
-            return Design.Text.primary
-        default:
-            return Design.Surfaces.strokeSecondary
-        }
-    }
+    // MARK: - Caption
 
     private func caption(for row: MigrationTransferRow) -> String {
         switch row.status {

--- a/secant/Sources/Features/Migration/MigrationTransferTimeline.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferTimeline.swift
@@ -1,0 +1,138 @@
+//
+//  MigrationTransferTimeline.swift
+//  zodl
+//
+//  Shared badge+connector+title/caption+amount/fiat timeline rows, extracted from
+//  `MigrationTransferPlanView` (MOB-1463) for MOB-1464's Status/Recovery screens — the third
+//  consumer of this row list. Screens own their own caption copy via the `caption` closure;
+//  everything else (badge mapping, connector color, amount + fiat display) lives here.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import SwiftUI
+
+struct MigrationTransferTimeline: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Shared(.inMemory(.exchangeRate)) private var currencyConversion: CurrencyConversion?
+
+    let rows: IdentifiedArrayOf<MigrationTransferRow>
+    let caption: (MigrationTransferRow) -> String
+    var skeletonPendingCaptions = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                timelineRow(row, isLast: index == rows.count - 1)
+            }
+        }
+    }
+
+    @ViewBuilder private func timelineRow(_ row: MigrationTransferRow, isLast: Bool) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 4) {
+                MigrationStepBadge(number: row.index + 1, style: badgeStyle(for: row.status))
+
+                if !isLast {
+                    Rectangle()
+                        .fill(connectorColor(for: row.status).color(colorScheme))
+                        .frame(width: 1.5, height: 28)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localizable: .migrationPlanTransferN(row.index + 1)))
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                captionOrSkeleton(for: row)
+            }
+            .padding(.top, 2)
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("\(row.amount.decimalString()) ZEC")
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                if let currencyConversion {
+                    Text(currencyConversion.convert(row.amount))
+                        .zFont(size: 13, style: Design.Text.tertiary)
+                }
+            }
+            .padding(.top, 2)
+            .padding(.bottom, 16)
+        }
+    }
+
+    @ViewBuilder private func captionOrSkeleton(for row: MigrationTransferRow) -> some View {
+        if skeletonPendingCaptions && row.status != .sent {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Design.Surfaces.bgTertiary.color(colorScheme))
+                .frame(width: 72, height: 12)
+        } else {
+            Text(caption(row))
+                .zFont(size: 14, style: Design.Text.tertiary)
+        }
+    }
+
+    private func badgeStyle(for status: MigrationTransferRow.Status) -> MigrationStepBadge.Style {
+        switch status {
+        case .sent:
+            return .sent
+        case .active, .overdue:
+            return .active
+        case .pending:
+            return .pending
+        case .invalid, .expired:
+            return .warning
+        }
+    }
+
+    private func connectorColor(for status: MigrationTransferRow.Status) -> Colorable {
+        switch badgeStyle(for: status) {
+        case .sent:
+            return Design.Utility.SuccessGreen._500
+        case .active:
+            return Design.Text.primary
+        case .pending:
+            return Design.Surfaces.strokeSecondary
+        case .warning:
+            return Design.Utility.WarningYellow._500
+        }
+    }
+}
+
+// MARK: - Previews
+
+private extension IdentifiedArray where ID == MigrationTransferRow.ID, Element == MigrationTransferRow {
+    static var previewRows: Self {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .active, hoursFromNow: 0),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .expired, hoursFromNow: 18)
+        ]
+    }
+}
+
+#Preview {
+    ScrollView {
+        MigrationTransferTimeline(
+            rows: .previewRows,
+            caption: { row in "hoursFromNow: \(row.hoursFromNow)" }
+        )
+        .padding()
+    }
+}
+
+#Preview("Skeleton pending captions") {
+    ScrollView {
+        MigrationTransferTimeline(
+            rows: .previewRows,
+            caption: { row in "hoursFromNow: \(row.hoursFromNow)" },
+            skeletonPendingCaptions: true
+        )
+        .padding()
+    }
+}

--- a/secant/Sources/Features/MigrationDebugGallery/MigrationDebugGalleryView.swift
+++ b/secant/Sources/Features/MigrationDebugGallery/MigrationDebugGalleryView.swift
@@ -1,0 +1,396 @@
+//
+//  MigrationDebugGalleryView.swift
+//  zodl
+//
+//  DEBUG-only gallery of every Ironwood migration screen (MOB-1460…1464), for visual QA. Reachable
+//  by long-pressing the balance on Home (see HomeView). Each row presents its screen with a canned
+//  fixture state from `MigrationMockData` — the same construction shape as that screen's own
+//  `#Preview`. No new reducer: every migration screen's reducer already swallows its own delegate
+//  actions, so this is visual-only plumbing (see MOB-1465 spec).
+//
+
+#if DEBUG
+
+import SwiftUI
+import ComposableArchitecture
+
+struct MigrationDebugGalleryView: View {
+    /// One row in the gallery. `Identifiable` via `title` so `.sheet(item:)` can key off it.
+    enum Item: String, Identifiable {
+        case entryPrivacy = "Entry — privacy selected"
+        case entryImmediate = "Entry — immediate selected"
+        case networkPrivacyImmediate = "Network Privacy — immediate"
+        case networkPrivacyScheduled = "Network Privacy — scheduled (5 transfers)"
+        case noteSplitExplainer = "Explainer"
+        case noteSplitSplitting = "Splitting"
+        case noteSplitConfirmed = "Confirmed"
+        case noteSplitFailure = "Failure sheet"
+        case backgroundDelivery = "Background Delivery"
+        case notificationsScheduled = "Notifications — scheduled"
+        case notificationsManual = "Notifications — manual"
+        case planScheduled = "Plan — scheduled (5 fresh rows)"
+        case planManual = "Plan — manual"
+        case planRecreated = "Plan — re-created (2 sent / 1 ready / 2 pending)"
+        case reviewImmediate = "Review — immediate"
+        case reviewManualStep = "Review — 3 of 5"
+        case sending = "Sending"
+        case sent = "Sent"
+        case sendingFailure = "Sending failure sheet"
+        case migrationScheduled = "Migration Scheduled"
+        case statusProgress = "Status — progress (2 sent / 1 active / 2 pending)"
+        case statusResume = "Status — resume (overdue)"
+        case statusRescheduling = "Status — re-scheduling"
+        case recoveryNotesSpent = "Recovery — notes spent"
+        case recoveryExpired = "Recovery — expired"
+        case completeWithDust = "Complete — with dust"
+        case completeClean = "Complete — clean"
+        case bannerAllStates = "Banner — all states"
+
+        var id: String { rawValue }
+    }
+
+    @State private var selected: Item?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Entry & Network Privacy") {
+                    row(.entryPrivacy)
+                    row(.entryImmediate)
+                    row(.networkPrivacyImmediate)
+                    row(.networkPrivacyScheduled)
+                }
+
+                Section("Note Split") {
+                    row(.noteSplitExplainer)
+                    row(.noteSplitSplitting)
+                    row(.noteSplitConfirmed)
+                    row(.noteSplitFailure)
+                }
+
+                Section("Permissions") {
+                    row(.backgroundDelivery)
+                    row(.notificationsScheduled)
+                    row(.notificationsManual)
+                }
+
+                Section("Plan & Review") {
+                    row(.planScheduled)
+                    row(.planManual)
+                    row(.planRecreated)
+                    row(.reviewImmediate)
+                    row(.reviewManualStep)
+                }
+
+                Section("Sending & Scheduled") {
+                    row(.sending)
+                    row(.sent)
+                    row(.sendingFailure)
+                    row(.migrationScheduled)
+                }
+
+                Section("Status, Recovery & Complete") {
+                    row(.statusProgress)
+                    row(.statusResume)
+                    row(.statusRescheduling)
+                    row(.recoveryNotesSpent)
+                    row(.recoveryExpired)
+                    row(.completeWithDust)
+                    row(.completeClean)
+                }
+
+                Section("Home banner") {
+                    row(.bannerAllStates)
+                }
+            }
+            .navigationTitle("Migration Gallery")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .sheet(item: $selected) { item in
+            content(for: item)
+        }
+    }
+
+    private func row(_ item: Item) -> some View {
+        Button {
+            selected = item
+        } label: {
+            Text(item.rawValue)
+        }
+    }
+
+    @ViewBuilder private func content(for item: Item) -> some View {
+        switch item {
+        case .entryPrivacy:
+            NavigationStack {
+                MigrationEntryView(
+                    store: StoreOf<MigrationEntry>(initialState: MigrationMockData.entryPrivacy) {
+                        MigrationEntry()
+                    }
+                )
+            }
+        case .entryImmediate:
+            NavigationStack {
+                MigrationEntryView(
+                    store: StoreOf<MigrationEntry>(initialState: MigrationMockData.entryImmediate) {
+                        MigrationEntry()
+                    }
+                )
+            }
+        case .networkPrivacyImmediate:
+            NavigationStack {
+                MigrationNetworkPrivacyView(
+                    store: StoreOf<MigrationNetworkPrivacy>(
+                        initialState: MigrationMockData.networkPrivacyImmediate
+                    ) {
+                        MigrationNetworkPrivacy()
+                    }
+                )
+            }
+        case .networkPrivacyScheduled:
+            NavigationStack {
+                MigrationNetworkPrivacyView(
+                    store: StoreOf<MigrationNetworkPrivacy>(
+                        initialState: MigrationMockData.networkPrivacyScheduled
+                    ) {
+                        MigrationNetworkPrivacy()
+                    }
+                )
+            }
+        case .noteSplitExplainer:
+            NavigationStack {
+                MigrationNoteSplitView(
+                    store: StoreOf<MigrationNoteSplit>(initialState: MigrationMockData.noteSplitExplainer) {
+                        MigrationNoteSplit()
+                    }
+                )
+            }
+        case .noteSplitSplitting:
+            NavigationStack {
+                MigrationNoteSplitView(
+                    store: StoreOf<MigrationNoteSplit>(initialState: MigrationMockData.noteSplitSplitting) {
+                        MigrationNoteSplit()
+                    }
+                )
+            }
+        case .noteSplitConfirmed:
+            NavigationStack {
+                MigrationNoteSplitView(
+                    store: StoreOf<MigrationNoteSplit>(initialState: MigrationMockData.noteSplitConfirmed) {
+                        MigrationNoteSplit()
+                    }
+                )
+            }
+        case .noteSplitFailure:
+            NavigationStack {
+                MigrationNoteSplitView(
+                    store: StoreOf<MigrationNoteSplit>(initialState: MigrationMockData.noteSplitFailure) {
+                        MigrationNoteSplit()
+                    }
+                )
+            }
+        case .backgroundDelivery:
+            NavigationStack {
+                MigrationBackgroundDeliveryView(
+                    store: StoreOf<MigrationBackgroundDelivery>(
+                        initialState: MigrationMockData.backgroundDelivery
+                    ) {
+                        MigrationBackgroundDelivery()
+                    }
+                )
+            }
+        case .notificationsScheduled:
+            NavigationStack {
+                MigrationNotificationsView(
+                    store: StoreOf<MigrationNotifications>(
+                        initialState: MigrationMockData.notificationsScheduled
+                    ) {
+                        MigrationNotifications()
+                    }
+                )
+            }
+        case .notificationsManual:
+            NavigationStack {
+                MigrationNotificationsView(
+                    store: StoreOf<MigrationNotifications>(
+                        initialState: MigrationMockData.notificationsManual
+                    ) {
+                        MigrationNotifications()
+                    }
+                )
+            }
+        case .planScheduled:
+            NavigationStack {
+                MigrationTransferPlanView(
+                    store: StoreOf<MigrationTransferPlan>(initialState: MigrationMockData.planScheduled) {
+                        MigrationTransferPlan()
+                    }
+                )
+            }
+        case .planManual:
+            NavigationStack {
+                MigrationTransferPlanView(
+                    store: StoreOf<MigrationTransferPlan>(initialState: MigrationMockData.planManual) {
+                        MigrationTransferPlan()
+                    }
+                )
+            }
+        case .planRecreated:
+            NavigationStack {
+                MigrationTransferPlanView(
+                    store: StoreOf<MigrationTransferPlan>(initialState: MigrationMockData.planRecreated) {
+                        MigrationTransferPlan()
+                    }
+                )
+            }
+        case .reviewImmediate:
+            NavigationStack {
+                MigrationReviewTransferView(
+                    store: StoreOf<MigrationReviewTransfer>(initialState: MigrationMockData.reviewImmediate) {
+                        MigrationReviewTransfer()
+                    }
+                )
+            }
+        case .reviewManualStep:
+            NavigationStack {
+                MigrationReviewTransferView(
+                    store: StoreOf<MigrationReviewTransfer>(initialState: MigrationMockData.reviewManualStep) {
+                        MigrationReviewTransfer()
+                    }
+                )
+            }
+        case .sending:
+            NavigationStack {
+                MigrationSendingView(
+                    store: StoreOf<MigrationSending>(initialState: MigrationMockData.sending) {
+                        MigrationSending()
+                    }
+                )
+            }
+        case .sent:
+            NavigationStack {
+                MigrationSendingView(
+                    store: StoreOf<MigrationSending>(initialState: MigrationMockData.sent) {
+                        MigrationSending()
+                    }
+                )
+            }
+        case .sendingFailure:
+            NavigationStack {
+                MigrationSendingView(
+                    store: StoreOf<MigrationSending>(initialState: MigrationMockData.sendingFailure) {
+                        MigrationSending()
+                    }
+                )
+            }
+        case .migrationScheduled:
+            NavigationStack {
+                MigrationScheduledView(
+                    store: StoreOf<MigrationScheduled>(initialState: MigrationMockData.migrationScheduled) {
+                        MigrationScheduled()
+                    }
+                )
+            }
+        case .statusProgress:
+            NavigationStack {
+                MigrationStatusView(
+                    store: StoreOf<MigrationStatus>(initialState: MigrationMockData.statusProgress) {
+                        MigrationStatus()
+                    }
+                )
+            }
+        case .statusResume:
+            NavigationStack {
+                MigrationStatusView(
+                    store: StoreOf<MigrationStatus>(initialState: MigrationMockData.statusResume) {
+                        MigrationStatus()
+                    }
+                )
+            }
+        case .statusRescheduling:
+            NavigationStack {
+                MigrationStatusView(
+                    store: StoreOf<MigrationStatus>(initialState: MigrationMockData.statusRescheduling) {
+                        MigrationStatus()
+                    }
+                )
+            }
+        case .recoveryNotesSpent:
+            NavigationStack {
+                MigrationRecoveryView(
+                    store: StoreOf<MigrationRecovery>(initialState: MigrationMockData.recoveryNotesSpent) {
+                        MigrationRecovery()
+                    }
+                )
+            }
+        case .recoveryExpired:
+            NavigationStack {
+                MigrationRecoveryView(
+                    store: StoreOf<MigrationRecovery>(initialState: MigrationMockData.recoveryExpired) {
+                        MigrationRecovery()
+                    }
+                )
+            }
+        case .completeWithDust:
+            NavigationStack {
+                MigrationCompleteView(
+                    store: StoreOf<MigrationComplete>(initialState: MigrationMockData.completeWithDust) {
+                        MigrationComplete()
+                    }
+                )
+            }
+        case .completeClean:
+            NavigationStack {
+                MigrationCompleteView(
+                    store: StoreOf<MigrationComplete>(initialState: MigrationMockData.completeClean) {
+                        MigrationComplete()
+                    }
+                )
+            }
+        case .bannerAllStates:
+            NavigationStack {
+                bannerAllStatesContent()
+            }
+        }
+    }
+
+    @ViewBuilder private func bannerAllStatesContent() -> some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                bannerStrip(.required)
+                bannerStrip(.splitting)
+                bannerStrip(.inProgress(done: 2, total: 5))
+                bannerStrip(.transferWaiting(number: 3))
+                bannerStrip(.updatePlan)
+                bannerStrip(.transfersExpired(first: 3, last: 5))
+                bannerStrip(.transferReady(number: 4))
+                bannerStrip(.complete)
+            }
+            .padding(16)
+        }
+        .navigationTitle("Banner — all states")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func bannerStrip(_ variant: MigrationBannerVariant) -> some View {
+        MigrationBannerContentView(variant: variant, onButtonTap: {})
+            .padding(16)
+            .background {
+                LinearGradient(
+                    stops: [
+                        Gradient.Stop(color: Design.Utility.Purple._700.color(.light), location: 0.00),
+                        Gradient.Stop(color: Design.Utility.Purple._950.color(.light), location: 1.00)
+                    ],
+                    startPoint: UnitPoint(x: 0.5, y: 0.0),
+                    endPoint: UnitPoint(x: 0.5, y: 1.0)
+                )
+            }
+            .clipShape(RoundedRectangle(cornerRadius: Design.Radius._2xl))
+    }
+}
+
+#Preview {
+    MigrationDebugGalleryView()
+}
+
+#endif

--- a/secant/Sources/Features/MigrationDebugGallery/MigrationDebugGalleryView.swift
+++ b/secant/Sources/Features/MigrationDebugGallery/MigrationDebugGalleryView.swift
@@ -378,8 +378,8 @@ struct MigrationDebugGalleryView: View {
             .background {
                 LinearGradient(
                     stops: [
-                        Gradient.Stop(color: Design.Utility.Purple._700.color(.light), location: 0.00),
-                        Gradient.Stop(color: Design.Utility.Purple._950.color(.light), location: 1.00)
+                        Gradient.Stop(color: Design.Utility.Gray._700.color(.light), location: 0.00),
+                        Gradient.Stop(color: Design.Utility.Gray._950.color(.light), location: 1.00)
                     ],
                     startPoint: UnitPoint(x: 0.5, y: 0.0),
                     endPoint: UnitPoint(x: 0.5, y: 1.0)

--- a/secant/Sources/Features/MigrationDebugGallery/MigrationMockData.swift
+++ b/secant/Sources/Features/MigrationDebugGallery/MigrationMockData.swift
@@ -1,0 +1,233 @@
+//
+//  MigrationMockData.swift
+//  zodl
+//
+//  DEBUG-only fixtures for the Ironwood migration screens gallery (MOB-1465). Values mirror the
+//  Figma frames / each screen's own `#Preview` states so visual parity holds between the gallery
+//  and the screens' previews. Deduplicating the previews themselves onto this namespace is
+//  deliberately deferred (see MOB-1465 spec) — no churn on in-review migration screen PRs.
+//
+
+#if DEBUG
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+/// Centralized fixture values for `MigrationDebugGalleryView`.
+enum MigrationMockData {
+    // MARK: - Shared amounts
+
+    static let fiatText = "$4,832.86"
+    static let orchardBalance = Zatoshi(1_245_800_000)
+    static let fee = Zatoshi(100_000)
+    static let txId = "e87f1c02a94b7d3e6f5041c9b8a2d7e6f5041c9b8a2d7e6f5041c9b8a2d7e6f5"
+
+    /// The 5-transfer set from the Figma frames: 3.51220 / 2.87410 / 2.43100 / 1.99830 / 1.64240 ZEC.
+    static var freshRows: IdentifiedArrayOf<MigrationTransferRow> {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .active, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .pending, hoursFromNow: 6),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 18),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 24)
+        ]
+    }
+
+    /// The re-created variant's frame: two already sent, one active, two pending.
+    static var recreatedRows: IdentifiedArrayOf<MigrationTransferRow> {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 17),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .active, hoursFromNow: 0),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 6),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 12)
+        ]
+    }
+
+    /// Status progress frame: two sent, one active, two pending.
+    static var progressRows: IdentifiedArrayOf<MigrationTransferRow> {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .active, hoursFromNow: 6),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 18)
+        ]
+    }
+
+    /// The resume/re-scheduling frame: two sent, one overdue, two pending.
+    static var resumeRows: IdentifiedArrayOf<MigrationTransferRow> {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 18),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 11),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 1),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 7)
+        ]
+    }
+
+    // MARK: - Entry & Network Privacy
+
+    static var entryPrivacy: MigrationEntry.State {
+        MigrationEntry.State(
+            selectedMode: .privateScheduled,
+            orchardBalance: orchardBalance,
+            fiatText: fiatText
+        )
+    }
+
+    static var entryImmediate: MigrationEntry.State {
+        MigrationEntry.State(
+            selectedMode: .immediate,
+            orchardBalance: orchardBalance,
+            fiatText: fiatText
+        )
+    }
+
+    static var networkPrivacyImmediate: MigrationNetworkPrivacy.State {
+        MigrationNetworkPrivacy.State(variant: .immediate)
+    }
+
+    static var networkPrivacyScheduled: MigrationNetworkPrivacy.State {
+        MigrationNetworkPrivacy.State(variant: .scheduled(transferCount: 5), isTorOn: true)
+    }
+
+    // MARK: - Note Split
+
+    static var noteSplitExplainer: MigrationNoteSplit.State {
+        MigrationNoteSplit.State(phase: .explainer, amount: orchardBalance, fee: fee)
+    }
+
+    static var noteSplitSplitting: MigrationNoteSplit.State {
+        MigrationNoteSplit.State(phase: .splitting, amount: orchardBalance, fee: fee, txId: txId)
+    }
+
+    static var noteSplitConfirmed: MigrationNoteSplit.State {
+        MigrationNoteSplit.State(phase: .confirmed, amount: orchardBalance, fee: fee, txId: txId)
+    }
+
+    static var noteSplitFailure: MigrationNoteSplit.State {
+        MigrationNoteSplit.State(
+            phase: .splitting,
+            amount: orchardBalance,
+            fee: fee,
+            txId: txId,
+            isFailurePresented: true
+        )
+    }
+
+    // MARK: - Permissions
+
+    static var backgroundDelivery: MigrationBackgroundDelivery.State {
+        MigrationBackgroundDelivery.State()
+    }
+
+    static var notificationsScheduled: MigrationNotifications.State {
+        MigrationNotifications.State(variant: .scheduled)
+    }
+
+    static var notificationsManual: MigrationNotifications.State {
+        MigrationNotifications.State(variant: .manual)
+    }
+
+    // MARK: - Plan & Review
+
+    static var planScheduled: MigrationTransferPlan.State {
+        MigrationTransferPlan.State(variant: .scheduled, rows: freshRows, totalDurationHours: 24)
+    }
+
+    static var planManual: MigrationTransferPlan.State {
+        MigrationTransferPlan.State(variant: .manual, rows: freshRows, totalDurationHours: 24)
+    }
+
+    static var planRecreated: MigrationTransferPlan.State {
+        MigrationTransferPlan.State(variant: .recreated, rows: recreatedRows, totalDurationHours: 12)
+    }
+
+    static var reviewImmediate: MigrationReviewTransfer.State {
+        MigrationReviewTransfer.State(mode: .immediate, amount: orchardBalance, fee: fee)
+    }
+
+    static var reviewManualStep: MigrationReviewTransfer.State {
+        MigrationReviewTransfer.State(
+            mode: .manualStep(number: 3, total: 5),
+            amount: Zatoshi(243_100_000),
+            fee: fee
+        )
+    }
+
+    // MARK: - Sending & Scheduled
+
+    static var sending: MigrationSending.State {
+        MigrationSending.State(phase: .sending)
+    }
+
+    static var sent: MigrationSending.State {
+        MigrationSending.State(phase: .success, txId: txId)
+    }
+
+    static var sendingFailure: MigrationSending.State {
+        MigrationSending.State(phase: .sending, isFailurePresented: true)
+    }
+
+    static var migrationScheduled: MigrationScheduled.State {
+        MigrationScheduled.State(totalAmount: orchardBalance, sentCount: 0, totalCount: 5, durationHours: 24)
+    }
+
+    // MARK: - Status, Recovery & Complete
+
+    static var statusProgress: MigrationStatus.State {
+        MigrationStatus.State(presentation: .progress, rows: progressRows, totalDurationHours: 24)
+    }
+
+    static var statusResume: MigrationStatus.State {
+        MigrationStatus.State(
+            presentation: .resume,
+            rows: resumeRows,
+            totalDurationHours: 24,
+            stalledNumber: 3,
+            stalledHoursAgo: 5
+        )
+    }
+
+    static var statusRescheduling: MigrationStatus.State {
+        MigrationStatus.State(
+            presentation: .resume,
+            rows: resumeRows,
+            totalDurationHours: 24,
+            stalledNumber: 3,
+            stalledHoursAgo: 5,
+            isRescheduling: true
+        )
+    }
+
+    static var recoveryNotesSpent: MigrationRecovery.State {
+        MigrationRecovery.State(reason: .notesSpent, firstTransfer: 3, lastTransfer: 5)
+    }
+
+    static var recoveryExpired: MigrationRecovery.State {
+        MigrationRecovery.State(reason: .expired, firstTransfer: 3, lastTransfer: 5)
+    }
+
+    static var completeWithDust: MigrationComplete.State {
+        MigrationComplete.State(
+            totalTransferred: orchardBalance,
+            dust: Zatoshi(31_000),
+            transfersSent: 5,
+            transfersTotal: 5,
+            durationHours: 24
+        )
+    }
+
+    static var completeClean: MigrationComplete.State {
+        MigrationComplete.State(
+            totalTransferred: orchardBalance,
+            dust: .zero,
+            transfersSent: 5,
+            transfersTotal: 5,
+            durationHours: 24
+        )
+    }
+}
+
+#endif

--- a/secant/Sources/Features/SmartBanner/SmartBannerContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerContent.swift
@@ -31,6 +31,7 @@ extension SmartBannerView {
             case .priority75: torSetupContent()
             case .priority8: currencyConversionContent()
             case .priority9: autoShieldingContent()
+            case .priorityMigration: migrationContent()
             default: EmptyView()
             }
         }

--- a/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
@@ -1,0 +1,139 @@
+//
+//  SmartBannerMigrationContent.swift
+//  zodl
+//
+//  Ironwood migration content for the SmartBanner's `priorityMigration` case (MOB-1464). Visual-only:
+//  the case can never be requested by the running evaluator chain yet — wiring the real
+//  triggering/evaluators/routing is MOB-1466's job. `MigrationBannerVariant` is a pure, testable
+//  mapping (see MigrationBannerVariantTests); `migrationContent()` mirrors `shieldingContent()`'s
+//  structure.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+enum MigrationBannerVariant: Equatable {
+    case required
+    case splitting
+    case inProgress(done: Int, total: Int)
+    case transferWaiting(number: Int)
+    case updatePlan
+    case transfersExpired(first: Int, last: Int)
+    case transferReady(number: Int)
+    case complete
+
+    var title: String {
+        switch self {
+        case .required, .splitting:
+            return String(localizable: .migrationBannerRequiredTitle)
+        case .inProgress:
+            return String(localizable: .migrationBannerProgressTitle)
+        case .transferWaiting(let number):
+            return String(localizable: .migrationBannerWaitingTitle(number))
+        case .updatePlan:
+            return String(localizable: .migrationBannerUpdatePlanTitle)
+        case .transfersExpired(let first, let last):
+            return String(localizable: .migrationBannerExpiredTitle(first, last))
+        case .transferReady(let number):
+            return String(localizable: .migrationBannerReadyTitle(number))
+        case .complete:
+            return String(localizable: .migrationBannerCompleteTitle)
+        }
+    }
+
+    var info: String {
+        switch self {
+        case .required:
+            return String(localizable: .migrationBannerRequiredInfo)
+        case .splitting:
+            return String(localizable: .migrationBannerSplittingInfo)
+        case .inProgress(let done, let total):
+            return String(localizable: .migrationBannerProgressInfo(done, total, percent ?? 0))
+        case .transferWaiting:
+            return String(localizable: .migrationBannerWaitingInfo)
+        case .updatePlan:
+            return String(localizable: .migrationBannerUpdatePlanInfo)
+        case .transfersExpired:
+            return String(localizable: .migrationBannerExpiredInfo)
+        case .transferReady:
+            return String(localizable: .migrationBannerReadyInfo)
+        case .complete:
+            return String(localizable: .migrationBannerCompleteInfo)
+        }
+    }
+
+    /// "More" everywhere except `transferReady`, which reads "Review".
+    var buttonLabel: String {
+        switch self {
+        case .transferReady:
+            return String(localizable: .sendReview)
+        default:
+            return String(localizable: .generalMore)
+        }
+    }
+
+    var percent: Int? {
+        guard case let .inProgress(done, total) = self else {
+            return nil
+        }
+        return Int((Double(done) / Double(max(total, 1)) * 100).rounded())
+    }
+}
+
+extension SmartBannerView {
+    @ViewBuilder func migrationContent() -> some View {
+        HStack(spacing: 0) {
+            migrationIcon()
+                .padding(.trailing, 12)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(store.migrationBannerVariant.title)
+                    .zFont(.medium, size: 14, color: titleStyle())
+
+                Text(store.migrationBannerVariant.info)
+                    .zFont(.medium, size: 12, color: infoStyle())
+            }
+
+            Spacer()
+
+            ZashiButton(
+                store.migrationBannerVariant.buttonLabel,
+                type: .ghost,
+                infinityWidth: false
+            ) {
+                store.send(.smartBannerContentTapped)
+            }
+        }
+    }
+
+    @ViewBuilder private func migrationIcon() -> some View {
+        switch store.migrationBannerVariant {
+        case .required, .splitting:
+            Asset.Assets.Icons.coinsSwap.image
+                .zImage(size: 20, color: titleStyle())
+        case .inProgress:
+            migrationProgressRing()
+        case .transferWaiting, .updatePlan, .transfersExpired, .transferReady:
+            Asset.Assets.Icons.alertCircle.image
+                .zImage(size: 20, color: titleStyle())
+        case .complete:
+            Asset.Assets.Icons.checkVerified.image
+                .zImage(size: 20, color: titleStyle())
+        }
+    }
+
+    @ViewBuilder private func migrationProgressRing() -> some View {
+        let percent = store.migrationBannerVariant.percent ?? 0
+
+        ZStack {
+            Circle()
+                .stroke(titleStyle().opacity(0.3), lineWidth: 2)
+
+            Circle()
+                .trim(from: 0, to: CGFloat(percent) / 100)
+                .stroke(titleStyle(), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: 20, height: 20)
+    }
+}

--- a/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
@@ -91,18 +91,20 @@ extension SmartBannerView {
 /// Standalone rendering of the `priorityMigration` banner content, extracted from
 /// `SmartBannerView.migrationContent()` (MOB-1465) so the DEBUG migration gallery can render every
 /// `MigrationBannerVariant` without hosting a live `SmartBannerView` (whose `onAppear` starts real
-/// dependency subscriptions). Colors mirror `SmartBannerView.titleStyle()` / `infoStyle()`
-/// (`SmartBannerContent.swift`) inlined here since those helpers are `SmartBannerView` members.
+/// dependency subscriptions). Tints use the Gray ramp (`utility-gray-50`/`-200`), matching the
+/// Figma migration-banner tokens — deliberately NOT `SmartBannerView.titleStyle()`/`infoStyle()`,
+/// which still use the pre-rebrand Purple ramp. When MOB-1466 hosts this content inside the live
+/// banner, the shared banner gradient (Purple._700 → ._950) likely needs the same Gray swap.
 struct MigrationBannerContentView: View {
     let variant: MigrationBannerVariant
     let onButtonTap: () -> Void
 
     private var titleStyle: Color {
-        Design.Utility.Purple._50.color(.light)
+        Design.Utility.Gray._50.color(.light)
     }
 
     private var infoStyle: Color {
-        Design.Utility.Purple._200.color(.light)
+        Design.Utility.Gray._200.color(.light)
     }
 
     var body: some View {

--- a/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
@@ -82,56 +82,80 @@ enum MigrationBannerVariant: Equatable {
 
 extension SmartBannerView {
     @ViewBuilder func migrationContent() -> some View {
+        MigrationBannerContentView(variant: store.migrationBannerVariant) {
+            store.send(.smartBannerContentTapped)
+        }
+    }
+}
+
+/// Standalone rendering of the `priorityMigration` banner content, extracted from
+/// `SmartBannerView.migrationContent()` (MOB-1465) so the DEBUG migration gallery can render every
+/// `MigrationBannerVariant` without hosting a live `SmartBannerView` (whose `onAppear` starts real
+/// dependency subscriptions). Colors mirror `SmartBannerView.titleStyle()` / `infoStyle()`
+/// (`SmartBannerContent.swift`) inlined here since those helpers are `SmartBannerView` members.
+struct MigrationBannerContentView: View {
+    let variant: MigrationBannerVariant
+    let onButtonTap: () -> Void
+
+    private var titleStyle: Color {
+        Design.Utility.Purple._50.color(.light)
+    }
+
+    private var infoStyle: Color {
+        Design.Utility.Purple._200.color(.light)
+    }
+
+    var body: some View {
         HStack(spacing: 0) {
             migrationIcon()
                 .padding(.trailing, 12)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(store.migrationBannerVariant.title)
-                    .zFont(.medium, size: 14, color: titleStyle())
+                Text(variant.title)
+                    .zFont(.medium, size: 14, color: titleStyle)
 
-                Text(store.migrationBannerVariant.info)
-                    .zFont(.medium, size: 12, color: infoStyle())
+                Text(variant.info)
+                    .zFont(.medium, size: 12, color: infoStyle)
             }
 
             Spacer()
 
             ZashiButton(
-                store.migrationBannerVariant.buttonLabel,
+                variant.buttonLabel,
                 type: .ghost,
                 infinityWidth: false
             ) {
-                store.send(.smartBannerContentTapped)
+                onButtonTap()
             }
         }
     }
 
     @ViewBuilder private func migrationIcon() -> some View {
-        switch store.migrationBannerVariant {
+        switch variant {
         case .required, .splitting:
             Asset.Assets.Icons.coinsSwap.image
-                .zImage(size: 20, color: titleStyle())
+                .zImage(size: 20, color: titleStyle)
         case .inProgress:
             migrationProgressRing()
         case .transferWaiting, .updatePlan, .transfersExpired, .transferReady:
             Asset.Assets.Icons.alertCircle.image
-                .zImage(size: 20, color: titleStyle())
+                .zImage(size: 20, color: titleStyle)
         case .complete:
             Asset.Assets.Icons.checkVerified.image
-                .zImage(size: 20, color: titleStyle())
+                .zImage(size: 20, color: titleStyle)
         }
     }
 
     @ViewBuilder private func migrationProgressRing() -> some View {
-        let percent = store.migrationBannerVariant.percent ?? 0
+        let percent = variant.percent ?? 0
 
         ZStack {
             Circle()
-                .stroke(titleStyle().opacity(0.3), lineWidth: 2)
+                .stroke(titleStyle.opacity(0.3), lineWidth: 2)
 
             Circle()
                 .trim(from: 0, to: CGFloat(percent) / 100)
-                .stroke(titleStyle(), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .stroke(titleStyle, style: StrokeStyle(lineWidth: 2, lineCap: .round))
                 .rotationEffect(.degrees(-90))
         }
         .frame(width: 20, height: 20)

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -35,9 +35,13 @@ struct SmartBanner {
             case priority75 // tor
             case priority8 // currency conversion
             case priority9 // auto-shielding
+            case priorityMigration = -1 // ironwood migration (MOB-1464; not triggered yet — MOB-1466)
 
             func next() -> PriorityContent {
-                PriorityContent.init(rawValue: self.rawValue - 1) ?? .priority9
+                // `priorityMigration` (-1) sits outside the walk-down chain — it is only ever
+                // triggered explicitly, so walking below `priority1` wraps to `priority9` as before.
+                guard rawValue > 0 else { return .priority9 }
+                return PriorityContent(rawValue: rawValue - 1) ?? .priority9
             }
         }
         
@@ -60,6 +64,7 @@ struct SmartBanner {
         var lastKnownErrorMessage = ""
         var lastKnownSyncPercentage = -1.0
         var messageToBeShared: String?
+        var migrationBannerVariant = MigrationBannerVariant.required
         var priorityContent: PriorityContent? = nil
         var priorityContentRequested: PriorityContent? = nil
         var remindMeShieldedPhaseCounter = 0

--- a/zodlTests/MigrationTests/MigrationBannerVariantTests.swift
+++ b/zodlTests/MigrationTests/MigrationBannerVariantTests.swift
@@ -1,0 +1,112 @@
+//
+//  MigrationBannerVariantTests.swift
+//  zodlTests
+//
+//  Covers the pure `MigrationBannerVariant` mappings
+//  (Features/SmartBanner/SmartBannerMigrationContent.swift) for MOB-1464: title/info/buttonLabel
+//  text per variant (including argument interpolation) and the `percent` rounding for `inProgress`.
+//  No reducer, no shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct MigrationBannerVariantTests {
+    @Test func requiredTitleAndInfo() {
+        let variant = MigrationBannerVariant.required
+
+        #expect(variant.title == String(localizable: .migrationBannerRequiredTitle))
+        #expect(variant.info == String(localizable: .migrationBannerRequiredInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func splittingTitleAndInfo() {
+        let variant = MigrationBannerVariant.splitting
+
+        #expect(variant.title == String(localizable: .migrationBannerRequiredTitle))
+        #expect(variant.info == String(localizable: .migrationBannerSplittingInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func inProgressTitleAndInfoInterpolatesDoneTotalAndPercent() {
+        let variant = MigrationBannerVariant.inProgress(done: 2, total: 5)
+
+        #expect(variant.title == String(localizable: .migrationBannerProgressTitle))
+        #expect(variant.info == String(localizable: .migrationBannerProgressInfo(2, 5, 40)))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == 40)
+    }
+
+    @Test func inProgressPercentRoundsToNearestInteger() {
+        #expect(MigrationBannerVariant.inProgress(done: 2, total: 5).percent == 40)
+        #expect(MigrationBannerVariant.inProgress(done: 1, total: 3).percent == 33)
+        #expect(MigrationBannerVariant.inProgress(done: 2, total: 3).percent == 67)
+        #expect(MigrationBannerVariant.inProgress(done: 0, total: 0).percent == 0)
+    }
+
+    @Test func transferWaitingTitleInterpolatesNumber() {
+        let variant = MigrationBannerVariant.transferWaiting(number: 3)
+
+        #expect(variant.title == String(localizable: .migrationBannerWaitingTitle(3)))
+        #expect(variant.info == String(localizable: .migrationBannerWaitingInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func updatePlanTitleAndInfo() {
+        let variant = MigrationBannerVariant.updatePlan
+
+        #expect(variant.title == String(localizable: .migrationBannerUpdatePlanTitle))
+        #expect(variant.info == String(localizable: .migrationBannerUpdatePlanInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func transfersExpiredTitleInterpolatesFirstAndLast() {
+        let variant = MigrationBannerVariant.transfersExpired(first: 3, last: 5)
+
+        #expect(variant.title == String(localizable: .migrationBannerExpiredTitle(3, 5)))
+        #expect(variant.info == String(localizable: .migrationBannerExpiredInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func transferReadyTitleInterpolatesNumberAndUsesReviewButtonLabel() {
+        let variant = MigrationBannerVariant.transferReady(number: 4)
+
+        #expect(variant.title == String(localizable: .migrationBannerReadyTitle(4)))
+        #expect(variant.info == String(localizable: .migrationBannerReadyInfo))
+        #expect(variant.buttonLabel == String(localizable: .sendReview))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func completeTitleAndInfo() {
+        let variant = MigrationBannerVariant.complete
+
+        #expect(variant.title == String(localizable: .migrationBannerCompleteTitle))
+        #expect(variant.info == String(localizable: .migrationBannerCompleteInfo))
+        #expect(variant.buttonLabel == String(localizable: .generalMore))
+        #expect(variant.percent == nil)
+    }
+
+    @Test func onlyTransferReadyUsesTheReviewButtonLabel() {
+        let allOtherVariants: [MigrationBannerVariant] = [
+            .required,
+            .splitting,
+            .inProgress(done: 1, total: 2),
+            .transferWaiting(number: 1),
+            .updatePlan,
+            .transfersExpired(first: 1, last: 2),
+            .complete
+        ]
+
+        for variant in allOtherVariants {
+            #expect(variant.buttonLabel == String(localizable: .generalMore))
+        }
+
+        #expect(MigrationBannerVariant.transferReady(number: 1).buttonLabel == String(localizable: .sendReview))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCompleteTests.swift
+++ b/zodlTests/MigrationTests/MigrationCompleteTests.swift
@@ -1,0 +1,57 @@
+//
+//  MigrationCompleteTests.swift
+//  zodlTests
+//
+//  Covers the MigrationComplete reducer
+//  (Features/Migration/MigrationComplete/MigrationCompleteStore.swift) for MOB-1464: the `hasDust`
+//  derivation at zero/nonzero dust, and the `gotItTapped` delegate contract. Visual-only screen —
+//  no SDK calls, no navigation. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationCompleteTests {
+    @MainActor @Test func defaultStateIsAllZeroWithNoDust() async {
+        let state = MigrationComplete.State()
+
+        #expect(state.totalTransferred == Zatoshi.zero)
+        #expect(state.dust == Zatoshi.zero)
+        #expect(state.transfersSent == 0)
+        #expect(state.transfersTotal == 0)
+        #expect(state.durationHours == 0)
+        #expect(state.hasDust == false)
+    }
+
+    @MainActor @Test func hasDustIsFalseWhenDustIsZero() async {
+        let state = MigrationComplete.State(dust: Zatoshi.zero)
+
+        #expect(state.hasDust == false)
+    }
+
+    @MainActor @Test func hasDustIsTrueWhenDustIsNonzero() async {
+        let state = MigrationComplete.State(dust: Zatoshi(31_000))
+
+        #expect(state.hasDust)
+    }
+
+    @MainActor @Test func gotItTappedEmitsDelegateDone() async {
+        let store = TestStore(initialState: MigrationComplete.State()) {
+            MigrationComplete()
+        }
+
+        await store.send(.gotItTapped)
+        await store.receive(.delegate(.done))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationComplete.State()) {
+            MigrationComplete()
+        }
+
+        await store.send(.delegate(.done))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationRecoveryTests.swift
+++ b/zodlTests/MigrationTests/MigrationRecoveryTests.swift
@@ -1,0 +1,56 @@
+//
+//  MigrationRecoveryTests.swift
+//  zodlTests
+//
+//  Covers the MigrationRecovery reducer
+//  (Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift) for MOB-1464: the default
+//  `.notesSpent` reason and the `continueTapped` delegate contract. Visual-only screen — no SDK
+//  calls, no navigation. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite struct MigrationRecoveryTests {
+    @MainActor @Test func defaultStateIsNotesSpentReasonWithDefaultTransferRange() async {
+        let state = MigrationRecovery.State()
+
+        #expect(state.reason == MigrationRecovery.State.Reason.notesSpent)
+        #expect(state.firstTransfer == 3)
+        #expect(state.lastTransfer == 5)
+    }
+
+    @MainActor @Test func expiredReasonIsPreservedInState() async {
+        let state = MigrationRecovery.State(reason: .expired)
+
+        #expect(state.reason == .expired)
+    }
+
+    @MainActor @Test func continueTappedEmitsDelegateRecreate() async {
+        let store = TestStore(initialState: MigrationRecovery.State()) {
+            MigrationRecovery()
+        }
+
+        await store.send(.continueTapped)
+        await store.receive(.delegate(.recreate))
+    }
+
+    @MainActor @Test func continueTappedEmitsDelegateRecreateForExpiredReason() async {
+        let store = TestStore(initialState: MigrationRecovery.State(reason: .expired)) {
+            MigrationRecovery()
+        }
+
+        await store.send(.continueTapped)
+        await store.receive(.delegate(.recreate))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationRecovery.State()) {
+            MigrationRecovery()
+        }
+
+        await store.send(.delegate(.recreate))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationStatusTests.swift
+++ b/zodlTests/MigrationTests/MigrationStatusTests.swift
@@ -1,0 +1,88 @@
+//
+//  MigrationStatusTests.swift
+//  zodlTests
+//
+//  Covers the MigrationStatus reducer (Features/Migration/MigrationStatus/MigrationStatusStore.swift)
+//  for MOB-1464: the default `.progress` presentation, the `gotItTapped`/`sendNowTapped`/
+//  `rescheduleTapped` delegate contracts, and the `remainingCount` derivation over a mixed row set.
+//  Visual-only screen — no SDK calls, no navigation. No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationStatusTests {
+    @MainActor @Test func defaultStateIsProgressPresentationWithNoRows() async {
+        let state = MigrationStatus.State()
+
+        #expect(state.presentation == MigrationStatus.State.Presentation.progress)
+        #expect(state.rows.isEmpty)
+        #expect(state.totalDurationHours == 0)
+        #expect(state.stalledNumber == 0)
+        #expect(state.stalledHoursAgo == 0)
+        #expect(state.isRescheduling == false)
+    }
+
+    @MainActor @Test func gotItTappedEmitsDelegateDone() async {
+        let store = TestStore(initialState: MigrationStatus.State()) {
+            MigrationStatus()
+        }
+
+        await store.send(.gotItTapped)
+        await store.receive(.delegate(.done))
+    }
+
+    @MainActor @Test func sendNowTappedEmitsDelegateSendNow() async {
+        let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
+            MigrationStatus()
+        }
+
+        await store.send(.sendNowTapped)
+        await store.receive(.delegate(.sendNow))
+    }
+
+    @MainActor @Test func rescheduleTappedSetsIsReschedulingAndEmitsDelegateReschedule() async {
+        let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
+            MigrationStatus()
+        }
+
+        await store.send(.rescheduleTapped) {
+            $0.isRescheduling = true
+        }
+        await store.receive(.delegate(.reschedule))
+    }
+
+    @MainActor @Test func remainingCountCountsAllRowsNotYetSent() async {
+        var state = MigrationStatus.State()
+        state.rows = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 18),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(2_000), status: .sent, hoursFromNow: 11),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(3_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(4_000), status: .pending, hoursFromNow: 1),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(5_000), status: .pending, hoursFromNow: 7)
+        ]
+
+        #expect(state.remainingCount == 3)
+    }
+
+    @MainActor @Test func remainingCountIsZeroWhenAllRowsSent() async {
+        var state = MigrationStatus.State()
+        state.rows = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 18),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(2_000), status: .sent, hoursFromNow: 11)
+        ]
+
+        #expect(state.remainingCount == 0)
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationStatus.State()) {
+            MigrationStatus()
+        }
+
+        await store.send(.delegate(.done))
+    }
+}


### PR DESCRIPTION
## Summary

Step 4 of the migration effort ([MOB-1465](https://linear.app/zodl/issue/MOB-1465)): a DEBUG-builds-only gallery for visual QA of everything built in MOB-1460…1464. Long-press (0.6 s) the balance on Home → a sheet with 7 sections / 28 rows covering every migration screen × variant, each opening as its own sheet rendered from the screen's real store with canned `MigrationMockData` fixtures.

Stacked PR #7: targets `michal/MOB-1464-status-recovery-complete-banner` (PR #1883).

## Design decisions

- **No TCA gallery reducer** — the screens' reducers already swallow their delegates, so the gallery constructs real stores exactly like the previews do. No logic ⇒ no new tests (deliberate TDD exception).
- **Sheets, not pushes** — several screens hide the back button (Sending/Scheduled/Complete) or have an inert ✕ (Status-progress); sheets stay swipe-dismissible, and each wraps its screen in a `NavigationStack` so `zashiBack`'s `dismiss()` closes the sheet.
- **Banner variants render standalone** via the extracted `MigrationBannerContentView` (SmartBannerView's `migrationContent()` is now a one-line wrapper; colors inlined from the same `Purple._50/._200` tokens, strip background copied from SmartBannerView's own gradient). Avoids instantiating `SmartBannerView`, whose `onAppear` starts live dependency subscriptions.
- **Plain string literals** in gallery UI — DEBUG-only, compiled out of release (deliberate localization exception; `Localizable.xcstrings` untouched).

## `#if DEBUG` guarantees

Both new files wrap their entire bodies in `#if DEBUG`/`#endif` (grep-verified: guards at lines 11–233 and 12–396); the HomeView property + modifiers are individually wrapped. Release configurations contain no gallery code.

## Verification

- `xcodebuild test` on `zodl-internal` (iPhone 17 Pro sim): **16 suites pass** (all 15 migration suites + `SmartBannerTests`, guarding the banner-content extraction), first run.
- Added Swift lines ≤ 150 chars; diff confined to 5 files.

## Try it

Run `zodl-internal` in the simulator, long-press the big balance number on Home, and flip through the rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)