### PR TITLE
[MOB-1466] Migration coordinator flow, routing, banner triggering, reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1463] Ironwood migration screens: transfer plan, transfer review, sending states, and migration scheduled. Not reachable in the app yet.
 - [MOB-1464] Ironwood migration screens: progress status, plan recovery, migration complete, and the home widget states. Not reachable in the app yet.
 - [MOB-1465] Internal DEBUG-only gallery of all Ironwood migration screens (long-press the balance on Home). Not present in release builds.
+- [MOB-1466] Ironwood migration screens are wired into a complete guided flow (entry, scheduling, status, recovery) driven by migration state, with a Home banner entry point — dormant until the migration SDK ships.
 
 ## 3.7.2 build 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1462] Ironwood migration screens: background delivery and notifications permissions. Not reachable in the app yet.
 - [MOB-1463] Ironwood migration screens: transfer plan, transfer review, sending states, and migration scheduled. Not reachable in the app yet.
 - [MOB-1464] Ironwood migration screens: progress status, plan recovery, migration complete, and the home widget states. Not reachable in the app yet.
+- [MOB-1465] Internal DEBUG-only gallery of all Ironwood migration screens (long-press the balance on Home). Not present in release builds.
 
 ## 3.7.2 build 1
 

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerInterface.swift
@@ -1,0 +1,30 @@
+//
+//  MigrationBGSchedulerInterface.swift
+//  Zashi
+//
+//  Background-refresh status check + scheduling seams for the Orchard -> Ironwood migration's
+//  background execution (MOB-1467). Only `backgroundRefreshStatus` is live in this ticket
+//  (MOB-1466); the scheduling members are inert stubs the coordinator calls at the right cadence
+//  points so MOB-1467 only has to fill the `LiveKey`, never touch call sites.
+//
+
+import UIKit
+import ComposableArchitecture
+
+extension DependencyValues {
+    var migrationBGScheduler: MigrationBGSchedulerClient {
+        get { self[MigrationBGSchedulerClient.self] }
+        set { self[MigrationBGSchedulerClient.self] = newValue }
+    }
+}
+
+@DependencyClient
+struct MigrationBGSchedulerClient: Sendable {
+    var backgroundRefreshStatus: @Sendable () async -> UIBackgroundRefreshStatus = { .available }
+    // +30 min rule — no-op until MOB-1467
+    var scheduleFirstWindow: @Sendable () -> Void
+    // +6.5 h rule — no-op until MOB-1467
+    var scheduleNextWindow: @Sendable () -> Void
+    // no-op until MOB-1467
+    var cancelAll: @Sendable () -> Void
+}

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
@@ -1,0 +1,33 @@
+//
+//  MigrationBGSchedulerLiveKey.swift
+//  Zashi
+//
+
+import UIKit
+import ComposableArchitecture
+
+extension MigrationBGSchedulerClient: DependencyKey {
+    static let liveValue: MigrationBGSchedulerClient = Self.live()
+
+    static func live() -> Self {
+        MigrationBGSchedulerClient(
+            backgroundRefreshStatus: {
+                await MainActor.run {
+                    UIApplication.shared.backgroundRefreshStatus
+                }
+            },
+            // TODO: [MOB-1467] Schedule the first background-refresh window ~30 minutes after a
+            // migration plan is committed (or re-committed via reschedule/recreate). Call sites in
+            // MOB-1466 already invoke this at every cadence-reset point (plan committed; reschedule
+            // confirmed; recovery recreate confirmed) — this only has to start honoring it.
+            scheduleFirstWindow: { },
+            // TODO: [MOB-1467] Schedule the next background-refresh window ~6.5 hours after the
+            // previous one fired (§8.3 cadence), or after a manual/immediate foreground send
+            // resets the cadence per the coordinator's call sites.
+            scheduleNextWindow: { },
+            // TODO: [MOB-1467] Cancel every pending background-refresh window (migration complete,
+            // user backed out, etc).
+            cancelAll: { }
+        )
+    }
+}

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
@@ -1,0 +1,59 @@
+//
+//  MigrationManagerInterface.swift
+//  Zashi
+//
+//  App-owned logic for the Orchard -> Ironwood migration (MOB-1466): persistence, the
+//  10-minute sync<->send gate, and the banner-variant / re-entry-route derivations. The SDK
+//  only exposes raw state (`MigrationState`, `MigrationProgress`, …) — this client is the
+//  single place that turns that state plus app-side flags into what the UI actually shows.
+//
+
+import Foundation
+@preconcurrency import ZcashLightClientKit
+import ComposableArchitecture
+
+extension DependencyValues {
+    var migrationManager: MigrationManagerClient {
+        get { self[MigrationManagerClient.self] }
+        set { self[MigrationManagerClient.self] = newValue }
+    }
+}
+
+@DependencyClient
+struct MigrationManagerClient: Sendable {
+    // Derivations (pure given SDK members + persistence; unit-tested as tables)
+    var bannerVariant: @Sendable (_ accountUUID: AccountUUID?) async -> MigrationBannerVariant? = { _ in nil }
+    var reentryRoute: @Sendable () -> MigrationReentryRoute = { .entry }
+    var orchardBalanceToMigrate: @Sendable (_ accountUUID: AccountUUID?) async -> Zatoshi = { _ in .zero }
+    // Persistence (UserDefaults-backed; keys in SharedStateKeys.swift)
+    var migrationMode: @Sendable () -> MigrationMode?
+    var setMigrationMode: @Sendable (MigrationMode) -> Void
+    var isManualDelivery: @Sendable () -> Bool = { false }
+    var setManualDelivery: @Sendable (Bool) -> Void
+    var networkPrivacyOptions: @Sendable () -> NetworkPrivacyOptions = { NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil) }
+    var setNetworkPrivacyOptions: @Sendable (NetworkPrivacyOptions) -> Void
+    var isCompleteAcknowledged: @Sendable () -> Bool = { false }
+    var acknowledgeComplete: @Sendable () -> Void
+    // 10-minute sync<->send gate
+    var sendGate: @Sendable () -> MigrationSendGate = { .allowed }
+    var recordMigrationBroadcast: @Sendable () -> Void
+    var isSyncDeferredAfterBroadcast: @Sendable () -> Bool = { false }   // consumed by MOB-1467
+    // Reconciliation
+    var reconcile: @Sendable () -> Void
+}
+
+enum MigrationSendGate: Equatable, Sendable {
+    case allowed
+    case syncRequired            // isSyncRequiredBeforeNextMigrationTransfer() == true — CTA disabled
+    case waitUntil(Date)         // required sync finished < 10 min ago — CTA disabled with ETA
+}
+
+enum MigrationReentryRoute: Equatable, Sendable {
+    case recovery(isExpired: Bool)       // §4.3 row 1 — variant from AttentionReason (.transferExpired → true, else false)
+    case statusResume                    // row 2
+    case statusProgress                  // row 3
+    case complete                        // row 4 (unacknowledged)
+    case noteSplitProgress               // row 5
+    case reviewManual(step: Int, total: Int)  // row 6 — manual delivery, next transfer due
+    case entry                           // row 7 (notStarted / readyToPropose)
+}

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -1,0 +1,422 @@
+//
+//  MigrationManagerLiveKey.swift
+//  Zashi
+//
+//  Live implementation of `MigrationManagerClient`. Every piece of actual logic is factored
+//  into pure, table-testable types below (`MigrationDerivations`, `MigrationGateStorage`) so
+//  `MigrationManagerTests` can exercise them without touching the SDK; this file is left with
+//  only the wiring between those types and `@Dependency(\.sdkSynchronizer)`.
+//
+
+import Foundation
+@preconcurrency import Combine
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import os
+
+extension MigrationManagerClient: DependencyKey {
+    static let liveValue: MigrationManagerClient = Self.live()
+
+    static func live() -> Self {
+        let impl = MigrationManagerImpl()
+
+        return MigrationManagerClient(
+            bannerVariant: { accountUUID in await impl.bannerVariant(accountUUID: accountUUID) },
+            reentryRoute: { impl.reentryRoute() },
+            orchardBalanceToMigrate: { accountUUID in await impl.orchardBalanceToMigrate(accountUUID: accountUUID) },
+            migrationMode: { impl.gateStorage.migrationMode() },
+            setMigrationMode: { impl.gateStorage.setMigrationMode($0) },
+            isManualDelivery: { impl.gateStorage.isManualDelivery() },
+            setManualDelivery: { impl.gateStorage.setManualDelivery($0) },
+            networkPrivacyOptions: { impl.gateStorage.networkPrivacyOptions() },
+            setNetworkPrivacyOptions: { impl.gateStorage.setNetworkPrivacyOptions($0) },
+            isCompleteAcknowledged: { impl.gateStorage.isCompleteAcknowledged() },
+            acknowledgeComplete: { impl.gateStorage.acknowledgeComplete() },
+            sendGate: { impl.sendGate() },
+            recordMigrationBroadcast: { impl.recordMigrationBroadcast() },
+            isSyncDeferredAfterBroadcast: { impl.isSyncDeferredAfterBroadcast() },
+            reconcile: { impl.reconcile() }
+        )
+    }
+}
+
+/// Composes `sdkSynchronizer` + `MigrationGateStorage` and owns the lazy `stateStream()`
+/// subscription that drives the sync<->send gate. `@unchecked Sendable`: the only mutable state
+/// is `gateStorage`'s own `OSAllocatedUnfairLock`-protected storage plus the Combine
+/// subscription handle below, both of which are safe to share across isolation domains.
+private final class MigrationManagerImpl: @unchecked Sendable {
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+
+    let gateStorage = MigrationGateStorage()
+
+    private let subscriptionState = OSAllocatedUnfairLock<AnyCancellable?>(initialState: nil)
+
+    /// Subscribes to `sdkSynchronizer.stateStream()` on first use so gate transitions (pending ->
+    /// resolved) are observed as soon as anything asks this client for a derivation or the gate,
+    /// without requiring reducer glue to kick it off (the `shieldingProcessor` precedent).
+    private func ensureSubscribed() {
+        subscriptionState.withLock { cancellable in
+            guard cancellable == nil else { return }
+
+            let gateStorage = self.gateStorage
+            cancellable = self.sdkSynchronizer.stateStream()
+                .sink { state in
+                    gateStorage.observeSyncStatus(state.syncStatus.isSyncing == false, at: Date())
+                }
+        }
+    }
+
+    func bannerVariant(accountUUID: AccountUUID?) async -> MigrationBannerVariant? {
+        ensureSubscribed()
+
+        let state = normalizedState()
+        let rows = sdkSynchronizer.migrationTransfers()
+        let balance = await orchardBalanceToMigrate(accountUUID: accountUUID)
+
+        return MigrationDerivations.bannerVariant(
+            state: state,
+            hasInvalid: sdkSynchronizer.hasInvalidMigrationTransfers(),
+            hasOverdue: sdkSynchronizer.hasOverdueMigrationTransfers(),
+            isManualDelivery: gateStorage.isManualDelivery(),
+            isNextTransferDue: isNextTransferDue(),
+            orchardBalance: balance,
+            isCompleteAcknowledged: gateStorage.isCompleteAcknowledged(),
+            transferRows: rows
+        )
+    }
+
+    func reentryRoute() -> MigrationReentryRoute {
+        ensureSubscribed()
+
+        let progress = sdkSynchronizer.getMigrationProgress()
+
+        return MigrationDerivations.reentryRoute(
+            state: normalizedState(),
+            hasInvalid: sdkSynchronizer.hasInvalidMigrationTransfers(),
+            hasOverdue: sdkSynchronizer.hasOverdueMigrationTransfers(),
+            isManualDelivery: gateStorage.isManualDelivery(),
+            isNextTransferDue: isNextTransferDue(),
+            isCompleteAcknowledged: gateStorage.isCompleteAcknowledged(),
+            progress: progress
+        )
+    }
+
+    func orchardBalanceToMigrate(accountUUID: AccountUUID?) async -> Zatoshi {
+        guard let accountUUID else { return .zero }
+
+        guard let balances = try? await sdkSynchronizer.getAccountsBalances(),
+              let balance = balances[accountUUID] else {
+            return .zero
+        }
+
+        return balance.orchardBalance.total()
+    }
+
+    func sendGate() -> MigrationSendGate {
+        ensureSubscribed()
+
+        if sdkSynchronizer.isSyncRequiredBeforeNextMigrationTransfer() {
+            gateStorage.markSyncRequired()
+        }
+
+        return gateStorage.sendGate(now: Date())
+    }
+
+    func recordMigrationBroadcast() {
+        gateStorage.recordMigrationBroadcast(at: Date())
+    }
+
+    func isSyncDeferredAfterBroadcast() -> Bool {
+        gateStorage.isSyncDeferredAfterBroadcast(now: Date())
+    }
+
+    func reconcile() {
+        sdkSynchronizer.initializeMigrationPostUpgrade()
+
+        // Stale-acknowledge reset: the acknowledged flag must never suppress a *new* migration's
+        // completion banner (reinstall, Path F). It's only meaningful while state is `.complete`.
+        if sdkSynchronizer.getMigrationState() != MigrationState.complete {
+            gateStorage.clearAcknowledgedComplete()
+        }
+    }
+
+    /// `.requiresAttention(.syncRequiredBeforeNext)` carries no progress payload of its own, but
+    /// per spec it renders identically to a plain `.inProgress(p)` banner — so it's normalized to
+    /// that shape here, using the SDK's own out-of-band `getMigrationProgress()` snapshot, before
+    /// ever reaching `MigrationDerivations` (which only needs to know about `.inProgress`).
+    private func normalizedState() -> MigrationState {
+        let state = sdkSynchronizer.getMigrationState()
+
+        guard case MigrationState.requiresAttention(AttentionReason.syncRequiredBeforeNext) = state,
+              let progress = sdkSynchronizer.getMigrationProgress() else {
+            return state
+        }
+
+        return MigrationState.inProgress(progress)
+    }
+
+    /// "Next due" (manual): ready height already reached (or unknown / no progress -> not due).
+    private func isNextTransferDue() -> Bool {
+        guard let readyAtHeight = sdkSynchronizer.getMigrationProgress()?.nextTransferReadyAtHeight else {
+            return false
+        }
+
+        return readyAtHeight <= sdkSynchronizer.latestState().latestBlockHeight
+    }
+}
+
+// MARK: - Pure derivations (table-testable, no SDK dependency)
+
+/// Pure mappings from SDK-observed migration state (plus a handful of app-side flags) onto what
+/// the UI shows. Every function here is a straight table lookup — no dates, no I/O, no SDK types
+/// beyond the value models already `Equatable`/`Sendable` (`MigrationState`, `MigrationProgress`,
+/// `AttentionReason`, `MigrationTransferRow`) — so `MigrationManagerTests` can exercise every row
+/// directly.
+enum MigrationDerivations {
+    /// See MOB-1466 spec, "bannerVariant derivation" table.
+    static func bannerVariant(
+        state: MigrationState,
+        hasInvalid: Bool,
+        hasOverdue: Bool,
+        isManualDelivery: Bool,
+        isNextTransferDue: Bool,
+        orchardBalance: Zatoshi,
+        isCompleteAcknowledged: Bool,
+        transferRows: [MigrationTransferRow]
+    ) -> MigrationBannerVariant? {
+        switch state {
+        case MigrationState.notStarted, MigrationState.readyToPropose:
+            return orchardBalance > Zatoshi.zero ? MigrationBannerVariant.required : nil
+
+        case MigrationState.splitPendingConfirmation:
+            return MigrationBannerVariant.splitting
+
+        case let MigrationState.inProgress(progress):
+            if isManualDelivery && isNextTransferDue {
+                return MigrationBannerVariant.transferReady(number: progress.completedTransfers + 1)
+            }
+            return MigrationBannerVariant.inProgress(done: progress.completedTransfers, total: progress.totalTransfers)
+
+        case let MigrationState.requiresAttention(reason):
+            switch reason {
+            case let AttentionReason.transferStalled(transferNumber):
+                return MigrationBannerVariant.transferWaiting(number: transferNumber)
+
+            case AttentionReason.invalidTransfer:
+                return MigrationBannerVariant.updatePlan
+
+            case AttentionReason.transferExpired:
+                let (first, last) = expiredBounds(transferRows: transferRows)
+                return MigrationBannerVariant.transfersExpired(first: first, last: last)
+
+            case AttentionReason.syncRequiredBeforeNext:
+                // Normalized to `.inProgress` by the LiveKey before this function is ever called
+                // with this state — this branch only exists so the switch stays exhaustive.
+                return nil
+            }
+
+        case MigrationState.complete:
+            return isCompleteAcknowledged ? nil : MigrationBannerVariant.complete
+        }
+    }
+
+    /// See MOB-1466 spec, "reentryRoute" — §4.3 table, checked in this exact order.
+    static func reentryRoute(
+        state: MigrationState,
+        hasInvalid: Bool,
+        hasOverdue: Bool,
+        isManualDelivery: Bool,
+        isNextTransferDue: Bool,
+        isCompleteAcknowledged: Bool,
+        progress: MigrationProgress?
+    ) -> MigrationReentryRoute {
+        if hasInvalid {
+            let isExpired = isTransferExpired(state)
+            return MigrationReentryRoute.recovery(isExpired: isExpired)
+        }
+
+        if hasOverdue {
+            return MigrationReentryRoute.statusResume
+        }
+
+        if isManualDelivery && isNextTransferDue, let progress {
+            return MigrationReentryRoute.reviewManual(step: progress.completedTransfers + 1, total: progress.totalTransfers)
+        }
+
+        if case MigrationState.inProgress = state {
+            return MigrationReentryRoute.statusProgress
+        }
+
+        if case MigrationState.complete = state {
+            return isCompleteAcknowledged ? MigrationReentryRoute.entry : MigrationReentryRoute.complete
+        }
+
+        if case MigrationState.splitPendingConfirmation = state {
+            return MigrationReentryRoute.noteSplitProgress
+        }
+
+        return MigrationReentryRoute.entry
+    }
+
+    /// Bounds for `.transfersExpired(first:last:)`: 1-based first/last position among rows whose
+    /// status is `.expired`; fallback `(1, total)` when none are marked expired (including an
+    /// empty row list, which falls back to `(1, 0)`).
+    private static func expiredBounds(transferRows: [MigrationTransferRow]) -> (first: Int, last: Int) {
+        let expiredIndexes = transferRows
+            .filter { $0.status == MigrationTransferRow.Status.expired }
+            .map { $0.index + 1 }
+
+        guard let first = expiredIndexes.min(), let last = expiredIndexes.max() else {
+            return (1, transferRows.count)
+        }
+
+        return (first, last)
+    }
+
+    private static func isTransferExpired(_ state: MigrationState) -> Bool {
+        guard case let MigrationState.requiresAttention(reason) = state else { return false }
+        return reason == AttentionReason.transferExpired
+    }
+}
+
+// MARK: - Persistence + 10-minute sync<->send gate
+
+/// `UserDefaults`-backed persistence for every app-owned migration flag, plus the 10-minute
+/// sync<->send gate math. Every method that depends on "now" takes it as a parameter — never
+/// reads `Date()` internally — so tests can drive the clock explicitly. Injectable
+/// `UserDefaults` (default `.standard`) lets tests use an isolated named suite.
+final class MigrationGateStorage: @unchecked Sendable {
+    private enum Constants {
+        static let tenMinutes: TimeInterval = 10 * 60
+    }
+
+    private let userDefaults: UserDefaults
+    /// Transient (not persisted): "a required-before-transfer sync is currently pending
+    /// resolution". Re-derived from a fresh SDK read on every `markSyncRequired()` call, so
+    /// losing it across relaunch is fine — the LiveKey re-observes the live SDK flag immediately.
+    private let isSyncCurrentlyRequired = OSAllocatedUnfairLock(initialState: false)
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    // MARK: Gate
+
+    /// Called whenever the LiveKey observes `isSyncRequiredBeforeNextMigrationTransfer() == true`.
+    /// Marks the gate as required outright — `sendGate()` checks this before the persisted
+    /// `gateUntil` window.
+    func markSyncRequired() {
+        isSyncCurrentlyRequired.withLock { $0 = true }
+    }
+
+    /// Called from the `stateStream()` subscription: `isSyncFinished` reflects whether the just
+    /// observed `SyncStatus` is no longer `.syncing` (i.e. reached up-to-date). Only takes effect
+    /// while a sync requirement is pending — an unrelated "already idle" tick is a no-op.
+    func observeSyncStatus(_ isSyncFinished: Bool, at now: Date) {
+        guard isSyncFinished else { return }
+
+        let wasPending = isSyncCurrentlyRequired.withLock { pending -> Bool in
+            let wasPending = pending
+            pending = false
+            return wasPending
+        }
+
+        guard wasPending else { return }
+
+        recordSyncCompletion(at: now)
+    }
+
+    /// Persists `gateUntil = syncCompletion + 10 min` and clears the pending flag. Exposed
+    /// separately from `observeSyncStatus` so tests can drive the gate without a fake stream tick.
+    func recordSyncCompletion(at syncCompletedAt: Date) {
+        isSyncCurrentlyRequired.withLock { $0 = false }
+        let gateUntil = syncCompletedAt.addingTimeInterval(Constants.tenMinutes)
+        userDefaults.set(gateUntil.timeIntervalSince1970, forKey: .migrationSyncGateUntil)
+    }
+
+    /// `sendGate()` precedence: sync currently required -> `.syncRequired`; `now < gateUntil` ->
+    /// `.waitUntil(gateUntil)`; else `.allowed`.
+    func sendGate(now: Date) -> MigrationSendGate {
+        if isSyncCurrentlyRequired.withLock({ $0 }) {
+            return MigrationSendGate.syncRequired
+        }
+
+        guard let gateUntil = storedGateUntil(), now < gateUntil else {
+            return MigrationSendGate.allowed
+        }
+
+        return MigrationSendGate.waitUntil(gateUntil)
+    }
+
+    private func storedGateUntil() -> Date? {
+        guard let interval = userDefaults.object(forKey: .migrationSyncGateUntil) as? Double else {
+            return nil
+        }
+
+        return Date(timeIntervalSince1970: interval)
+    }
+
+    // MARK: Broadcast timestamp (consumed by MOB-1467)
+
+    /// Persisted (not merely in-memory) so relaunching the app cannot dodge the post-broadcast
+    /// sync deferral MOB-1467's scheduler will apply.
+    func recordMigrationBroadcast(at now: Date) {
+        userDefaults.set(now.timeIntervalSince1970, forKey: .migrationLastBroadcastAt)
+    }
+
+    /// Sync side of the 10-minute sync<->send separation (feature spec section 8.2): background
+    /// syncs must not start sooner than 10 minutes after a foreground migration broadcast.
+    /// MOB-1467's scheduler is the consumer; nothing reads this in MOB-1466.
+    func isSyncDeferredAfterBroadcast(now: Date) -> Bool {
+        guard let interval = userDefaults.object(forKey: .migrationLastBroadcastAt) as? Double else {
+            return false
+        }
+
+        return now < Date(timeIntervalSince1970: interval).addingTimeInterval(Constants.tenMinutes)
+    }
+
+    // MARK: Mode / manual delivery / network privacy / acknowledge
+
+    func migrationMode() -> MigrationMode? {
+        guard let rawValue = userDefaults.string(forKey: .migrationMode) else { return nil }
+        return MigrationMode(rawValue: rawValue)
+    }
+
+    func setMigrationMode(_ mode: MigrationMode) {
+        userDefaults.set(mode.rawValue, forKey: .migrationMode)
+    }
+
+    func isManualDelivery() -> Bool {
+        userDefaults.bool(forKey: .migrationManualDelivery)
+    }
+
+    func setManualDelivery(_ isManual: Bool) {
+        userDefaults.set(isManual, forKey: .migrationManualDelivery)
+    }
+
+    func networkPrivacyOptions() -> NetworkPrivacyOptions {
+        guard let data = userDefaults.data(forKey: .migrationNetworkPrivacyOptions),
+              let options = try? JSONDecoder().decode(NetworkPrivacyOptions.self, from: data) else {
+            return NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        }
+
+        return options
+    }
+
+    func setNetworkPrivacyOptions(_ options: NetworkPrivacyOptions) {
+        guard let data = try? JSONEncoder().encode(options) else { return }
+        userDefaults.set(data, forKey: .migrationNetworkPrivacyOptions)
+    }
+
+    func isCompleteAcknowledged() -> Bool {
+        userDefaults.bool(forKey: .migrationCompleteAcknowledged)
+    }
+
+    func acknowledgeComplete() {
+        userDefaults.set(true, forKey: .migrationCompleteAcknowledged)
+    }
+
+    func clearAcknowledgedComplete() {
+        userDefaults.set(false, forKey: .migrationCompleteAcknowledged)
+    }
+}

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -44,10 +44,16 @@ extension MigrationManagerClient: DependencyKey {
 /// subscription that drives the sync<->send gate. `@unchecked Sendable`: the only mutable state
 /// is `gateStorage`'s own `OSAllocatedUnfairLock`-protected storage plus the Combine
 /// subscription handle below, both of which are safe to share across isolation domains.
-private final class MigrationManagerImpl: @unchecked Sendable {
+final class MigrationManagerImpl: @unchecked Sendable {
     @Dependency(\.sdkSynchronizer) var sdkSynchronizer
 
-    let gateStorage = MigrationGateStorage()
+    let gateStorage: MigrationGateStorage
+
+    /// Internal (not private) with injectable storage so unit tests can exercise the real
+    /// `reconcile()` against a scoped `UserDefaults` suite.
+    init(gateStorage: MigrationGateStorage = MigrationGateStorage()) {
+        self.gateStorage = gateStorage
+    }
 
     private let subscriptionState = OSAllocatedUnfairLock<AnyCancellable?>(initialState: nil)
 

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -292,22 +292,43 @@ extension SDKSynchronizerClient: DependencyKey {
             },
             // Migration (Orchard → Ironwood) — STUB: the SDK API does not exist yet (MOB-1455).
             // These compile the app against the expected contract and do nothing. When the real
-            // SDK lands, replace these closures here — broadcast-capable ones (`submitNoteSplit`,
-            // `executeNextPendingMigrationTransfer`) must then acquire the transaction guard
-            // inside this LiveKey (same pattern as `createAndSubmitProposedTransactions`),
-            // never at call sites. `storeSignedMigrationTransactions` only stores locally —
-            // it is not a broadcast and must stay unguarded.
+            // SDK lands, replace these closures here. The two broadcast-path stubs
+            // (`submitNoteSplit`, `executeNextPendingMigrationTransfer`) already acquire the
+            // transaction guard below — same `withSubmission` pattern as
+            // `createAndSubmitProposedTransactions` — so they are correct-by-construction once
+            // real broadcasting lands; every other migration stub here is read-only/non-broadcast
+            // and stays unguarded. `storeSignedMigrationTransactions` (Keystone/PCZT path,
+            // MOB-1468) only stores locally — it is not a broadcast and must stay unguarded.
             getMigrationState: { .notStarted },
             migrationStateStream: { Just(MigrationState.notStarted).eraseToAnyPublisher() },
             getMigrationProgress: { nil },
             isNoteSplitNeeded: { false },
             prepareNoteSplit: { NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero) },
-            submitNoteSplit: { _ in TransferResult.success(txId: "") },
+            submitNoteSplit: { _ in
+                @Dependency(\.transactionGuard) var transactionGuard
+                do {
+                    return try await transactionGuard.withSubmission {
+                        TransferResult.success(txId: "")
+                    }
+                } catch {
+                    return TransferResult.networkError(retryable: true)
+                }
+            },
             selectMigrationMode: { _ in },
             proposeMigrationTransfers: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },
             signAndStoreMigrationSchedule: { _ in },
             isSyncRequiredBeforeNextMigrationTransfer: { false },
-            executeNextPendingMigrationTransfer: { _ in nil },
+            executeNextPendingMigrationTransfer: { _ in
+                @Dependency(\.transactionGuard) var transactionGuard
+                do {
+                    return try await transactionGuard.withSubmission {
+                        let stubResult: TransferResult? = nil
+                        return stubResult
+                    }
+                } catch {
+                    return nil
+                }
+            },
             hasOverdueMigrationTransfers: { false },
             hasInvalidMigrationTransfers: { false },
             restartCurrentMigrationStep: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },

--- a/secant/Sources/Dependencies/UserNotifications/UserNotificationsInterface.swift
+++ b/secant/Sources/Dependencies/UserNotifications/UserNotificationsInterface.swift
@@ -1,0 +1,24 @@
+//
+//  UserNotificationsInterface.swift
+//  Zashi
+//
+//  Authorization-only seam over `UNUserNotificationCenter` for the Orchard -> Ironwood
+//  migration's Notifications permission screen (MOB-1466). MOB-1467 extends this client with
+//  local-notification scheduling (§4.4 matrix) — do not add those members here yet.
+//
+
+import UserNotifications
+import ComposableArchitecture
+
+extension DependencyValues {
+    var userNotifications: UserNotificationsClient {
+        get { self[UserNotificationsClient.self] }
+        set { self[UserNotificationsClient.self] = newValue }
+    }
+}
+
+@DependencyClient
+struct UserNotificationsClient: Sendable {
+    var authorizationStatus: @Sendable () async -> UNAuthorizationStatus = { .notDetermined }
+    var requestAuthorization: @Sendable () async -> Bool = { false }   // .alert, .sound, .badge
+}

--- a/secant/Sources/Dependencies/UserNotifications/UserNotificationsLiveKey.swift
+++ b/secant/Sources/Dependencies/UserNotifications/UserNotificationsLiveKey.swift
@@ -1,0 +1,28 @@
+//
+//  UserNotificationsLiveKey.swift
+//  Zashi
+//
+
+import UserNotifications
+import ComposableArchitecture
+
+extension UserNotificationsClient: DependencyKey {
+    static let liveValue: UserNotificationsClient = Self.live()
+
+    static func live() -> Self {
+        UserNotificationsClient(
+            authorizationStatus: {
+                await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+            },
+            requestAuthorization: {
+                do {
+                    return try await UNUserNotificationCenter.current().requestAuthorization(
+                        options: [.alert, .sound, .badge]
+                    )
+                } catch {
+                    return false
+                }
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -105,7 +105,7 @@ extension MigrationCoordFlow {
                 if state.mode == .immediate {
                     state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
                 } else {
-                    state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+                    state.path.append(.transferPlan(MigrationTransferPlan.State(variant: freshPlanVariant())))
                 }
                 return .none
 
@@ -290,9 +290,15 @@ extension MigrationCoordFlow {
         }
 
         return MigrationCoordFlow.PermissionStepResult(
-            pathState: .transferPlan(MigrationTransferPlan.State(variant: .scheduled)),
+            pathState: .transferPlan(MigrationTransferPlan.State(variant: freshPlanVariant())),
             forcedUseTor: true
         )
+    }
+
+    /// Fresh-entry plan variant: manual delivery (background delivery declined) shows the manual
+    /// copy and its confirm sends the first transfer now (§6.3); otherwise the scheduled variant.
+    private func freshPlanVariant() -> MigrationTransferPlan.State.Variant {
+        migrationManager.isManualDelivery() ? .manual : .scheduled
     }
 
     // MARK: - Reschedule / Recovery: TransferPlan hydration

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -1,0 +1,402 @@
+//
+//  MigrationCoordFlowCoordinator.swift
+//  Zashi
+//
+//  Routing brain for `MigrationCoordFlow` (MOB-1466): re-entry (`.onAppear`), the chaining table
+//  from Entry through Complete, and the shared permission-step helper (BackgroundDelivery ->
+//  Notifications -> NetworkPrivacy -> TransferPlan). See the MOB-1466 implementation spec's
+//  `MigrationCoordFlow` section for the full chaining table this mirrors row by row.
+//
+
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+extension MigrationCoordFlow {
+    func coordinatorReduce() -> Reduce<MigrationCoordFlow.State, MigrationCoordFlow.Action> {
+        Reduce { state, action in
+            switch action {
+                // MARK: - Self: onAppear (re-entry)
+
+            case .onAppear:
+                guard state.path.isEmpty else { return .none }
+                return .run { send in
+                    let pathState = await reentryPathState()
+                    await send(.pushNextPermissionStep(PermissionStepResult(pathState: pathState)))
+                }
+
+            case .pushNextPermissionStep(let result):
+                if result.forcedUseTor {
+                    state.networkPrivacyOptions.useTor = true
+                }
+                if let pathState = result.pathState {
+                    state.path.append(pathState)
+                }
+                return .none
+
+                // MARK: - Entry
+
+            case .entry(.delegate(.chose(let mode))):
+                state.mode = mode
+                migrationManager.setMigrationMode(mode)
+                sdkSynchronizer.selectMigrationMode(mode)
+
+                switch mode {
+                case .immediate:
+                    // Skip Network Privacy (S5) iff the app-wide Tor setup flag is on — in that
+                    // case `useTor` is implicitly `true` and Review is pushed directly; otherwise
+                    // Network Privacy is shown so the user can opt in explicitly. Both checks here
+                    // are synchronous SDK/dependency reads, so no effect is needed.
+                    if walletStorage.exportTorSetupFlag() == true {
+                        state.networkPrivacyOptions.useTor = true
+                        state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+                    } else {
+                        state.path.append(.networkPrivacy(MigrationNetworkPrivacy.State(variant: .immediate)))
+                    }
+                    return .none
+
+                case .privateScheduled:
+                    if sdkSynchronizer.isNoteSplitNeeded() {
+                        state.path.append(.noteSplit(MigrationNoteSplit.State()))
+                        return .none
+                    }
+                    return .run { send in
+                        await send(.pushNextPermissionStep(await nextPermissionStepResult()))
+                    }
+                }
+
+                // MARK: - NoteSplit
+
+            case .path(.element(id: let id, action: .noteSplit(.delegate(.continued)))):
+                // NoteSplit's `closeTapped` (flow-root back, splitting phase) and `continueTapped`
+                // (normal chain progression, confirmed phase) both emit the same `.continued`
+                // delegate value — `isFlowRoot` on the element disambiguates them, since only the
+                // flow-root splitting re-entry root can reach `closeTapped` at all.
+                if case .noteSplit(let noteSplitState) = state.path[id: id], noteSplitState.isFlowRoot {
+                    return .send(.flowFinished)
+                }
+                return .run { send in
+                    await send(.pushNextPermissionStep(await nextPermissionStepResult()))
+                }
+
+                // MARK: - BackgroundDelivery
+
+            case .path(.element(id: _, action: .backgroundDelivery(.delegate(.continued(let backgroundAllowed))))):
+                if !backgroundAllowed {
+                    migrationManager.setManualDelivery(true)
+                }
+                return .run { send in
+                    await send(.pushNextPermissionStep(await nextPermissionStepResult()))
+                }
+
+                // MARK: - Notifications
+
+            case .path(.element(id: _, action: .notifications(.delegate(.continued)))):
+                return .run { send in
+                    await send(.pushNextPermissionStep(await nextPermissionStepResult()))
+                }
+
+                // MARK: - NetworkPrivacy
+
+            case .path(.element(id: _, action: .networkPrivacy(.delegate(.confirmed(let options))))):
+                migrationManager.setNetworkPrivacyOptions(options)
+                state.networkPrivacyOptions = options
+
+                if state.mode == .immediate {
+                    state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+                } else {
+                    state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+                }
+                return .none
+
+                // MARK: - TransferPlan
+
+            case .path(.element(id: _, action: .transferPlan(.delegate(.confirmed)))):
+                guard case let .transferPlan(planState) = state.path.last else { return .none }
+
+                // Rescheduled variant (`requiresSigning == false`): its confirm is a plain
+                // acknowledgment of an already-committed reschedule (`scheduleFirstWindow()` ran
+                // once already, at reschedule-initiation) — no re-sign, no terminal `.scheduled`
+                // screen, straight to `.flowFinished` ("Got-it" per the spec).
+                guard planState.requiresSigning else {
+                    return .send(.flowFinished)
+                }
+
+                migrationBGScheduler.scheduleFirstWindow()
+
+                switch planState.variant {
+                case .scheduled, .recreated:
+                    state.path.append(.scheduled(MigrationScheduled.State()))
+                case .manual:
+                    var sendingState = MigrationSending.State(totalCount: 1)
+                    sendingState.networkPrivacyOptions = state.networkPrivacyOptions
+                    state.path.append(.sending(sendingState))
+                }
+                return .none
+
+                // MARK: - ReviewTransfer
+
+            case .path(.element(id: _, action: .reviewTransfer(.delegate(.confirmed)))):
+                var sendingState = MigrationSending.State(totalCount: 1)
+                sendingState.networkPrivacyOptions = state.networkPrivacyOptions
+                state.path.append(.sending(sendingState))
+                return .none
+
+                // MARK: - Sending
+
+            case .path(.element(id: _, action: .sending(.delegate(.closed)))):
+                if state.mode == .immediate {
+                    migrationManager.acknowledgeComplete()
+                    return .send(.flowFinished)
+                }
+
+                let hasStatusBeneath = state.path.contains { $0.is(\.status) }
+                if hasStatusBeneath {
+                    return .run { [sdkSynchronizer] send in
+                        await send(.sendNowCompleted(rows: sdkSynchronizer.migrationTransfers()))
+                    }
+                }
+
+                // Manual-first-transfer path: no `.status` yet on the path — push a fresh one.
+                return .run { send in
+                    await send(.pushHydratedStatus(await statusProgressState(isFlowRoot: false)))
+                }
+
+                // MARK: - Self: pushHydratedStatus / pushHydratedPathState / sendNowCompleted
+
+            case .pushHydratedStatus(let statusState):
+                state.path.append(.status(statusState))
+                return .none
+
+            case .pushHydratedPathState(let pathState):
+                state.path.append(pathState)
+                return .none
+
+            case .sendNowCompleted(let rows):
+                // Pop the Sending element and refresh the `.status` element now on top.
+                let _ = state.path.popLast()
+                guard let statusId = state.path.ids.last, case .status(var statusState) = state.path.last else {
+                    return .none
+                }
+                statusState.rows = IdentifiedArrayOf(uniqueElements: rows)
+                state.path[id: statusId] = .status(statusState)
+                return .none
+
+                // MARK: - Status
+
+            case .path(.element(id: _, action: .status(.delegate(.sendNow)))):
+                let networkPrivacyOptions = state.networkPrivacyOptions
+                return .run { [sdkSynchronizer] send in
+                    let rows = sdkSynchronizer.migrationTransfers()
+                    let overdueCount = rows.filter { $0.status == MigrationTransferRow.Status.overdue }.count
+                    var sendingState = MigrationSending.State(totalCount: max(overdueCount, 1))
+                    sendingState.networkPrivacyOptions = networkPrivacyOptions
+                    await send(.pushHydratedPathState(.sending(sendingState)))
+                }
+
+            case .path(.element(id: let id, action: .status(.delegate(.reschedule)))):
+                if case .status(var statusState) = state.path[id: id] {
+                    statusState.isRescheduling = true
+                    state.path[id: id] = .status(statusState)
+                }
+                return .run { [migrationBGScheduler, sdkSynchronizer] send in
+                    await sdkSynchronizer.rescheduleStalledMigrationTransfer()
+                    migrationBGScheduler.scheduleFirstWindow()
+                    let rows = sdkSynchronizer.migrationTransfers()
+                    let planState = rescheduledPlanState(rows: rows)
+                    await send(.pushHydratedPathState(.transferPlan(planState)))
+                }
+
+                // MARK: - Recovery
+
+            case .path(.element(id: _, action: .recovery(.delegate(.recreate)))):
+                return .run { [sdkSynchronizer] send in
+                    let schedule = await sdkSynchronizer.restartCurrentMigrationStep()
+                    let planState = recreatedPlanState(schedule: schedule)
+                    await send(.pushHydratedPathState(.transferPlan(planState)))
+                }
+
+                // MARK: - Flow-root closes / terminal delegates -> .flowFinished
+
+            case .path(.element(id: _, action: .complete(.delegate(.done)))):
+                migrationManager.acknowledgeComplete()
+                return .send(.flowFinished)
+
+            case .path(.element(id: _, action: .status(.delegate(.done)))),
+                 .path(.element(id: _, action: .scheduled(.delegate(.done)))),
+                 .path(.element(id: _, action: .recovery(.delegate(.close)))),
+                 .path(.element(id: _, action: .reviewTransfer(.delegate(.closed)))):
+                return .send(.flowFinished)
+
+            default: return .none
+            }
+        }
+    }
+
+    // MARK: - Re-entry
+
+    /// Maps `manager.reentryRoute()` onto the flow-root screen State to append, hydrated from SDK
+    /// members per the MOB-1466 spec's re-entry table. `.entry` appends nothing (Entry is the
+    /// coordinator's own root screen, already showing).
+    private func reentryPathState() async -> MigrationCoordFlow.Path.State? {
+        switch migrationManager.reentryRoute() {
+        case .recovery(let isExpired):
+            return .recovery(recoveryState(isExpired: isExpired, isFlowRoot: true))
+
+        case .statusResume:
+            return .status(await statusResumeState(isFlowRoot: true))
+
+        case .statusProgress:
+            return .status(await statusProgressState(isFlowRoot: true))
+
+        case .complete:
+            return .complete(completeState(isFlowRoot: true))
+
+        case .noteSplitProgress:
+            return .noteSplit(MigrationNoteSplit.State(phase: .splitting, isFlowRoot: true))
+
+        case .reviewManual(let step, let total):
+            return .reviewTransfer(await reviewManualState(step: step, total: total, isFlowRoot: true))
+
+        case .entry:
+            return nil
+        }
+    }
+
+    // MARK: - Permission-step routing
+
+    /// Shared helper (used after Entry-scheduled-no-split, NoteSplit-continued, and each
+    /// permission screen's continue/skip): computes the next needed screen in order —
+    /// `backgroundDelivery` iff background refresh isn't `.available` -> `notifications` iff
+    /// authorization is still `.notDetermined` (granted/denied both skip, per §5 S4) ->
+    /// `networkPrivacy` iff the app-wide Tor setup flag isn't on -> `transferPlan`. When S5 is
+    /// skipped because Tor is already on, `forcedUseTor` tells the reducer to set
+    /// `networkPrivacyOptions.useTor = true` before the plan screen is reached.
+    private func nextPermissionStepResult() async -> MigrationCoordFlow.PermissionStepResult {
+        if await migrationBGScheduler.backgroundRefreshStatus() != .available {
+            return MigrationCoordFlow.PermissionStepResult(pathState: .backgroundDelivery(MigrationBackgroundDelivery.State()))
+        }
+
+        if await userNotifications.authorizationStatus() == .notDetermined {
+            return MigrationCoordFlow.PermissionStepResult(pathState: .notifications(MigrationNotifications.State()))
+        }
+
+        if walletStorage.exportTorSetupFlag() != true {
+            let transferCount = sdkSynchronizer.migrationTransfers().count
+            let variant = MigrationNetworkPrivacy.State.Variant.scheduled(transferCount: transferCount)
+            return MigrationCoordFlow.PermissionStepResult(
+                pathState: .networkPrivacy(MigrationNetworkPrivacy.State(variant: variant))
+            )
+        }
+
+        return MigrationCoordFlow.PermissionStepResult(
+            pathState: .transferPlan(MigrationTransferPlan.State(variant: .scheduled)),
+            forcedUseTor: true
+        )
+    }
+
+    // MARK: - Reschedule / Recovery: TransferPlan hydration
+
+    /// Status `.reschedule`'s follow-up plan screen: `rescheduleStalledMigrationTransfer()`
+    /// returns `Void` (no schedule), so `rows` are built directly from a fresh
+    /// `migrationTransfers()` read rather than via `injectedSchedule`. `requiresSigning: false`
+    /// marks this variant's confirm as a plain acknowledgment (transfers are already signed).
+    private func rescheduledPlanState(rows: [MigrationTransferRow]) -> MigrationTransferPlan.State {
+        MigrationTransferPlan.State(
+            variant: .scheduled,
+            rows: IdentifiedArrayOf(uniqueElements: rows),
+            totalDurationHours: sdkSynchronizer.migrationSummary().estimatedDurationHours,
+            requiresSigning: false
+        )
+    }
+
+    /// Recovery `.recreate`'s follow-up plan screen: `restartCurrentMigrationStep()` returns a
+    /// fresh `MigrationSchedule`, injected via `injectedSchedule` so the screen's own `onAppear`
+    /// populates rows (no coordinator-side duplication of that row-building logic). This variant
+    /// DOES sign — `requiresSigning` stays at its default `true`.
+    private func recreatedPlanState(schedule: MigrationSchedule) -> MigrationTransferPlan.State {
+        var state = MigrationTransferPlan.State(variant: .recreated)
+        state.injectedSchedule = schedule
+        return state
+    }
+
+    private func recoveryState(isExpired: Bool, isFlowRoot: Bool) -> MigrationRecovery.State {
+        let rows = sdkSynchronizer.migrationTransfers()
+        let (first, last) = expiredOrInvalidBounds(rows: rows)
+        return MigrationRecovery.State(
+            reason: isExpired ? .expired : .notesSpent,
+            firstTransfer: first,
+            lastTransfer: last,
+            isFlowRoot: isFlowRoot
+        )
+    }
+
+    private func statusResumeState(isFlowRoot: Bool) async -> MigrationStatus.State {
+        let rows = sdkSynchronizer.migrationTransfers()
+        let summary = sdkSynchronizer.migrationSummary()
+        let stalledRow = rows.first { $0.status == MigrationTransferRow.Status.overdue }
+        var state = MigrationStatus.State(
+            presentation: .resume,
+            rows: IdentifiedArrayOf(uniqueElements: rows),
+            totalDurationHours: summary.estimatedDurationHours,
+            stalledNumber: (stalledRow?.index ?? 0) + 1,
+            stalledHoursAgo: stalledRow?.hoursFromNow ?? 0,
+            isFlowRoot: isFlowRoot
+        )
+        state.isSendNowDisabled = migrationManager.sendGate() != MigrationSendGate.allowed
+        return state
+    }
+
+    private func statusProgressState(isFlowRoot: Bool) async -> MigrationStatus.State {
+        let rows = sdkSynchronizer.migrationTransfers()
+        let summary = sdkSynchronizer.migrationSummary()
+        var state = MigrationStatus.State(
+            presentation: .progress,
+            rows: IdentifiedArrayOf(uniqueElements: rows),
+            totalDurationHours: summary.estimatedDurationHours,
+            isFlowRoot: isFlowRoot
+        )
+        state.isSendNowDisabled = migrationManager.sendGate() != MigrationSendGate.allowed
+        return state
+    }
+
+    private func completeState(isFlowRoot: Bool) -> MigrationComplete.State {
+        let summary = sdkSynchronizer.migrationSummary()
+        return MigrationComplete.State(
+            totalTransferred: summary.transferred,
+            dust: summary.dust,
+            transfersSent: summary.transfersSent,
+            transfersTotal: summary.transfersTotal,
+            durationHours: summary.estimatedDurationHours,
+            isFlowRoot: isFlowRoot
+        )
+    }
+
+    private func reviewManualState(step: Int, total: Int, isFlowRoot: Bool) async -> MigrationReviewTransfer.State {
+        let rows = sdkSynchronizer.migrationTransfers()
+        let nextRow = rows.first { $0.status == MigrationTransferRow.Status.active }
+            ?? rows.first { $0.status == MigrationTransferRow.Status.overdue }
+        return MigrationReviewTransfer.State(
+            mode: .manualStep(number: step, total: total),
+            amount: nextRow?.amount ?? Zatoshi.zero,
+            // Standard ZIP-317 marginal fee (`MigrationReviewTransfer.State.standardFee`'s value —
+            // that constant is `fileprivate` to its own file, so it's mirrored here literally).
+            fee: Zatoshi(100_000),
+            isFlowRoot: isFlowRoot
+        )
+    }
+
+    /// 1-based `(first, last)` bounds among rows flagged `.expired` or `.invalid`; falls back to
+    /// `(1, total)` when none match (mirrors `MigrationDerivations.expiredBounds`'s fallback shape).
+    private func expiredOrInvalidBounds(rows: [MigrationTransferRow]) -> (first: Int, last: Int) {
+        let flaggedIndexes = rows
+            .filter { $0.status == MigrationTransferRow.Status.expired || $0.status == MigrationTransferRow.Status.invalid }
+            .map { $0.index + 1 }
+
+        guard let first = flaggedIndexes.min(), let last = flaggedIndexes.max() else {
+            return (1, rows.count)
+        }
+
+        return (first, last)
+    }
+}

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
@@ -1,0 +1,98 @@
+//
+//  MigrationCoordFlowStore.swift
+//  Zashi
+//
+//  Coordinator for the Orchard -> Ironwood migration flow (MOB-1466). Chains the visual-only
+//  migration screens (MOB-1460...1464) into a live, state-driven flow: re-entry routing, mode/
+//  network-privacy persistence, permission-step sequencing, and the scheduled/manual/immediate
+//  chaining table. `MigrationEntry` is the flow's root screen (mirroring `SendCoordFlow`'s
+//  `sendFormState`); every other screen lives in `path`. Everything here runs against the inert
+//  SDK stubs — it goes live when the real SDK (MOB-1455) fills them in.
+//
+
+import SwiftUI
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationCoordFlow {
+    @Reducer(state: .equatable)
+    enum Path {
+        case backgroundDelivery(MigrationBackgroundDelivery)
+        case complete(MigrationComplete)
+        case networkPrivacy(MigrationNetworkPrivacy)
+        case noteSplit(MigrationNoteSplit)
+        case notifications(MigrationNotifications)
+        case recovery(MigrationRecovery)
+        case reviewTransfer(MigrationReviewTransfer)
+        case scheduled(MigrationScheduled)
+        case sending(MigrationSending)
+        case status(MigrationStatus)
+        case transferPlan(MigrationTransferPlan)
+    }
+
+    @ObservableState
+    struct State: Equatable {
+        var path = StackState<Path.State>()
+        var entryState = MigrationEntry.State()
+        /// Persisted via `manager.setMigrationMode` once chosen; held here too so later hops in
+        /// the same run (e.g. immediate's Tor-skip) don't need to re-read the dependency.
+        var mode: MigrationMode?
+        /// Held here once confirmed on the Network Privacy screen (or defaulted when S5 is
+        /// skipped) so Sending's coordinator-configured state can inject it.
+        var networkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+
+        init() { }
+    }
+
+    /// Result of the async permission-step helper (`nextPermissionStepPathState()`): the screen
+    /// to push (`nil` once every permission step is satisfied and the flow can proceed straight to
+    /// the plan/review screen the caller already knows to push), plus whether Network Privacy (S5)
+    /// was skipped because the app-wide Tor setup flag is already on — in which case the
+    /// coordinator force-sets `networkPrivacyOptions.useTor = true` before proceeding.
+    struct PermissionStepResult: Equatable {
+        var pathState: Path.State?
+        var forcedUseTor = false
+    }
+
+    enum Action {
+        case entry(MigrationEntry.Action)
+        case flowFinished
+        case onAppear
+        case path(StackActionOf<Path>)
+        /// Internal: the async re-entry/permission-step helper resolved the next screen to push
+        /// (or `nil` when nothing needs appending — the `.entry` re-entry route).
+        case pushNextPermissionStep(PermissionStepResult)
+        /// Internal: a fresh `MigrationStatus.State` (already hydrated) to push — used by Sending's
+        /// manual-first-transfer close (no `.status` beneath yet). A dedicated case (rather than
+        /// reusing `pushHydratedPathState`) so its `isFlowRoot: false` (mid-flow push) stays
+        /// visibly distinct in the reducer from the re-entry root's `isFlowRoot: true` status push.
+        case pushHydratedStatus(MigrationStatus.State)
+        /// Internal: a fresh `Path.State` (already hydrated) to push — used by Status `.sendNow`'s
+        /// overdue-batch Sending screen, Status `.reschedule`'s rescheduled plan, and Recovery
+        /// `.recreate`'s re-created plan.
+        case pushHydratedPathState(Path.State)
+        /// Internal: sendNow's Sending screen finished (`.closed`) — refresh the `.status` element
+        /// beneath with freshly-read rows and pop back to it.
+        case sendNowCompleted(rows: [MigrationTransferRow])
+    }
+
+    @Dependency(\.migrationBGScheduler) var migrationBGScheduler
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+    @Dependency(\.userNotifications) var userNotifications
+    @Dependency(\.walletStorage) var walletStorage
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        coordinatorReduce()
+
+        Scope(state: \.entryState, action: \.entry) {
+            MigrationEntry()
+        }
+
+        Reduce { _, _ in .none }
+            .forEach(\.path, action: \.path)
+    }
+}

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowView.swift
@@ -1,0 +1,81 @@
+//
+//  MigrationCoordFlowView.swift
+//  Zashi
+//
+//  NavigationStack for the Orchard -> Ironwood migration flow (MOB-1466). `MigrationEntry` is the
+//  root screen; every other migration screen is pushed onto `path` by the coordinator.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct MigrationCoordFlowView: View {
+    @Perception.Bindable var store: StoreOf<MigrationCoordFlow>
+
+    init(store: StoreOf<MigrationCoordFlow>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+                MigrationEntryView(
+                    store:
+                        store.scope(
+                            state: \.entryState,
+                            action: \.entry
+                        )
+                )
+            } destination: { store in
+                switch store.case {
+                case let .backgroundDelivery(store):
+                    MigrationBackgroundDeliveryView(store: store)
+                case let .complete(store):
+                    MigrationCompleteView(store: store)
+                case let .networkPrivacy(store):
+                    MigrationNetworkPrivacyView(store: store)
+                case let .noteSplit(store):
+                    MigrationNoteSplitView(store: store)
+                case let .notifications(store):
+                    MigrationNotificationsView(store: store)
+                case let .recovery(store):
+                    MigrationRecoveryView(store: store)
+                case let .reviewTransfer(store):
+                    MigrationReviewTransferView(store: store)
+                case let .scheduled(store):
+                    MigrationScheduledView(store: store)
+                case let .sending(store):
+                    MigrationSendingView(store: store)
+                case let .status(store):
+                    MigrationStatusView(store: store)
+                case let .transferPlan(store):
+                    MigrationTransferPlanView(store: store)
+                }
+            }
+        }
+        .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
+    }
+}
+
+// MARK: - Placeholders
+
+extension MigrationCoordFlow.State {
+    static var initial: MigrationCoordFlow.State { MigrationCoordFlow.State() }
+}
+
+extension MigrationCoordFlow {
+    @MainActor static let placeholder = StoreOf<MigrationCoordFlow>(
+        initialState: .initial
+    ) {
+        MigrationCoordFlow()
+    }
+}
+
+#Preview {
+    NavigationView {
+        MigrationCoordFlowView(store: MigrationCoordFlow.placeholder)
+    }
+}

--- a/secant/Sources/Features/Home/HomeView.swift
+++ b/secant/Sources/Features/Home/HomeView.swift
@@ -11,6 +11,10 @@ struct HomeView: View {
     @Shared(.appStorage(.sensitiveContent)) var isSensitiveContentHidden = false
     @Shared(.inMemory(.walletStatus)) var walletStatus: WalletStatus = .none
 
+    #if DEBUG
+    @State private var isMigrationGalleryPresented = false
+    #endif
+
     init(store: StoreOf<Home>, tokenName: String) {
         self.store = store
         self.tokenName = tokenName
@@ -29,6 +33,12 @@ struct HomeView: View {
                     shortened: true
                 )
                 .padding(.top, 1)
+                #if DEBUG
+                .onLongPressGesture(minimumDuration: 0.6) { isMigrationGalleryPresented = true }
+                .sheet(isPresented: $isMigrationGalleryPresented) {
+                    MigrationDebugGalleryView()
+                }
+                #endif
 
                 HStack {
                     button(

--- a/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift
@@ -7,7 +7,7 @@
 //  the Settings deep-link from the view (`@Environment(\.openURL)`) — the action here is just the
 //  tap signal. `scenePhaseActive` re-checks Background App Refresh on return and auto-advances via
 //  `.continued(backgroundAllowed: true)` once it becomes available (MOB-1466). The `skipTapped`
-//  delegate is emitted but consumed by nobody yet — chaining is the coordinator's job (phase 3).
+//  delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift
@@ -3,10 +3,11 @@
 //  zodl
 //
 //  "Allow Background Delivery" screen (MOB-1462, Figma S3 · 2840:4480). Explains why ZODL needs
-//  Background App Refresh to send migration transfers at their scheduled times. Visual-only:
-//  `allowTapped` (opening the Settings deep-link) and `scenePhaseActive` (re-checking BAR on
-//  return) are declared but inert — wiring them up is MOB-1466's job. The `skipTapped` delegate is
-//  emitted but consumed by nobody yet.
+//  Background App Refresh to send migration transfers at their scheduled times. `allowTapped` opens
+//  the Settings deep-link from the view (`@Environment(\.openURL)`) — the action here is just the
+//  tap signal. `scenePhaseActive` re-checks Background App Refresh on return and auto-advances via
+//  `.continued(backgroundAllowed: true)` once it becomes available (MOB-1466). The `skipTapped`
+//  delegate is emitted but consumed by nobody yet — chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -18,10 +19,10 @@ struct MigrationBackgroundDelivery {
     }
 
     enum Action: Equatable {
-        /// Inert now — MOB-1466 opens the Settings deep-link.
+        /// The Settings deep-link opens from the view; this action is just the tap signal.
         case allowTapped
         case delegate(Delegate)
-        /// Declared for MOB-1466 (re-check Background App Refresh on return) — inert.
+        /// Re-checks Background App Refresh on return; auto-advances when it becomes available.
         case scenePhaseActive
         case skipTapped
 
@@ -29,6 +30,8 @@ struct MigrationBackgroundDelivery {
             case continued(backgroundAllowed: Bool)
         }
     }
+
+    @Dependency(\.migrationBGScheduler) var migrationBGScheduler
 
     init() { }
 
@@ -42,7 +45,11 @@ struct MigrationBackgroundDelivery {
                 return .none
 
             case .scenePhaseActive:
-                return .none
+                return .run { send in
+                    let status = await migrationBGScheduler.backgroundRefreshStatus()
+                    guard status == .available else { return }
+                    await send(.delegate(.continued(backgroundAllowed: true)))
+                }
 
             case .skipTapped:
                 return .send(.delegate(.continued(backgroundAllowed: false)))

--- a/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryView.swift
+++ b/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryView.swift
@@ -2,16 +2,18 @@
 //  MigrationBackgroundDeliveryView.swift
 //  zodl
 //
-//  "Allow Background Delivery" screen (MOB-1462, Figma S3 · 2840:4480). Visually complete per
-//  Figma; `allowTapped` (Settings deep-link) and `scenePhaseActive` (BAR re-check) are declared but
-//  inert — wiring them up lands in MOB-1466. The `skipTapped` delegate is emitted but consumed by
-//  nobody yet.
+//  "Allow Background Delivery" screen (MOB-1462, Figma S3 · 2840:4480). `allowTapped` opens the
+//  Settings deep-link; `scenePhaseActive` re-checks Background App Refresh on return and the store
+//  auto-advances once it's available (MOB-1466). The `skipTapped` delegate is emitted but consumed
+//  by nobody yet — chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
 import SwiftUI
 
 struct MigrationBackgroundDeliveryView: View {
+    @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
     @Perception.Bindable var store: StoreOf<MigrationBackgroundDelivery>
 
     init(store: StoreOf<MigrationBackgroundDelivery>) {
@@ -49,6 +51,9 @@ struct MigrationBackgroundDeliveryView: View {
 
                 ZashiButton(String(localizable: .migrationAllow)) {
                     store.send(.allowTapped)
+                    if let settingsUrl = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(settingsUrl)
+                    }
                 }
                 .padding(.bottom, 24)
             }
@@ -56,6 +61,11 @@ struct MigrationBackgroundDeliveryView: View {
             .zashiBack()
         }
         .applyScreenBackground()
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .active {
+                store.send(.scenePhaseActive)
+            }
+        }
     }
 
     // MARK: - Bullet rows

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
@@ -2,9 +2,12 @@
 //  MigrationCompleteStore.swift
 //  zodl
 //
-//  "Migration Complete" screen (MOB-1464, Figma S12 · 2696:7267). Visually complete per Figma; all
-//  summary fields are placeholders — wiring the real data lands in MOB-1466. The `gotItTapped`
-//  delegate is emitted but consumed by nobody yet.
+//  "Migration Complete" screen (MOB-1464, Figma S12 · 2696:7267). Display-only summary fields are
+//  injected by the coordinator (MOB-1466). This screen has no back control at all
+//  (`.navigationBarBackButtonHidden()`); `isFlowRoot` is carried in State for coordinator-injection
+//  consistency with the other re-entry roots even though there's no back-control behavior to gate
+//  here. The `gotItTapped` delegate is emitted but consumed by nobody yet — wiring is the
+//  coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -19,6 +22,9 @@ struct MigrationComplete {
         var transfersSent = 0
         var transfersTotal = 0
         var durationHours = 0
+        /// Carried for consistency with the other re-entry-root screens; this screen has no back
+        /// control to gate (`.navigationBarBackButtonHidden()`, no custom leading toolbar item).
+        var isFlowRoot = false
 
         var hasDust: Bool {
             dust.amount > 0
@@ -29,13 +35,15 @@ struct MigrationComplete {
             dust: Zatoshi = .zero,
             transfersSent: Int = 0,
             transfersTotal: Int = 0,
-            durationHours: Int = 0
+            durationHours: Int = 0,
+            isFlowRoot: Bool = false
         ) {
             self.totalTransferred = totalTransferred
             self.dust = dust
             self.transfersSent = transfersSent
             self.transfersTotal = transfersTotal
             self.durationHours = durationHours
+            self.isFlowRoot = isFlowRoot
         }
     }
 

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
@@ -6,8 +6,7 @@
 //  injected by the coordinator (MOB-1466). This screen has no back control at all
 //  (`.navigationBarBackButtonHidden()`); `isFlowRoot` is carried in State for coordinator-injection
 //  consistency with the other re-entry roots even though there's no back-control behavior to gate
-//  here. The `gotItTapped` delegate is emitted but consumed by nobody yet — wiring is the
-//  coordinator's job (phase 3).
+//  here. The `gotItTapped` delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
@@ -5,8 +5,7 @@
 //  "Move to Ironwood" entry screen (MOB-1460, Figma S1 · 2867:10445 / 2867:5641 / 2867:5731). Lets
 //  the user pick between migrating with privacy (scheduled, split transfers) or immediately (single
 //  transfer, less privacy). `onAppear` loads the orchard-balance-to-migrate for the selected account
-//  (MOB-1466); chaining `nextTapped`'s delegate into the rest of the migration flow is the
-//  coordinator's job (MOB-1466 phase 3).
+//  (MOB-1466); `nextTapped`'s delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
@@ -4,8 +4,9 @@
 //
 //  "Move to Ironwood" entry screen (MOB-1460, Figma S1 · 2867:10445 / 2867:5641 / 2867:5731). Lets
 //  the user pick between migrating with privacy (scheduled, split transfers) or immediately (single
-//  transfer, less privacy). The delegate is emitted but consumed by nobody yet — chaining into the
-//  rest of the migration flow lands in MOB-1466.
+//  transfer, less privacy). `onAppear` loads the orchard-balance-to-migrate for the selected account
+//  (MOB-1466); chaining `nextTapped`'s delegate into the rest of the migration flow is the
+//  coordinator's job (MOB-1466 phase 3).
 //
 
 import ComposableArchitecture
@@ -16,10 +17,10 @@ struct MigrationEntry {
     @ObservableState
     struct State: Equatable {
         var selectedMode = MigrationMode.privateScheduled
-        /// Placeholder; real balance data lands in MOB-1466.
         var orchardBalance = Zatoshi.zero
         /// e.g. `"$4,832.86"`; `nil` omits the parenthesized fiat amount.
         var fiatText: String?
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
 
         var isDisclaimerVisible: Bool {
             selectedMode == .immediate
@@ -37,22 +38,31 @@ struct MigrationEntry {
     }
 
     enum Action: Equatable {
+        /// The orchard balance to migrate for the selected account, loaded on `onAppear`.
+        case balanceLoaded(Zatoshi)
         case delegate(Delegate)
         /// Inert for now; the "Find out more" destination (O-7) is undecided.
         case findOutMoreTapped
         case modeTapped(MigrationMode)
         case nextTapped
+        case onAppear
 
         enum Delegate: Equatable {
             case chose(MigrationMode)
         }
     }
 
+    @Dependency(\.migrationManager) var migrationManager
+
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .balanceLoaded(let balance):
+                state.orchardBalance = balance
+                return .none
+
             case .delegate:
                 return .none
 
@@ -65,6 +75,13 @@ struct MigrationEntry {
 
             case .nextTapped:
                 return .send(.delegate(.chose(state.selectedMode)))
+
+            case .onAppear:
+                let accountUUID = state.selectedWalletAccount?.id
+                return .run { send in
+                    let balance = await migrationManager.orchardBalanceToMigrate(accountUUID)
+                    await send(.balanceLoaded(balance))
+                }
             }
         }
     }

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
@@ -67,6 +67,9 @@ struct MigrationEntryView: View {
             .zashiBack()
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Description

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
@@ -146,7 +146,7 @@ struct MigrationEntryView: View {
                     .overlay {
                         if isSelected {
                             RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                                .stroke(
+                                .strokeBorder(
                                     isWarning ? Design.Utility.WarningYellow._500.color(colorScheme) : Design.Checkboxes.onBg.color(colorScheme),
                                     lineWidth: 2
                                 )

--- a/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift
@@ -3,8 +3,8 @@
 //  zodl
 //
 //  "Network Privacy" screen (MOB-1460, Figma S5 · 2867:5801 immediate / 2867:10835 scheduled).
-//  Lets the user opt in to routing migration transfer submission via Tor. The delegate is emitted
-//  but consumed by nobody yet — chaining into the rest of the migration flow lands in MOB-1466.
+//  Lets the user opt in to routing migration transfer submission via Tor. The `confirmed` delegate
+//  is consumed by MigrationCoordFlowCoordinator (MOB-1466), which persists the chosen options.
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyView.swift
+++ b/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyView.swift
@@ -158,7 +158,7 @@ struct MigrationNetworkPrivacyView: View {
                 .fill(Design.Surfaces.bgPrimary.color(colorScheme))
                 .overlay {
                     RoundedRectangle(cornerRadius: Design.Radius._2xl)
-                        .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+                        .strokeBorder(Design.Surfaces.strokeSecondary.color(colorScheme))
                 }
         }
     }

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
@@ -5,11 +5,14 @@
 //  "Split Your Wallet Funds" screen (MOB-1461, Figma S2 · 2867:10535 explainer / 2867:10741
 //  progress / 2867:10645 success / 2670:15570 failure sheet). One screen, three phases (explainer
 //  -> splitting -> confirmed) plus a failure bottom sheet presented over the splitting phase.
-//  Visual-only: SDK-driven actions (`splitConfirmed`, `splitResult`) are declared but inert, and the
-//  screen never transitions phases itself — wiring that up against the SDK is MOB-1466's job. The
-//  `continueTapped` delegate is emitted but consumed by nobody yet.
+//  `onAppear` resumes an already-pending split or prepares a fresh one; `confirmTapped`/`retryTapped`
+//  submit it; a `migrationStateStream()` subscription advances `.splitting` -> `.confirmed` once the
+//  SDK reports `.readyToPropose`. When the splitting phase is a flow re-entry root (`isFlowRoot`),
+//  its back control closes the flow (`closeTapped` -> `.delegate(.continued)`) instead of popping
+//  (MOB-1466). Chaining into the rest of the migration flow is the coordinator's job (phase 3).
 //
 
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
@@ -24,13 +27,18 @@ struct MigrationNoteSplit {
         }
 
         var phase = Phase.explainer
-        /// Placeholder; real proposal data lands in MOB-1466.
         var amount = Zatoshi.zero
         var fee = Zatoshi.zero
         /// Shown from the splitting phase on.
         var txId = ""
         /// Failure sheet presented over the splitting phase.
         var isFailurePresented = false
+        /// The prepared split proposal, held so `retryTapped` can re-submit without re-preparing.
+        var proposal: NoteSplitProposal?
+        var CancelStateStreamId = UUID()
+        /// True when the splitting phase is the coordinator's re-entry root — its back control then
+        /// closes the flow instead of popping.
+        var isFlowRoot = false
         @Shared(.inMemory(.toast)) var toast: Toast.Edge? = nil
 
         init(
@@ -38,13 +46,15 @@ struct MigrationNoteSplit {
             amount: Zatoshi = Zatoshi.zero,
             fee: Zatoshi = Zatoshi.zero,
             txId: String = "",
-            isFailurePresented: Bool = false
+            isFailurePresented: Bool = false,
+            isFlowRoot: Bool = false
         ) {
             self.phase = phase
             self.amount = amount
             self.fee = fee
             self.txId = txId
             self.isFailurePresented = isFailurePresented
+            self.isFlowRoot = isFlowRoot
         }
     }
 
@@ -52,17 +62,21 @@ struct MigrationNoteSplit {
         case binding(BindingAction<State>)
         /// Failure sheet: dismiss (stay on screen).
         case cancelTapped
-        /// Explainer CTA — inert now; MOB-1466 submits the split.
+        /// Flow-root back control (splitting phase only): closes the flow instead of popping.
+        case closeTapped
+        /// Explainer CTA — submits the prepared split.
         case confirmTapped
         /// Confirmed CTA.
         case continueTapped
         case copyTxIdTapped
         case delegate(Delegate)
-        /// Failure sheet: dismiss — inert re-submit (MOB-1466).
+        /// `prepareNoteSplit()` result — populates amount/fee and stores the proposal for submission.
+        case noteSplitPrepared(NoteSplitProposal)
+        case onAppear
+        /// Failure sheet: dismiss, then re-submit the stored proposal.
         case retryTapped
-        /// Declared for MOB-1466 (SDK-driven) — inert.
+        /// `migrationStateStream()` reported `.readyToPropose` while splitting.
         case splitConfirmed
-        /// Declared for MOB-1466 (SDK-driven) — inert.
         case splitResult(TransferResult)
 
         enum Delegate: Equatable {
@@ -71,6 +85,7 @@ struct MigrationNoteSplit {
     }
 
     @Dependency(\.pasteboard) var pasteboard
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
 
     init() { }
 
@@ -86,8 +101,12 @@ struct MigrationNoteSplit {
                 state.isFailurePresented = false
                 return .none
 
+            case .closeTapped:
+                return .send(.delegate(.continued))
+
             case .confirmTapped:
-                return .none
+                state.phase = .splitting
+                return submitNoteSplit(state.proposal)
 
             case .continueTapped:
                 return .send(.delegate(.continued))
@@ -100,16 +119,67 @@ struct MigrationNoteSplit {
             case .delegate:
                 return .none
 
+            case .noteSplitPrepared(let proposal):
+                state.proposal = proposal
+                state.amount = Zatoshi(proposal.outputNotes.reduce(0) { $0 + $1.amount })
+                state.fee = proposal.fee
+                return .none
+
+            case .onAppear:
+                let isPendingConfirmation = sdkSynchronizer.getMigrationState() == .splitPendingConfirmation
+                if isPendingConfirmation {
+                    state.phase = .splitting
+                }
+
+                return .merge(
+                    subscribeToMigrationState(cancelId: state.CancelStateStreamId),
+                    isPendingConfirmation ? .none : prepareNoteSplit()
+                )
+
             case .retryTapped:
                 state.isFailurePresented = false
-                return .none
+                return submitNoteSplit(state.proposal)
 
             case .splitConfirmed:
+                state.phase = .confirmed
                 return .none
 
-            case .splitResult:
+            case .splitResult(let result):
+                switch result {
+                case .success(let txId):
+                    state.txId = txId
+                    state.isFailurePresented = false
+                case .networkError, .invalidNote, .expired:
+                    state.isFailurePresented = true
+                }
                 return .none
             }
         }
+    }
+
+    private func prepareNoteSplit() -> Effect<Action> {
+        .run { send in
+            let proposal = await sdkSynchronizer.prepareNoteSplit()
+            await send(.noteSplitPrepared(proposal))
+        }
+    }
+
+    private func submitNoteSplit(_ proposal: NoteSplitProposal?) -> Effect<Action> {
+        guard let proposal else { return .none }
+
+        return .run { send in
+            let result = await sdkSynchronizer.submitNoteSplit(proposal)
+            await send(.splitResult(result))
+        }
+    }
+
+    private func subscribeToMigrationState(cancelId: UUID) -> Effect<Action> {
+        .publisher {
+            sdkSynchronizer.migrationStateStream()
+                .compactMap { state -> Action? in
+                    state == .readyToPropose ? Action.splitConfirmed : nil
+                }
+        }
+        .cancellable(id: cancelId, cancelInFlight: true)
     }
 }

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
@@ -9,7 +9,7 @@
 //  submit it; a `migrationStateStream()` subscription advances `.splitting` -> `.confirmed` once the
 //  SDK reports `.readyToPropose`. When the splitting phase is a flow re-entry root (`isFlowRoot`),
 //  its back control closes the flow (`closeTapped` -> `.delegate(.continued)`) instead of popping
-//  (MOB-1466). Chaining into the rest of the migration flow is the coordinator's job (phase 3).
+//  (MOB-1466). The `.continued` delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import Foundation
@@ -35,7 +35,7 @@ struct MigrationNoteSplit {
         var isFailurePresented = false
         /// The prepared split proposal, held so `retryTapped` can re-submit without re-preparing.
         var proposal: NoteSplitProposal?
-        var CancelStateStreamId = UUID()
+        var cancelStateStreamId = UUID()
         /// True when the splitting phase is the coordinator's re-entry root — its back control then
         /// closes the flow instead of popping.
         var isFlowRoot = false
@@ -132,7 +132,7 @@ struct MigrationNoteSplit {
                 }
 
                 return .merge(
-                    subscribeToMigrationState(cancelId: state.CancelStateStreamId),
+                    subscribeToMigrationState(cancelId: state.cancelStateStreamId),
                     isPendingConfirmation ? .none : prepareNoteSplit()
                 )
 

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
@@ -197,7 +197,7 @@ struct MigrationNoteSplitView: View {
                 ZashiButton(
                     String(localizable: .migrationNoteSplitSplittingTitle),
                     type: .secondary,
-                    accessoryView: ProgressView()
+                    prefixView: ProgressView()
                 ) { }
                 .disabled(true)
             }

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
@@ -3,9 +3,10 @@
 //  zodl
 //
 //  "Split Your Wallet Funds" screen (MOB-1461, Figma S2 · 2867:10535 explainer / 2867:10741
-//  progress / 2867:10645 success / 2670:15570 failure sheet). Visually complete per Figma; phase
-//  transitions and the SDK-driven split submission are declared but inert — wiring them up lands in
-//  MOB-1466. The `continueTapped` delegate is emitted but consumed by nobody yet.
+//  progress / 2867:10645 success / 2670:15570 failure sheet). `onAppear` loads/resumes the split
+//  live via the store (MOB-1466); when the splitting phase is a flow re-entry root (`isFlowRoot`),
+//  its back control closes the flow instead of popping. The `continueTapped` delegate is emitted
+//  but consumed by nobody yet — chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -66,12 +67,15 @@ struct MigrationNoteSplitView: View {
                 footer
             }
             .screenHorizontalPadding()
-            .zashiBack()
+            .applyPresentationModifier(store: store)
             .zashiSheet(isPresented: $store.isFailurePresented) {
                 failureSheetContent
             }
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Header badge
@@ -272,6 +276,22 @@ struct MigrationNoteSplitView: View {
                 store.send(.retryTapped)
             }
             .padding(.bottom, Design.Spacing.sheetBottomSpace)
+        }
+    }
+}
+
+// MARK: - Presentation modifier
+
+private extension View {
+    /// Only the splitting phase can be a re-entry root — explainer/confirmed are always reached via
+    /// normal push, so a plain pop stands there regardless of `isFlowRoot`.
+    @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationNoteSplit>) -> some View {
+        if store.phase == .splitting && store.isFlowRoot {
+            zashiBackV2 {
+                store.send(.closeTapped)
+            }
+        } else {
+            zashiBack()
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift
@@ -6,8 +6,8 @@
 //  Explains what migration-related notifications the user will get, with copy that differs by
 //  `variant` (scheduled vs. manual send cadence). `allowTapped` requests `UNUserNotificationCenter`
 //  authorization; either outcome continues the flow — permission is a nice-to-have, not a blocker
-//  (MOB-1466). The `skipTapped`/`.continued` delegate is emitted but consumed by nobody yet —
-//  chaining is the coordinator's job (phase 3).
+//  (MOB-1466). The `skipTapped`/`.continued` delegate is consumed by `MigrationCoordFlowCoordinator`
+//  (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift
@@ -4,10 +4,10 @@
 //
 //  "Allow Notifications" screen (MOB-1462, Figma S4 scheduled · 2840:4728 / manual · 2867:1921).
 //  Explains what migration-related notifications the user will get, with copy that differs by
-//  `variant` (scheduled vs. manual send cadence). Visual-only: `allowTapped` (requesting
-//  `UNUserNotificationCenter` authorization) and `authorizationResult` are declared but inert —
-//  wiring them up is MOB-1466's job. The `skipTapped` delegate is emitted but consumed by nobody
-//  yet.
+//  `variant` (scheduled vs. manual send cadence). `allowTapped` requests `UNUserNotificationCenter`
+//  authorization; either outcome continues the flow — permission is a nice-to-have, not a blocker
+//  (MOB-1466). The `skipTapped`/`.continued` delegate is emitted but consumed by nobody yet —
+//  chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -29,9 +29,9 @@ struct MigrationNotifications {
     }
 
     enum Action: Equatable {
-        /// Inert now — MOB-1466 requests notification authorization.
+        /// Requests notification authorization.
         case allowTapped
-        /// Declared for MOB-1466 — inert.
+        /// `requestAuthorization()` result — either outcome continues the flow.
         case authorizationResult(Bool)
         case delegate(Delegate)
         case skipTapped
@@ -41,16 +41,21 @@ struct MigrationNotifications {
         }
     }
 
+    @Dependency(\.userNotifications) var userNotifications
+
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
             case .allowTapped:
-                return .none
+                return .run { send in
+                    let isAuthorized = await userNotifications.requestAuthorization()
+                    await send(.authorizationResult(isAuthorized))
+                }
 
             case .authorizationResult:
-                return .none
+                return .send(.delegate(.continued))
 
             case .delegate:
                 return .none

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
@@ -3,8 +3,10 @@
 //  zodl
 //
 //  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
-//  2696:5626 / expired 2973:5698). Visually complete per Figma; the `continueTapped` delegate is
-//  emitted but consumed by nobody yet — wiring the real plan-recreation flow lands in MOB-1466.
+//  2696:5626 / expired 2973:5698). When this screen is the coordinator's re-entry root
+//  (`isFlowRoot`), its back control closes the flow (`closeTapped` -> `.delegate(.close)`) instead
+//  of popping (MOB-1466). The `continueTapped` delegate is emitted but consumed by nobody yet —
+//  wiring the real plan-recreation flow is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -22,19 +24,31 @@ struct MigrationRecovery {
         /// "Transfers {a}–{b}" range in copy.
         var firstTransfer = 3
         var lastTransfer = 5
+        /// True when this screen is the coordinator's re-entry root — its back control then closes
+        /// the flow instead of popping.
+        var isFlowRoot = false
 
-        init(reason: Reason = .notesSpent, firstTransfer: Int = 3, lastTransfer: Int = 5) {
+        init(
+            reason: Reason = .notesSpent,
+            firstTransfer: Int = 3,
+            lastTransfer: Int = 5,
+            isFlowRoot: Bool = false
+        ) {
             self.reason = reason
             self.firstTransfer = firstTransfer
             self.lastTransfer = lastTransfer
+            self.isFlowRoot = isFlowRoot
         }
     }
 
     enum Action: Equatable {
+        /// Flow-root back control: closes the flow instead of popping.
+        case closeTapped
         case continueTapped
         case delegate(Delegate)
 
         enum Delegate: Equatable {
+            case close
             case recreate
         }
     }
@@ -44,6 +58,9 @@ struct MigrationRecovery {
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .closeTapped:
+                return .send(.delegate(.close))
+
             case .continueTapped:
                 return .send(.delegate(.recreate))
 

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
@@ -5,8 +5,8 @@
 //  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
 //  2696:5626 / expired 2973:5698). When this screen is the coordinator's re-entry root
 //  (`isFlowRoot`), its back control closes the flow (`closeTapped` -> `.delegate(.close)`) instead
-//  of popping (MOB-1466). The `continueTapped` delegate is emitted but consumed by nobody yet —
-//  wiring the real plan-recreation flow is the coordinator's job (phase 3).
+//  of popping (MOB-1466). The `continueTapped` delegate (plan-recreation) is consumed by
+//  `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryView.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryView.swift
@@ -3,8 +3,9 @@
 //  zodl
 //
 //  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
-//  2696:5626 / expired 2973:5698). Visually complete per Figma; the `continueTapped` delegate is
-//  emitted but consumed by nobody yet — wiring the real plan-recreation flow lands in MOB-1466.
+//  2696:5626 / expired 2973:5698). When `isFlowRoot` is set, the back control closes the flow
+//  instead of popping (MOB-1466). The `continueTapped` delegate is emitted but consumed by nobody
+//  yet — wiring the real plan-recreation flow is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -49,7 +50,7 @@ struct MigrationRecoveryView: View {
                 .padding(.bottom, 24)
             }
             .screenHorizontalPadding()
-            .zashiBack()
+            .applyPresentationModifier(store: store)
         }
         .applyScreenBackground()
     }
@@ -122,6 +123,20 @@ struct MigrationRecoveryView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 2)
                 .padding(.bottom, 12)
+        }
+    }
+}
+
+// MARK: - Presentation modifier
+
+private extension View {
+    @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationRecovery>) -> some View {
+        if store.isFlowRoot {
+            zashiBackV2 {
+                store.send(.closeTapped)
+            }
+        } else {
+            zashiBack()
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
@@ -10,8 +10,8 @@
 //  coordinator (no propose) and confirm delegates directly — the transfer was already signed at plan
 //  commit. When the manual-step variant is a flow re-entry root (`isFlowRoot`), its back control
 //  closes the flow via a new `.closed` delegate instead of popping — reusing `.confirmed` for a
-//  back-tap would incorrectly signal the transfer was confirmed (MOB-1466). Chaining is the
-//  coordinator's job (phase 3).
+//  back-tap would incorrectly signal the transfer was confirmed (MOB-1466). Both delegates are
+//  consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
@@ -5,9 +5,13 @@
 //  "Review Transfer" screen (MOB-1463, Figma S7 · immediate 2867:5924 / manual "3 of 5" 2729:8544,
 //  equivalent to frame 2712:7779 which fails to render via MCP). Final confirmation before a
 //  migration transfer is sent — either the single immediate transfer, or one step of a scheduled
-//  plan. Visual-only: `amount`/`fee` are placeholders and `sendResult` is declared but inert —
-//  submitting the transfer lands in MOB-1466. The `confirmTapped` delegate is emitted but consumed
-//  by nobody yet.
+//  plan. Immediate mode proposes its own single-transfer schedule on `onAppear` (for Amount/Fee) and
+//  signs+stores it on confirm before delegating; manual step has its data injected by the
+//  coordinator (no propose) and confirm delegates directly — the transfer was already signed at plan
+//  commit. When the manual-step variant is a flow re-entry root (`isFlowRoot`), its back control
+//  closes the flow via a new `.closed` delegate instead of popping — reusing `.confirmed` for a
+//  back-tap would incorrectly signal the transfer was confirmed (MOB-1466). Chaining is the
+//  coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -22,46 +26,91 @@ struct MigrationReviewTransfer {
             case manualStep(number: Int, total: Int)
         }
 
+        /// Standard ZIP-317 marginal fee shown throughout the app (`Zatoshi(100_000)` precedent —
+        /// migration schedules don't carry a fee field of their own).
+        fileprivate static let standardFee = Zatoshi(100_000)
+
         var mode = Mode.immediate
-        /// Placeholder; real proposal data lands in MOB-1466.
         var amount = Zatoshi.zero
         var fee = Zatoshi.zero
+        /// Immediate mode: the single-transfer schedule proposed on `onAppear`, signed+stored on
+        /// confirm. `nil` in manual-step mode (nothing to propose or sign here).
+        var schedule: MigrationSchedule?
+        /// True when the manual-step variant is the coordinator's re-entry root — its back control
+        /// then closes the flow instead of popping.
+        var isFlowRoot = false
 
         init(
             mode: Mode = .immediate,
             amount: Zatoshi = Zatoshi.zero,
-            fee: Zatoshi = Zatoshi.zero
+            fee: Zatoshi = Zatoshi.zero,
+            isFlowRoot: Bool = false
         ) {
             self.mode = mode
             self.amount = amount
             self.fee = fee
+            self.isFlowRoot = isFlowRoot
         }
     }
 
     enum Action: Equatable {
-        /// Inert now; MOB-1466 submits the transfer.
+        /// Flow-root back control (manual step only): closes the flow instead of popping.
+        case closeTapped
+        /// Immediate mode signs+stores the schedule then delegates; manual step delegates directly.
         case confirmTapped
         case delegate(Delegate)
-        /// Declared for MOB-1466 (SDK-driven) — inert.
-        case sendResult(TransferResult)
+        /// Immediate mode only: proposes a single-transfer schedule for Amount/Fee display.
+        case onAppear
+        /// `signAndStoreMigrationSchedule` completed (immediate mode only).
+        case scheduleSigned
+        /// `proposeMigrationTransfers()` result (immediate mode only).
+        case transferProposed(MigrationSchedule)
 
         enum Delegate: Equatable {
+            case closed
             case confirmed
         }
     }
+
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
 
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .closeTapped:
+                return .send(.delegate(.closed))
+
             case .confirmTapped:
-                return .send(.delegate(.confirmed))
+                guard case .immediate = state.mode, let schedule = state.schedule else {
+                    // Manual step: the transfer was already signed at plan commit — delegate directly.
+                    return .send(.delegate(.confirmed))
+                }
+
+                return .run { send in
+                    await sdkSynchronizer.signAndStoreMigrationSchedule(schedule)
+                    await send(.scheduleSigned)
+                }
 
             case .delegate:
                 return .none
 
-            case .sendResult:
+            case .onAppear:
+                guard case .immediate = state.mode else { return .none }
+
+                return .run { send in
+                    let schedule = await sdkSynchronizer.proposeMigrationTransfers()
+                    await send(.transferProposed(schedule))
+                }
+
+            case .scheduleSigned:
+                return .send(.delegate(.confirmed))
+
+            case .transferProposed(let schedule):
+                state.schedule = schedule
+                state.amount = schedule.transfers.first?.amount ?? Zatoshi.zero
+                state.fee = State.standardFee
                 return .none
             }
         }

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferView.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferView.swift
@@ -3,8 +3,10 @@
 //  zodl
 //
 //  "Review Transfer" screen (MOB-1463, Figma S7 · immediate 2867:5924 / manual "3 of 5"
-//  2729:8544). Visually complete per Figma; `sendResult` is declared but inert — submitting the
-//  transfer lands in MOB-1466. The `confirmTapped` delegate is emitted but consumed by nobody yet.
+//  2729:8544). `onAppear` loads Amount/Fee live (immediate mode) via the store; when the manual-step
+//  variant is a flow re-entry root (`isFlowRoot`), its back control closes the flow instead of
+//  popping (MOB-1466). The `confirmTapped` delegate is emitted but consumed by nobody yet —
+//  chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -50,9 +52,12 @@ struct MigrationReviewTransferView: View {
                 .padding(.bottom, 24)
             }
             .screenHorizontalPadding()
-            .zashiBack()
+            .applyPresentationModifier(store: store)
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Header
@@ -96,6 +101,22 @@ struct MigrationReviewTransferView: View {
                 value: "\(store.fee.decimalString()) ZEC",
                 rowAppereance: .bottom
             )
+        }
+    }
+}
+
+// MARK: - Presentation modifier
+
+private extension View {
+    /// Only the manual-step variant can be a re-entry root — immediate mode is always reached via
+    /// normal push, so a plain pop stands there regardless of `isFlowRoot`.
+    @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationReviewTransfer>) -> some View {
+        if store.mode != .immediate && store.isFlowRoot {
+            zashiBackV2 {
+                store.send(.closeTapped)
+            }
+        } else {
+            zashiBack()
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledStore.swift
+++ b/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledStore.swift
@@ -4,8 +4,8 @@
 //
 //  "Migration Scheduled" screen (MOB-1463, Figma S9 · 2630:11282). Terminal success screen shown
 //  once a scheduled migration plan has been confirmed: a summary card of what's being transferred
-//  and over how long. Visual-only: all fields are placeholders — the real summary data lands in
-//  MOB-1466. The `doneTapped` delegate is emitted but consumed by nobody yet.
+//  and over how long. The coordinator hydrates the summary fields and consumes the `doneTapped`
+//  delegate (MigrationCoordFlowCoordinator, MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
@@ -3,10 +3,13 @@
 //  zodl
 //
 //  "Sending" / "Sent" screen (MOB-1463, Figma S8 · sending 2618:6858 / sent 2618:6895). Shown while
-//  a migration transfer broadcasts, then flips to a success state. Visual-only: `txId` is a
-//  placeholder and `result` is declared but inert — resubmitting after a failure and wiring the
-//  real broadcast result land in MOB-1466. The `closeTapped` / `viewTransactionTapped` delegates
-//  are emitted but consumed by nobody yet.
+//  migration transfers broadcast — one for immediate/manual/plan-first sends, or a sequential batch
+//  for "send now" — then flips to a success state once every transfer in `totalCount` has been
+//  executed. `onAppear` runs `executeNextPendingMigrationTransfer` strictly in sequence, recording a
+//  broadcast and scheduling the next background window after each success; a failure/`nil` result
+//  stops the sequence and presents the failure sheet, and `retryTapped` re-runs only the failed step
+//  (MOB-1466). The `closeTapped` / `viewTransactionTapped` delegates are emitted but consumed by
+//  nobody yet — chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -24,30 +27,46 @@ struct MigrationSending {
         var phase = Phase.sending
         /// Failure sheet presented over the sending phase.
         var isFailurePresented = false
-        /// Placeholder; real tx id lands in MOB-1466 (wires up View Transaction).
+        /// The most recently broadcast transfer's tx id (wires up View Transaction).
         var txId = ""
+        /// How many transfers this screen instance is responsible for: 1 for immediate/manual/
+        /// plan-first sends, N for a sequential "send now" batch. Coordinator-configured.
+        var totalCount = 1
+        /// How many of `totalCount` have been successfully broadcast so far.
+        var sentCount = 0
+        /// Submission options for `executeNextPendingMigrationTransfer`, injected by the coordinator.
+        var networkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
 
         init(
             phase: Phase = .sending,
             isFailurePresented: Bool = false,
-            txId: String = ""
+            txId: String = "",
+            totalCount: Int = 1,
+            sentCount: Int = 0,
+            networkPrivacyOptions: NetworkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
         ) {
             self.phase = phase
             self.isFailurePresented = isFailurePresented
             self.txId = txId
+            self.totalCount = totalCount
+            self.sentCount = sentCount
+            self.networkPrivacyOptions = networkPrivacyOptions
         }
     }
 
     enum Action: BindableAction, Equatable {
+        /// All `totalCount` transfers have been successfully broadcast.
+        case allTransfersSent
         case binding(BindingAction<State>)
         /// Failure sheet: dismiss (stay on screen).
         case cancelTapped
         case closeTapped
         case delegate(Delegate)
-        /// Declared for MOB-1466 (SDK-driven) — inert.
-        case result(TransferResult)
-        /// Failure sheet: dismiss — inert re-submit (MOB-1466).
+        case onAppear
+        /// Failure sheet: dismiss, then re-run the failed step.
         case retryTapped
+        /// `executeNextPendingMigrationTransfer` result for the current step; `nil` on a stub/no-op.
+        case transferResult(TransferResult?)
         case viewTransactionTapped
 
         enum Delegate: Equatable {
@@ -56,6 +75,10 @@ struct MigrationSending {
         }
     }
 
+    @Dependency(\.migrationBGScheduler) var migrationBGScheduler
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+
     init() { }
 
     var body: some Reducer<State, Action> {
@@ -63,6 +86,10 @@ struct MigrationSending {
 
         Reduce { state, action in
             switch action {
+            case .allTransfersSent:
+                state.phase = .success
+                return .none
+
             case .binding:
                 return .none
 
@@ -76,16 +103,41 @@ struct MigrationSending {
             case .delegate:
                 return .none
 
-            case .result:
-                return .none
+            case .onAppear:
+                return executeNextTransfer(options: state.networkPrivacyOptions)
 
             case .retryTapped:
                 state.isFailurePresented = false
-                return .none
+                return executeNextTransfer(options: state.networkPrivacyOptions)
+
+            case .transferResult(let result):
+                switch result {
+                case .success(let txId):
+                    state.txId = txId
+                    state.sentCount += 1
+                    // Both are synchronous, non-throwing dependency closures — no effect needed.
+                    migrationManager.recordMigrationBroadcast()
+                    migrationBGScheduler.scheduleNextWindow()
+
+                    return state.sentCount >= state.totalCount
+                        ? .send(.allTransfersSent)
+                        : executeNextTransfer(options: state.networkPrivacyOptions)
+
+                case .networkError, .invalidNote, .expired, nil:
+                    state.isFailurePresented = true
+                    return .none
+                }
 
             case .viewTransactionTapped:
                 return .send(.delegate(.viewTransaction))
             }
+        }
+    }
+
+    private func executeNextTransfer(options: NetworkPrivacyOptions) -> Effect<Action> {
+        .run { send in
+            let result = await sdkSynchronizer.executeNextPendingMigrationTransfer(options)
+            await send(.transferResult(result))
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
@@ -8,8 +8,8 @@
 //  executed. `onAppear` runs `executeNextPendingMigrationTransfer` strictly in sequence, recording a
 //  broadcast and scheduling the next background window after each success; a failure/`nil` result
 //  stops the sequence and presents the failure sheet, and `retryTapped` re-runs only the failed step
-//  (MOB-1466). The `closeTapped` / `viewTransactionTapped` delegates are emitted but consumed by
-//  nobody yet — chaining is the coordinator's job (phase 3).
+//  (MOB-1466). The `closeTapped` / `viewTransactionTapped` delegates are consumed by
+//  `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingView.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingView.swift
@@ -2,10 +2,10 @@
 //  MigrationSendingView.swift
 //  zodl
 //
-//  "Sending" / "Sent" screen (MOB-1463, Figma S8 · sending 2618:6858 / sent 2618:6895). Visually
-//  complete per Figma; `result` is declared but inert — wiring the real broadcast result and
-//  resubmission after a failure lands in MOB-1466. The `closeTapped` / `viewTransactionTapped`
-//  delegates are emitted but consumed by nobody yet.
+//  "Sending" / "Sent" screen (MOB-1463, Figma S8 · sending 2618:6858 / sent 2618:6895). `onAppear`
+//  drives the store's sequential transfer execution (MOB-1466). The `closeTapped` /
+//  `viewTransactionTapped` delegates are emitted but consumed by nobody yet — chaining is the
+//  coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -34,6 +34,9 @@ struct MigrationSendingView: View {
                 .zashiSheet(isPresented: $store.isFailurePresented) {
                     failureSheetContent
                 }
+        }
+        .onAppear {
+            store.send(.onAppear)
         }
     }
 

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
@@ -7,8 +7,8 @@
 //  via `migrationTransfers()`/`migrationSummary()`, derives `isSendNowDisabled` from
 //  `manager.sendGate()`, and subscribes `migrationStateStream()` to refresh rows live (MOB-1466).
 //  When this screen is a flow re-entry root (`isFlowRoot`), its back control closes the flow
-//  (`.done`) instead of popping — every other delegate is emitted but consumed by nobody yet;
-//  chaining is the coordinator's job (phase 3).
+//  (`.done`) instead of popping — every other delegate is consumed by
+//  `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import Foundation
@@ -37,7 +37,7 @@ struct MigrationStatus {
         var isFlowRoot = false
         /// Send-now CTA disabled per `manager.sendGate()` (`.syncRequired`/`.waitUntil` -> disabled).
         var isSendNowDisabled = false
-        var CancelStateStreamId = UUID()
+        var cancelStateStreamId = UUID()
 
         var remainingCount: Int {
             rows.filter { $0.status != .sent }.count
@@ -110,7 +110,7 @@ struct MigrationStatus {
                         sdkSynchronizer.migrationStateStream()
                             .map { _ in Action.migrationStateChanged }
                     }
-                    .cancellable(id: state.CancelStateStreamId, cancelInFlight: true)
+                    .cancellable(id: state.cancelStateStreamId, cancelInFlight: true)
                 )
 
             case .rescheduleTapped:

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
@@ -3,12 +3,15 @@
 //  zodl
 //
 //  "Migration Progress" / "Resume Migration" / "Re-scheduling…" screen (MOB-1464, Figma S10 ·
-//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). Visually complete per Figma;
-//  `rows` is a placeholder and every delegate is emitted but consumed by nobody yet — wiring the
-//  real reschedule/send-now behavior and chaining into the rest of the migration flow lands in
-//  MOB-1466.
+//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). `onAppear` loads rows/summary
+//  via `migrationTransfers()`/`migrationSummary()`, derives `isSendNowDisabled` from
+//  `manager.sendGate()`, and subscribes `migrationStateStream()` to refresh rows live (MOB-1466).
+//  When this screen is a flow re-entry root (`isFlowRoot`), its back control closes the flow
+//  (`.done`) instead of popping — every other delegate is emitted but consumed by nobody yet;
+//  chaining is the coordinator's job (phase 3).
 //
 
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
@@ -22,7 +25,6 @@ struct MigrationStatus {
         }
 
         var presentation = Presentation.progress
-        /// Placeholder; real proposal data lands in MOB-1466.
         var rows: IdentifiedArrayOf<MigrationTransferRow> = []
         var totalDurationHours = 0
         /// Resume header: "Transfer {n} of {m} …".
@@ -30,6 +32,12 @@ struct MigrationStatus {
         var stalledHoursAgo = 0
         /// Visual-only: skeleton captions + disabled spinner button on the resume presentation.
         var isRescheduling = false
+        /// True when this screen is the coordinator's re-entry root (both presentations) — its back
+        /// control then closes the flow instead of popping.
+        var isFlowRoot = false
+        /// Send-now CTA disabled per `manager.sendGate()` (`.syncRequired`/`.waitUntil` -> disabled).
+        var isSendNowDisabled = false
+        var CancelStateStreamId = UUID()
 
         var remainingCount: Int {
             rows.filter { $0.status != .sent }.count
@@ -41,7 +49,8 @@ struct MigrationStatus {
             totalDurationHours: Int = 0,
             stalledNumber: Int = 0,
             stalledHoursAgo: Int = 0,
-            isRescheduling: Bool = false
+            isRescheduling: Bool = false,
+            isFlowRoot: Bool = false
         ) {
             self.presentation = presentation
             self.rows = rows
@@ -49,15 +58,23 @@ struct MigrationStatus {
             self.stalledNumber = stalledNumber
             self.stalledHoursAgo = stalledHoursAgo
             self.isRescheduling = isRescheduling
+            self.isFlowRoot = isFlowRoot
         }
     }
 
     enum Action: Equatable {
+        /// Flow-root back control: closes the flow instead of popping.
+        case closeTapped
         /// Progress CTA and the X close.
         case gotItTapped
         case delegate(Delegate)
+        /// `migrationStateStream()` ticked — reloads rows/summary/gate.
+        case migrationStateChanged
+        case onAppear
         case rescheduleTapped
         case sendNowTapped
+        /// `migrationTransfers()` + `migrationSummary()` + `manager.sendGate()` result.
+        case statusLoaded(rows: [MigrationTransferRow], totalDurationHours: Int, isSendNowDisabled: Bool)
 
         enum Delegate: Equatable {
             case done
@@ -66,13 +83,35 @@ struct MigrationStatus {
         }
     }
 
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .closeTapped:
+                return .send(.delegate(.done))
+
             case .gotItTapped:
                 return .send(.delegate(.done))
+
+            case .delegate:
+                return .none
+
+            case .migrationStateChanged:
+                return loadStatus()
+
+            case .onAppear:
+                return .merge(
+                    loadStatus(),
+                    .publisher {
+                        sdkSynchronizer.migrationStateStream()
+                            .map { _ in Action.migrationStateChanged }
+                    }
+                    .cancellable(id: state.CancelStateStreamId, cancelInFlight: true)
+                )
 
             case .rescheduleTapped:
                 state.isRescheduling = true
@@ -81,9 +120,27 @@ struct MigrationStatus {
             case .sendNowTapped:
                 return .send(.delegate(.sendNow))
 
-            case .delegate:
+            case .statusLoaded(let rows, let totalDurationHours, let isSendNowDisabled):
+                state.rows = IdentifiedArrayOf(uniqueElements: rows)
+                state.totalDurationHours = totalDurationHours
+                state.isSendNowDisabled = isSendNowDisabled
                 return .none
             }
+        }
+    }
+
+    private func loadStatus() -> Effect<Action> {
+        .run { send in
+            let rows = sdkSynchronizer.migrationTransfers()
+            let summary = sdkSynchronizer.migrationSummary()
+            let isSendNowDisabled = migrationManager.sendGate() != MigrationSendGate.allowed
+            await send(
+                .statusLoaded(
+                    rows: rows,
+                    totalDurationHours: summary.estimatedDurationHours,
+                    isSendNowDisabled: isSendNowDisabled
+                )
+            )
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
@@ -3,9 +3,10 @@
 //  zodl
 //
 //  "Migration Progress" / "Resume Migration" / "Re-scheduling…" screen (MOB-1464, Figma S10 ·
-//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). Visually complete per Figma;
-//  every delegate emitted here is consumed by nobody yet — wiring the real reschedule/send-now
-//  behavior and chaining into the rest of the migration flow lands in MOB-1466.
+//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). `onAppear` loads live rows via
+//  the store; every other delegate emitted here is consumed by nobody yet — chaining is the
+//  coordinator's job (phase 3). When `isFlowRoot` is set, the back control closes the flow instead
+//  of popping (MOB-1466).
 //
 
 import ComposableArchitecture
@@ -56,6 +57,9 @@ struct MigrationStatusView: View {
             .applyPresentationModifier(store: store)
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Title + description
@@ -145,6 +149,7 @@ struct MigrationStatusView: View {
                 ZashiButton(String(localizable: .migrationStatusSendNow)) {
                     store.send(.sendNowTapped)
                 }
+                .disabled(store.isSendNowDisabled)
             }
         }
     }
@@ -153,10 +158,18 @@ struct MigrationStatusView: View {
 // MARK: - Presentation modifier
 
 private extension View {
+    /// `.progress`'s back was already close-like (`zashiBackV2` sending `.gotItTapped`) before
+    /// `isFlowRoot` existed — that stands unconditionally. `.resume`'s back is a plain pop unless
+    /// this screen is the coordinator's re-entry root, in which case it closes the flow instead
+    /// (MOB-1466 back-semantics: "when `isFlowRoot == false`, current behavior stands").
     @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationStatus>) -> some View {
         if store.presentation == .progress {
             zashiBackV2 {
                 store.send(.gotItTapped)
+            }
+        } else if store.isFlowRoot {
+            zashiBackV2 {
+                store.send(.closeTapped)
             }
         } else {
             zashiBack()

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
@@ -131,13 +131,13 @@ struct MigrationStatusView: View {
                     ZashiButton(
                         String(localizable: .migrationStatusReschedulingTitle),
                         type: .tertiary,
-                        accessoryView: ProgressView()
+                        prefixView: ProgressView()
                     ) {
                         store.send(.rescheduleTapped)
                     }
                     .disabled(true)
                 } else {
-                    ZashiButton(String(localizable: .migrationStatusReschedule), type: .ghost) {
+                    ZashiButton(String(localizable: .migrationStatusReschedule), type: .secondary) {
                         store.send(.rescheduleTapped)
                     }
                 }

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -98,6 +98,12 @@ struct MigrationTransferPlan {
                     return .none
                 }
 
+                // Coordinator-hydrated rows (the rescheduled variant — no schedule object exists
+                // for it) must not be overwritten by a fresh proposal.
+                if !state.rows.isEmpty {
+                    return .none
+                }
+
                 return .run { send in
                     let schedule = await sdkSynchronizer.proposeMigrationTransfers()
                     await send(.transfersProposed(schedule))

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -4,11 +4,15 @@
 //
 //  "Transfer Plan" screen (MOB-1463, Figma S6 · scheduled 2867:10211 / manual 2867:2198 /
 //  re-created 2709:3519). One-time review of the migration schedule before signing: a timeline of
-//  transfer rows, each showing its amount, status, and ETA. Visual-only: `rows` is a placeholder —
-//  the real proposal (and signing/storing it) lands in MOB-1466. The `confirmTapped` delegate is
-//  emitted but consumed by nobody yet.
+//  transfer rows, each showing its amount, status, and ETA. A fresh entry proposes its own schedule
+//  on `onAppear`; a recovery/reschedule variant instead has its schedule injected by the coordinator
+//  (`injectedSchedule`) and must not re-propose. `confirmTapped` signs and stores whichever schedule
+//  is active, unless `requiresSigning == false` (the rescheduled variant, whose transfers are
+//  already signed), in which case it's a plain acknowledgment (MOB-1466). Chaining the
+//  `confirmTapped` delegate into the rest of the flow is `MigrationCoordFlow`'s job.
 //
 
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
@@ -23,31 +27,50 @@ struct MigrationTransferPlan {
         }
 
         var variant = Variant.scheduled
-        /// Placeholder; real proposal data lands in MOB-1466.
         var rows: IdentifiedArrayOf<MigrationTransferRow> = []
         var totalDurationHours = 0
         @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion?
+        /// Coordinator-injected schedule for recovery/reschedule variants — when set, `onAppear`
+        /// populates rows from it directly instead of calling `proposeMigrationTransfers()`.
+        var injectedSchedule: MigrationSchedule?
+        /// The schedule currently backing `rows` (either `injectedSchedule` or a freshly proposed
+        /// one) — what `confirmTapped` signs and stores.
+        var schedule: MigrationSchedule?
+        /// `false` for the rescheduled variant only (MOB-1466): its transfers are already signed at
+        /// the original plan commit, so `confirmTapped` is a plain acknowledgment — `false` skips
+        /// `signAndStoreMigrationSchedule` and delegates `.confirmed` directly. The re-created
+        /// (recovery) variant signs a fresh schedule, so it keeps the default `true`.
+        var requiresSigning = true
 
         init(
             variant: Variant = .scheduled,
             rows: IdentifiedArrayOf<MigrationTransferRow> = [],
-            totalDurationHours: Int = 0
+            totalDurationHours: Int = 0,
+            requiresSigning: Bool = true
         ) {
             self.variant = variant
             self.rows = rows
             self.totalDurationHours = totalDurationHours
+            self.requiresSigning = requiresSigning
         }
     }
 
     enum Action: Equatable {
-        /// Inert now; MOB-1466 signs and stores the schedule.
+        /// Signs and stores the active schedule.
         case confirmTapped
         case delegate(Delegate)
+        case onAppear
+        /// `signAndStoreMigrationSchedule` completed.
+        case scheduleSigned
+        /// `proposeMigrationTransfers()` result — populates rows/duration for a fresh entry.
+        case transfersProposed(MigrationSchedule)
 
         enum Delegate: Equatable {
             case confirmed
         }
     }
+
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
 
     init() { }
 
@@ -55,11 +78,65 @@ struct MigrationTransferPlan {
         Reduce { state, action in
             switch action {
             case .confirmTapped:
-                return .send(.delegate(.confirmed))
+                guard state.requiresSigning else {
+                    // Rescheduled variant: transfers are already signed — this is acknowledgment.
+                    return .send(.delegate(.confirmed))
+                }
+
+                let schedule = state.schedule ?? MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+                return .run { send in
+                    await sdkSynchronizer.signAndStoreMigrationSchedule(schedule)
+                    await send(.scheduleSigned)
+                }
 
             case .delegate:
                 return .none
+
+            case .onAppear:
+                if let injectedSchedule = state.injectedSchedule {
+                    apply(injectedSchedule, to: &state)
+                    return .none
+                }
+
+                return .run { send in
+                    let schedule = await sdkSynchronizer.proposeMigrationTransfers()
+                    await send(.transfersProposed(schedule))
+                }
+
+            case .scheduleSigned:
+                return .send(.delegate(.confirmed))
+
+            case .transfersProposed(let schedule):
+                apply(schedule, to: &state)
+                return .none
             }
         }
+    }
+
+    /// Populates `rows`/`totalDurationHours`/`schedule` from a `MigrationSchedule`, whether it was
+    /// freshly proposed or injected by the coordinator. The first transfer is `.active` (ready now);
+    /// the rest are `.pending`. `hoursFromNow` comes from `estimateTimestamp` where the SDK can
+    /// resolve a height to a timestamp; unresolved (incl. the inert stub) defaults to `0`.
+    private func apply(_ schedule: MigrationSchedule, to state: inout State) {
+        state.rows = IdentifiedArrayOf(
+            uniqueElements: schedule.transfers.enumerated().map { index, transfer in
+                MigrationTransferRow(
+                    id: transfer.id,
+                    index: index,
+                    amount: transfer.amount,
+                    status: index == 0 ? .active : .pending,
+                    hoursFromNow: hoursFromNow(forHeightReadyAt: transfer.nextExecutableAfterHeight)
+                )
+            }
+        )
+        state.totalDurationHours = schedule.estimatedDurationHours
+        state.schedule = schedule
+    }
+
+    private func hoursFromNow(forHeightReadyAt height: BlockHeight) -> Int {
+        guard let readyTimestamp = sdkSynchronizer.estimateTimestamp(height) else { return 0 }
+
+        let seconds = Date(timeIntervalSince1970: readyTimestamp).timeIntervalSinceNow
+        return max(0, Int(seconds / 3_600))
     }
 }

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
@@ -3,9 +3,9 @@
 //  zodl
 //
 //  "Transfer Plan" screen (MOB-1463, Figma S6 · scheduled 2867:10211 / manual 2867:2198 /
-//  re-created 2709:3519). Visually complete per Figma; `rows` is a placeholder and the
-//  `confirmTapped` delegate is emitted but consumed by nobody yet — wiring the real proposal and
-//  chaining into the rest of the migration flow lands in MOB-1466.
+//  re-created 2709:3519). `onAppear` loads a fresh proposal (or leaves an injected schedule alone)
+//  via the store; the `confirmTapped` delegate is emitted but consumed by nobody yet — chaining
+//  into the rest of the migration flow is the coordinator's job (MOB-1466 phase 3).
 //
 
 import ComposableArchitecture
@@ -49,6 +49,9 @@ struct MigrationTransferPlanView: View {
             .zashiBack()
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Title + description

--- a/secant/Sources/Features/MigrationDebugGallery/MigrationDebugGalleryView.swift
+++ b/secant/Sources/Features/MigrationDebugGallery/MigrationDebugGalleryView.swift
@@ -1,0 +1,396 @@
+//
+//  MigrationDebugGalleryView.swift
+//  zodl
+//
+//  DEBUG-only gallery of every Ironwood migration screen (MOB-1460…1464), for visual QA. Reachable
+//  by long-pressing the balance on Home (see HomeView). Each row presents its screen with a canned
+//  fixture state from `MigrationMockData` — the same construction shape as that screen's own
+//  `#Preview`. No new reducer: every migration screen's reducer already swallows its own delegate
+//  actions, so this is visual-only plumbing (see MOB-1465 spec).
+//
+
+#if DEBUG
+
+import SwiftUI
+import ComposableArchitecture
+
+struct MigrationDebugGalleryView: View {
+    /// One row in the gallery. `Identifiable` via `title` so `.sheet(item:)` can key off it.
+    enum Item: String, Identifiable {
+        case entryPrivacy = "Entry — privacy selected"
+        case entryImmediate = "Entry — immediate selected"
+        case networkPrivacyImmediate = "Network Privacy — immediate"
+        case networkPrivacyScheduled = "Network Privacy — scheduled (5 transfers)"
+        case noteSplitExplainer = "Explainer"
+        case noteSplitSplitting = "Splitting"
+        case noteSplitConfirmed = "Confirmed"
+        case noteSplitFailure = "Failure sheet"
+        case backgroundDelivery = "Background Delivery"
+        case notificationsScheduled = "Notifications — scheduled"
+        case notificationsManual = "Notifications — manual"
+        case planScheduled = "Plan — scheduled (5 fresh rows)"
+        case planManual = "Plan — manual"
+        case planRecreated = "Plan — re-created (2 sent / 1 ready / 2 pending)"
+        case reviewImmediate = "Review — immediate"
+        case reviewManualStep = "Review — 3 of 5"
+        case sending = "Sending"
+        case sent = "Sent"
+        case sendingFailure = "Sending failure sheet"
+        case migrationScheduled = "Migration Scheduled"
+        case statusProgress = "Status — progress (2 sent / 1 active / 2 pending)"
+        case statusResume = "Status — resume (overdue)"
+        case statusRescheduling = "Status — re-scheduling"
+        case recoveryNotesSpent = "Recovery — notes spent"
+        case recoveryExpired = "Recovery — expired"
+        case completeWithDust = "Complete — with dust"
+        case completeClean = "Complete — clean"
+        case bannerAllStates = "Banner — all states"
+
+        var id: String { rawValue }
+    }
+
+    @State private var selected: Item?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Entry & Network Privacy") {
+                    row(.entryPrivacy)
+                    row(.entryImmediate)
+                    row(.networkPrivacyImmediate)
+                    row(.networkPrivacyScheduled)
+                }
+
+                Section("Note Split") {
+                    row(.noteSplitExplainer)
+                    row(.noteSplitSplitting)
+                    row(.noteSplitConfirmed)
+                    row(.noteSplitFailure)
+                }
+
+                Section("Permissions") {
+                    row(.backgroundDelivery)
+                    row(.notificationsScheduled)
+                    row(.notificationsManual)
+                }
+
+                Section("Plan & Review") {
+                    row(.planScheduled)
+                    row(.planManual)
+                    row(.planRecreated)
+                    row(.reviewImmediate)
+                    row(.reviewManualStep)
+                }
+
+                Section("Sending & Scheduled") {
+                    row(.sending)
+                    row(.sent)
+                    row(.sendingFailure)
+                    row(.migrationScheduled)
+                }
+
+                Section("Status, Recovery & Complete") {
+                    row(.statusProgress)
+                    row(.statusResume)
+                    row(.statusRescheduling)
+                    row(.recoveryNotesSpent)
+                    row(.recoveryExpired)
+                    row(.completeWithDust)
+                    row(.completeClean)
+                }
+
+                Section("Home banner") {
+                    row(.bannerAllStates)
+                }
+            }
+            .navigationTitle("Migration Gallery")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .sheet(item: $selected) { item in
+            content(for: item)
+        }
+    }
+
+    private func row(_ item: Item) -> some View {
+        Button {
+            selected = item
+        } label: {
+            Text(item.rawValue)
+        }
+    }
+
+    @ViewBuilder private func content(for item: Item) -> some View {
+        switch item {
+        case .entryPrivacy:
+            NavigationStack {
+                MigrationEntryView(
+                    store: StoreOf<MigrationEntry>(initialState: MigrationMockData.entryPrivacy) {
+                        MigrationEntry()
+                    }
+                )
+            }
+        case .entryImmediate:
+            NavigationStack {
+                MigrationEntryView(
+                    store: StoreOf<MigrationEntry>(initialState: MigrationMockData.entryImmediate) {
+                        MigrationEntry()
+                    }
+                )
+            }
+        case .networkPrivacyImmediate:
+            NavigationStack {
+                MigrationNetworkPrivacyView(
+                    store: StoreOf<MigrationNetworkPrivacy>(
+                        initialState: MigrationMockData.networkPrivacyImmediate
+                    ) {
+                        MigrationNetworkPrivacy()
+                    }
+                )
+            }
+        case .networkPrivacyScheduled:
+            NavigationStack {
+                MigrationNetworkPrivacyView(
+                    store: StoreOf<MigrationNetworkPrivacy>(
+                        initialState: MigrationMockData.networkPrivacyScheduled
+                    ) {
+                        MigrationNetworkPrivacy()
+                    }
+                )
+            }
+        case .noteSplitExplainer:
+            NavigationStack {
+                MigrationNoteSplitView(
+                    store: StoreOf<MigrationNoteSplit>(initialState: MigrationMockData.noteSplitExplainer) {
+                        MigrationNoteSplit()
+                    }
+                )
+            }
+        case .noteSplitSplitting:
+            NavigationStack {
+                MigrationNoteSplitView(
+                    store: StoreOf<MigrationNoteSplit>(initialState: MigrationMockData.noteSplitSplitting) {
+                        MigrationNoteSplit()
+                    }
+                )
+            }
+        case .noteSplitConfirmed:
+            NavigationStack {
+                MigrationNoteSplitView(
+                    store: StoreOf<MigrationNoteSplit>(initialState: MigrationMockData.noteSplitConfirmed) {
+                        MigrationNoteSplit()
+                    }
+                )
+            }
+        case .noteSplitFailure:
+            NavigationStack {
+                MigrationNoteSplitView(
+                    store: StoreOf<MigrationNoteSplit>(initialState: MigrationMockData.noteSplitFailure) {
+                        MigrationNoteSplit()
+                    }
+                )
+            }
+        case .backgroundDelivery:
+            NavigationStack {
+                MigrationBackgroundDeliveryView(
+                    store: StoreOf<MigrationBackgroundDelivery>(
+                        initialState: MigrationMockData.backgroundDelivery
+                    ) {
+                        MigrationBackgroundDelivery()
+                    }
+                )
+            }
+        case .notificationsScheduled:
+            NavigationStack {
+                MigrationNotificationsView(
+                    store: StoreOf<MigrationNotifications>(
+                        initialState: MigrationMockData.notificationsScheduled
+                    ) {
+                        MigrationNotifications()
+                    }
+                )
+            }
+        case .notificationsManual:
+            NavigationStack {
+                MigrationNotificationsView(
+                    store: StoreOf<MigrationNotifications>(
+                        initialState: MigrationMockData.notificationsManual
+                    ) {
+                        MigrationNotifications()
+                    }
+                )
+            }
+        case .planScheduled:
+            NavigationStack {
+                MigrationTransferPlanView(
+                    store: StoreOf<MigrationTransferPlan>(initialState: MigrationMockData.planScheduled) {
+                        MigrationTransferPlan()
+                    }
+                )
+            }
+        case .planManual:
+            NavigationStack {
+                MigrationTransferPlanView(
+                    store: StoreOf<MigrationTransferPlan>(initialState: MigrationMockData.planManual) {
+                        MigrationTransferPlan()
+                    }
+                )
+            }
+        case .planRecreated:
+            NavigationStack {
+                MigrationTransferPlanView(
+                    store: StoreOf<MigrationTransferPlan>(initialState: MigrationMockData.planRecreated) {
+                        MigrationTransferPlan()
+                    }
+                )
+            }
+        case .reviewImmediate:
+            NavigationStack {
+                MigrationReviewTransferView(
+                    store: StoreOf<MigrationReviewTransfer>(initialState: MigrationMockData.reviewImmediate) {
+                        MigrationReviewTransfer()
+                    }
+                )
+            }
+        case .reviewManualStep:
+            NavigationStack {
+                MigrationReviewTransferView(
+                    store: StoreOf<MigrationReviewTransfer>(initialState: MigrationMockData.reviewManualStep) {
+                        MigrationReviewTransfer()
+                    }
+                )
+            }
+        case .sending:
+            NavigationStack {
+                MigrationSendingView(
+                    store: StoreOf<MigrationSending>(initialState: MigrationMockData.sending) {
+                        MigrationSending()
+                    }
+                )
+            }
+        case .sent:
+            NavigationStack {
+                MigrationSendingView(
+                    store: StoreOf<MigrationSending>(initialState: MigrationMockData.sent) {
+                        MigrationSending()
+                    }
+                )
+            }
+        case .sendingFailure:
+            NavigationStack {
+                MigrationSendingView(
+                    store: StoreOf<MigrationSending>(initialState: MigrationMockData.sendingFailure) {
+                        MigrationSending()
+                    }
+                )
+            }
+        case .migrationScheduled:
+            NavigationStack {
+                MigrationScheduledView(
+                    store: StoreOf<MigrationScheduled>(initialState: MigrationMockData.migrationScheduled) {
+                        MigrationScheduled()
+                    }
+                )
+            }
+        case .statusProgress:
+            NavigationStack {
+                MigrationStatusView(
+                    store: StoreOf<MigrationStatus>(initialState: MigrationMockData.statusProgress) {
+                        MigrationStatus()
+                    }
+                )
+            }
+        case .statusResume:
+            NavigationStack {
+                MigrationStatusView(
+                    store: StoreOf<MigrationStatus>(initialState: MigrationMockData.statusResume) {
+                        MigrationStatus()
+                    }
+                )
+            }
+        case .statusRescheduling:
+            NavigationStack {
+                MigrationStatusView(
+                    store: StoreOf<MigrationStatus>(initialState: MigrationMockData.statusRescheduling) {
+                        MigrationStatus()
+                    }
+                )
+            }
+        case .recoveryNotesSpent:
+            NavigationStack {
+                MigrationRecoveryView(
+                    store: StoreOf<MigrationRecovery>(initialState: MigrationMockData.recoveryNotesSpent) {
+                        MigrationRecovery()
+                    }
+                )
+            }
+        case .recoveryExpired:
+            NavigationStack {
+                MigrationRecoveryView(
+                    store: StoreOf<MigrationRecovery>(initialState: MigrationMockData.recoveryExpired) {
+                        MigrationRecovery()
+                    }
+                )
+            }
+        case .completeWithDust:
+            NavigationStack {
+                MigrationCompleteView(
+                    store: StoreOf<MigrationComplete>(initialState: MigrationMockData.completeWithDust) {
+                        MigrationComplete()
+                    }
+                )
+            }
+        case .completeClean:
+            NavigationStack {
+                MigrationCompleteView(
+                    store: StoreOf<MigrationComplete>(initialState: MigrationMockData.completeClean) {
+                        MigrationComplete()
+                    }
+                )
+            }
+        case .bannerAllStates:
+            NavigationStack {
+                bannerAllStatesContent()
+            }
+        }
+    }
+
+    @ViewBuilder private func bannerAllStatesContent() -> some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                bannerStrip(.required)
+                bannerStrip(.splitting)
+                bannerStrip(.inProgress(done: 2, total: 5))
+                bannerStrip(.transferWaiting(number: 3))
+                bannerStrip(.updatePlan)
+                bannerStrip(.transfersExpired(first: 3, last: 5))
+                bannerStrip(.transferReady(number: 4))
+                bannerStrip(.complete)
+            }
+            .padding(16)
+        }
+        .navigationTitle("Banner — all states")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func bannerStrip(_ variant: MigrationBannerVariant) -> some View {
+        MigrationBannerContentView(variant: variant, onButtonTap: {})
+            .padding(16)
+            .background {
+                LinearGradient(
+                    stops: [
+                        Gradient.Stop(color: Design.Utility.Purple._700.color(.light), location: 0.00),
+                        Gradient.Stop(color: Design.Utility.Purple._950.color(.light), location: 1.00)
+                    ],
+                    startPoint: UnitPoint(x: 0.5, y: 0.0),
+                    endPoint: UnitPoint(x: 0.5, y: 1.0)
+                )
+            }
+            .clipShape(RoundedRectangle(cornerRadius: Design.Radius._2xl))
+    }
+}
+
+#Preview {
+    MigrationDebugGalleryView()
+}
+
+#endif

--- a/secant/Sources/Features/MigrationDebugGallery/MigrationDebugGalleryView.swift
+++ b/secant/Sources/Features/MigrationDebugGallery/MigrationDebugGalleryView.swift
@@ -378,8 +378,8 @@ struct MigrationDebugGalleryView: View {
             .background {
                 LinearGradient(
                     stops: [
-                        Gradient.Stop(color: Design.Utility.Purple._700.color(.light), location: 0.00),
-                        Gradient.Stop(color: Design.Utility.Purple._950.color(.light), location: 1.00)
+                        Gradient.Stop(color: Design.Utility.Gray._700.color(.light), location: 0.00),
+                        Gradient.Stop(color: Design.Utility.Gray._950.color(.light), location: 1.00)
                     ],
                     startPoint: UnitPoint(x: 0.5, y: 0.0),
                     endPoint: UnitPoint(x: 0.5, y: 1.0)

--- a/secant/Sources/Features/MigrationDebugGallery/MigrationMockData.swift
+++ b/secant/Sources/Features/MigrationDebugGallery/MigrationMockData.swift
@@ -1,0 +1,233 @@
+//
+//  MigrationMockData.swift
+//  zodl
+//
+//  DEBUG-only fixtures for the Ironwood migration screens gallery (MOB-1465). Values mirror the
+//  Figma frames / each screen's own `#Preview` states so visual parity holds between the gallery
+//  and the screens' previews. Deduplicating the previews themselves onto this namespace is
+//  deliberately deferred (see MOB-1465 spec) — no churn on in-review migration screen PRs.
+//
+
+#if DEBUG
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+/// Centralized fixture values for `MigrationDebugGalleryView`.
+enum MigrationMockData {
+    // MARK: - Shared amounts
+
+    static let fiatText = "$4,832.86"
+    static let orchardBalance = Zatoshi(1_245_800_000)
+    static let fee = Zatoshi(100_000)
+    static let txId = "e87f1c02a94b7d3e6f5041c9b8a2d7e6f5041c9b8a2d7e6f5041c9b8a2d7e6f5"
+
+    /// The 5-transfer set from the Figma frames: 3.51220 / 2.87410 / 2.43100 / 1.99830 / 1.64240 ZEC.
+    static var freshRows: IdentifiedArrayOf<MigrationTransferRow> {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .active, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .pending, hoursFromNow: 6),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 18),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 24)
+        ]
+    }
+
+    /// The re-created variant's frame: two already sent, one active, two pending.
+    static var recreatedRows: IdentifiedArrayOf<MigrationTransferRow> {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 17),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .active, hoursFromNow: 0),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 6),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 12)
+        ]
+    }
+
+    /// Status progress frame: two sent, one active, two pending.
+    static var progressRows: IdentifiedArrayOf<MigrationTransferRow> {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .active, hoursFromNow: 6),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 12),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 18)
+        ]
+    }
+
+    /// The resume/re-scheduling frame: two sent, one overdue, two pending.
+    static var resumeRows: IdentifiedArrayOf<MigrationTransferRow> {
+        [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 18),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .sent, hoursFromNow: 11),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(243_100_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "3", index: 3, amount: Zatoshi(199_830_000), status: .pending, hoursFromNow: 1),
+            MigrationTransferRow(id: "4", index: 4, amount: Zatoshi(164_240_000), status: .pending, hoursFromNow: 7)
+        ]
+    }
+
+    // MARK: - Entry & Network Privacy
+
+    static var entryPrivacy: MigrationEntry.State {
+        MigrationEntry.State(
+            selectedMode: .privateScheduled,
+            orchardBalance: orchardBalance,
+            fiatText: fiatText
+        )
+    }
+
+    static var entryImmediate: MigrationEntry.State {
+        MigrationEntry.State(
+            selectedMode: .immediate,
+            orchardBalance: orchardBalance,
+            fiatText: fiatText
+        )
+    }
+
+    static var networkPrivacyImmediate: MigrationNetworkPrivacy.State {
+        MigrationNetworkPrivacy.State(variant: .immediate)
+    }
+
+    static var networkPrivacyScheduled: MigrationNetworkPrivacy.State {
+        MigrationNetworkPrivacy.State(variant: .scheduled(transferCount: 5), isTorOn: true)
+    }
+
+    // MARK: - Note Split
+
+    static var noteSplitExplainer: MigrationNoteSplit.State {
+        MigrationNoteSplit.State(phase: .explainer, amount: orchardBalance, fee: fee)
+    }
+
+    static var noteSplitSplitting: MigrationNoteSplit.State {
+        MigrationNoteSplit.State(phase: .splitting, amount: orchardBalance, fee: fee, txId: txId)
+    }
+
+    static var noteSplitConfirmed: MigrationNoteSplit.State {
+        MigrationNoteSplit.State(phase: .confirmed, amount: orchardBalance, fee: fee, txId: txId)
+    }
+
+    static var noteSplitFailure: MigrationNoteSplit.State {
+        MigrationNoteSplit.State(
+            phase: .splitting,
+            amount: orchardBalance,
+            fee: fee,
+            txId: txId,
+            isFailurePresented: true
+        )
+    }
+
+    // MARK: - Permissions
+
+    static var backgroundDelivery: MigrationBackgroundDelivery.State {
+        MigrationBackgroundDelivery.State()
+    }
+
+    static var notificationsScheduled: MigrationNotifications.State {
+        MigrationNotifications.State(variant: .scheduled)
+    }
+
+    static var notificationsManual: MigrationNotifications.State {
+        MigrationNotifications.State(variant: .manual)
+    }
+
+    // MARK: - Plan & Review
+
+    static var planScheduled: MigrationTransferPlan.State {
+        MigrationTransferPlan.State(variant: .scheduled, rows: freshRows, totalDurationHours: 24)
+    }
+
+    static var planManual: MigrationTransferPlan.State {
+        MigrationTransferPlan.State(variant: .manual, rows: freshRows, totalDurationHours: 24)
+    }
+
+    static var planRecreated: MigrationTransferPlan.State {
+        MigrationTransferPlan.State(variant: .recreated, rows: recreatedRows, totalDurationHours: 12)
+    }
+
+    static var reviewImmediate: MigrationReviewTransfer.State {
+        MigrationReviewTransfer.State(mode: .immediate, amount: orchardBalance, fee: fee)
+    }
+
+    static var reviewManualStep: MigrationReviewTransfer.State {
+        MigrationReviewTransfer.State(
+            mode: .manualStep(number: 3, total: 5),
+            amount: Zatoshi(243_100_000),
+            fee: fee
+        )
+    }
+
+    // MARK: - Sending & Scheduled
+
+    static var sending: MigrationSending.State {
+        MigrationSending.State(phase: .sending)
+    }
+
+    static var sent: MigrationSending.State {
+        MigrationSending.State(phase: .success, txId: txId)
+    }
+
+    static var sendingFailure: MigrationSending.State {
+        MigrationSending.State(phase: .sending, isFailurePresented: true)
+    }
+
+    static var migrationScheduled: MigrationScheduled.State {
+        MigrationScheduled.State(totalAmount: orchardBalance, sentCount: 0, totalCount: 5, durationHours: 24)
+    }
+
+    // MARK: - Status, Recovery & Complete
+
+    static var statusProgress: MigrationStatus.State {
+        MigrationStatus.State(presentation: .progress, rows: progressRows, totalDurationHours: 24)
+    }
+
+    static var statusResume: MigrationStatus.State {
+        MigrationStatus.State(
+            presentation: .resume,
+            rows: resumeRows,
+            totalDurationHours: 24,
+            stalledNumber: 3,
+            stalledHoursAgo: 5
+        )
+    }
+
+    static var statusRescheduling: MigrationStatus.State {
+        MigrationStatus.State(
+            presentation: .resume,
+            rows: resumeRows,
+            totalDurationHours: 24,
+            stalledNumber: 3,
+            stalledHoursAgo: 5,
+            isRescheduling: true
+        )
+    }
+
+    static var recoveryNotesSpent: MigrationRecovery.State {
+        MigrationRecovery.State(reason: .notesSpent, firstTransfer: 3, lastTransfer: 5)
+    }
+
+    static var recoveryExpired: MigrationRecovery.State {
+        MigrationRecovery.State(reason: .expired, firstTransfer: 3, lastTransfer: 5)
+    }
+
+    static var completeWithDust: MigrationComplete.State {
+        MigrationComplete.State(
+            totalTransferred: orchardBalance,
+            dust: Zatoshi(31_000),
+            transfersSent: 5,
+            transfersTotal: 5,
+            durationHours: 24
+        )
+    }
+
+    static var completeClean: MigrationComplete.State {
+        MigrationComplete.State(
+            totalTransferred: orchardBalance,
+            dust: .zero,
+            transfersSent: 5,
+            transfersTotal: 5,
+            durationHours: 24
+        )
+    }
+}
+
+#endif

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -246,10 +246,36 @@ extension Root {
                 state.walletBackupCoordFlowState = .initial
                 state.path = .walletBackup
                 return .none
-                
+
             case .home(.smartBanner(.serverSwitchRequested)):
                 state.serverSetupState = .initial
                 state.path = .serverSwitch
+                return .none
+
+                // MARK: - Migration Coord Flow
+
+            case .home(.smartBanner(.migrationScreenRequested)):
+                state.migrationCoordFlowState = MigrationCoordFlow.State.initial
+                state.path = .migrationCoordFlow
+                return .none
+
+            case .migrationCoordFlow(.flowFinished):
+                state.path = nil
+                return .none
+
+            case .migrationCoordFlow(
+                .path(.element(id: _, action: .sending(.delegate(.viewTransaction))))
+            ):
+                // The migration Sending delegate carries only a bare stub `txId: String`
+                // (`MigrationSending.State.txId`), never a real `TransactionState` — but
+                // `TransactionsCoordFlow`'s existing open-a-transaction plumbing (mirrored from
+                // `.home(.transactionList(.transactionTapped))` above) requires a non-optional
+                // `TransactionState` looked up from `state.transactions`, which a synthetic
+                // migration txid will never be a member of. Until the real SDK (MOB-1455) fills
+                // in migration transfers with transactions the rest of the app can see, treat
+                // View Transaction as a flow close rather than a broken/empty detail screen.
+                // TODO: [MOB-1458] route to transaction detail once real txids exist
+                state.path = nil
                 return .none
 
                 // MARK: - Keystone

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -66,10 +66,16 @@ extension Root {
                     }
                 }
                 state.appStartState = .willEnterForeground
+                // MOB-1466: reconcile migration state on every foreground entry (idempotent
+                // `initializeMigrationPostUpgrade()` + the stale-acknowledge reset) so a banner/
+                // re-entry route that changed while backgrounded is picked up promptly. Banner
+                // freshness itself stays reactive (SmartBanner's own subscription + walk) — this
+                // is deliberately the minimal Root-side hook the spec calls for.
+                let reconcileEffect: Effect<Action> = .run { [migrationManager] _ in migrationManager.reconcile() }
                 if state.isLockedInKeychainUnavailableState || !sdkSynchronizer.latestState().syncStatus.isPrepared {
-                    return .send(.initialization(.initialSetups))
+                    return .merge(reconcileEffect, .send(.initialization(.initialSetups)))
                 } else {
-                    return .send(.initialization(.retryStart))
+                    return .merge(reconcileEffect, .send(.initialization(.retryStart)))
                 }
                 
             case .initialization(.appDelegate(.didEnterBackground)):
@@ -253,7 +259,13 @@ extension Root {
                 // TODO: [#524] finish all the wallet events according to definition, https://github.com/Electric-Coin-Company/zashi-ios/issues/524
                 LoggerProxy.event(".appDelegate(.didFinishLaunching)")
                 /// We need to fetch data from keychain, in order to be 100% sure the keychain can be read we delay the check a bit
-                return .send(.initialization(.checkWalletInitialization))
+                return .merge(
+                    // MOB-1466: reconcile migration state once per launch — off the hot path
+                    // (`initializeMigrationPostUpgrade()` is idempotent), so it never blocks or
+                    // reorders the existing wallet-initialization sequence below.
+                    .run { [migrationManager] _ in migrationManager.reconcile() },
+                    .send(.initialization(.checkWalletInitialization))
+                )
 
                 /// Evaluate the wallet's state based on keychain keys and database files presence
             case .initialization(.checkWalletInitialization):

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -16,6 +16,7 @@ struct Root {
         enum Path {
             case addKeystoneHWWalletCoordFlow
             case currencyConversionSetup
+            case migrationCoordFlow
             case receive
             case requestZecCoordFlow
             case scanCoordFlow
@@ -101,6 +102,7 @@ struct Root {
 
         var addKeystoneHWWalletCoordFlowState = AddKeystoneHWWalletCoordFlow.State.initial
         var currencyConversionSetupState = CurrencyConversionSetup.State.initial
+        var migrationCoordFlowState = MigrationCoordFlow.State.initial
         var receiveState = Receive.State.initial
         var requestZecCoordFlowState = RequestZecCoordFlow.State.initial
         var scanCoordFlowState = ScanCoordFlow.State.initial
@@ -137,7 +139,7 @@ struct Root {
             // it; if voting ever gets its own `Path` case, move the sensitivity there.
             case .settings:
                 return true
-            case .sendCoordFlow, .scanCoordFlow, .swapAndPayCoordFlow, .transactionsCoordFlow:
+            case .migrationCoordFlow, .sendCoordFlow, .scanCoordFlow, .swapAndPayCoordFlow, .transactionsCoordFlow:
                 return true
             case .addKeystoneHWWalletCoordFlow, .currencyConversionSetup, .receive,
                  .requestZecCoordFlow, .serverSwitch, .torSetup, .walletBackup:
@@ -216,6 +218,7 @@ struct Root {
 
         case addKeystoneHWWalletCoordFlow(AddKeystoneHWWalletCoordFlow.Action)
         case currencyConversionSetup(CurrencyConversionSetup.Action)
+        case migrationCoordFlow(MigrationCoordFlow.Action)
         case receive(Receive.Action)
         case requestZecCoordFlow(RequestZecCoordFlow.Action)
         case scanCoordFlow(ScanCoordFlow.Action)
@@ -290,6 +293,7 @@ struct Root {
     @Dependency(\.flexaHandler) var flexaHandler
     @Dependency(\.localAuthentication) var localAuthentication
     @Dependency(\.mainQueue) var mainQueue
+    @Dependency(\.migrationManager) var migrationManager
     @Dependency(\.mnemonic) var mnemonic
     @Dependency(\.numberFormatter) var numberFormatter
     @Dependency(\.pasteboard) var pasteboard
@@ -371,6 +375,10 @@ struct Root {
         
         Scope(state: \.addKeystoneHWWalletCoordFlowState, action: \.addKeystoneHWWalletCoordFlow) {
             AddKeystoneHWWalletCoordFlow()
+        }
+
+        Scope(state: \.migrationCoordFlowState, action: \.migrationCoordFlow) {
+            MigrationCoordFlow()
         }
 
         Scope(state: \.transactionsCoordFlowState, action: \.transactionsCoordFlow) {

--- a/secant/Sources/Features/Root/RootView.swift
+++ b/secant/Sources/Features/Root/RootView.swift
@@ -202,6 +202,15 @@ private extension RootView {
                                 )
                                 .transition(.move(edge: .trailing))
                                 .zIndex(1)
+                            } else if path == .migrationCoordFlow {
+                                MigrationCoordFlowView(
+                                    store:
+                                        store.scope(
+                                            state: \.migrationCoordFlowState,
+                                            action: \.migrationCoordFlow)
+                                )
+                                .transition(.move(edge: .trailing))
+                                .zIndex(1)
                             } else if path == .currencyConversionSetup {
                                 NavigationStack {
                                     CurrencyConversionSetupView(

--- a/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
@@ -2,11 +2,10 @@
 //  SmartBannerMigrationContent.swift
 //  zodl
 //
-//  Ironwood migration content for the SmartBanner's `priorityMigration` case (MOB-1464). Visual-only:
-//  the case can never be requested by the running evaluator chain yet — wiring the real
-//  triggering/evaluators/routing is MOB-1466's job. `MigrationBannerVariant` is a pure, testable
-//  mapping (see MigrationBannerVariantTests); `migrationContent()` mirrors `shieldingContent()`'s
-//  structure.
+//  Ironwood migration content for the SmartBanner's `priorityMigration` case (MOB-1464), triggered
+//  live via the `.evaluatePriorityMigration` walk step and the `migrationStateStream()` subscription
+//  (MOB-1466 — see SmartBannerStore.swift). `MigrationBannerVariant` is a pure, testable mapping
+//  (see MigrationBannerVariantTests); `migrationContent()` mirrors `shieldingContent()`'s structure.
 //
 
 import SwiftUI
@@ -93,8 +92,10 @@ extension SmartBannerView {
 /// `MigrationBannerVariant` without hosting a live `SmartBannerView` (whose `onAppear` starts real
 /// dependency subscriptions). Tints use the Gray ramp (`utility-gray-50`/`-200`), matching the
 /// Figma migration-banner tokens — deliberately NOT `SmartBannerView.titleStyle()`/`infoStyle()`,
-/// which still use the pre-rebrand Purple ramp. When MOB-1466 hosts this content inside the live
-/// banner, the shared banner gradient (Purple._700 → ._950) likely needs the same Gray swap.
+/// which still use the pre-rebrand Purple ramp. Resolved by MOB-1466 (per-priority gradient, not an
+/// app-wide restyle): `SmartBannerView`'s background `LinearGradient` swaps to this same Gray._700
+/// → ._950 pair only while `store.priorityContent == .priorityMigration`; every other banner keeps
+/// the Purple._700 → ._950 pair unchanged.
 struct MigrationBannerContentView: View {
     let variant: MigrationBannerVariant
     let onButtonTap: () -> Void

--- a/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
@@ -91,18 +91,20 @@ extension SmartBannerView {
 /// Standalone rendering of the `priorityMigration` banner content, extracted from
 /// `SmartBannerView.migrationContent()` (MOB-1465) so the DEBUG migration gallery can render every
 /// `MigrationBannerVariant` without hosting a live `SmartBannerView` (whose `onAppear` starts real
-/// dependency subscriptions). Colors mirror `SmartBannerView.titleStyle()` / `infoStyle()`
-/// (`SmartBannerContent.swift`) inlined here since those helpers are `SmartBannerView` members.
+/// dependency subscriptions). Tints use the Gray ramp (`utility-gray-50`/`-200`), matching the
+/// Figma migration-banner tokens — deliberately NOT `SmartBannerView.titleStyle()`/`infoStyle()`,
+/// which still use the pre-rebrand Purple ramp. When MOB-1466 hosts this content inside the live
+/// banner, the shared banner gradient (Purple._700 → ._950) likely needs the same Gray swap.
 struct MigrationBannerContentView: View {
     let variant: MigrationBannerVariant
     let onButtonTap: () -> Void
 
     private var titleStyle: Color {
-        Design.Utility.Purple._50.color(.light)
+        Design.Utility.Gray._50.color(.light)
     }
 
     private var infoStyle: Color {
-        Design.Utility.Purple._200.color(.light)
+        Design.Utility.Gray._200.color(.light)
     }
 
     var body: some View {

--- a/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
@@ -82,56 +82,80 @@ enum MigrationBannerVariant: Equatable {
 
 extension SmartBannerView {
     @ViewBuilder func migrationContent() -> some View {
+        MigrationBannerContentView(variant: store.migrationBannerVariant) {
+            store.send(.smartBannerContentTapped)
+        }
+    }
+}
+
+/// Standalone rendering of the `priorityMigration` banner content, extracted from
+/// `SmartBannerView.migrationContent()` (MOB-1465) so the DEBUG migration gallery can render every
+/// `MigrationBannerVariant` without hosting a live `SmartBannerView` (whose `onAppear` starts real
+/// dependency subscriptions). Colors mirror `SmartBannerView.titleStyle()` / `infoStyle()`
+/// (`SmartBannerContent.swift`) inlined here since those helpers are `SmartBannerView` members.
+struct MigrationBannerContentView: View {
+    let variant: MigrationBannerVariant
+    let onButtonTap: () -> Void
+
+    private var titleStyle: Color {
+        Design.Utility.Purple._50.color(.light)
+    }
+
+    private var infoStyle: Color {
+        Design.Utility.Purple._200.color(.light)
+    }
+
+    var body: some View {
         HStack(spacing: 0) {
             migrationIcon()
                 .padding(.trailing, 12)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(store.migrationBannerVariant.title)
-                    .zFont(.medium, size: 14, color: titleStyle())
+                Text(variant.title)
+                    .zFont(.medium, size: 14, color: titleStyle)
 
-                Text(store.migrationBannerVariant.info)
-                    .zFont(.medium, size: 12, color: infoStyle())
+                Text(variant.info)
+                    .zFont(.medium, size: 12, color: infoStyle)
             }
 
             Spacer()
 
             ZashiButton(
-                store.migrationBannerVariant.buttonLabel,
+                variant.buttonLabel,
                 type: .ghost,
                 infinityWidth: false
             ) {
-                store.send(.smartBannerContentTapped)
+                onButtonTap()
             }
         }
     }
 
     @ViewBuilder private func migrationIcon() -> some View {
-        switch store.migrationBannerVariant {
+        switch variant {
         case .required, .splitting:
             Asset.Assets.Icons.coinsSwap.image
-                .zImage(size: 20, color: titleStyle())
+                .zImage(size: 20, color: titleStyle)
         case .inProgress:
             migrationProgressRing()
         case .transferWaiting, .updatePlan, .transfersExpired, .transferReady:
             Asset.Assets.Icons.alertCircle.image
-                .zImage(size: 20, color: titleStyle())
+                .zImage(size: 20, color: titleStyle)
         case .complete:
             Asset.Assets.Icons.checkVerified.image
-                .zImage(size: 20, color: titleStyle())
+                .zImage(size: 20, color: titleStyle)
         }
     }
 
     @ViewBuilder private func migrationProgressRing() -> some View {
-        let percent = store.migrationBannerVariant.percent ?? 0
+        let percent = variant.percent ?? 0
 
         ZStack {
             Circle()
-                .stroke(titleStyle().opacity(0.3), lineWidth: 2)
+                .stroke(titleStyle.opacity(0.3), lineWidth: 2)
 
             Circle()
                 .trim(from: 0, to: CGFloat(percent) / 100)
-                .stroke(titleStyle(), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .stroke(titleStyle, style: StrokeStyle(lineWidth: 2, lineCap: .round))
                 .rotationEffect(.degrees(-90))
         }
         .frame(width: 20, height: 20)

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -35,7 +35,7 @@ struct SmartBanner {
             case priority75 // tor
             case priority8 // currency conversion
             case priority9 // auto-shielding
-            case priorityMigration = -1 // ironwood migration (MOB-1464; not triggered yet — MOB-1466)
+            case priorityMigration = -1 // ironwood migration (MOB-1464; triggered — MOB-1466)
 
             func next() -> PriorityContent {
                 // `priorityMigration` (-1) sits outside the walk-down chain — it is only ever
@@ -43,10 +43,15 @@ struct SmartBanner {
                 guard rawValue > 0 else { return .priority9 }
                 return PriorityContent(rawValue: rawValue - 1) ?? .priority9
             }
+
+            /// Display rank — lower wins. `priorityMigration` slots between `priority2` (sync error)
+            /// and `priority3` (restoring): operational alerts outrank migration; migration outranks the rest.
+            var rank: Double { self == .priorityMigration ? 1.5 : Double(rawValue) }
         }
         
         var CancelNetworkMonitorId = UUID()
         var CancelStateStreamId = UUID()
+        var CancelMigrationStateStreamId = UUID()
         var CancelShieldingProcessorId = UUID()
 
         var isScanProgressComplete = false
@@ -118,6 +123,7 @@ struct SmartBanner {
         case onDisappear
         case evaluatePriority1
         case evaluatePriority2
+        case evaluatePriorityMigration
         case evaluatePriority3
         case evaluatePriority4
         case evaluatePriority45
@@ -127,6 +133,9 @@ struct SmartBanner {
         case evaluatePriority75
         case evaluatePriority8
         case evaluatePriority9
+        case migrationStateChanged(MigrationState)
+        case migrationVariantLoaded(MigrationBannerVariant?)
+        case migrationVariantUpdated(MigrationBannerVariant?)
         case networkMonitorChanged(Bool)
         case openBanner
         case openBannerRequest
@@ -146,6 +155,7 @@ struct SmartBanner {
         case autoShieldingTapped
         case currencyConversionScreenRequested
         case currencyConversionTapped
+        case migrationScreenRequested
         case serverSwitchRequested
         case shieldFundsTapped
         case torSettingsRequested
@@ -155,6 +165,7 @@ struct SmartBanner {
     }
 
     @Dependency(\.mainQueue) var mainQueue
+    @Dependency(\.migrationManager) var migrationManager
     @Dependency(\.networkMonitor) var networkMonitor
     @Dependency(\.sdkSynchronizer) var sdkSynchronizer
     @Dependency(\.shieldingProcessor) var shieldingProcessor
@@ -195,6 +206,12 @@ struct SmartBanner {
                     }
                     .cancellable(id: state.CancelStateStreamId, cancelInFlight: true),
                     .publisher {
+                        sdkSynchronizer.migrationStateStream()
+                            .throttle(for: .seconds(0.2), scheduler: mainQueue, latest: true)
+                            .map(Action.migrationStateChanged)
+                    }
+                    .cancellable(id: state.CancelMigrationStateStreamId, cancelInFlight: true),
+                    .publisher {
                         shieldingProcessor.observe()
                             .map(Action.shieldingProcessorStateChanged)
                     }
@@ -206,6 +223,7 @@ struct SmartBanner {
                 return .merge(
                     .cancel(id: state.CancelNetworkMonitorId),
                     .cancel(id: state.CancelStateStreamId),
+                    .cancel(id: state.CancelMigrationStateStreamId),
                     .cancel(id: state.CancelShieldingProcessorId)
                 )
 
@@ -300,6 +318,8 @@ struct SmartBanner {
                     return .send(.torSetupScreenRequested)
                 } else if state.priorityContent == .priority8 {
                     return .send(.currencyConversionScreenRequested)
+                } else if state.priorityContent == .priorityMigration {
+                    return .send(.migrationScreenRequested)
                 } else if state.isSyncTimedOut {
                     state.isSyncTimedOutSheetPresented = true
                     return .none
@@ -411,7 +431,11 @@ struct SmartBanner {
                     }
                     
                     // return of restoring/syncing
-                    let isSyncingHigherPriority = (state.priorityContent?.rawValue ?? 0) > State.PriorityContent.priority4.rawValue
+                    // `rank` (not `rawValue`) so `priorityMigration`'s rank (1.5, between priority2
+                    // and priority3) correctly keeps this branch from replacing a showing migration
+                    // banner with priority3/priority4 — `rawValue` (-1) would give the same numeric
+                    // answer here today only by coincidence.
+                    let isSyncingHigherPriority = (state.priorityContent?.rank ?? 0) > State.PriorityContent.priority4.rank
                     if isSyncing && (state.priorityContent == nil || isSyncingHigherPriority) {
                         if state.walletStatus == .resyncing {
                             //return .send(.triggerPriority(.priority45))
@@ -425,13 +449,51 @@ struct SmartBanner {
 
                 return .none
 
+            case .migrationStateChanged:
+                // The stream only tells us migration state changed, not what it resolved to — the
+                // manager owns the state->variant derivation (balances, persistence, transfer rows),
+                // so recompute the same way the walk step does, via `migrationManager.bannerVariant`.
+                return .run { [accountUUID = state.selectedWalletAccount?.id] send in
+                    await send(.migrationVariantUpdated(migrationManager.bannerVariant(accountUUID)))
+                }
+
+            case .migrationVariantUpdated(let variant):
+                if let variant {
+                    state.migrationBannerVariant = variant
+                    if state.priorityContent != .priorityMigration {
+                        return .send(.triggerPriority(.priorityMigration))
+                    }
+                    // Already showing migration — content re-renders from the updated variant
+                    // alone; re-triggering would just be rejected by the `openBannerRequest`
+                    // rank guard anyway (equal rank), so skip the round trip.
+                    return .none
+                }
+                if state.priorityContent == .priorityMigration {
+                    // Send `.closeBanner(true)` directly rather than `.closeAndCleanupBanner` —
+                    // the latter wraps its send in its own `.run`, which only schedules that
+                    // nested effect rather than awaiting it, so a second `await send(...)` right
+                    // after it would race the close instead of running after it settles (the same
+                    // reason `.walletAccountChanged` above sends `.closeBanner(true)` directly).
+                    return .run { send in
+                        await send(.closeBanner(true), animation: .easeInOut(duration: Constants.easeInOutDuration))
+                        await send(.evaluatePriority1)
+                    }
+                }
+                return .none
+
                 // disconnected
             case .evaluatePriority1:
                 return .send(.evaluatePriority2)
 
                 // syncing error
             case .evaluatePriority2:
-                return .send(.evaluatePriority3)
+                return .send(.evaluatePriorityMigration)
+
+                // ironwood migration
+            case .evaluatePriorityMigration:
+                return .run { [accountUUID = state.selectedWalletAccount?.id] send in
+                    await send(.migrationVariantLoaded(migrationManager.bannerVariant(accountUUID)))
+                }
 
                 // restoring
             case .evaluatePriority3:
@@ -541,7 +603,14 @@ struct SmartBanner {
                 // auto-shielding
             case .evaluatePriority9:
                 return .none
-                
+
+            case .migrationVariantLoaded(let variant):
+                guard let variant else {
+                    return .send(.evaluatePriority3)
+                }
+                state.migrationBannerVariant = variant
+                return .send(.triggerPriority(.priorityMigration))
+
             case .triggerPriority(let priority):
                 state.priorityContentRequested = priority
                 return .send(.openBannerRequest)
@@ -554,7 +623,7 @@ struct SmartBanner {
                 guard let priorityContentRequested = state.priorityContentRequested else {
                     return .none
                 }
-                if let priorityContent = state.priorityContent, priorityContentRequested.rawValue >= priorityContent.rawValue {
+                if let priorityContent = state.priorityContent, priorityContentRequested.rank >= priorityContent.rank {
                     return .none
                 }
                 if state.isOpen {
@@ -596,6 +665,12 @@ struct SmartBanner {
                 
             case .currencyConversionTapped:
                 return .send(.smartBannerContentTapped)
+
+            case .migrationScreenRequested:
+                // No state change here — Root intercepts this leaf action to open
+                // `MigrationCoordFlow` (MOB-1466 phase 5), the same shape as
+                // `currencyConversionScreenRequested` / `torSetupScreenRequested` above.
+                return .none
 
             case .torSetupScreenRequested:
                 return .none

--- a/secant/Sources/Features/SmartBanner/SmartBannerView.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerView.swift
@@ -81,7 +81,12 @@ struct SmartBannerView: View {
                         .frame(height: 2)
                         .frame(maxWidth: .infinity)
                     LinearGradient(
-                        stops: [
+                        stops: store.priorityContent == .priorityMigration
+                        ? [
+                            Gradient.Stop(color: Design.Utility.Gray._700.color(.light), location: 0.00),
+                            Gradient.Stop(color: Design.Utility.Gray._950.color(.light), location: 1.00)
+                        ]
+                        : [
                             Gradient.Stop(color: Design.Utility.Purple._700.color(.light), location: 0.00),
                             Gradient.Stop(color: Design.Utility.Purple._950.color(.light), location: 1.00)
                         ],

--- a/secant/Sources/Generated/SharedStateKeys.swift
+++ b/secant/Sources/Generated/SharedStateKeys.swift
@@ -27,4 +27,10 @@ public extension String {
     static let hasSeenHowToVoteKeystone = "sharedStateKey_hasSeenHowToVoteKeystone"
     static let votingConfigOverrideURL = "sharedStateKey_votingConfigOverrideURL"
     static let votingCustomChains = "sharedStateKey_votingCustomChains"
+    static let migrationMode = "sharedStateKey_migrationMode"
+    static let migrationManualDelivery = "sharedStateKey_migrationManualDelivery"
+    static let migrationNetworkPrivacyOptions = "sharedStateKey_migrationNetworkPrivacyOptions"
+    static let migrationCompleteAcknowledged = "sharedStateKey_migrationCompleteAcknowledged"
+    static let migrationLastBroadcastAt = "sharedStateKey_migrationLastBroadcastAt"
+    static let migrationSyncGateUntil = "sharedStateKey_migrationSyncGateUntil"
 }

--- a/zodlTests/MigrationTests/MigrationBackgroundDeliveryTests.swift
+++ b/zodlTests/MigrationTests/MigrationBackgroundDeliveryTests.swift
@@ -4,13 +4,16 @@
 //
 //  Covers the MigrationBackgroundDelivery reducer
 //  (Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift) for
-//  MOB-1462: the `skipTapped` delegate contract, and that `allowTapped` / `scenePhaseActive` are
-//  no-ops for now — the Settings deep-link and BAR re-check land in MOB-1466. No shared/global
-//  state -> no `.serialized`.
+//  MOB-1462/1466: the `skipTapped` delegate contract, that `allowTapped` produces no state/effects
+//  (the Settings deep-link opens from the view via `@Environment(\.openURL)`), and (MOB-1466)
+//  `scenePhaseActive` re-checking `MigrationBGSchedulerClient.backgroundRefreshStatus()` and
+//  auto-advancing via `.continued(backgroundAllowed: true)` once it becomes `.available`. No
+//  shared/global state -> no `.serialized`.
 //
 
 import Testing
 import Foundation
+import UIKit
 import ComposableArchitecture
 @testable import zodl_internal
 
@@ -32,19 +35,42 @@ import ComposableArchitecture
         await store.send(.allowTapped)
     }
 
-    @MainActor @Test func scenePhaseActiveProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
-            MigrationBackgroundDelivery()
-        }
-
-        await store.send(.scenePhaseActive)
-    }
-
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
         let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
             MigrationBackgroundDelivery()
         }
 
         await store.send(.delegate(.continued(backgroundAllowed: false)))
+    }
+
+    @MainActor @Test func scenePhaseActiveWithAvailableStatusEmitsDelegateContinuedAllowed() async {
+        let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
+            MigrationBackgroundDelivery()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+        }
+
+        await store.send(.scenePhaseActive)
+        await store.receive(.delegate(.continued(backgroundAllowed: true)))
+    }
+
+    @MainActor @Test func scenePhaseActiveWithDeniedStatusProducesNoDelegate() async {
+        let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
+            MigrationBackgroundDelivery()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .denied }
+        }
+
+        await store.send(.scenePhaseActive)
+    }
+
+    @MainActor @Test func scenePhaseActiveWithRestrictedStatusProducesNoDelegate() async {
+        let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
+            MigrationBackgroundDelivery()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .restricted }
+        }
+
+        await store.send(.scenePhaseActive)
     }
 }

--- a/zodlTests/MigrationTests/MigrationCompleteTests.swift
+++ b/zodlTests/MigrationTests/MigrationCompleteTests.swift
@@ -3,9 +3,12 @@
 //  zodlTests
 //
 //  Covers the MigrationComplete reducer
-//  (Features/Migration/MigrationComplete/MigrationCompleteStore.swift) for MOB-1464: the `hasDust`
-//  derivation at zero/nonzero dust, and the `gotItTapped` delegate contract. Visual-only screen —
-//  no SDK calls, no navigation. No shared/global state -> no `.serialized`.
+//  (Features/Migration/MigrationComplete/MigrationCompleteStore.swift) for MOB-1464/1466: the
+//  `hasDust` derivation at zero/nonzero dust, and the `gotItTapped` delegate contract. This screen
+//  has no back control at all (`.navigationBarBackButtonHidden()`, no custom leading toolbar item)
+//  — `isFlowRoot` is added to State for coordinator-injection consistency with the other re-entry
+//  roots, but there is no back-control behavior to gate here. No SDK calls, no navigation. No
+//  shared/global state -> no `.serialized`.
 //
 
 import Testing
@@ -24,6 +27,7 @@ import ComposableArchitecture
         #expect(state.transfersTotal == 0)
         #expect(state.durationHours == 0)
         #expect(state.hasDust == false)
+        #expect(state.isFlowRoot == false)
     }
 
     @MainActor @Test func hasDustIsFalseWhenDustIsZero() async {

--- a/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
@@ -1,0 +1,865 @@
+//
+//  MigrationCoordFlowTests.swift
+//  zodlTests
+//
+//  Covers `MigrationCoordFlow` (Features/CoordFlows/MigrationCoordFlow{Store,Coordinator}.swift)
+//  for MOB-1466: re-entry routing (`.onAppear`), the chaining table from Entry through Complete
+//  for all three modes (immediate/scheduled/manual), the permission-step helper's skip logic,
+//  sendNow/reschedule/recovery orchestration, and every flow-root close path's `.flowFinished`
+//  emission. `.serialized`: every `MigrationCoordFlow.State()` carries a `MigrationEntry.State`
+//  (`entryState`), which reads the process-global `@Shared(.inMemory(.selectedWalletAccount))` on
+//  init — matching the precedent in `MigrationEntryTests`, which mutates the same key directly.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) struct MigrationCoordFlowTests {
+    // MARK: - Re-entry: .onAppear with empty path
+
+    @MainActor @Test func onAppearWithEntryRouteAppendsNothing() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .entry }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        #expect(store.state.path.isEmpty)
+    }
+
+    @MainActor @Test func onAppearWithStatusProgressRouteAppendsFlowRootStatusScreen() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)
+        ]
+        let summary = MigrationSummary(
+            transferred: Zatoshi.zero,
+            dust: Zatoshi.zero,
+            transfersSent: 0,
+            transfersTotal: 1,
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .statusProgress }
+            $0.migrationManager.sendGate = { .allowed }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.sdkSynchronizer.migrationSummary = { summary }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        #expect(store.state.path.count == 1)
+        guard case let .status(statusState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .status as the only path element")
+            return
+        }
+        #expect(statusState.presentation == MigrationStatus.State.Presentation.progress)
+        #expect(statusState.isFlowRoot == true)
+        #expect(statusState.rows == IdentifiedArrayOf(uniqueElements: rows))
+        #expect(statusState.totalDurationHours == 24)
+    }
+
+    @MainActor @Test func onAppearWithRecoveryNotExpiredRouteAppendsFlowRootRecoveryScreen() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .invalid, hoursFromNow: 0),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(1_000), status: .invalid, hoursFromNow: 0)
+        ]
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .recovery(isExpired: false) }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .recovery(recoveryState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .recovery on the path")
+            return
+        }
+        #expect(recoveryState.reason == MigrationRecovery.State.Reason.notesSpent)
+        #expect(recoveryState.isFlowRoot == true)
+        #expect(recoveryState.firstTransfer == 2)
+        #expect(recoveryState.lastTransfer == 3)
+    }
+
+    @MainActor @Test func onAppearWithRecoveryExpiredRouteAppendsFlowRootRecoveryScreenWithExpiredReason() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .recovery(isExpired: true) }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { [] }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .recovery(recoveryState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .recovery on the path")
+            return
+        }
+        #expect(recoveryState.reason == MigrationRecovery.State.Reason.expired)
+        #expect(recoveryState.isFlowRoot == true)
+    }
+
+    @MainActor @Test func onAppearWithStatusResumeRouteAppendsFlowRootStatusScreenInResumePresentation() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .overdue, hoursFromNow: 5)
+        ]
+        let summary = MigrationSummary(
+            transferred: Zatoshi.zero,
+            dust: Zatoshi.zero,
+            transfersSent: 1,
+            transfersTotal: 2,
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .statusResume }
+            $0.migrationManager.sendGate = { .syncRequired }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.sdkSynchronizer.migrationSummary = { summary }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .status(statusState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .status on the path")
+            return
+        }
+        #expect(statusState.presentation == MigrationStatus.State.Presentation.resume)
+        #expect(statusState.isFlowRoot == true)
+        #expect(statusState.stalledNumber == 2)
+        #expect(statusState.stalledHoursAgo == 5)
+        #expect(statusState.isSendNowDisabled == true)
+    }
+
+    @MainActor @Test func onAppearWithCompleteRouteAppendsFlowRootCompleteScreen() async {
+        let summary = MigrationSummary(
+            transferred: Zatoshi(1_245_800_000),
+            dust: Zatoshi(31_000),
+            transfersSent: 5,
+            transfersTotal: 5,
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .complete }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationSummary = { summary }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .complete(completeState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .complete on the path")
+            return
+        }
+        #expect(completeState.isFlowRoot == true)
+        #expect(completeState.totalTransferred == Zatoshi(1_245_800_000))
+        #expect(completeState.dust == Zatoshi(31_000))
+        #expect(completeState.transfersSent == 5)
+        #expect(completeState.transfersTotal == 5)
+        #expect(completeState.durationHours == 24)
+    }
+
+    @MainActor @Test func onAppearWithNoteSplitProgressRouteAppendsFlowRootSplittingScreen() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .noteSplitProgress }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .noteSplit(noteSplitState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .noteSplit on the path")
+            return
+        }
+        #expect(noteSplitState.phase == MigrationNoteSplit.State.Phase.splitting)
+        #expect(noteSplitState.isFlowRoot == true)
+    }
+
+    @MainActor @Test func onAppearWithReviewManualRouteAppendsFlowRootManualStepReviewScreen() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(2_000), status: .active, hoursFromNow: 0)
+        ]
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .reviewManual(step: 2, total: 5) }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .reviewTransfer(reviewState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .reviewTransfer on the path")
+            return
+        }
+        #expect(reviewState.mode == MigrationReviewTransfer.State.Mode.manualStep(number: 2, total: 5))
+        #expect(reviewState.isFlowRoot == true)
+        #expect(reviewState.amount == Zatoshi(2_000))
+        #expect(reviewState.fee == Zatoshi(100_000))
+    }
+
+    // MARK: - Immediate flow (§6.1)
+
+    @MainActor @Test func entryChoseImmediateWithTorFlagOnSkipsNetworkPrivacyAndPushesReview() async {
+        let setMigrationModeCalls = LockIsolated<[MigrationMode]>([])
+        let selectMigrationModeCalls = LockIsolated<[MigrationMode]>([])
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setMigrationMode = { mode in setMigrationModeCalls.withValue { $0.append(mode) } }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.selectMigrationMode = { mode in selectMigrationModeCalls.withValue { $0.append(mode) } }
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { true }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.entry(.delegate(.chose(.immediate))))
+
+        #expect(store.state.mode == MigrationMode.immediate)
+        #expect(setMigrationModeCalls.value == [MigrationMode.immediate])
+        #expect(selectMigrationModeCalls.value == [MigrationMode.immediate])
+        #expect(store.state.networkPrivacyOptions.useTor == true)
+        guard case let .reviewTransfer(reviewState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .reviewTransfer on the path (NetworkPrivacy skipped)")
+            return
+        }
+        #expect(reviewState.mode == MigrationReviewTransfer.State.Mode.immediate)
+    }
+
+    @MainActor @Test func entryChoseImmediateWithTorFlagOffShowsNetworkPrivacy() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setMigrationMode = { _ in }
+            $0.sdkSynchronizer = .noOp
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { false }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.entry(.delegate(.chose(.immediate))))
+
+        guard case let .networkPrivacy(networkPrivacyState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .networkPrivacy on the path (Tor flag off)")
+            return
+        }
+        #expect(networkPrivacyState.variant == MigrationNetworkPrivacy.State.Variant.immediate)
+    }
+
+    @MainActor @Test func networkPrivacyConfirmedInImmediateModePushesReviewTransferImmediate() async {
+        let setOptionsCalls = LockIsolated<[NetworkPrivacyOptions]>([])
+        var state = MigrationCoordFlow.State()
+        state.mode = .immediate
+        state.path.append(.networkPrivacy(MigrationNetworkPrivacy.State(variant: .immediate)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setNetworkPrivacyOptions = { options in setOptionsCalls.withValue { $0.append(options) } }
+        }
+        store.exhaustivity = .off
+
+        let options = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        await store.send(.path(.element(id: 0, action: .networkPrivacy(.delegate(.confirmed(options))))))
+
+        #expect(setOptionsCalls.value == [options])
+        #expect(store.state.networkPrivacyOptions == options)
+        guard case let .reviewTransfer(reviewState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .reviewTransfer pushed on top")
+            return
+        }
+        #expect(reviewState.mode == MigrationReviewTransfer.State.Mode.immediate)
+    }
+
+    @MainActor @Test func networkPrivacyConfirmedInScheduledModePushesTransferPlan() async {
+        var state = MigrationCoordFlow.State()
+        state.mode = .privateScheduled
+        state.path.append(.networkPrivacy(MigrationNetworkPrivacy.State(variant: .scheduled(transferCount: 5))))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setNetworkPrivacyOptions = { _ in }
+        }
+        store.exhaustivity = .off
+
+        let options = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        await store.send(.path(.element(id: 0, action: .networkPrivacy(.delegate(.confirmed(options))))))
+
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan pushed on top")
+            return
+        }
+        #expect(planState.variant == MigrationTransferPlan.State.Variant.scheduled)
+    }
+
+    @MainActor @Test func reviewTransferConfirmedPushesSending() async {
+        var state = MigrationCoordFlow.State()
+        state.mode = .immediate
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .reviewTransfer(.delegate(.confirmed)))))
+
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed on top")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
+        #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    @MainActor @Test func sendingClosedInImmediateModeAcknowledgesCompleteAndFinishesFlow() async {
+        let acknowledgeCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.mode = .immediate
+        state.path.append(.sending(MigrationSending.State(phase: .success)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.acknowledgeComplete = { acknowledgeCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .sending(.delegate(.closed)))))
+        await store.receive(\.flowFinished)
+
+        #expect(acknowledgeCalls.value == 1)
+    }
+
+    // MARK: - Scheduled flow (§6.2): note-split skip
+
+    @MainActor @Test func entryChoseScheduledWithNoteSplitNeededPushesNoteSplit() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setMigrationMode = { _ in }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.isNoteSplitNeeded = { true }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.entry(.delegate(.chose(.privateScheduled))))
+
+        guard case .noteSplit = try? #require(store.state.path.last) else {
+            Issue.record("Expected .noteSplit pushed (note split needed)")
+            return
+        }
+    }
+
+    @MainActor @Test func entryChoseScheduledWithoutNoteSplitNeededGoesStraightToPermissionSteps() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+            $0.userNotifications.authorizationStatus = { .authorized }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.isNoteSplitNeeded = { false }
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { true }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.entry(.delegate(.chose(.privateScheduled))))
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan pushed (all permission steps skipped)")
+            return
+        }
+        #expect(planState.variant == MigrationTransferPlan.State.Variant.scheduled)
+        #expect(store.state.networkPrivacyOptions.useTor == true)
+    }
+
+    // MARK: - Scheduled flow (§6.2): permission-step skip combinations
+
+    @MainActor @Test func noteSplitContinuedWithAllPermissionStepsNeededPushesBackgroundDelivery() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .confirmed)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .denied }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .noteSplit(.delegate(.continued)))))
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case .backgroundDelivery = try? #require(store.state.path.last) else {
+            Issue.record("Expected .backgroundDelivery pushed (background refresh not available)")
+            return
+        }
+    }
+
+    @MainActor @Test func noteSplitFlowRootCloseFinishesFlowInsteadOfContinuingPermissionSteps() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .splitting, isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        // Same `.continued` delegate value as a normal continue, but `closeTapped` on a flow-root
+        // splitting screen — must finish the flow, not proceed to permission-step routing.
+        await store.send(.path(.element(id: 0, action: .noteSplit(.delegate(.continued)))))
+        await store.receive(\.flowFinished)
+    }
+
+    @MainActor @Test func backgroundDeliveryDeclinedSetsManualDeliveryAndContinuesToNotifications() async {
+        let setManualDeliveryCalls = LockIsolated<[Bool]>([])
+        var state = MigrationCoordFlow.State()
+        state.path.append(.backgroundDelivery(MigrationBackgroundDelivery.State()))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setManualDelivery = { allowed in setManualDeliveryCalls.withValue { $0.append(allowed) } }
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+            $0.userNotifications.authorizationStatus = { .notDetermined }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .backgroundDelivery(.delegate(.continued(backgroundAllowed: false))))))
+        await store.receive(\.pushNextPermissionStep)
+
+        #expect(setManualDeliveryCalls.value == [true])
+        guard case .notifications = try? #require(store.state.path.last) else {
+            Issue.record("Expected .notifications pushed (authorization not determined)")
+            return
+        }
+    }
+
+    @MainActor @Test func notificationsContinuedWithTorFlagOffPushesNetworkPrivacyScheduledVariant() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .pending, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .pending, hoursFromNow: 0)
+        ]
+        var state = MigrationCoordFlow.State()
+        state.path.append(.notifications(MigrationNotifications.State()))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+            $0.userNotifications.authorizationStatus = { .authorized }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { false }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .notifications(.delegate(.continued)))))
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .networkPrivacy(networkPrivacyState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .networkPrivacy pushed (Tor flag off)")
+            return
+        }
+        #expect(networkPrivacyState.variant == MigrationNetworkPrivacy.State.Variant.scheduled(transferCount: 2))
+    }
+
+    @MainActor @Test func allPermissionStepsSkippedGoesStraightToTransferPlanWithForcedTor() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.notifications(MigrationNotifications.State()))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+            $0.userNotifications.authorizationStatus = { .denied }
+            $0.sdkSynchronizer = .noOp
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { true }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .notifications(.delegate(.continued)))))
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case .transferPlan = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan pushed (all permission steps skipped)")
+            return
+        }
+        #expect(store.state.networkPrivacyOptions.useTor == true)
+    }
+
+    // MARK: - Scheduled flow (§6.2): plan confirm -> Scheduled
+
+    @MainActor @Test func transferPlanConfirmedInScheduledVariantSchedulesFirstWindowAndPushesScheduled() async {
+        let scheduleFirstWindowCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.scheduleFirstWindow = { scheduleFirstWindowCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.confirmed)))))
+
+        #expect(scheduleFirstWindowCalls.value == 1)
+        guard case .scheduled = try? #require(store.state.path.last) else {
+            Issue.record("Expected .scheduled pushed")
+            return
+        }
+    }
+
+    @MainActor @Test func scheduledDoneFinishesFlow() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.scheduled(MigrationScheduled.State()))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .scheduled(.delegate(.done)))))
+        await store.receive(\.flowFinished)
+    }
+
+    // MARK: - Manual flow (§6.3)
+
+    @MainActor @Test func transferPlanConfirmedInManualVariantSchedulesFirstWindowAndPushesSendingWithTotalCountOne() async {
+        let scheduleFirstWindowCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .manual)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.scheduleFirstWindow = { scheduleFirstWindowCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.confirmed)))))
+
+        #expect(scheduleFirstWindowCalls.value == 1)
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
+        #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    @MainActor @Test func sendingClosedInManualModeWithNoStatusBeneathPushesFreshStatus() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0)
+        ]
+        let summary = MigrationSummary(
+            transferred: Zatoshi(1_000),
+            dust: Zatoshi.zero,
+            transfersSent: 1,
+            transfersTotal: 1,
+            estimatedDurationHours: 24
+        )
+        var state = MigrationCoordFlow.State()
+        state.mode = .privateScheduled
+        state.path.append(.sending(MigrationSending.State(phase: .success)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.sendGate = { .allowed }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.sdkSynchronizer.migrationSummary = { summary }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .sending(.delegate(.closed)))))
+        await store.receive(\.pushHydratedStatus)
+
+        #expect(store.state.path.count == 2)
+        guard case let .status(statusState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .status pushed on top of the (still-present) .sending element")
+            return
+        }
+        #expect(statusState.presentation == MigrationStatus.State.Presentation.progress)
+        #expect(statusState.isFlowRoot == false)
+    }
+
+    // MARK: - sendNow: overdue count drives Sending totalCount, completion returns to Status
+
+    @MainActor @Test func statusSendNowPushesSendingConfiguredForOverdueCount() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(1_000), status: .overdue, hoursFromNow: 3)
+        ]
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.path.append(.status(MigrationStatus.State(presentation: .resume, isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .status(.delegate(.sendNow)))))
+        await store.receive(\.pushHydratedPathState)
+
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed")
+            return
+        }
+        #expect(sendingState.totalCount == 2)
+        #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    @MainActor @Test func sendingClosedAfterSendNowPopsBackToStatusWithRefreshedRows() async {
+        let refreshedRows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0)
+        ]
+        var state = MigrationCoordFlow.State()
+        state.path.append(.status(MigrationStatus.State(presentation: .resume, isFlowRoot: true)))
+        state.path.append(.sending(MigrationSending.State(phase: .success, totalCount: 2)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { refreshedRows }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 1, action: .sending(.delegate(.closed)))))
+        await store.receive(\.sendNowCompleted)
+
+        #expect(store.state.path.count == 1)
+        guard case let .status(statusState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending popped, .status remaining on top")
+            return
+        }
+        #expect(statusState.rows == IdentifiedArrayOf(uniqueElements: refreshedRows))
+        #expect(statusState.isFlowRoot == true)
+    }
+
+    // MARK: - Reschedule: SDK + scheduler spies called in order, rescheduled plan pushed
+
+    @MainActor @Test func statusRescheduleSetsIsReschedulingCallsSDKAndSchedulerThenPushesPlan() async {
+        let callOrder = LockIsolated<[String]>([])
+        let refreshedRows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)
+        ]
+        var state = MigrationCoordFlow.State()
+        state.path.append(.status(MigrationStatus.State(presentation: .resume, isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.rescheduleStalledMigrationTransfer = {
+                callOrder.withValue { $0.append("reschedule") }
+            }
+            $0.sdkSynchronizer.migrationTransfers = { refreshedRows }
+            $0.migrationBGScheduler.scheduleFirstWindow = { callOrder.withValue { $0.append("scheduleFirstWindow") } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .status(.delegate(.reschedule)))))
+        await store.receive(\.pushHydratedPathState)
+
+        #expect(callOrder.value == ["reschedule", "scheduleFirstWindow"])
+        guard case let .status(statusState) = try? #require(store.state.path[id: 0]) else {
+            Issue.record("Expected .status still at the bottom of the path with isRescheduling set")
+            return
+        }
+        #expect(statusState.isRescheduling == true)
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan (rescheduled) pushed")
+            return
+        }
+        #expect(planState.requiresSigning == false)
+        #expect(planState.rows == IdentifiedArrayOf(uniqueElements: refreshedRows))
+    }
+
+    @MainActor @Test func rescheduledPlanConfirmDoesNotSignAndFinishesFlow() async {
+        let signCalls = LockIsolated<Int>(0)
+        var planState = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: false)
+        planState.rows = [MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)]
+        let store = TestStore(initialState: planState) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in signCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signCalls.value == 0)
+    }
+
+    @MainActor @Test func rescheduledPlanConfirmedInCoordinatorFinishesFlowWithoutPushingScheduled() async {
+        let scheduleFirstWindowCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled, requiresSigning: false)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.scheduleFirstWindow = { scheduleFirstWindowCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.confirmed)))))
+        await store.receive(\.flowFinished)
+
+        #expect(scheduleFirstWindowCalls.value == 0)
+    }
+
+    // MARK: - Recovery: restartCurrentMigrationStep spy, re-created plan injected, its confirm DOES sign
+
+    @MainActor @Test func recoveryRecreateCallsRestartAndPushesRecreatedPlanWithInjectedSchedule() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        let restartCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.path.append(.recovery(MigrationRecovery.State(isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.restartCurrentMigrationStep = {
+                restartCalls.withValue { $0 += 1 }
+                return schedule
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .recovery(.delegate(.recreate)))))
+        await store.receive(\.pushHydratedPathState)
+
+        #expect(restartCalls.value == 1)
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan (re-created) pushed")
+            return
+        }
+        #expect(planState.variant == MigrationTransferPlan.State.Variant.recreated)
+        #expect(planState.injectedSchedule == schedule)
+        #expect(planState.requiresSigning == true)
+    }
+
+    @MainActor @Test func recreatedPlanConfirmDoesSign() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        var planState = MigrationTransferPlan.State(variant: .recreated)
+        planState.schedule = schedule
+        let signedSchedule = LockIsolated<MigrationSchedule?>(nil)
+        let store = TestStore(initialState: planState) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { signedSchedule.setValue($0) }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signedSchedule.value == schedule)
+    }
+
+    // MARK: - Every flow-root back -> .flowFinished
+
+    @MainActor @Test func statusDoneFinishesFlow() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.status(MigrationStatus.State(isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .status(.delegate(.done)))))
+        await store.receive(\.flowFinished)
+    }
+
+    @MainActor @Test func recoveryCloseFinishesFlow() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.recovery(MigrationRecovery.State(isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .recovery(.delegate(.close)))))
+        await store.receive(\.flowFinished)
+    }
+
+    @MainActor @Test func reviewTransferClosedFinishesFlow() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(
+            .reviewTransfer(MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5), isFlowRoot: true))
+        )
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .reviewTransfer(.delegate(.closed)))))
+        await store.receive(\.flowFinished)
+    }
+
+    @MainActor @Test func completeDoneAcknowledgesCompleteAndFinishesFlow() async {
+        let acknowledgeCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.path.append(.complete(MigrationComplete.State(isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.acknowledgeComplete = { acknowledgeCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .complete(.delegate(.done)))))
+        await store.receive(\.flowFinished)
+
+        #expect(acknowledgeCalls.value == 1)
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
@@ -327,6 +327,28 @@ import ComposableArchitecture
         #expect(planState.variant == MigrationTransferPlan.State.Variant.scheduled)
     }
 
+    @MainActor @Test func manualDeliveryFreshPlanUsesManualVariant() async {
+        var state = MigrationCoordFlow.State()
+        state.mode = .privateScheduled
+        state.path.append(.networkPrivacy(MigrationNetworkPrivacy.State(variant: .scheduled(transferCount: 5))))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setNetworkPrivacyOptions = { _ in }
+            $0.migrationManager.isManualDelivery = { true }
+        }
+        store.exhaustivity = .off
+
+        let options = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        await store.send(.path(.element(id: 0, action: .networkPrivacy(.delegate(.confirmed(options))))))
+
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan pushed on top")
+            return
+        }
+        #expect(planState.variant == MigrationTransferPlan.State.Variant.manual)
+    }
+
     @MainActor @Test func reviewTransferConfirmedPushesSending() async {
         var state = MigrationCoordFlow.State()
         state.mode = .immediate
@@ -505,6 +527,7 @@ import ComposableArchitecture
         } withDependencies: {
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .denied }
+            $0.migrationManager.isManualDelivery = { false }
             $0.sdkSynchronizer = .noOp
             $0.walletStorage = .noOp
             $0.walletStorage.exportTorSetupFlag = { true }
@@ -578,6 +601,34 @@ import ComposableArchitecture
         }
         #expect(sendingState.totalCount == 1)
         #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    @MainActor @Test func manualPlanConfirmPushesSendingWithSingleTransfer() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        var planState = MigrationTransferPlan.State(variant: .manual, requiresSigning: true)
+        planState.schedule = schedule
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.path.append(.transferPlan(planState))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.scheduleFirstWindow = { }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.confirmed)))))
+
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
     }
 
     @MainActor @Test func sendingClosedInManualModeWithNoStatusBeneathPushesFreshStatus() async {

--- a/zodlTests/MigrationTests/MigrationEntryTests.swift
+++ b/zodlTests/MigrationTests/MigrationEntryTests.swift
@@ -3,22 +3,40 @@
 //  zodlTests
 //
 //  Covers the MigrationEntry reducer (Features/Migration/MigrationEntry/MigrationEntryStore.swift)
-//  for MOB-1460: mode selection, the disclaimer-visibility derivation, and the `nextTapped` delegate
-//  contract. No SDK calls, no navigation — chaining lands in MOB-1466. No shared/global state ->
-//  no `.serialized`.
+//  for MOB-1460/1466: mode selection, the disclaimer-visibility derivation, the `nextTapped`
+//  delegate contract, and (MOB-1466) `onAppear` loading the orchard-balance-to-migrate amount for
+//  the selected account via `MigrationManagerClient`. `.serialized`: state mutates the
+//  process-global `@Shared(.inMemory(.selectedWalletAccount))`.
 //
 
 import Testing
 import Foundation
 import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite struct MigrationEntryTests {
+@Suite(.serialized) struct MigrationEntryTests {
+    private func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
     @MainActor @Test func defaultStateIsPrivateScheduledWithNoDisclaimer() async {
         let state = MigrationEntry.State()
 
         #expect(state.selectedMode == MigrationMode.privateScheduled)
         #expect(state.isDisclaimerVisible == false)
+        #expect(state.orchardBalance == Zatoshi.zero)
+        #expect(state.selectedWalletAccount == nil)
     }
 
     @MainActor @Test func modeTappedImmediateSelectsModeAndRevealsDisclaimer() async {
@@ -85,5 +103,42 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.chose(.immediate)))
+    }
+
+    @MainActor @Test func onAppearWithNoSelectedAccountLoadsZeroBalance() async {
+        var state = MigrationEntry.State()
+        state.$selectedWalletAccount.withLock { $0 = nil }
+        let store = TestStore(initialState: state) {
+            MigrationEntry()
+        } withDependencies: {
+            $0.migrationManager.orchardBalanceToMigrate = { accountUUID in
+                #expect(accountUUID == nil)
+                return Zatoshi(999)
+            }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.balanceLoaded) {
+            $0.orchardBalance = Zatoshi(999)
+        }
+    }
+
+    @MainActor @Test func onAppearWithSelectedAccountLoadsOrchardBalanceToMigrate() async {
+        let account = walletAccount(idByte: 7)
+        var state = MigrationEntry.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+        let store = TestStore(initialState: state) {
+            MigrationEntry()
+        } withDependencies: {
+            $0.migrationManager.orchardBalanceToMigrate = { accountUUID in
+                #expect(accountUUID == account.id)
+                return Zatoshi(1_245_800_000)
+            }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.balanceLoaded) {
+            $0.orchardBalance = Zatoshi(1_245_800_000)
+        }
     }
 }

--- a/zodlTests/MigrationTests/MigrationManagerTests.swift
+++ b/zodlTests/MigrationTests/MigrationManagerTests.swift
@@ -10,6 +10,7 @@
 
 import Testing
 import Foundation
+import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
@@ -305,8 +306,9 @@ struct MigrationManagerTests {
     @Test func acknowledgedFlagIsIgnoredOutsideCompleteState() {
         // The acknowledged flag is only consulted while state is `.complete` — a `notStarted`
         // state with a positive balance must still show `.required` even if `isCompleteAcknowledged`
-        // is stale-true from a previous migration (that reset is `reconcile()`'s job, exercised
-        // separately below via `MigrationGateStorage`/manager-level tests, not this pure table).
+        // is stale-true from a previous migration (that reset is `reconcile()`'s job, exercised by
+        // `reconcileClearsAcknowledgedFlagWhenStateIsNotComplete` /
+        // `reconcileKeepsAcknowledgedFlagWhenStateIsComplete` below, not this pure table).
         let variant = MigrationDerivations.bannerVariant(
             state: MigrationState.notStarted,
             hasInvalid: false,
@@ -885,5 +887,62 @@ struct MigrationManagerTests {
 
         storage.clearAcknowledgedComplete()
         #expect(storage.isCompleteAcknowledged() == false)
+    }
+
+    // MARK: - reconcile(): stale-acknowledge reset
+    //
+    // These two exercise the real `MigrationManagerImpl.reconcile()` (MigrationManagerLiveKey.swift)
+    // against an isolated `UserDefaults` suite via the Impl's injectable `gateStorage` seam, with
+    // `getMigrationState` stubbed through `withDependencies` — the stale-acknowledge reset must
+    // clear the flag for any non-`.complete` state and preserve it while `.complete`.
+
+    @Test func reconcileClearsAcknowledgedFlagWhenStateIsNotComplete() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testReconcileClearsAcknowledgedFlagWhenStateIsNotComplete"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: "testReconcileClearsAcknowledgedFlagWhenStateIsNotComplete")
+        }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        storage.acknowledgeComplete()
+        #expect(storage.isCompleteAcknowledged() == true)
+
+        withDependencies {
+            $0.sdkSynchronizer = SDKSynchronizerClient.noOp
+            $0.sdkSynchronizer.getMigrationState = {
+                MigrationState.inProgress(
+                    MigrationProgress(completedTransfers: 1, totalTransfers: 5, remainingOrchard: Zatoshi(1), nextTransferReadyAtHeight: nil)
+                )
+            }
+        } operation: {
+            let impl = MigrationManagerImpl(gateStorage: storage)
+            impl.reconcile()
+        }
+
+        #expect(storage.isCompleteAcknowledged() == false)
+    }
+
+    @Test func reconcileKeepsAcknowledgedFlagWhenStateIsComplete() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testReconcileKeepsAcknowledgedFlagWhenStateIsComplete"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testReconcileKeepsAcknowledgedFlagWhenStateIsComplete") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        storage.acknowledgeComplete()
+        #expect(storage.isCompleteAcknowledged() == true)
+
+        withDependencies {
+            $0.sdkSynchronizer = SDKSynchronizerClient.noOp
+            $0.sdkSynchronizer.getMigrationState = { MigrationState.complete }
+        } operation: {
+            let impl = MigrationManagerImpl(gateStorage: storage)
+            impl.reconcile()
+        }
+
+        #expect(storage.isCompleteAcknowledged() == true)
     }
 }

--- a/zodlTests/MigrationTests/MigrationManagerTests.swift
+++ b/zodlTests/MigrationTests/MigrationManagerTests.swift
@@ -1,0 +1,889 @@
+//
+//  MigrationManagerTests.swift
+//  zodlTests
+//
+//  Covers `MigrationManagerClient`'s pure derivations (Dependencies/MigrationManager/) for
+//  MOB-1466: `MigrationDerivations.bannerVariant`/`reentryRoute` tables, the 10-minute
+//  sync<->send gate math (`MigrationGateStorage`), and every UserDefaults-backed persistence
+//  roundtrip. `.serialized` because every test shares the `UserDefaults` global.
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized)
+struct MigrationManagerTests {
+    // MARK: - bannerVariant
+
+    @Test func notStartedWithPositiveBalanceIsRequired() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi(1),
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.required)
+    }
+
+    @Test func notStartedWithZeroBalanceIsNil() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == nil)
+    }
+
+    @Test func readyToProposeWithPositiveBalanceIsRequired() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.readyToPropose,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi(500),
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.required)
+    }
+
+    @Test func readyToProposeWithZeroBalanceIsNil() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.readyToPropose,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == nil)
+    }
+
+    @Test func splitPendingConfirmationIsSplitting() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.splitPendingConfirmation,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.splitting)
+    }
+
+    @Test func inProgressManualAndDueIsTransferReady() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: true,
+            isNextTransferDue: true,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.transferReady(number: 3))
+    }
+
+    @Test func inProgressManualButNotDueIsPlainProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: true,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.inProgress(done: 2, total: 5))
+    }
+
+    @Test func inProgressNonManualIsPlainProgressEvenWhenDue() {
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 4,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: true,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.inProgress(done: 1, total: 4))
+    }
+
+    @Test func requiresAttentionSyncRequiredBeforeNextRendersAsPlainProgress() {
+        // The LiveKey normalizes `.requiresAttention(.syncRequiredBeforeNext)` into
+        // `.inProgress(progress)` using its own `getMigrationProgress()` snapshot before calling
+        // the pure function (`syncRequiredBeforeNext` itself carries no progress payload) — so at
+        // this layer it is indistinguishable from a plain `.inProgress` state.
+        let progress = MigrationProgress(
+            completedTransfers: 3,
+            totalTransfers: 6,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.inProgress(done: 3, total: 6))
+    }
+
+    @Test func requiresAttentionTransferStalledIsTransferWaiting() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.transferStalled(transferNumber: 3)),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.transferWaiting(number: 3))
+    }
+
+    @Test func requiresAttentionInvalidTransferIsUpdatePlan() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+            hasInvalid: true,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.updatePlan)
+    }
+
+    @Test func requiresAttentionTransferExpiredUsesExpiredRowBounds() {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "r0", index: 0, amount: Zatoshi(100), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "r1", index: 1, amount: Zatoshi(100), status: .expired, hoursFromNow: 0),
+            MigrationTransferRow(id: "r2", index: 2, amount: Zatoshi(100), status: .expired, hoursFromNow: 0),
+            MigrationTransferRow(id: "r3", index: 3, amount: Zatoshi(100), status: .expired, hoursFromNow: 0),
+            MigrationTransferRow(id: "r4", index: 4, amount: Zatoshi(100), status: .pending, hoursFromNow: 1)
+        ]
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.transferExpired),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: rows
+        )
+
+        #expect(variant == MigrationBannerVariant.transfersExpired(first: 2, last: 4))
+    }
+
+    @Test func requiresAttentionTransferExpiredFallsBackToOneAndTotalWhenNoRowsAreExpired() {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "r0", index: 0, amount: Zatoshi(100), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "r1", index: 1, amount: Zatoshi(100), status: .pending, hoursFromNow: 1)
+        ]
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.transferExpired),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: rows
+        )
+
+        #expect(variant == MigrationBannerVariant.transfersExpired(first: 1, last: 2))
+    }
+
+    @Test func requiresAttentionTransferExpiredFallsBackToOneAndZeroWithNoRowsAtAll() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.transferExpired),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.transfersExpired(first: 1, last: 0))
+    }
+
+    @Test func completeUnacknowledgedIsComplete() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.complete)
+    }
+
+    @Test func completeAcknowledgedIsNil() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: true,
+            transferRows: []
+        )
+
+        #expect(variant == nil)
+    }
+
+    @Test func acknowledgedFlagIsIgnoredOutsideCompleteState() {
+        // The acknowledged flag is only consulted while state is `.complete` — a `notStarted`
+        // state with a positive balance must still show `.required` even if `isCompleteAcknowledged`
+        // is stale-true from a previous migration (that reset is `reconcile()`'s job, exercised
+        // separately below via `MigrationGateStorage`/manager-level tests, not this pure table).
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi(1),
+            isCompleteAcknowledged: true,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.required)
+    }
+
+    // MARK: - reentryRoute
+
+    @Test func hasInvalidTransfersWinsOverEverythingElse() {
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 2,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: nil
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.complete,
+            hasInvalid: true,
+            hasOverdue: true,
+            isManualDelivery: true,
+            isNextTransferDue: true,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.recovery(isExpired: false))
+    }
+
+    @Test func invalidTransferWithTransferExpiredAttentionReasonIsExpiredRecovery() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.requiresAttention(AttentionReason.transferExpired),
+            hasInvalid: true,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.recovery(isExpired: true))
+    }
+
+    @Test func invalidTransferWithOtherAttentionReasonIsNonExpiredRecovery() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+            hasInvalid: true,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.recovery(isExpired: false))
+    }
+
+    @Test func hasOverdueWinsOverInProgressAndComplete() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: true,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.statusResume)
+    }
+
+    @Test func manualDueWinsOverPlainInProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: 100
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: true,
+            isNextTransferDue: true,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.reviewManual(step: 3, total: 5))
+    }
+
+    @Test func manualButNotDueFallsThroughToPlainInProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: 100
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: true,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.statusProgress)
+    }
+
+    @Test func dueButNotManualFallsThroughToPlainInProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: 100
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: true,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.statusProgress)
+    }
+
+    @Test func plainInProgressIsStatusProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 0,
+            totalTransfers: 3,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: nil
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.statusProgress)
+    }
+
+    @Test func completeUnacknowledgedIsCompleteRoute() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.complete)
+    }
+
+    @Test func completeAcknowledgedFallsThroughToEntry() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: true,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.entry)
+    }
+
+    @Test func splitPendingConfirmationIsNoteSplitProgress() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.splitPendingConfirmation,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.noteSplitProgress)
+    }
+
+    @Test func notStartedIsEntry() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.entry)
+    }
+
+    @Test func readyToProposeIsEntry() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.readyToPropose,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.entry)
+    }
+
+    @Test func allSevenRoutesInPriorityOrder() {
+        // §4.3 priority order, verified as one table so a future reordering trips a single test.
+        struct Row {
+            let name: String
+            let hasInvalid: Bool
+            let hasOverdue: Bool
+            let isManualDelivery: Bool
+            let isNextTransferDue: Bool
+            let isCompleteAcknowledged: Bool
+            let state: MigrationState
+            let expected: MigrationReentryRoute
+        }
+
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 4,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: 100
+        )
+
+        let rows: [Row] = [
+            Row(
+                name: "1: recovery",
+                hasInvalid: true,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+                expected: MigrationReentryRoute.recovery(isExpired: false)
+            ),
+            Row(
+                name: "2: statusResume",
+                hasInvalid: false,
+                hasOverdue: true,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.inProgress(progress),
+                expected: MigrationReentryRoute.statusResume
+            ),
+            Row(
+                name: "3: reviewManual",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: true,
+                isNextTransferDue: true,
+                isCompleteAcknowledged: false,
+                state: MigrationState.inProgress(progress),
+                expected: MigrationReentryRoute.reviewManual(step: 2, total: 4)
+            ),
+            Row(
+                name: "4: statusProgress",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.inProgress(progress),
+                expected: MigrationReentryRoute.statusProgress
+            ),
+            Row(
+                name: "5: complete",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.complete,
+                expected: MigrationReentryRoute.complete
+            ),
+            Row(
+                name: "6: noteSplitProgress",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.splitPendingConfirmation,
+                expected: MigrationReentryRoute.noteSplitProgress
+            ),
+            Row(
+                name: "7: entry",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.notStarted,
+                expected: MigrationReentryRoute.entry
+            )
+        ]
+
+        for row in rows {
+            let route = MigrationDerivations.reentryRoute(
+                state: row.state,
+                hasInvalid: row.hasInvalid,
+                hasOverdue: row.hasOverdue,
+                isManualDelivery: row.isManualDelivery,
+                isNextTransferDue: row.isNextTransferDue,
+                isCompleteAcknowledged: row.isCompleteAcknowledged,
+                progress: progress
+            )
+
+            #expect(route == row.expected, "Row \(row.name) expected \(row.expected) but got \(route)")
+        }
+    }
+
+    // MARK: - Gate: MigrationGateStorage
+
+    @Test func gateAllowedByDefault() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateAllowedByDefault"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGateAllowedByDefault") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let now = Date(timeIntervalSince1970: 1_000_000)
+
+        #expect(storage.sendGate(now: now) == MigrationSendGate.allowed)
+    }
+
+    @Test func gateSyncRequiredWhilePending() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateSyncRequiredWhilePending"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGateSyncRequiredWhilePending") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let now = Date(timeIntervalSince1970: 1_000_000)
+
+        storage.markSyncRequired()
+
+        #expect(storage.sendGate(now: now) == MigrationSendGate.syncRequired)
+    }
+
+    @Test func gateWaitUntilTenMinutesAfterSyncCompletion() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateWaitUntilTenMinutesAfterSyncCompletion"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGateWaitUntilTenMinutesAfterSyncCompletion") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let syncCompletedAt = Date(timeIntervalSince1970: 1_000_000)
+
+        storage.markSyncRequired()
+        storage.recordSyncCompletion(at: syncCompletedAt)
+
+        let justAfterCompletion = syncCompletedAt.addingTimeInterval(1)
+        guard case let MigrationSendGate.waitUntil(gateUntil) = storage.sendGate(now: justAfterCompletion) else {
+            Issue.record("Expected .waitUntil right after sync completion")
+            return
+        }
+
+        #expect(gateUntil == syncCompletedAt.addingTimeInterval(10 * 60))
+    }
+
+    @Test func gateTransitionsToAllowedAfterTenMinutesElapse() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateTransitionsToAllowedAfterTenMinutesElapse"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: "testMigrationGateTransitionsToAllowedAfterTenMinutesElapse")
+        }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let syncCompletedAt = Date(timeIntervalSince1970: 1_000_000)
+
+        storage.markSyncRequired()
+        storage.recordSyncCompletion(at: syncCompletedAt)
+
+        let exactlyAtGate = syncCompletedAt.addingTimeInterval(10 * 60)
+        #expect(storage.sendGate(now: exactlyAtGate) == MigrationSendGate.allowed)
+
+        let wellAfterGate = syncCompletedAt.addingTimeInterval(20 * 60)
+        #expect(storage.sendGate(now: wellAfterGate) == MigrationSendGate.allowed)
+    }
+
+    @Test func gateFullSyncRequiredToWaitUntilToAllowedTransition() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateFullTransition"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGateFullTransition") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let t0 = Date(timeIntervalSince1970: 2_000_000)
+
+        // Before any sync requirement is observed: allowed.
+        #expect(storage.sendGate(now: t0) == MigrationSendGate.allowed)
+
+        // Sync becomes required: CTA disabled outright.
+        storage.markSyncRequired()
+        #expect(storage.sendGate(now: t0) == MigrationSendGate.syncRequired)
+
+        // Sync completes: 10-minute countdown starts.
+        storage.recordSyncCompletion(at: t0)
+        guard case .waitUntil = storage.sendGate(now: t0.addingTimeInterval(60)) else {
+            Issue.record("Expected .waitUntil 1 minute after sync completion")
+            return
+        }
+
+        // 10 minutes elapse: allowed again.
+        #expect(storage.sendGate(now: t0.addingTimeInterval(10 * 60 + 1)) == MigrationSendGate.allowed)
+    }
+
+    @Test func gateStatePersistsAcrossStorageInstancesUsingTheSameSuite() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGatePersistsAcrossInstances"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGatePersistsAcrossInstances") }
+
+        let syncCompletedAt = Date(timeIntervalSince1970: 3_000_000)
+
+        let firstStorage = MigrationGateStorage(userDefaults: userDefaults)
+        firstStorage.markSyncRequired()
+        firstStorage.recordSyncCompletion(at: syncCompletedAt)
+
+        // A fresh instance over the same UserDefaults suite (simulating relaunch) must observe
+        // the persisted gate, not reset to `.allowed` — the whole point of persisting
+        // `migrationSyncGateUntil` is that a relaunch cannot dodge the send-side gate.
+        let secondStorage = MigrationGateStorage(userDefaults: userDefaults)
+        guard case let MigrationSendGate.waitUntil(gateUntil) = secondStorage.sendGate(
+            now: syncCompletedAt.addingTimeInterval(1)
+        ) else {
+            Issue.record("Expected persisted .waitUntil to survive a fresh MigrationGateStorage instance")
+            return
+        }
+
+        #expect(gateUntil == syncCompletedAt.addingTimeInterval(10 * 60))
+    }
+
+    @Test func recordMigrationBroadcastPersistsTimestamp() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testRecordMigrationBroadcastPersistsTimestamp"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testRecordMigrationBroadcastPersistsTimestamp") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let broadcastAt = Date(timeIntervalSince1970: 4_000_000)
+
+        storage.recordMigrationBroadcast(at: broadcastAt)
+
+        let stored = userDefaults.object(forKey: .migrationLastBroadcastAt) as? Double
+        #expect(stored == broadcastAt.timeIntervalSince1970)
+    }
+
+    @Test func syncDeferredForTenMinutesAfterBroadcast() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testSyncDeferredForTenMinutesAfterBroadcast"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testSyncDeferredForTenMinutesAfterBroadcast") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let broadcastAt = Date(timeIntervalSince1970: 4_000_000)
+
+        // No broadcast recorded yet -> never deferred.
+        #expect(storage.isSyncDeferredAfterBroadcast(now: broadcastAt) == false)
+
+        storage.recordMigrationBroadcast(at: broadcastAt)
+
+        // Deferred strictly within the 10-minute window after the broadcast, allowed at/after it
+        // (the sync side of the feature spec section 8.2 separation, consumed by MOB-1467).
+        #expect(storage.isSyncDeferredAfterBroadcast(now: broadcastAt.addingTimeInterval(1)) == true)
+        #expect(storage.isSyncDeferredAfterBroadcast(now: broadcastAt.addingTimeInterval(10 * 60 - 1)) == true)
+        #expect(storage.isSyncDeferredAfterBroadcast(now: broadcastAt.addingTimeInterval(10 * 60)) == false)
+    }
+
+    // MARK: - Persistence: mode / manual delivery / network privacy / acknowledge
+
+    @Test func migrationModePersistenceRoundTrip() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationModePersistenceRoundTrip"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationModePersistenceRoundTrip") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+
+        #expect(storage.migrationMode() == nil)
+
+        storage.setMigrationMode(MigrationMode.immediate)
+        #expect(storage.migrationMode() == MigrationMode.immediate)
+
+        storage.setMigrationMode(MigrationMode.privateScheduled)
+        #expect(storage.migrationMode() == MigrationMode.privateScheduled)
+    }
+
+    @Test func manualDeliveryPersistenceRoundTrip() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testManualDeliveryPersistenceRoundTrip"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testManualDeliveryPersistenceRoundTrip") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+
+        #expect(storage.isManualDelivery() == false)
+
+        storage.setManualDelivery(true)
+        #expect(storage.isManualDelivery() == true)
+
+        storage.setManualDelivery(false)
+        #expect(storage.isManualDelivery() == false)
+    }
+
+    @Test func networkPrivacyOptionsPersistenceRoundTrip() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testNetworkPrivacyOptionsPersistenceRoundTrip"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testNetworkPrivacyOptionsPersistenceRoundTrip") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+
+        #expect(storage.networkPrivacyOptions() == NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil))
+
+        let options = NetworkPrivacyOptions(useTor: true, submissionEndpoint: "https://example.com:9067")
+        storage.setNetworkPrivacyOptions(options)
+        #expect(storage.networkPrivacyOptions() == options)
+    }
+
+    @Test func completeAcknowledgedPersistenceRoundTrip() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testCompleteAcknowledgedPersistenceRoundTrip"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testCompleteAcknowledgedPersistenceRoundTrip") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+
+        #expect(storage.isCompleteAcknowledged() == false)
+
+        storage.acknowledgeComplete()
+        #expect(storage.isCompleteAcknowledged() == true)
+
+        storage.clearAcknowledgedComplete()
+        #expect(storage.isCompleteAcknowledged() == false)
+    }
+}

--- a/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
+++ b/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
@@ -3,15 +3,17 @@
 //  zodlTests
 //
 //  Covers the MigrationNoteSplit reducer
-//  (Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift) for MOB-1461: the default
-//  phase/state, the txid pasteboard copy, the failure sheet dismissal (cancel/retry), and the
-//  `continueTapped` delegate contract. Phase transitions and SDK calls are inert/declared-only —
-//  wiring them up is MOB-1466's job. The copy action writes the shared toast (`@Shared` in-memory
-//  state) -> `.serialized` per the repo rule for suites mutating process-global state.
+//  (Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift) for MOB-1461/1466: the
+//  default phase/state, the txid pasteboard copy, the failure sheet dismissal (cancel/retry), the
+//  `continueTapped` delegate contract, and (MOB-1466) `onAppear` load/resume, `confirmTapped`
+//  submission, the `migrationStateStream()` subscription driving `.splitConfirmed`, and retry
+//  re-submission. The copy action writes the shared toast (`@Shared` in-memory state) ->
+//  `.serialized` per the repo rule for suites mutating process-global state.
 //
 
 import Testing
 import Foundation
+@preconcurrency import Combine
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
@@ -25,6 +27,16 @@ import ComposableArchitecture
         #expect(state.fee == Zatoshi.zero)
         #expect(state.txId == "")
         #expect(state.isFailurePresented == false)
+        #expect(state.isFlowRoot == false)
+    }
+
+    @MainActor @Test func closeTappedWhenFlowRootEmitsDelegateContinued() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting, isFlowRoot: true)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.continued))
     }
 
     @MainActor @Test func copyTxIdTappedCopiesTxIdToPasteboard() async {
@@ -56,18 +68,6 @@ import ComposableArchitecture
         }
     }
 
-    @MainActor @Test func retryTappedDismissesFailureSheet() async {
-        let store = TestStore(
-            initialState: MigrationNoteSplit.State(phase: .splitting, isFailurePresented: true)
-        ) {
-            MigrationNoteSplit()
-        }
-
-        await store.send(.retryTapped) {
-            $0.isFailurePresented = false
-        }
-    }
-
     @MainActor @Test func continueTappedEmitsDelegateContinued() async {
         let store = TestStore(initialState: MigrationNoteSplit.State(phase: .confirmed)) {
             MigrationNoteSplit()
@@ -77,28 +77,14 @@ import ComposableArchitecture
         await store.receive(.delegate(.continued))
     }
 
-    @MainActor @Test func confirmTappedProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationNoteSplit.State()) {
-            MigrationNoteSplit()
-        }
-
-        await store.send(.confirmTapped)
-    }
-
-    @MainActor @Test func splitConfirmedProducesNoStateChangeOrEffects() async {
+    @MainActor @Test func splitConfirmedSetsConfirmedPhase() async {
         let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
             MigrationNoteSplit()
         }
 
-        await store.send(.splitConfirmed)
-    }
-
-    @MainActor @Test func splitResultInvalidNoteProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
-            MigrationNoteSplit()
+        await store.send(.splitConfirmed) {
+            $0.phase = .confirmed
         }
-
-        await store.send(.splitResult(.invalidNote))
     }
 
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
@@ -107,5 +93,186 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.continued))
+    }
+
+    // MARK: - onAppear: fresh load vs. resume
+
+    @MainActor @Test func onAppearWhenNotPendingConfirmationPreparesNoteSplitAndPopulatesAmountFee() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let store = TestStore(initialState: MigrationNoteSplit.State()) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.getMigrationState = { .readyToPropose }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.prepareNoteSplit = {
+                NoteSplitProposal(outputNotes: [Zatoshi(500_000_000), Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+            }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.noteSplitPrepared) {
+            $0.proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000), Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+            $0.amount = Zatoshi(1_000_000_000)
+            $0.fee = Zatoshi(100_000)
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func onAppearWhenSplitPendingConfirmationJumpsToSplittingPhaseWithoutPreparing() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let prepareCalls = LockIsolated<Int>(0)
+        let store = TestStore(initialState: MigrationNoteSplit.State()) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.getMigrationState = { .splitPendingConfirmation }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.prepareNoteSplit = {
+                prepareCalls.withValue { $0 += 1 }
+                return NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero)
+            }
+        }
+
+        await store.send(.onAppear) {
+            $0.phase = .splitting
+        }
+
+        #expect(prepareCalls.value == 0)
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func migrationStateStreamReadyToProposeAfterSplittingEmitsSplitConfirmed() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let store = TestStore(initialState: MigrationNoteSplit.State()) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.getMigrationState = { .splitPendingConfirmation }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+        }
+
+        await store.send(.onAppear) {
+            $0.phase = .splitting
+        }
+
+        stateStream.send(.readyToPropose)
+        await store.receive(\.splitConfirmed) {
+            $0.phase = .confirmed
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    // MARK: - confirmTapped / submission
+
+    @MainActor @Test func confirmTappedEntersSplittingPhaseAndSubmitsProposal() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let submittedProposal = LockIsolated<NoteSplitProposal?>(nil)
+        let proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+        var state = MigrationNoteSplit.State(phase: .explainer)
+        state.proposal = proposal
+        let store = TestStore(initialState: state) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.submitNoteSplit = { submitted in
+                submittedProposal.setValue(submitted)
+                return .success(txId: "e87f1234567890abcdef6f28b")
+            }
+        }
+
+        await store.send(.confirmTapped) {
+            $0.phase = .splitting
+        }
+        await store.receive(\.splitResult) {
+            $0.txId = "e87f1234567890abcdef6f28b"
+        }
+
+        #expect(submittedProposal.value == proposal)
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func splitResultSuccessStoresTxIdAndStaysInSplittingPhase() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.success(txId: "e87f1234567890abcdef6f28b"))) {
+            $0.txId = "e87f1234567890abcdef6f28b"
+        }
+
+        #expect(store.state.phase == .splitting)
+        #expect(store.state.isFailurePresented == false)
+    }
+
+    @MainActor @Test func splitResultNetworkErrorPresentsFailureSheet() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.networkError(retryable: true))) {
+            $0.isFailurePresented = true
+        }
+    }
+
+    @MainActor @Test func splitResultInvalidNotePresentsFailureSheet() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.invalidNote)) {
+            $0.isFailurePresented = true
+        }
+    }
+
+    @MainActor @Test func splitResultExpiredPresentsFailureSheet() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.expired)) {
+            $0.isFailurePresented = true
+        }
+    }
+
+    // MARK: - retryTapped: dismiss + re-submit
+
+    @MainActor @Test func retryTappedDismissesFailureSheetAndResubmitsStoredProposal() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let submitCalls = LockIsolated<Int>(0)
+        let proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+        var state = MigrationNoteSplit.State(phase: .splitting, isFailurePresented: true)
+        state.proposal = proposal
+        let store = TestStore(initialState: state) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.submitNoteSplit = { _ in
+                submitCalls.withValue { $0 += 1 }
+                return .success(txId: "retried-tx-id")
+            }
+        }
+
+        await store.send(.retryTapped) {
+            $0.isFailurePresented = false
+        }
+        await store.receive(\.splitResult) {
+            $0.txId = "retried-tx-id"
+        }
+
+        #expect(submitCalls.value == 1)
+
+        stateStream.send(completion: .finished)
+        await store.finish()
     }
 }

--- a/zodlTests/MigrationTests/MigrationNotificationsTests.swift
+++ b/zodlTests/MigrationTests/MigrationNotificationsTests.swift
@@ -3,10 +3,10 @@
 //  zodlTests
 //
 //  Covers the MigrationNotifications reducer
-//  (Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift) for MOB-1462: the
-//  default `variant`, the `skipTapped` delegate contract, and that `allowTapped` /
-//  `authorizationResult` are no-ops for now — the `UNUserNotificationCenter` request lands in
-//  MOB-1466. No shared/global state -> no `.serialized`.
+//  (Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift) for MOB-1462/1466:
+//  the default `variant`, the `skipTapped` delegate contract, and (MOB-1466) `allowTapped`
+//  requesting `UserNotificationsClient` authorization and `authorizationResult` emitting
+//  `.delegate(.continued)` regardless of outcome. No shared/global state -> no `.serialized`.
 //
 
 import Testing
@@ -30,28 +30,46 @@ import ComposableArchitecture
         await store.receive(.delegate(.continued))
     }
 
-    @MainActor @Test func allowTappedProducesNoStateChangeOrEffects() async {
+    @MainActor @Test func allowTappedRequestsAuthorizationAndEmitsResultTrue() async {
         let store = TestStore(initialState: MigrationNotifications.State()) {
             MigrationNotifications()
+        } withDependencies: {
+            $0.userNotifications.requestAuthorization = { true }
         }
 
         await store.send(.allowTapped)
+        await store.receive(.authorizationResult(true))
+        await store.receive(.delegate(.continued))
     }
 
-    @MainActor @Test func authorizationResultTrueProducesNoStateChangeOrEffects() async {
+    @MainActor @Test func allowTappedRequestsAuthorizationAndEmitsResultFalse() async {
+        let store = TestStore(initialState: MigrationNotifications.State()) {
+            MigrationNotifications()
+        } withDependencies: {
+            $0.userNotifications.requestAuthorization = { false }
+        }
+
+        await store.send(.allowTapped)
+        await store.receive(.authorizationResult(false))
+        await store.receive(.delegate(.continued))
+    }
+
+    @MainActor @Test func authorizationResultTrueEmitsDelegateContinued() async {
         let store = TestStore(initialState: MigrationNotifications.State()) {
             MigrationNotifications()
         }
 
         await store.send(.authorizationResult(true))
+        await store.receive(.delegate(.continued))
     }
 
-    @MainActor @Test func authorizationResultFalseProducesNoStateChangeOrEffects() async {
+    @MainActor @Test func authorizationResultFalseEmitsDelegateContinued() async {
         let store = TestStore(initialState: MigrationNotifications.State()) {
             MigrationNotifications()
         }
 
         await store.send(.authorizationResult(false))
+        await store.receive(.delegate(.continued))
     }
 
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {

--- a/zodlTests/MigrationTests/MigrationRecoveryTests.swift
+++ b/zodlTests/MigrationTests/MigrationRecoveryTests.swift
@@ -3,9 +3,10 @@
 //  zodlTests
 //
 //  Covers the MigrationRecovery reducer
-//  (Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift) for MOB-1464: the default
-//  `.notesSpent` reason and the `continueTapped` delegate contract. Visual-only screen — no SDK
-//  calls, no navigation. No shared/global state -> no `.serialized`.
+//  (Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift) for MOB-1464/1466: the
+//  default `.notesSpent` reason, the `continueTapped` delegate contract, and (MOB-1466) the
+//  `isFlowRoot`-gated back control — `closeTapped` emits the new `.delegate(.close)` case when this
+//  screen is the coordinator's re-entry root. No shared/global state -> no `.serialized`.
 //
 
 import Testing
@@ -20,6 +21,7 @@ import ComposableArchitecture
         #expect(state.reason == MigrationRecovery.State.Reason.notesSpent)
         #expect(state.firstTransfer == 3)
         #expect(state.lastTransfer == 5)
+        #expect(state.isFlowRoot == false)
     }
 
     @MainActor @Test func expiredReasonIsPreservedInState() async {
@@ -52,5 +54,22 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.recreate))
+    }
+
+    @MainActor @Test func closeTappedEmitsDelegateClose() async {
+        let store = TestStore(initialState: MigrationRecovery.State(isFlowRoot: true)) {
+            MigrationRecovery()
+        }
+
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.close))
+    }
+
+    @MainActor @Test func delegateCloseActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationRecovery.State()) {
+            MigrationRecovery()
+        }
+
+        await store.send(.delegate(.close))
     }
 }

--- a/zodlTests/MigrationTests/MigrationReviewTransferTests.swift
+++ b/zodlTests/MigrationTests/MigrationReviewTransferTests.swift
@@ -3,9 +3,15 @@
 //  zodlTests
 //
 //  Covers the MigrationReviewTransfer reducer
-//  (Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift) for MOB-1463:
-//  the default `mode`, the `confirmTapped` delegate contract, and that `sendResult` is a no-op for
-//  now — submitting the transfer is MOB-1466's job. No shared/global state -> no `.serialized`.
+//  (Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift) for MOB-1463/1466:
+//  the default `mode`, and (MOB-1466) two divergent `onAppear`/`confirmTapped` paths keyed off
+//  `mode` — immediate proposes a single-transfer schedule via `proposeMigrationTransfers()` for
+//  Amount/Fee and signs+stores it on confirm before delegating; manual step has its data injected by
+//  the coordinator (no propose) and confirm delegates directly (the transfer was already signed at
+//  plan commit). Also covers the `isFlowRoot`-gated back control for the manual-step variant: a new
+//  `Delegate.closed` case (reusing `.confirmed` for a back-tap would be a correctness bug — that
+//  case means "user confirmed the transfer", not "user backed out"). No shared/global state ->
+//  no `.serialized`.
 //
 
 import Testing
@@ -21,26 +27,26 @@ import ComposableArchitecture
         #expect(state.mode == MigrationReviewTransfer.State.Mode.immediate)
         #expect(state.amount == Zatoshi.zero)
         #expect(state.fee == Zatoshi.zero)
+        #expect(state.isFlowRoot == false)
     }
 
-    @MainActor @Test func confirmTappedEmitsDelegateConfirmed() async {
-        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
-            MigrationReviewTransfer()
-        }
-
-        await store.send(.confirmTapped)
-        await store.receive(.delegate(.confirmed))
-    }
-
-    @MainActor @Test func confirmTappedEmitsDelegateConfirmedForManualStepMode() async {
+    @MainActor @Test func closeTappedWhenFlowRootEmitsDelegateClosed() async {
         let store = TestStore(
-            initialState: MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5))
+            initialState: MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5), isFlowRoot: true)
         ) {
             MigrationReviewTransfer()
         }
 
-        await store.send(.confirmTapped)
-        await store.receive(.delegate(.confirmed))
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.closed))
+    }
+
+    @MainActor @Test func delegateClosedActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
+            MigrationReviewTransfer()
+        }
+
+        await store.send(.delegate(.closed))
     }
 
     @MainActor @Test func manualStepModeIsPreservedInState() async {
@@ -49,19 +55,100 @@ import ComposableArchitecture
         #expect(state.mode == .manualStep(number: 3, total: 5))
     }
 
-    @MainActor @Test func sendResultExpiredProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
-            MigrationReviewTransfer()
-        }
-
-        await store.send(.sendResult(.expired))
-    }
-
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
         let store = TestStore(initialState: MigrationReviewTransfer.State()) {
             MigrationReviewTransfer()
         }
 
         await store.send(.delegate(.confirmed))
+    }
+
+    // MARK: - Immediate mode: onAppear proposes, confirm signs+stores then delegates
+
+    @MainActor @Test func onAppearInImmediateModeProposesSingleTransferScheduleForAmountFee() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(1_245_800_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 0
+        )
+        let store = TestStore(initialState: MigrationReviewTransfer.State(mode: .immediate)) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = { schedule }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferProposed) {
+            $0.amount = Zatoshi(1_245_800_000)
+            $0.fee = Zatoshi(100_000)
+            $0.schedule = schedule
+        }
+    }
+
+    @MainActor @Test func onAppearInManualStepModeDoesNotProposeAndLeavesInjectedDataAlone() async {
+        let proposeCalls = LockIsolated<Int>(0)
+        let store = TestStore(
+            initialState: MigrationReviewTransfer.State(
+                mode: .manualStep(number: 3, total: 5),
+                amount: Zatoshi(243_100_000),
+                fee: Zatoshi(100_000)
+            )
+        ) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = {
+                proposeCalls.withValue { $0 += 1 }
+                return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+            }
+        }
+
+        await store.send(.onAppear)
+
+        #expect(proposeCalls.value == 0)
+        #expect(store.state.amount == Zatoshi(243_100_000))
+    }
+
+    @MainActor @Test func confirmTappedInImmediateModeSignsAndStoresScheduleThenDelegatesConfirmed() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(1_245_800_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 0
+        )
+        let signedSchedule = LockIsolated<MigrationSchedule?>(nil)
+        var state = MigrationReviewTransfer.State(mode: .immediate)
+        state.schedule = schedule
+        let store = TestStore(initialState: state) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { signedSchedule.setValue($0) }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signedSchedule.value == schedule)
+    }
+
+    @MainActor @Test func confirmTappedInManualStepModeDelegatesConfirmedDirectlyWithoutSigning() async {
+        let signCalls = LockIsolated<Int>(0)
+        let store = TestStore(
+            initialState: MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5))
+        ) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in signCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signCalls.value == 0)
     }
 }

--- a/zodlTests/MigrationTests/MigrationSendingTests.swift
+++ b/zodlTests/MigrationTests/MigrationSendingTests.swift
@@ -3,10 +3,13 @@
 //  zodlTests
 //
 //  Covers the MigrationSending reducer
-//  (Features/Migration/MigrationSending/MigrationSendingStore.swift) for MOB-1463: the default
+//  (Features/Migration/MigrationSending/MigrationSendingStore.swift) for MOB-1463/1466: the default
 //  phase/state, the `closeTapped` / `viewTransactionTapped` delegate contracts, the failure sheet
-//  dismissal (cancel/retry), and that `result` is a no-op for now — resubmitting the transfer is
-//  MOB-1466's job. No shared/global state -> no `.serialized`.
+//  dismissal (cancel/retry), and (MOB-1466) `onAppear` executing `totalCount` transfers strictly in
+//  sequence via `executeNextPendingMigrationTransfer`, recording a broadcast +
+//  scheduling the next background window after each success, presenting the failure sheet on
+//  failure/`nil`, and retry re-running only the failed step. No shared/global state ->
+//  no `.serialized`.
 //
 
 import Testing
@@ -22,6 +25,8 @@ import ComposableArchitecture
         #expect(state.phase == MigrationSending.State.Phase.sending)
         #expect(state.isFailurePresented == false)
         #expect(state.txId == "")
+        #expect(state.totalCount == 1)
+        #expect(state.sentCount == 0)
     }
 
     @MainActor @Test func closeTappedEmitsDelegateClosed() async {
@@ -52,29 +57,176 @@ import ComposableArchitecture
         }
     }
 
-    @MainActor @Test func retryTappedDismissesFailureSheet() async {
-        let store = TestStore(initialState: MigrationSending.State(isFailurePresented: true)) {
-            MigrationSending()
-        }
-
-        await store.send(.retryTapped) {
-            $0.isFailurePresented = false
-        }
-    }
-
-    @MainActor @Test func resultNetworkErrorRetryableProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationSending.State()) {
-            MigrationSending()
-        }
-
-        await store.send(.result(.networkError(retryable: true)))
-    }
-
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
         let store = TestStore(initialState: MigrationSending.State()) {
             MigrationSending()
         }
 
         await store.send(.delegate(.closed))
+    }
+
+    // MARK: - onAppear: single transfer (immediate/manual/plan-first)
+
+    @MainActor @Test func onAppearWithSingleTransferSucceedsAndReachesSentPhase() async {
+        let recordBroadcastCalls = LockIsolated<Int>(0)
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 1)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in .success(txId: "tx-0") }
+            $0.migrationManager.recordMigrationBroadcast = { recordBroadcastCalls.withValue { $0 += 1 } }
+            $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.sentCount = 1
+            $0.txId = "tx-0"
+        }
+        await store.receive(\.allTransfersSent) {
+            $0.phase = .success
+        }
+
+        #expect(recordBroadcastCalls.value == 1)
+        #expect(scheduleNextWindowCalls.value == 1)
+    }
+
+    // MARK: - onAppear: sequential N transfers (send-now)
+
+    @MainActor @Test func onAppearWithMultipleTransfersExecutesStrictlyInSequence() async {
+        let executedCount = LockIsolated<Int>(0)
+        let recordBroadcastCalls = LockIsolated<Int>(0)
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 3)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in
+                let callIndex = executedCount.withValue { count -> Int in
+                    count += 1
+                    return count
+                }
+                return .success(txId: "tx-\(callIndex)")
+            }
+            $0.migrationManager.recordMigrationBroadcast = { recordBroadcastCalls.withValue { $0 += 1 } }
+            $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.sentCount = 1
+            $0.txId = "tx-1"
+        }
+        await store.receive(\.transferResult) {
+            $0.sentCount = 2
+            $0.txId = "tx-2"
+        }
+        await store.receive(\.transferResult) {
+            $0.sentCount = 3
+            $0.txId = "tx-3"
+        }
+        await store.receive(\.allTransfersSent) {
+            $0.phase = .success
+        }
+
+        #expect(executedCount.value == 3)
+        #expect(recordBroadcastCalls.value == 3)
+        #expect(scheduleNextWindowCalls.value == 3)
+    }
+
+    @MainActor @Test func onAppearPassesInjectedNetworkPrivacyOptionsToExecute() async {
+        let capturedOptions = LockIsolated<NetworkPrivacyOptions?>(nil)
+        let options = NetworkPrivacyOptions(useTor: true, submissionEndpoint: "https://example.com:9067")
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 1, networkPrivacyOptions: options)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { passedOptions in
+                capturedOptions.setValue(passedOptions)
+                return .success(txId: "tx-0")
+            }
+            $0.migrationManager.recordMigrationBroadcast = { }
+            $0.migrationBGScheduler.scheduleNextWindow = { }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.sentCount = 1
+            $0.txId = "tx-0"
+        }
+        await store.receive(\.allTransfersSent) {
+            $0.phase = .success
+        }
+
+        #expect(capturedOptions.value == options)
+    }
+
+    // MARK: - Failure / nil result: presents failure sheet, stops the sequence
+
+    @MainActor @Test func onAppearWithFailureResultPresentsFailureSheetAndStopsSequence() async {
+        let executedCount = LockIsolated<Int>(0)
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 3)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in
+                executedCount.withValue { $0 += 1 }
+                return .networkError(retryable: true)
+            }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.isFailurePresented = true
+        }
+
+        #expect(executedCount.value == 1)
+        #expect(store.state.sentCount == 0)
+    }
+
+    @MainActor @Test func onAppearWithNilResultPresentsFailureSheet() async {
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 1)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in nil }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.isFailurePresented = true
+        }
+    }
+
+    // MARK: - retryTapped: re-runs only the failed step
+
+    @MainActor @Test func retryTappedDismissesFailureSheetAndReRunsFailedStep() async {
+        let executedCount = LockIsolated<Int>(0)
+        let state = MigrationSending.State(isFailurePresented: true, totalCount: 2, sentCount: 1)
+        let store = TestStore(initialState: state) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in
+                executedCount.withValue { $0 += 1 }
+                return .success(txId: "retried-tx")
+            }
+            $0.migrationManager.recordMigrationBroadcast = { }
+            $0.migrationBGScheduler.scheduleNextWindow = { }
+        }
+
+        await store.send(.retryTapped) {
+            $0.isFailurePresented = false
+        }
+        await store.receive(\.transferResult) {
+            $0.sentCount = 2
+            $0.txId = "retried-tx"
+        }
+        await store.receive(\.allTransfersSent) {
+            $0.phase = .success
+        }
+
+        #expect(executedCount.value == 1)
     }
 }

--- a/zodlTests/MigrationTests/MigrationStatusTests.swift
+++ b/zodlTests/MigrationTests/MigrationStatusTests.swift
@@ -3,13 +3,17 @@
 //  zodlTests
 //
 //  Covers the MigrationStatus reducer (Features/Migration/MigrationStatus/MigrationStatusStore.swift)
-//  for MOB-1464: the default `.progress` presentation, the `gotItTapped`/`sendNowTapped`/
-//  `rescheduleTapped` delegate contracts, and the `remainingCount` derivation over a mixed row set.
-//  Visual-only screen — no SDK calls, no navigation. No shared/global state -> no `.serialized`.
+//  for MOB-1464/1466: the default `.progress` presentation, the `gotItTapped`/`sendNowTapped`/
+//  `rescheduleTapped` delegate contracts, the `remainingCount` derivation over a mixed row set, and
+//  (MOB-1466) `onAppear` loading rows/summary via `migrationTransfers()`/`migrationSummary()`,
+//  subscribing `migrationStateStream()` to refresh rows on change, the `isSendNowDisabled`
+//  derivation from `manager.sendGate()`, and the `isFlowRoot`-gated close-instead-of-pop back
+//  action. No shared/global state -> no `.serialized`.
 //
 
 import Testing
 import Foundation
+@preconcurrency import Combine
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
@@ -24,6 +28,8 @@ import ComposableArchitecture
         #expect(state.stalledNumber == 0)
         #expect(state.stalledHoursAgo == 0)
         #expect(state.isRescheduling == false)
+        #expect(state.isFlowRoot == false)
+        #expect(state.isSendNowDisabled == false)
     }
 
     @MainActor @Test func gotItTappedEmitsDelegateDone() async {
@@ -84,5 +90,130 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.done))
+    }
+
+    // MARK: - onAppear: load rows/summary + sendGate, subscribe to state stream
+
+    @MainActor @Test func onAppearLoadsRowsSummaryAndSendGate() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .active, hoursFromNow: 0)
+        ]
+        let summary = MigrationSummary(
+            transferred: Zatoshi(351_220_000),
+            dust: Zatoshi.zero,
+            transfersSent: 1,
+            transfersTotal: 2,
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationStatus.State()) {
+            MigrationStatus()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.sdkSynchronizer.migrationSummary = { summary }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.migrationManager.sendGate = { .allowed }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.statusLoaded) {
+            $0.rows = IdentifiedArrayOf(uniqueElements: rows)
+            $0.totalDurationHours = 24
+            $0.isSendNowDisabled = false
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func onAppearWithSyncRequiredGateDisablesSendNow() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
+            MigrationStatus()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.migrationManager.sendGate = { .syncRequired }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.statusLoaded) {
+            $0.isSendNowDisabled = true
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func onAppearWithWaitUntilGateDisablesSendNow() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
+            MigrationStatus()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.migrationManager.sendGate = { .waitUntil(Date(timeIntervalSince1970: 1_000_000)) }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.statusLoaded) {
+            $0.isSendNowDisabled = true
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func migrationStateStreamChangeRefreshesRows() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let initialRows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)
+        ]
+        let refreshedRows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0)
+        ]
+        let currentRows = LockIsolated(initialRows)
+        let store = TestStore(initialState: MigrationStatus.State()) {
+            MigrationStatus()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { currentRows.value }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.migrationManager.sendGate = { .allowed }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.statusLoaded) {
+            $0.rows = IdentifiedArrayOf(uniqueElements: initialRows)
+        }
+
+        currentRows.setValue(refreshedRows)
+        let tickProgress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 1,
+            remainingOrchard: .zero,
+            nextTransferReadyAtHeight: nil
+        )
+        stateStream.send(.inProgress(tickProgress))
+        await store.receive(\.migrationStateChanged)
+        await store.receive(\.statusLoaded) {
+            $0.rows = IdentifiedArrayOf(uniqueElements: refreshedRows)
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    // MARK: - isFlowRoot: close-instead-of-pop back
+
+    @MainActor @Test func closeTappedWhenFlowRootEmitsDelegateDone() async {
+        let store = TestStore(initialState: MigrationStatus.State(isFlowRoot: true)) {
+            MigrationStatus()
+        }
+
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.done))
     }
 }

--- a/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
@@ -3,10 +3,13 @@
 //  zodlTests
 //
 //  Covers the MigrationTransferPlan reducer
-//  (Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift) for MOB-1463: the
-//  default `variant`, and the `confirmTapped` delegate contract. Signing and storing the schedule
-//  is inert for now — wiring it up is MOB-1466's job. State carries the shared exchange rate but
-//  only reads it — nothing here mutates process-global state -> no `.serialized`.
+//  (Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift) for MOB-1463/1466:
+//  the default `variant`, the `confirmTapped` delegate contract, and (MOB-1466) `onAppear` — a
+//  fresh entry proposes transfers via `proposeMigrationTransfers()` and populates rows/duration,
+//  while an injected schedule (recovery/reschedule variants) is left untouched (no re-propose) —
+//  plus `confirmTapped` signing and storing the schedule via `signAndStoreMigrationSchedule`.
+//  State carries the shared exchange rate but only reads it — nothing here mutates process-global
+//  state -> no `.serialized`.
 //
 
 import Testing
@@ -22,24 +25,7 @@ import ComposableArchitecture
         #expect(state.variant == MigrationTransferPlan.State.Variant.scheduled)
         #expect(state.rows.isEmpty)
         #expect(state.totalDurationHours == 0)
-    }
-
-    @MainActor @Test func confirmTappedEmitsDelegateConfirmed() async {
-        let store = TestStore(initialState: MigrationTransferPlan.State()) {
-            MigrationTransferPlan()
-        }
-
-        await store.send(.confirmTapped)
-        await store.receive(.delegate(.confirmed))
-    }
-
-    @MainActor @Test func confirmTappedEmitsDelegateConfirmedForManualVariant() async {
-        let store = TestStore(initialState: MigrationTransferPlan.State(variant: .manual)) {
-            MigrationTransferPlan()
-        }
-
-        await store.send(.confirmTapped)
-        await store.receive(.delegate(.confirmed))
+        #expect(state.injectedSchedule == nil)
     }
 
     @MainActor @Test func recreatedVariantIsPreservedInState() async {
@@ -54,5 +40,105 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.confirmed))
+    }
+
+    // MARK: - onAppear: fresh propose vs. injected schedule
+
+    @MainActor @Test func onAppearWithNoInjectedScheduleProposesTransfersAndPopulatesRows() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200),
+                TransferProposal(id: "t1", amount: Zatoshi(300_000_000), anchorHeight: 100, nextExecutableAfterHeight: 150, expiryHeight: 250)
+            ],
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationTransferPlan.State(variant: .scheduled)) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = { schedule }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transfersProposed) {
+            $0.rows = [
+                MigrationTransferRow(id: "t0", index: 0, amount: Zatoshi(500_000_000), status: .active, hoursFromNow: 0),
+                MigrationTransferRow(id: "t1", index: 1, amount: Zatoshi(300_000_000), status: .pending, hoursFromNow: 0)
+            ]
+            $0.totalDurationHours = 24
+            $0.schedule = schedule
+        }
+    }
+
+    @MainActor @Test func onAppearWithInjectedScheduleDoesNotReProposeAndPopulatesRowsDirectly() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(200_000_000), anchorHeight: 50, nextExecutableAfterHeight: 50, expiryHeight: 150)
+            ],
+            estimatedDurationHours: 12
+        )
+        let proposeCalls = LockIsolated<Int>(0)
+        var state = MigrationTransferPlan.State(variant: .recreated)
+        state.injectedSchedule = schedule
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = {
+                proposeCalls.withValue { $0 += 1 }
+                return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+            }
+        }
+
+        await store.send(.onAppear) {
+            $0.rows = [
+                MigrationTransferRow(id: "t0", index: 0, amount: Zatoshi(200_000_000), status: .active, hoursFromNow: 0)
+            ]
+            $0.totalDurationHours = 12
+            $0.schedule = schedule
+        }
+
+        #expect(proposeCalls.value == 0)
+    }
+
+    // MARK: - confirmTapped: sign + store, then delegate
+
+    @MainActor @Test func confirmTappedSignsAndStoresScheduleThenEmitsDelegateConfirmed() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        let signedSchedule = LockIsolated<MigrationSchedule?>(nil)
+        var state = MigrationTransferPlan.State()
+        state.schedule = schedule
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { signedSchedule.setValue($0) }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signedSchedule.value == schedule)
+    }
+
+    @MainActor @Test func confirmTappedForManualVariantSignsAndStoresScheduleThenEmitsDelegateConfirmed() async {
+        let schedule = MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+        var state = MigrationTransferPlan.State(variant: .manual)
+        state.schedule = schedule
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
     }
 }

--- a/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
@@ -101,6 +101,32 @@ import ComposableArchitecture
         #expect(proposeCalls.value == 0)
     }
 
+    @MainActor @Test func onAppearWithCoordinatorHydratedRowsDoesNotRePropose() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)
+        ]
+        let state = MigrationTransferPlan.State(
+            variant: .scheduled,
+            rows: IdentifiedArrayOf(uniqueElements: rows),
+            totalDurationHours: 12,
+            requiresSigning: false
+        )
+        let called = LockIsolated<Bool>(false)
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = {
+                called.setValue(true)
+                return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+            }
+        }
+
+        await store.send(.onAppear)
+
+        #expect(called.value == false)
+    }
+
     // MARK: - confirmTapped: sign + store, then delegate
 
     @MainActor @Test func confirmTappedSignsAndStoresScheduleThenEmitsDelegateConfirmed() async {

--- a/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
@@ -1,0 +1,232 @@
+//
+//  RootMigrationRoutingTests.swift
+//  zodlTests
+//
+//  Covers MOB-1466 phase 5's Root-level wiring for the migration flow
+//  (Features/Root/{RootStore,RootCoordinator,RootInitialization}.swift): the SmartBanner-tap ->
+//  `.migrationCoordFlow` route (with flow-state reset), `isSensitiveFlowActive` classifying the new
+//  `Path` case, `flowFinished` closing the path, launch/foreground reconciliation invoking
+//  `migrationManager.reconcile()`, and the Sending `.viewTransaction` delegate's Root-level handling
+//  (v1: treated as a flow close — see the `RootCoordinator` doc comment at that case for why).
+//
+//  `.serialized`: constructing `Root.State` builds `migrationCoordFlowState = MigrationCoordFlow
+//  .State.initial`, which itself builds a `MigrationEntry.State` reading the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` key — same precedent as `MigrationCoordFlowTests`.
+//  Uses a plain `Store` (not `TestStore`) with heavy `withDependencies` overrides, mirroring
+//  `FlexaTests/FlexaSecurityTests.swift`: Root's init effects are too heavy for exhaustive
+//  `TestStore` assertion, so behavior is observed via `LockIsolated` spies and polling.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct RootMigrationRoutingTests {
+    // MARK: - Banner tap -> .migrationCoordFlow
+
+    /// Tapping the migration banner (`.home(.smartBanner(.migrationScreenRequested))`) must open
+    /// `.migrationCoordFlow` and reset its flow state fresh — same shape as `.walletBackupTapped`
+    /// opening `.walletBackup`.
+    @Test func migrationScreenRequestedOpensMigrationCoordFlowWithFreshState() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            // Poison the pre-existing flow state so a reset is actually observable.
+            initialState.migrationCoordFlowState.mode = MigrationMode.immediate
+            initialState.migrationCoordFlowState.path.append(.complete(MigrationComplete.State()))
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            store.send(.home(.smartBanner(.migrationScreenRequested)))
+            await waitForRootStore { store.state.path == Root.State.Path.migrationCoordFlow }
+
+            #expect(store.state.path == Root.State.Path.migrationCoordFlow)
+            #expect(store.state.migrationCoordFlowState.mode == nil)
+            #expect(store.state.migrationCoordFlowState.path.isEmpty)
+        }
+    }
+
+    // MARK: - flowFinished -> path == nil
+
+    /// `MigrationCoordFlow`'s `.flowFinished` (every flow-root close / terminal delegate) must
+    /// close the migration path back to Home.
+    @Test func migrationCoordFlowFinishedClosesPath() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.path = Root.State.Path.migrationCoordFlow
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            store.send(.migrationCoordFlow(.flowFinished))
+            await waitForRootStore { store.state.path == nil }
+
+            #expect(store.state.path == nil)
+        }
+    }
+
+    // MARK: - isSensitiveFlowActive
+
+    /// Pure computed-property check: `.migrationCoordFlow` must classify as sensitive, alongside
+    /// send/scan/swap/transactions — the exhaustive switch forces this classification by design.
+    @Test func isSensitiveFlowActiveIsTrueForMigrationCoordFlow() {
+        var state = Root.State.initial
+        state.path = Root.State.Path.migrationCoordFlow
+
+        #expect(state.isSensitiveFlowActive == true)
+    }
+
+    // MARK: - Reconciliation: willEnterForeground
+
+    /// Every foreground entry must invoke `migrationManager.reconcile()`, regardless of the
+    /// keychain/sync-status branch taken afterward.
+    @Test func willEnterForegroundInvokesMigrationReconcile() async {
+        let reconcileCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.migrationManager.reconcile = { reconcileCalls.withValue { $0 += 1 } }
+            }
+
+            store.send(.initialization(.appDelegate(.willEnterForeground)))
+            await waitForRootStore { reconcileCalls.withValue { $0 } == 1 }
+
+            #expect(reconcileCalls.withValue { $0 } == 1)
+        }
+    }
+
+    // MARK: - Reconciliation: launch (initialSetups)
+
+    /// The launch path (`initialSetups`, past the disk-space guard) must also invoke
+    /// `migrationManager.reconcile()`, independent of `willEnterForeground`'s own hook.
+    @Test func initialSetupsInvokesMigrationReconcile() async {
+        let reconcileCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.migrationManager.reconcile = { reconcileCalls.withValue { $0 += 1 } }
+                $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+            }
+
+            store.send(.initialization(.initialSetups))
+            await waitForRootStore { reconcileCalls.withValue { $0 } == 1 }
+
+            #expect(reconcileCalls.withValue { $0 } == 1)
+        }
+    }
+
+    // MARK: - View Transaction (Sending delegate)
+
+    /// The migration Sending screen's `.viewTransaction` delegate carries only a bare stub
+    /// `txId: String` — never a real `TransactionState` the existing transaction-detail plumbing
+    /// (`TransactionDetails.State.transaction`, non-optional) could open. Root's v1 handling (see
+    /// the doc comment on this case in `RootCoordinator.swift`) treats it as a flow close rather
+    /// than opening a broken/empty detail screen, pending real txids from the SDK (MOB-1455).
+    @Test func sendingViewTransactionDelegateClosesMigrationFlow() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.path = Root.State.Path.migrationCoordFlow
+            let sendingState = MigrationSending.State(phase: .success, txId: "stub-tx-id")
+            initialState.migrationCoordFlowState.path.append(.sending(sendingState))
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            let sendingId = try? #require(initialState.migrationCoordFlowState.path.ids.last)
+            guard let sendingId else {
+                Issue.record("Expected a sending element id on the migration path")
+                return
+            }
+
+            store.send(
+                .migrationCoordFlow(
+                    .path(.element(id: sendingId, action: .sending(.delegate(.viewTransaction))))
+                )
+            )
+            await waitForRootStore { store.state.path == nil }
+
+            #expect(store.state.path == nil)
+        }
+    }
+}
+
+// MARK: - Shared dependency baseline
+
+/// Base override set for driving a full `Root` `Store` without its heavy init effects crashing on
+/// unimplemented dependency defaults — mirrors `FlexaSecurityTests`' override set, plus the
+/// migration-specific clients and the `.initialization(...)` launch-path dependencies (`
+/// databaseFiles`, `diskSpaceChecker`) this suite's reconciliation tests additionally traverse.
+/// `diskSpaceChecker` defaults to "full disk" (`hasEnoughFreeSpaceForSync == false`) so a bare
+/// `.willEnterForeground` send — which can itself fall through to `.initialSetups` — doesn't
+/// also run `initialSetups`'s own reconcile effect and double-count the spy; tests that need the
+/// `initialSetups` continuation (past the disk-space guard) override it back to `true` locally.
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mainQueue = .immediate
+    values.mnemonic = .mock
+    values.migrationBGScheduler.backgroundRefreshStatus = { .available }
+    values.migrationBGScheduler.scheduleFirstWindow = { }
+    values.migrationBGScheduler.scheduleNextWindow = { }
+    values.migrationBGScheduler.cancelAll = { }
+    values.migrationManager.bannerVariant = { _ in nil }
+    values.migrationManager.reentryRoute = { .entry }
+    values.migrationManager.migrationMode = { nil }
+    values.migrationManager.setMigrationMode = { _ in }
+    values.migrationManager.setManualDelivery = { _ in }
+    values.migrationManager.setNetworkPrivacyOptions = { _ in }
+    values.migrationManager.acknowledgeComplete = { }
+    values.migrationManager.recordMigrationBroadcast = { }
+    values.migrationManager.reconcile = { }
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.load = { _ in }
+    values.userNotifications.authorizationStatus = { .notDetermined }
+    values.userNotifications.requestAuthorization = { false }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}
+
+@MainActor
+private func waitForRootStore(
+    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for migration-routing Root store state", sourceLocation: sourceLocation)
+}

--- a/zodlTests/SmartBannerTests/SmartBannerMigrationTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerMigrationTests.swift
@@ -1,0 +1,361 @@
+//
+//  SmartBannerMigrationTests.swift
+//  zodlTests
+//
+//  MOB-1466: covers the `priorityMigration` wiring added to `SmartBannerStore.swift` — the
+//  `PriorityContent.rank` ordering (below priority1/priority2, above everything else), the
+//  `.evaluatePriorityMigration` walk step slotted between priority2 and priority3, the
+//  `migrationStateStream()` reactive trigger (`.migrationStateChanged`/`.migrationVariantUpdated`),
+//  and the `.migrationScreenRequested` tap leaf action. `.serialized`: state touches the
+//  process-global `@Shared(.inMemory(.selectedWalletAccount))`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) struct SmartBannerMigrationTests {
+    private func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    // MARK: - Rank interplay
+
+    @MainActor @Test func migrationRequestIsRejectedWhilePriority1Shows() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority1
+        state.priorityContentRequested = .priority1
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.triggerPriority(.priorityMigration)) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        // Guard rejects: priorityMigration.rank (1.5) >= priority1.rank (0) — no further effects.
+        await store.receive(\.openBannerRequest)
+    }
+
+    @MainActor @Test func migrationRequestIsRejectedWhilePriority2Shows() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority2
+        state.priorityContentRequested = .priority2
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.triggerPriority(.priorityMigration)) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        // Guard rejects: priorityMigration.rank (1.5) >= priority2.rank (1) — no further effects.
+        await store.receive(\.openBannerRequest)
+    }
+
+    @MainActor @Test func priority1RequestReplacesAShowingMigrationBanner() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.triggerPriority(.priority1)) {
+            $0.priorityContentRequested = .priority1
+        }
+        // priority1.rank (0) < priorityMigration.rank (1.5) — allowed; banner is open, so it closes
+        // (non-clean) first, then re-requests, then re-opens with the new priority.
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priority1
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    @MainActor @Test func migrationRequestReplacesAShowingPriority3Banner() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority3
+        state.priorityContentRequested = .priority3
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.triggerPriority(.priorityMigration)) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        // priorityMigration.rank (1.5) < priority3.rank (2) — allowed.
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    @MainActor @Test func migrationRequestReplacesAShowingPriority9Banner() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority9
+        state.priorityContentRequested = .priority9
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.triggerPriority(.priorityMigration)) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        // priorityMigration.rank (1.5) < priority9.rank (10) — allowed.
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    @MainActor @Test func priority3RequestIsRejectedWhileMigrationShows() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.triggerPriority(.priority3)) {
+            $0.priorityContentRequested = .priority3
+        }
+        // Guard rejects: priority3.rank (2) >= priorityMigration.rank (1.5) — no further effects.
+        await store.receive(\.openBannerRequest)
+    }
+
+    @MainActor @Test func priority9RequestIsRejectedWhileMigrationShows() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.triggerPriority(.priority9)) {
+            $0.priorityContentRequested = .priority9
+        }
+        // Guard rejects: priority9.rank (10) >= priorityMigration.rank (1.5) — no further effects.
+        await store.receive(\.openBannerRequest)
+    }
+
+    // MARK: - Walk step
+
+    @MainActor @Test func priority2WalkDownReachesEvaluatePriorityMigration() async {
+        let store = TestStore(initialState: SmartBanner.State()) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+        // A nil variant lets the walk continue all the way to priority9 (untouched, unrelated
+        // steps) — only priority2 -> evaluatePriorityMigration -> priority3 is under test here.
+        store.exhaustivity = .off
+
+        await store.send(.evaluatePriority2)
+        await store.receive(\.evaluatePriorityMigration)
+        // Falls through with a nil variant — verified in detail below; here we only assert the
+        // walk actually reaches the new step rather than jumping straight to priority3.
+        await store.receive(\.migrationVariantLoaded)
+        await store.receive(\.evaluatePriority3)
+    }
+
+    @MainActor @Test func evaluatePriorityMigrationWithNonNilVariantTriggersMigration() async {
+        let account = walletAccount(idByte: 3)
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { accountUUID in
+                #expect(accountUUID == account.id)
+                return MigrationBannerVariant.complete
+            }
+        }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.evaluatePriorityMigration)
+        await store.receive(\.migrationVariantLoaded) {
+            // `.complete`, not the `State()` default (`.required`), so the assignment is an
+            // observable change — proves the loaded variant actually lands in state.
+            $0.migrationBannerVariant = MigrationBannerVariant.complete
+        }
+        await store.receive(\.triggerPriority) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    @MainActor @Test func evaluatePriorityMigrationWithNilVariantFallsThroughToPriority3() async {
+        let store = TestStore(initialState: SmartBanner.State()) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+        // A nil variant lets the walk continue all the way to priority9 (untouched, unrelated
+        // steps) — only the migration -> priority3 hop is under test here.
+        store.exhaustivity = .off
+
+        await store.send(.evaluatePriorityMigration)
+        await store.receive(\.migrationVariantLoaded)
+        await store.receive(\.evaluatePriority3)
+        // walletStatus defaults to `.none` — priority3 (restoring) itself is a no-op walk-through.
+        await store.receive(\.evaluatePriority4)
+    }
+
+    // MARK: - Reactive trigger: variant-only update while showing
+
+    @MainActor @Test func migrationStateChangedWithNonNilVariantWhileShowingOnlyUpdatesState() async {
+        let account = walletAccount(idByte: 5)
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        state.migrationBannerVariant = MigrationBannerVariant.inProgress(done: 2, total: 5)
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { accountUUID in
+                #expect(accountUUID == account.id)
+                return MigrationBannerVariant.inProgress(done: 3, total: 5)
+            }
+        }
+
+        await store.send(.migrationStateChanged(MigrationState.inProgress(
+            MigrationProgress(
+                completedTransfers: 3,
+                totalTransfers: 5,
+                remainingOrchard: Zatoshi.zero,
+                nextTransferReadyAtHeight: nil
+            )
+        )))
+        await store.receive(\.migrationVariantUpdated) {
+            $0.migrationBannerVariant = MigrationBannerVariant.inProgress(done: 3, total: 5)
+        }
+        // No `.triggerPriority`/`.closeAndCleanupBanner` follow-up — content re-renders live from
+        // the state mutation alone, banner stays open on the same priority.
+        #expect(store.state.priorityContent == .priorityMigration)
+        #expect(store.state.isOpen)
+    }
+
+    @MainActor @Test func migrationStateChangedWithNonNilVariantWhileNotShowingTriggers() async {
+        let store = TestStore(initialState: SmartBanner.State()) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in MigrationBannerVariant.complete }
+        }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.migrationStateChanged(MigrationState.notStarted))
+        await store.receive(\.migrationVariantUpdated) {
+            // `.complete`, not the `State()` default (`.required`) — see the analogous comment in
+            // `evaluatePriorityMigrationWithNonNilVariantTriggersMigration` above.
+            $0.migrationBannerVariant = MigrationBannerVariant.complete
+        }
+        await store.receive(\.triggerPriority) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    // MARK: - Reactive trigger: variant nil while migration showing
+
+    @MainActor @Test func migrationStateChangedWithNilVariantWhileMigrationShowingClosesAndRewalks() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.migrationStateChanged(MigrationState.complete))
+        await store.receive(\.migrationVariantUpdated)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+            $0.priorityContentRequested = nil
+            $0.priorityContent = nil
+        }
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.evaluatePriority1)
+        // The re-walk continues (evaluatePriority2 -> evaluatePriorityMigration -> ...); with the
+        // same `nil`-returning override it walks all the way down without re-triggering migration.
+        #expect(store.state.priorityContent == nil)
+    }
+
+    @MainActor @Test func migrationStateChangedWithNilVariantWhileNotShowingIsANoOp() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority6
+        state.priorityContentRequested = .priority6
+        state.isOpen = true
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+
+        await store.send(.migrationStateChanged(MigrationState.complete))
+        await store.receive(\.migrationVariantUpdated)
+        // Nil while some other priority (not migration) is showing: nothing else happens.
+        #expect(store.state.priorityContent == .priority6)
+        #expect(store.state.isOpen)
+    }
+
+    // MARK: - Tap
+
+    @MainActor @Test func smartBannerContentTappedWithMigrationShowingRequestsMigrationScreen() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.smartBannerContentTapped)
+        await store.receive(\.migrationScreenRequested)
+    }
+
+    @MainActor @Test func migrationScreenRequestedProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: SmartBanner.State()) { SmartBanner() }
+
+        await store.send(.migrationScreenRequested)
+    }
+}


### PR DESCRIPTION
Implements [MOB-1466](https://linear.app/zodl/issue/MOB-1466/ironwood-migration-coordinator-flow-routing-reconciliation) — the full spec lives in the ticket description. Stacked on #1884 (MOB-1465).

Chains the visual-only migration screens into a live, state-driven flow. Everything runs against the inert SDK stubs: it compiles, navigates, and is fully unit-tested, and goes live when the real SDK (MOB-1455) fills the stubs. Background execution + notification scheduling stay in MOB-1467 (seams created here).

## What's here

- **`MigrationCoordFlow`** (Store/View/Coordinator in `CoordFlows/`): Entry as root screen; the full chaining table for the three flows (immediate / privacy-scheduled / privacy-manual) with conditional skips (note split, Background App Refresh, notification permission, app-wide Tor); re-entry routing per the 7-row table; close-instead-of-pop back on re-entry roots.
- **`MigrationManagerClient`** (new dependency): banner-variant + re-entry derivations (pure, table-tested), persisted mode/manual-delivery/Tor-options/complete-acknowledged flag, and the 10-minute sync↔send gate (persisted, relaunch-proof). Acknowledge flag is only consulted while state is `.complete`, with a stale-reset in `reconcile()`.
- **`MigrationBGSchedulerClient`** (new, inert): the MOB-1467 seam — called at plan-commit / reschedule / manual-send (cadence-reset points); `backgroundRefreshStatus` is live. **`UserNotificationsClient`** (new): authorization only.
- **SmartBanner**: `priorityMigration` now triggers — ranked **below disconnected + sync error, above everything else** (new `rank` comparator; both live `rawValue` comparisons audited/converted); walk-chain step between priority2→3 + reactive `migrationStateStream()` subscription; per-priority gradient (migration = Gray 700→950 per Figma, all existing banners keep Purple); banner tap → Root opens the flow.
- **Root**: new `Path.migrationCoordFlow` (classified **sensitive**), view branch, banner-tap routing, `flowFinished` handling, `migrationManager.reconcile()` on launch + foreground.
- **Transaction guard**: `submitNoteSplit` / `executeNextPendingMigrationTransfer` LiveKey stubs now acquire the guard (`withSubmission`) — inert today, correct-by-construction when the SDK lands.

## Flagged decisions / follow-ups

- **View Transaction** on the migration Sent screen closes the flow for now (`TODO: [MOB-1458]`) — stub txids can't resolve to a real `TransactionState` in the shared transactions list. Wire to transaction detail once real txids exist.
- `MigrationReviewTransfer.Delegate.closed` and `MigrationRecovery.Delegate.close` added (flow-root back-out); `MigrationTransferPlan.State.requiresSigning` distinguishes the rescheduled variant (already-signed; confirm = acknowledgment) from the re-created one (signs).
- Fee rows for proposed transfers use the repo's standard `Zatoshi(100_000)` display constant — `MigrationSchedule`/`TransferProposal` carry no fee field (SDK-contract note).
- Test-infra gotcha discovered: `-only-testing:zodlTests/<Directory>` silently matches **zero** Swift Testing suites (identifiers resolve by `@Suite` name, not folder) — final verification here ran the full target instead.

## Verification

- Full `zodlTests` target on `zodl-internal` (iPhone 17 Pro sim, `-skipMacroValidation`): **844 tests / 122 suites, all green** (+87 tests vs. base; 1 pre-existing unrelated known issue). New suites: `MigrationManagerTests` (43), `MigrationCoordFlowTests` (36), `SmartBannerMigrationTests` (16), `RootMigrationRoutingTests` (6); all existing `SmartBannerTests` untouched and green.
- Full build green. Added Swift lines ≤ 150 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)