### PR TITLE
[MOB-1467] Migration background scheduling and local notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1464] Ironwood migration screens: progress status, plan recovery, migration complete, and the home widget states. Not reachable in the app yet.
 - [MOB-1465] Internal DEBUG-only gallery of all Ironwood migration screens (long-press the balance on Home). Not present in release builds.
 - [MOB-1466] Ironwood migration screens are wired into a complete guided flow (entry, scheduling, status, recovery) driven by migration state, with a Home banner entry point — dormant until the migration SDK ships.
+- [MOB-1467] Scheduled Ironwood migration transfers can now send from background tasks, with local notifications for progress, required actions, and manual-mode send reminders — dormant until the migration SDK ships.
 
 ## 3.7.2 build 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1463] Ironwood migration screens: transfer plan, transfer review, sending states, and migration scheduled. Not reachable in the app yet.
 - [MOB-1464] Ironwood migration screens: progress status, plan recovery, migration complete, and the home widget states. Not reachable in the app yet.
 - [MOB-1465] Internal DEBUG-only gallery of all Ironwood migration screens (long-press the balance on Home). Not present in release builds.
+- [MOB-1466] Ironwood migration screens are wired into a complete guided flow (entry, scheduling, status, recovery) driven by migration state, with a Home banner entry point — dormant until the migration SDK ships.
 
 ## 3.7.2 build 1
 

--- a/secant-distrib-Info.plist
+++ b/secant-distrib-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -19434,6 +19434,142 @@
         }
       }
     },
+    "migrationNotification.transferCompleteTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration update"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualización de la migración"
+          }
+        }
+      }
+    },
+    "migrationNotification.transferCompleteBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld of %2$lld complete — next send in ~%3$lld hours. %4$@ ZEC remaining in Orchard."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld de %2$lld completada — el próximo envío será en ~%3$lld horas. Quedan %4$@ ZEC en Orchard."
+          }
+        }
+      }
+    },
+    "migrationNotification.actionNeededTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Action needed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acción necesaria"
+          }
+        }
+      }
+    },
+    "migrationNotification.transferWaitingBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld waiting. Open ZODL to send or re-schedule."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld en espera. Abre ZODL para enviarla o reprogramarla."
+          }
+        }
+      }
+    },
+    "migrationNotification.planNeedsUpdateBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration plan needs update. Open ZODL to review the details."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El plan de migración necesita una actualización. Abre ZODL para revisar los detalles."
+          }
+        }
+      }
+    },
+    "migrationNotification.manualTransferReadyBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld — ready to send. Open ZODL to review the details."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld — lista para enviar. Abre ZODL para revisar los detalles."
+          }
+        }
+      }
+    },
+    "migrationNotification.migrationCompleteTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migración completada"
+          }
+        }
+      }
+    },
+    "migrationNotification.migrationCompleteBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration complete. Open ZODL to review the details."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migración completada. Abre ZODL para revisar los detalles."
+          }
+        }
+      }
+    },
     "migrationNotifications.title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/AppDelegate.swift
+++ b/secant/Sources/AppDelegate.swift
@@ -22,6 +22,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     private let workerQueue = DispatchQueue(label: "Monitor")
     private let isConnectedToWifi = ManagedAtomic(false)
 
+    // Owned strongly so it outlives this method scope — `UNUserNotificationCenter.current()`
+    // only holds its delegate weakly.
+    private let notificationDelegate = MigrationNotificationCenterDelegate()
+
     let rootStore = StoreOf<Root>(
         initialState: .initial
     ) {
@@ -40,9 +44,14 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 #endif
         handleBackgroundTask()
 
+        // Synchronous, before anything else touches notifications — required to catch cold-start
+        // taps (the app can be launched directly by a notification tap).
+        notificationDelegate.rootStore = rootStore
+        UNUserNotificationCenter.current().delegate = notificationDelegate
+
         // set the default behavior for the NSDecimalNumber
         NSDecimalNumber.defaultBehavior = Zatoshi.decimalHandler
-        
+
         rootStore.send(.initialization(.appDelegate(.didFinishLaunching)))
 
         return true
@@ -97,11 +106,41 @@ extension AppDelegate {
 
             scheduleSchedulerBackgroundTask()
             scheduleBackgroundTask()
-            
+
             task.setTaskCompleted(success: true)
         }
-        
+
         LoggerProxy.event("BGTask SCHEDULER registered \(bcgSchedulerTaskResult)")
+
+        let bcgMigrationTaskResult = BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: MigrationBGTask.identifier,
+            using: DispatchQueue.main
+        ) { [self] task in
+            LoggerProxy.event("BGTask BGTaskScheduler.shared.register MIGRATION called")
+            guard let task = task as? BGProcessingTask else {
+                return
+            }
+
+            startMigrationBackgroundTask(task)
+        }
+
+        LoggerProxy.event("BGTask MIGRATION registered \(bcgMigrationTaskResult)")
+    }
+
+    /// Unlike `startBackgroundTask` (the `power_wifi_sync` handler above), there is deliberately
+    /// NO WiFi gate here: migration's `BGProcessingTaskRequest.requiresNetworkConnectivity` already
+    /// covers the network requirement, and migration must not additionally demand WiFi/power.
+    private func startMigrationBackgroundTask(_ task: BGProcessingTask) {
+        LoggerProxy.event("BGTask startMigrationBackgroundTask called")
+
+        rootStore.send(.initialization(.appDelegate(.migrationBackgroundTask(task))))
+
+        task.expirationHandler = { [rootStore] in
+            LoggerProxy.event("BGTask startMigrationBackgroundTask expirationHandler called")
+            DispatchQueue.main.async {
+                rootStore.send(.initialization(.appDelegate(.migrationBackgroundTaskExpired)))
+            }
+        }
     }
     
     private func startBackgroundTask(_ task: BGProcessingTask) {
@@ -180,6 +219,47 @@ extension AppDelegate {
             LoggerProxy.event("BGTask scheduleSchedulerBackgroundTask succeeded to submit")
         } catch {
             LoggerProxy.event("BGTask scheduleSchedulerBackgroundTask failed to submit, error: \(error)")
+        }
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate (MOB-1467)
+
+/// Routes migration notification taps into the app (`.migrationNotificationTapped`) and controls
+/// foreground presentation of migration notifications (the SmartBanner already covers live state,
+/// so migration notifications present nothing while the app is in the foreground). `rootStore` is
+/// injected by `AppDelegate` rather than held here at construction time, since this delegate is
+/// set on `UNUserNotificationCenter.current()` synchronously in `didFinishLaunching`, before
+/// `AppDelegate`'s own `rootStore` would otherwise be considered "ready" — it's a stored property
+/// on `AppDelegate` either way, so both are initialized together in practice.
+final class MigrationNotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate {
+    var rootStore: StoreOf<Root>?
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if response.notification.request.identifier.hasPrefix(MigrationNotification.identifierPrefix) {
+            let rootStore = self.rootStore
+            DispatchQueue.main.async {
+                rootStore?.send(.initialization(.appDelegate(.migrationNotificationTapped)))
+            }
+        }
+
+        completionHandler()
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        if notification.request.identifier.hasPrefix(MigrationNotification.identifierPrefix) {
+            // The SmartBanner already covers live migration state while the app is foregrounded.
+            completionHandler([])
+        } else {
+            completionHandler([.banner, .list, .sound])
         }
     }
 }

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerInterface.swift
@@ -2,10 +2,10 @@
 //  MigrationBGSchedulerInterface.swift
 //  Zashi
 //
-//  Background-refresh status check + scheduling seams for the Orchard -> Ironwood migration's
-//  background execution (MOB-1467). Only `backgroundRefreshStatus` is live in this ticket
-//  (MOB-1466); the scheduling members are inert stubs the coordinator calls at the right cadence
-//  points so MOB-1467 only has to fill the `LiveKey`, never touch call sites.
+//  Background-refresh status check + scheduling seam for the Orchard -> Ironwood migration's
+//  background execution (MOB-1467): the `co.electriccoin.migration_transfer` `BGProcessingTask`
+//  cadence (§8.3) in scheduled mode, or a pre-scheduled "ready to send" local notification in
+//  manual mode — see `MigrationBGSchedulerLiveKey`'s `WakeupAction` decision function.
 //
 
 import UIKit
@@ -21,10 +21,20 @@ extension DependencyValues {
 @DependencyClient
 struct MigrationBGSchedulerClient: Sendable {
     var backgroundRefreshStatus: @Sendable () async -> UIBackgroundRefreshStatus = { .available }
-    // +30 min rule — no-op until MOB-1467
-    var scheduleFirstWindow: @Sendable () -> Void
-    // +6.5 h rule — no-op until MOB-1467
-    var scheduleNextWindow: @Sendable () -> Void
-    // no-op until MOB-1467
-    var cancelAll: @Sendable () -> Void
+    // Arms the next wakeup (+30 min rule): BG task request in scheduled mode, pre-scheduled
+    // "ready to send" notification in manual mode. First-check: no-ops (cancels) if migration is
+    // already `.complete`.
+    var scheduleFirstWindow: @Sendable () async -> Void
+    // Arms the next wakeup (+6.5 h rule), same branching as scheduleFirstWindow. Also the reset
+    // point after a manual/immediate foreground send.
+    var scheduleNextWindow: @Sendable () async -> Void
+    // Cancels the pending BG task request and every migration-prefixed notification (pending +
+    // delivered).
+    var cancelAll: @Sendable () async -> Void
+}
+
+/// Background-task identifier for the migration transfer wakeup (AppDelegate registers with it;
+/// prototype precedent).
+enum MigrationBGTask {
+    static let identifier = "co.electriccoin.migration_transfer"
 }

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerInterface.swift
@@ -1,0 +1,30 @@
+//
+//  MigrationBGSchedulerInterface.swift
+//  Zashi
+//
+//  Background-refresh status check + scheduling seams for the Orchard -> Ironwood migration's
+//  background execution (MOB-1467). Only `backgroundRefreshStatus` is live in this ticket
+//  (MOB-1466); the scheduling members are inert stubs the coordinator calls at the right cadence
+//  points so MOB-1467 only has to fill the `LiveKey`, never touch call sites.
+//
+
+import UIKit
+import ComposableArchitecture
+
+extension DependencyValues {
+    var migrationBGScheduler: MigrationBGSchedulerClient {
+        get { self[MigrationBGSchedulerClient.self] }
+        set { self[MigrationBGSchedulerClient.self] = newValue }
+    }
+}
+
+@DependencyClient
+struct MigrationBGSchedulerClient: Sendable {
+    var backgroundRefreshStatus: @Sendable () async -> UIBackgroundRefreshStatus = { .available }
+    // +30 min rule — no-op until MOB-1467
+    var scheduleFirstWindow: @Sendable () -> Void
+    // +6.5 h rule — no-op until MOB-1467
+    var scheduleNextWindow: @Sendable () -> Void
+    // no-op until MOB-1467
+    var cancelAll: @Sendable () -> Void
+}

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
@@ -1,0 +1,33 @@
+//
+//  MigrationBGSchedulerLiveKey.swift
+//  Zashi
+//
+
+import UIKit
+import ComposableArchitecture
+
+extension MigrationBGSchedulerClient: DependencyKey {
+    static let liveValue: MigrationBGSchedulerClient = Self.live()
+
+    static func live() -> Self {
+        MigrationBGSchedulerClient(
+            backgroundRefreshStatus: {
+                await MainActor.run {
+                    UIApplication.shared.backgroundRefreshStatus
+                }
+            },
+            // TODO: [MOB-1467] Schedule the first background-refresh window ~30 minutes after a
+            // migration plan is committed (or re-committed via reschedule/recreate). Call sites in
+            // MOB-1466 already invoke this at every cadence-reset point (plan committed; reschedule
+            // confirmed; recovery recreate confirmed) — this only has to start honoring it.
+            scheduleFirstWindow: { },
+            // TODO: [MOB-1467] Schedule the next background-refresh window ~6.5 hours after the
+            // previous one fired (§8.3 cadence), or after a manual/immediate foreground send
+            // resets the cadence per the coordinator's call sites.
+            scheduleNextWindow: { },
+            // TODO: [MOB-1467] Cancel every pending background-refresh window (migration complete,
+            // user backed out, etc).
+            cancelAll: { }
+        )
+    }
+}

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
@@ -2,32 +2,121 @@
 //  MigrationBGSchedulerLiveKey.swift
 //  Zashi
 //
+//  Live implementation of `MigrationBGSchedulerClient`. The branch decision (submit a BG task vs.
+//  schedule a manual-mode "ready" notification vs. cancel everything because the migration is
+//  done) is factored into the pure, table-testable `WakeupAction.decide` (mirroring
+//  `MigrationDerivations` in MigrationManagerLiveKey.swift) so `MigrationBGSchedulerTests` can
+//  exercise every row without touching `BGTaskScheduler` or `UNUserNotificationCenter`; this file
+//  only computes the inputs and executes the resulting action.
+//
 
+@preconcurrency import BackgroundTasks
 import UIKit
 import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
 
 extension MigrationBGSchedulerClient: DependencyKey {
     static let liveValue: MigrationBGSchedulerClient = Self.live()
 
     static func live() -> Self {
-        MigrationBGSchedulerClient(
+        let impl = MigrationBGSchedulerImpl()
+
+        return MigrationBGSchedulerClient(
             backgroundRefreshStatus: {
                 await MainActor.run {
                     UIApplication.shared.backgroundRefreshStatus
                 }
             },
-            // TODO: [MOB-1467] Schedule the first background-refresh window ~30 minutes after a
-            // migration plan is committed (or re-committed via reschedule/recreate). Call sites in
-            // MOB-1466 already invoke this at every cadence-reset point (plan committed; reschedule
-            // confirmed; recovery recreate confirmed) — this only has to start honoring it.
-            scheduleFirstWindow: { },
-            // TODO: [MOB-1467] Schedule the next background-refresh window ~6.5 hours after the
-            // previous one fired (§8.3 cadence), or after a manual/immediate foreground send
-            // resets the cadence per the coordinator's call sites.
-            scheduleNextWindow: { },
-            // TODO: [MOB-1467] Cancel every pending background-refresh window (migration complete,
-            // user backed out, etc).
-            cancelAll: { }
+            scheduleFirstWindow: { await impl.arm(margin: MigrationCadence.firstWindowMargin) },
+            scheduleNextWindow: { await impl.arm(margin: MigrationCadence.nextWindowMargin) },
+            cancelAll: { await impl.cancelAll() }
         )
+    }
+}
+
+/// Composes `migrationManager` + `sdkSynchronizer` + `userNotifications` and turns their current
+/// readings into a `WakeupAction`, then executes it. `@unchecked Sendable`: holds no mutable state
+/// of its own — every dependency it wraps is itself `Sendable`.
+private final class MigrationBGSchedulerImpl: @unchecked Sendable {
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+    @Dependency(\.userNotifications) var userNotifications
+
+    /// Shared by `scheduleFirstWindow`/`scheduleNextWindow` — only the margin differs. The
+    /// complete-check choke point lives inside `WakeupAction.decide`, so both call sites uniformly
+    /// no-op (cancel) once the migration is done, without duplicating that check here.
+    func arm(margin: TimeInterval) async {
+        let progress = sdkSynchronizer.getMigrationProgress()
+        let preferredExecutableAt = progress?.nextTransferReadyAtHeight.flatMap { height in
+            sdkSynchronizer.estimateTimestamp(height).map { Date(timeIntervalSince1970: $0) }
+        }
+        let window = MigrationCadence.window(
+            margin: margin,
+            preferredExecutableAt: preferredExecutableAt,
+            now: Date()
+        )
+
+        let action = WakeupAction.decide(
+            state: sdkSynchronizer.getMigrationState(),
+            isManualDelivery: migrationManager.isManualDelivery(),
+            window: window,
+            nextTransferNumber: (progress?.completedTransfers ?? 0) + 1
+        )
+
+        await execute(action)
+    }
+
+    func cancelAll() async {
+        await execute(WakeupAction.cancelAll)
+    }
+
+    private func execute(_ action: WakeupAction) async {
+        switch action {
+        case let .submitTask(earliestBeginDate):
+            let request = BGProcessingTaskRequest(identifier: MigrationBGTask.identifier)
+            request.earliestBeginDate = earliestBeginDate
+            request.requiresNetworkConnectivity = true
+            request.requiresExternalPower = false
+            try? BGTaskScheduler.shared.submit(request)
+
+        case let .scheduleReadyNotification(number, at):
+            await userNotifications.scheduleMigrationNotification(.manualTransferReady(number: number), at)
+
+        case .cancelAll:
+            BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: MigrationBGTask.identifier)
+            await userNotifications.cancelMigrationNotifications()
+        }
+    }
+}
+
+// MARK: - Pure decision (table-testable, no SDK/framework dependency)
+
+/// What to do when arming the next migration wakeup. Scheduled mode submits a `BGProcessingTask`
+/// request; manual mode pre-schedules the "ready to send" notification (§4.4 approved decision 3
+/// — manual mode has no BG sessions, so its reminder is time-scheduled up front rather than
+/// posted live from a session). Either branch is skipped in favor of `.cancelAll` once the
+/// migration is `.complete` — the choke point that prevents an infinite +6.5 h no-op chain.
+enum WakeupAction: Equatable {
+    case submitTask(earliestBeginDate: Date)
+    case scheduleReadyNotification(number: Int, at: Date)
+    case cancelAll
+
+    /// `state` gates everything: `.complete` always wins, regardless of `isManualDelivery`.
+    /// Otherwise: manual -> `.scheduleReadyNotification`, scheduled -> `.submitTask`.
+    static func decide(
+        state: MigrationState,
+        isManualDelivery: Bool,
+        window: Date,
+        nextTransferNumber: Int
+    ) -> WakeupAction {
+        guard state != MigrationState.complete else {
+            return WakeupAction.cancelAll
+        }
+
+        if isManualDelivery {
+            return WakeupAction.scheduleReadyNotification(number: nextTransferNumber, at: window)
+        }
+
+        return WakeupAction.submitTask(earliestBeginDate: window)
     }
 }

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationCadence.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationCadence.swift
@@ -1,0 +1,25 @@
+//
+//  MigrationCadence.swift
+//  Zashi
+//
+//  Pure background-wakeup timing math for the Orchard -> Ironwood migration (MOB-1467, §8.3).
+//  `window(margin:preferredExecutableAt:now:)` is the single formula both `scheduleFirstWindow`
+//  and `scheduleNextWindow` use in the `MigrationBGSchedulerClient` LiveKey — only the margin
+//  constant differs between them. Table-tested directly, no SDK dependency (see
+//  MigrationCadenceTests).
+//
+
+import Foundation
+
+enum MigrationCadence {
+    static let firstWindowMargin: TimeInterval = 30 * 60          // §8.3
+    static let nextWindowMargin: TimeInterval = 6.5 * 60 * 60     // §8.3
+
+    /// earliestBeginDate for the next wakeup. The SDK's per-transfer executable time is
+    /// authoritative when known; the app margin is both the fallback (stubs return nil) and a
+    /// floor (never wake before the margin — §8.3's 30 min/6.5 h cushions over the SDK's
+    /// ~10 min/~6 h expectations).
+    static func window(margin: TimeInterval, preferredExecutableAt: Date?, now: Date) -> Date {
+        max(preferredExecutableAt ?? Date.distantPast, now.addingTimeInterval(margin))
+    }
+}

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
@@ -1,0 +1,59 @@
+//
+//  MigrationManagerInterface.swift
+//  Zashi
+//
+//  App-owned logic for the Orchard -> Ironwood migration (MOB-1466): persistence, the
+//  10-minute sync<->send gate, and the banner-variant / re-entry-route derivations. The SDK
+//  only exposes raw state (`MigrationState`, `MigrationProgress`, …) — this client is the
+//  single place that turns that state plus app-side flags into what the UI actually shows.
+//
+
+import Foundation
+@preconcurrency import ZcashLightClientKit
+import ComposableArchitecture
+
+extension DependencyValues {
+    var migrationManager: MigrationManagerClient {
+        get { self[MigrationManagerClient.self] }
+        set { self[MigrationManagerClient.self] = newValue }
+    }
+}
+
+@DependencyClient
+struct MigrationManagerClient: Sendable {
+    // Derivations (pure given SDK members + persistence; unit-tested as tables)
+    var bannerVariant: @Sendable (_ accountUUID: AccountUUID?) async -> MigrationBannerVariant? = { _ in nil }
+    var reentryRoute: @Sendable () -> MigrationReentryRoute = { .entry }
+    var orchardBalanceToMigrate: @Sendable (_ accountUUID: AccountUUID?) async -> Zatoshi = { _ in .zero }
+    // Persistence (UserDefaults-backed; keys in SharedStateKeys.swift)
+    var migrationMode: @Sendable () -> MigrationMode?
+    var setMigrationMode: @Sendable (MigrationMode) -> Void
+    var isManualDelivery: @Sendable () -> Bool = { false }
+    var setManualDelivery: @Sendable (Bool) -> Void
+    var networkPrivacyOptions: @Sendable () -> NetworkPrivacyOptions = { NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil) }
+    var setNetworkPrivacyOptions: @Sendable (NetworkPrivacyOptions) -> Void
+    var isCompleteAcknowledged: @Sendable () -> Bool = { false }
+    var acknowledgeComplete: @Sendable () -> Void
+    // 10-minute sync<->send gate
+    var sendGate: @Sendable () -> MigrationSendGate = { .allowed }
+    var recordMigrationBroadcast: @Sendable () -> Void
+    var isSyncDeferredAfterBroadcast: @Sendable () -> Bool = { false }   // consumed by MOB-1467
+    // Reconciliation
+    var reconcile: @Sendable () -> Void
+}
+
+enum MigrationSendGate: Equatable, Sendable {
+    case allowed
+    case syncRequired            // isSyncRequiredBeforeNextMigrationTransfer() == true — CTA disabled
+    case waitUntil(Date)         // required sync finished < 10 min ago — CTA disabled with ETA
+}
+
+enum MigrationReentryRoute: Equatable, Sendable {
+    case recovery(isExpired: Bool)       // §4.3 row 1 — variant from AttentionReason (.transferExpired → true, else false)
+    case statusResume                    // row 2
+    case statusProgress                  // row 3
+    case complete                        // row 4 (unacknowledged)
+    case noteSplitProgress               // row 5
+    case reviewManual(step: Int, total: Int)  // row 6 — manual delivery, next transfer due
+    case entry                           // row 7 (notStarted / readyToPropose)
+}

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -1,0 +1,422 @@
+//
+//  MigrationManagerLiveKey.swift
+//  Zashi
+//
+//  Live implementation of `MigrationManagerClient`. Every piece of actual logic is factored
+//  into pure, table-testable types below (`MigrationDerivations`, `MigrationGateStorage`) so
+//  `MigrationManagerTests` can exercise them without touching the SDK; this file is left with
+//  only the wiring between those types and `@Dependency(\.sdkSynchronizer)`.
+//
+
+import Foundation
+@preconcurrency import Combine
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+import os
+
+extension MigrationManagerClient: DependencyKey {
+    static let liveValue: MigrationManagerClient = Self.live()
+
+    static func live() -> Self {
+        let impl = MigrationManagerImpl()
+
+        return MigrationManagerClient(
+            bannerVariant: { accountUUID in await impl.bannerVariant(accountUUID: accountUUID) },
+            reentryRoute: { impl.reentryRoute() },
+            orchardBalanceToMigrate: { accountUUID in await impl.orchardBalanceToMigrate(accountUUID: accountUUID) },
+            migrationMode: { impl.gateStorage.migrationMode() },
+            setMigrationMode: { impl.gateStorage.setMigrationMode($0) },
+            isManualDelivery: { impl.gateStorage.isManualDelivery() },
+            setManualDelivery: { impl.gateStorage.setManualDelivery($0) },
+            networkPrivacyOptions: { impl.gateStorage.networkPrivacyOptions() },
+            setNetworkPrivacyOptions: { impl.gateStorage.setNetworkPrivacyOptions($0) },
+            isCompleteAcknowledged: { impl.gateStorage.isCompleteAcknowledged() },
+            acknowledgeComplete: { impl.gateStorage.acknowledgeComplete() },
+            sendGate: { impl.sendGate() },
+            recordMigrationBroadcast: { impl.recordMigrationBroadcast() },
+            isSyncDeferredAfterBroadcast: { impl.isSyncDeferredAfterBroadcast() },
+            reconcile: { impl.reconcile() }
+        )
+    }
+}
+
+/// Composes `sdkSynchronizer` + `MigrationGateStorage` and owns the lazy `stateStream()`
+/// subscription that drives the sync<->send gate. `@unchecked Sendable`: the only mutable state
+/// is `gateStorage`'s own `OSAllocatedUnfairLock`-protected storage plus the Combine
+/// subscription handle below, both of which are safe to share across isolation domains.
+private final class MigrationManagerImpl: @unchecked Sendable {
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+
+    let gateStorage = MigrationGateStorage()
+
+    private let subscriptionState = OSAllocatedUnfairLock<AnyCancellable?>(initialState: nil)
+
+    /// Subscribes to `sdkSynchronizer.stateStream()` on first use so gate transitions (pending ->
+    /// resolved) are observed as soon as anything asks this client for a derivation or the gate,
+    /// without requiring reducer glue to kick it off (the `shieldingProcessor` precedent).
+    private func ensureSubscribed() {
+        subscriptionState.withLock { cancellable in
+            guard cancellable == nil else { return }
+
+            let gateStorage = self.gateStorage
+            cancellable = self.sdkSynchronizer.stateStream()
+                .sink { state in
+                    gateStorage.observeSyncStatus(state.syncStatus.isSyncing == false, at: Date())
+                }
+        }
+    }
+
+    func bannerVariant(accountUUID: AccountUUID?) async -> MigrationBannerVariant? {
+        ensureSubscribed()
+
+        let state = normalizedState()
+        let rows = sdkSynchronizer.migrationTransfers()
+        let balance = await orchardBalanceToMigrate(accountUUID: accountUUID)
+
+        return MigrationDerivations.bannerVariant(
+            state: state,
+            hasInvalid: sdkSynchronizer.hasInvalidMigrationTransfers(),
+            hasOverdue: sdkSynchronizer.hasOverdueMigrationTransfers(),
+            isManualDelivery: gateStorage.isManualDelivery(),
+            isNextTransferDue: isNextTransferDue(),
+            orchardBalance: balance,
+            isCompleteAcknowledged: gateStorage.isCompleteAcknowledged(),
+            transferRows: rows
+        )
+    }
+
+    func reentryRoute() -> MigrationReentryRoute {
+        ensureSubscribed()
+
+        let progress = sdkSynchronizer.getMigrationProgress()
+
+        return MigrationDerivations.reentryRoute(
+            state: normalizedState(),
+            hasInvalid: sdkSynchronizer.hasInvalidMigrationTransfers(),
+            hasOverdue: sdkSynchronizer.hasOverdueMigrationTransfers(),
+            isManualDelivery: gateStorage.isManualDelivery(),
+            isNextTransferDue: isNextTransferDue(),
+            isCompleteAcknowledged: gateStorage.isCompleteAcknowledged(),
+            progress: progress
+        )
+    }
+
+    func orchardBalanceToMigrate(accountUUID: AccountUUID?) async -> Zatoshi {
+        guard let accountUUID else { return .zero }
+
+        guard let balances = try? await sdkSynchronizer.getAccountsBalances(),
+              let balance = balances[accountUUID] else {
+            return .zero
+        }
+
+        return balance.orchardBalance.total()
+    }
+
+    func sendGate() -> MigrationSendGate {
+        ensureSubscribed()
+
+        if sdkSynchronizer.isSyncRequiredBeforeNextMigrationTransfer() {
+            gateStorage.markSyncRequired()
+        }
+
+        return gateStorage.sendGate(now: Date())
+    }
+
+    func recordMigrationBroadcast() {
+        gateStorage.recordMigrationBroadcast(at: Date())
+    }
+
+    func isSyncDeferredAfterBroadcast() -> Bool {
+        gateStorage.isSyncDeferredAfterBroadcast(now: Date())
+    }
+
+    func reconcile() {
+        sdkSynchronizer.initializeMigrationPostUpgrade()
+
+        // Stale-acknowledge reset: the acknowledged flag must never suppress a *new* migration's
+        // completion banner (reinstall, Path F). It's only meaningful while state is `.complete`.
+        if sdkSynchronizer.getMigrationState() != MigrationState.complete {
+            gateStorage.clearAcknowledgedComplete()
+        }
+    }
+
+    /// `.requiresAttention(.syncRequiredBeforeNext)` carries no progress payload of its own, but
+    /// per spec it renders identically to a plain `.inProgress(p)` banner — so it's normalized to
+    /// that shape here, using the SDK's own out-of-band `getMigrationProgress()` snapshot, before
+    /// ever reaching `MigrationDerivations` (which only needs to know about `.inProgress`).
+    private func normalizedState() -> MigrationState {
+        let state = sdkSynchronizer.getMigrationState()
+
+        guard case MigrationState.requiresAttention(AttentionReason.syncRequiredBeforeNext) = state,
+              let progress = sdkSynchronizer.getMigrationProgress() else {
+            return state
+        }
+
+        return MigrationState.inProgress(progress)
+    }
+
+    /// "Next due" (manual): ready height already reached (or unknown / no progress -> not due).
+    private func isNextTransferDue() -> Bool {
+        guard let readyAtHeight = sdkSynchronizer.getMigrationProgress()?.nextTransferReadyAtHeight else {
+            return false
+        }
+
+        return readyAtHeight <= sdkSynchronizer.latestState().latestBlockHeight
+    }
+}
+
+// MARK: - Pure derivations (table-testable, no SDK dependency)
+
+/// Pure mappings from SDK-observed migration state (plus a handful of app-side flags) onto what
+/// the UI shows. Every function here is a straight table lookup — no dates, no I/O, no SDK types
+/// beyond the value models already `Equatable`/`Sendable` (`MigrationState`, `MigrationProgress`,
+/// `AttentionReason`, `MigrationTransferRow`) — so `MigrationManagerTests` can exercise every row
+/// directly.
+enum MigrationDerivations {
+    /// See MOB-1466 spec, "bannerVariant derivation" table.
+    static func bannerVariant(
+        state: MigrationState,
+        hasInvalid: Bool,
+        hasOverdue: Bool,
+        isManualDelivery: Bool,
+        isNextTransferDue: Bool,
+        orchardBalance: Zatoshi,
+        isCompleteAcknowledged: Bool,
+        transferRows: [MigrationTransferRow]
+    ) -> MigrationBannerVariant? {
+        switch state {
+        case MigrationState.notStarted, MigrationState.readyToPropose:
+            return orchardBalance > Zatoshi.zero ? MigrationBannerVariant.required : nil
+
+        case MigrationState.splitPendingConfirmation:
+            return MigrationBannerVariant.splitting
+
+        case let MigrationState.inProgress(progress):
+            if isManualDelivery && isNextTransferDue {
+                return MigrationBannerVariant.transferReady(number: progress.completedTransfers + 1)
+            }
+            return MigrationBannerVariant.inProgress(done: progress.completedTransfers, total: progress.totalTransfers)
+
+        case let MigrationState.requiresAttention(reason):
+            switch reason {
+            case let AttentionReason.transferStalled(transferNumber):
+                return MigrationBannerVariant.transferWaiting(number: transferNumber)
+
+            case AttentionReason.invalidTransfer:
+                return MigrationBannerVariant.updatePlan
+
+            case AttentionReason.transferExpired:
+                let (first, last) = expiredBounds(transferRows: transferRows)
+                return MigrationBannerVariant.transfersExpired(first: first, last: last)
+
+            case AttentionReason.syncRequiredBeforeNext:
+                // Normalized to `.inProgress` by the LiveKey before this function is ever called
+                // with this state — this branch only exists so the switch stays exhaustive.
+                return nil
+            }
+
+        case MigrationState.complete:
+            return isCompleteAcknowledged ? nil : MigrationBannerVariant.complete
+        }
+    }
+
+    /// See MOB-1466 spec, "reentryRoute" — §4.3 table, checked in this exact order.
+    static func reentryRoute(
+        state: MigrationState,
+        hasInvalid: Bool,
+        hasOverdue: Bool,
+        isManualDelivery: Bool,
+        isNextTransferDue: Bool,
+        isCompleteAcknowledged: Bool,
+        progress: MigrationProgress?
+    ) -> MigrationReentryRoute {
+        if hasInvalid {
+            let isExpired = isTransferExpired(state)
+            return MigrationReentryRoute.recovery(isExpired: isExpired)
+        }
+
+        if hasOverdue {
+            return MigrationReentryRoute.statusResume
+        }
+
+        if isManualDelivery && isNextTransferDue, let progress {
+            return MigrationReentryRoute.reviewManual(step: progress.completedTransfers + 1, total: progress.totalTransfers)
+        }
+
+        if case MigrationState.inProgress = state {
+            return MigrationReentryRoute.statusProgress
+        }
+
+        if case MigrationState.complete = state {
+            return isCompleteAcknowledged ? MigrationReentryRoute.entry : MigrationReentryRoute.complete
+        }
+
+        if case MigrationState.splitPendingConfirmation = state {
+            return MigrationReentryRoute.noteSplitProgress
+        }
+
+        return MigrationReentryRoute.entry
+    }
+
+    /// Bounds for `.transfersExpired(first:last:)`: 1-based first/last position among rows whose
+    /// status is `.expired`; fallback `(1, total)` when none are marked expired (including an
+    /// empty row list, which falls back to `(1, 0)`).
+    private static func expiredBounds(transferRows: [MigrationTransferRow]) -> (first: Int, last: Int) {
+        let expiredIndexes = transferRows
+            .filter { $0.status == MigrationTransferRow.Status.expired }
+            .map { $0.index + 1 }
+
+        guard let first = expiredIndexes.min(), let last = expiredIndexes.max() else {
+            return (1, transferRows.count)
+        }
+
+        return (first, last)
+    }
+
+    private static func isTransferExpired(_ state: MigrationState) -> Bool {
+        guard case let MigrationState.requiresAttention(reason) = state else { return false }
+        return reason == AttentionReason.transferExpired
+    }
+}
+
+// MARK: - Persistence + 10-minute sync<->send gate
+
+/// `UserDefaults`-backed persistence for every app-owned migration flag, plus the 10-minute
+/// sync<->send gate math. Every method that depends on "now" takes it as a parameter — never
+/// reads `Date()` internally — so tests can drive the clock explicitly. Injectable
+/// `UserDefaults` (default `.standard`) lets tests use an isolated named suite.
+final class MigrationGateStorage: @unchecked Sendable {
+    private enum Constants {
+        static let tenMinutes: TimeInterval = 10 * 60
+    }
+
+    private let userDefaults: UserDefaults
+    /// Transient (not persisted): "a required-before-transfer sync is currently pending
+    /// resolution". Re-derived from a fresh SDK read on every `markSyncRequired()` call, so
+    /// losing it across relaunch is fine — the LiveKey re-observes the live SDK flag immediately.
+    private let isSyncCurrentlyRequired = OSAllocatedUnfairLock(initialState: false)
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    // MARK: Gate
+
+    /// Called whenever the LiveKey observes `isSyncRequiredBeforeNextMigrationTransfer() == true`.
+    /// Marks the gate as required outright — `sendGate()` checks this before the persisted
+    /// `gateUntil` window.
+    func markSyncRequired() {
+        isSyncCurrentlyRequired.withLock { $0 = true }
+    }
+
+    /// Called from the `stateStream()` subscription: `isSyncFinished` reflects whether the just
+    /// observed `SyncStatus` is no longer `.syncing` (i.e. reached up-to-date). Only takes effect
+    /// while a sync requirement is pending — an unrelated "already idle" tick is a no-op.
+    func observeSyncStatus(_ isSyncFinished: Bool, at now: Date) {
+        guard isSyncFinished else { return }
+
+        let wasPending = isSyncCurrentlyRequired.withLock { pending -> Bool in
+            let wasPending = pending
+            pending = false
+            return wasPending
+        }
+
+        guard wasPending else { return }
+
+        recordSyncCompletion(at: now)
+    }
+
+    /// Persists `gateUntil = syncCompletion + 10 min` and clears the pending flag. Exposed
+    /// separately from `observeSyncStatus` so tests can drive the gate without a fake stream tick.
+    func recordSyncCompletion(at syncCompletedAt: Date) {
+        isSyncCurrentlyRequired.withLock { $0 = false }
+        let gateUntil = syncCompletedAt.addingTimeInterval(Constants.tenMinutes)
+        userDefaults.set(gateUntil.timeIntervalSince1970, forKey: .migrationSyncGateUntil)
+    }
+
+    /// `sendGate()` precedence: sync currently required -> `.syncRequired`; `now < gateUntil` ->
+    /// `.waitUntil(gateUntil)`; else `.allowed`.
+    func sendGate(now: Date) -> MigrationSendGate {
+        if isSyncCurrentlyRequired.withLock({ $0 }) {
+            return MigrationSendGate.syncRequired
+        }
+
+        guard let gateUntil = storedGateUntil(), now < gateUntil else {
+            return MigrationSendGate.allowed
+        }
+
+        return MigrationSendGate.waitUntil(gateUntil)
+    }
+
+    private func storedGateUntil() -> Date? {
+        guard let interval = userDefaults.object(forKey: .migrationSyncGateUntil) as? Double else {
+            return nil
+        }
+
+        return Date(timeIntervalSince1970: interval)
+    }
+
+    // MARK: Broadcast timestamp (consumed by MOB-1467)
+
+    /// Persisted (not merely in-memory) so relaunching the app cannot dodge the post-broadcast
+    /// sync deferral MOB-1467's scheduler will apply.
+    func recordMigrationBroadcast(at now: Date) {
+        userDefaults.set(now.timeIntervalSince1970, forKey: .migrationLastBroadcastAt)
+    }
+
+    /// Sync side of the 10-minute sync<->send separation (feature spec section 8.2): background
+    /// syncs must not start sooner than 10 minutes after a foreground migration broadcast.
+    /// MOB-1467's scheduler is the consumer; nothing reads this in MOB-1466.
+    func isSyncDeferredAfterBroadcast(now: Date) -> Bool {
+        guard let interval = userDefaults.object(forKey: .migrationLastBroadcastAt) as? Double else {
+            return false
+        }
+
+        return now < Date(timeIntervalSince1970: interval).addingTimeInterval(Constants.tenMinutes)
+    }
+
+    // MARK: Mode / manual delivery / network privacy / acknowledge
+
+    func migrationMode() -> MigrationMode? {
+        guard let rawValue = userDefaults.string(forKey: .migrationMode) else { return nil }
+        return MigrationMode(rawValue: rawValue)
+    }
+
+    func setMigrationMode(_ mode: MigrationMode) {
+        userDefaults.set(mode.rawValue, forKey: .migrationMode)
+    }
+
+    func isManualDelivery() -> Bool {
+        userDefaults.bool(forKey: .migrationManualDelivery)
+    }
+
+    func setManualDelivery(_ isManual: Bool) {
+        userDefaults.set(isManual, forKey: .migrationManualDelivery)
+    }
+
+    func networkPrivacyOptions() -> NetworkPrivacyOptions {
+        guard let data = userDefaults.data(forKey: .migrationNetworkPrivacyOptions),
+              let options = try? JSONDecoder().decode(NetworkPrivacyOptions.self, from: data) else {
+            return NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        }
+
+        return options
+    }
+
+    func setNetworkPrivacyOptions(_ options: NetworkPrivacyOptions) {
+        guard let data = try? JSONEncoder().encode(options) else { return }
+        userDefaults.set(data, forKey: .migrationNetworkPrivacyOptions)
+    }
+
+    func isCompleteAcknowledged() -> Bool {
+        userDefaults.bool(forKey: .migrationCompleteAcknowledged)
+    }
+
+    func acknowledgeComplete() {
+        userDefaults.set(true, forKey: .migrationCompleteAcknowledged)
+    }
+
+    func clearAcknowledgedComplete() {
+        userDefaults.set(false, forKey: .migrationCompleteAcknowledged)
+    }
+}

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -44,10 +44,16 @@ extension MigrationManagerClient: DependencyKey {
 /// subscription that drives the sync<->send gate. `@unchecked Sendable`: the only mutable state
 /// is `gateStorage`'s own `OSAllocatedUnfairLock`-protected storage plus the Combine
 /// subscription handle below, both of which are safe to share across isolation domains.
-private final class MigrationManagerImpl: @unchecked Sendable {
+final class MigrationManagerImpl: @unchecked Sendable {
     @Dependency(\.sdkSynchronizer) var sdkSynchronizer
 
-    let gateStorage = MigrationGateStorage()
+    let gateStorage: MigrationGateStorage
+
+    /// Internal (not private) with injectable storage so unit tests can exercise the real
+    /// `reconcile()` against a scoped `UserDefaults` suite.
+    init(gateStorage: MigrationGateStorage = MigrationGateStorage()) {
+        self.gateStorage = gateStorage
+    }
 
     private let subscriptionState = OSAllocatedUnfairLock<AnyCancellable?>(initialState: nil)
 

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -292,22 +292,43 @@ extension SDKSynchronizerClient: DependencyKey {
             },
             // Migration (Orchard → Ironwood) — STUB: the SDK API does not exist yet (MOB-1455).
             // These compile the app against the expected contract and do nothing. When the real
-            // SDK lands, replace these closures here — broadcast-capable ones (`submitNoteSplit`,
-            // `executeNextPendingMigrationTransfer`) must then acquire the transaction guard
-            // inside this LiveKey (same pattern as `createAndSubmitProposedTransactions`),
-            // never at call sites. `storeSignedMigrationTransactions` only stores locally —
-            // it is not a broadcast and must stay unguarded.
+            // SDK lands, replace these closures here. The two broadcast-path stubs
+            // (`submitNoteSplit`, `executeNextPendingMigrationTransfer`) already acquire the
+            // transaction guard below — same `withSubmission` pattern as
+            // `createAndSubmitProposedTransactions` — so they are correct-by-construction once
+            // real broadcasting lands; every other migration stub here is read-only/non-broadcast
+            // and stays unguarded. `storeSignedMigrationTransactions` (Keystone/PCZT path,
+            // MOB-1468) only stores locally — it is not a broadcast and must stay unguarded.
             getMigrationState: { .notStarted },
             migrationStateStream: { Just(MigrationState.notStarted).eraseToAnyPublisher() },
             getMigrationProgress: { nil },
             isNoteSplitNeeded: { false },
             prepareNoteSplit: { NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero) },
-            submitNoteSplit: { _ in TransferResult.success(txId: "") },
+            submitNoteSplit: { _ in
+                @Dependency(\.transactionGuard) var transactionGuard
+                do {
+                    return try await transactionGuard.withSubmission {
+                        TransferResult.success(txId: "")
+                    }
+                } catch {
+                    return TransferResult.networkError(retryable: true)
+                }
+            },
             selectMigrationMode: { _ in },
             proposeMigrationTransfers: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },
             signAndStoreMigrationSchedule: { _ in },
             isSyncRequiredBeforeNextMigrationTransfer: { false },
-            executeNextPendingMigrationTransfer: { _ in nil },
+            executeNextPendingMigrationTransfer: { _ in
+                @Dependency(\.transactionGuard) var transactionGuard
+                do {
+                    return try await transactionGuard.withSubmission {
+                        let stubResult: TransferResult? = nil
+                        return stubResult
+                    }
+                } catch {
+                    return nil
+                }
+            },
             hasOverdueMigrationTransfers: { false },
             hasInvalidMigrationTransfers: { false },
             restartCurrentMigrationStep: { MigrationSchedule(transfers: [], estimatedDurationHours: 0) },

--- a/secant/Sources/Dependencies/UserNotifications/MigrationNotification.swift
+++ b/secant/Sources/Dependencies/UserNotifications/MigrationNotification.swift
@@ -1,0 +1,82 @@
+//
+//  MigrationNotification.swift
+//  Zashi
+//
+//  Pure mapping from a migration background event onto the local notification's identifier/
+//  title/body (MOB-1467, feature spec §4.4). `MigrationBannerVariant`-style: no SDK dependency,
+//  no I/O — `MigrationBGSchedulerLiveKey` and `RootInitialization`'s BG session decision tree
+//  construct a case and hand it to `userNotifications.scheduleMigrationNotification(_:at:)`.
+//  Table-tested directly (see MigrationNotificationTests).
+//
+//  Titles are short new copy ("Migration update" / "Action needed" / "Migration complete") —
+//  §4.4 only pins the bodies verbatim; PR flags these for design confirmation against the Figma
+//  lock-screen mocks.
+//
+
+@preconcurrency import ZcashLightClientKit
+
+enum MigrationNotification: Equatable, Sendable {
+    /// Stable prefix shared by every identifier below — phase 2's tap-routing (matching a
+    /// delivered notification's identifier) and `cancelMigrationNotifications`/
+    /// `clearDeliveredMigrationNotifications` (filtering pending/delivered requests) both key off
+    /// this constant rather than restating the literal.
+    static let identifierPrefix = "migration."
+
+    case transferComplete(number: Int, total: Int, nextInHours: Int, remaining: Zatoshi)
+    case transferWaiting(number: Int)
+    case planNeedsUpdate                 // covers BOTH matrix rows 3+4 (identical copy)
+    case manualTransferReady(number: Int)
+    case migrationComplete
+
+    /// Stable, "migration."-prefixed — re-posting the same case replaces the previous pending/
+    /// delivered notification (no dedup marker needed elsewhere).
+    var identifier: String {
+        switch self {
+        case .transferComplete:
+            return "\(Self.identifierPrefix)transferComplete"
+        case .transferWaiting:
+            return "\(Self.identifierPrefix)transferWaiting"
+        case .planNeedsUpdate:
+            return "\(Self.identifierPrefix)planNeedsUpdate"
+        case .manualTransferReady:
+            return "\(Self.identifierPrefix)manualTransferReady"
+        case .migrationComplete:
+            return "\(Self.identifierPrefix)complete"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .transferComplete:
+            return String(localizable: .migrationNotificationTransferCompleteTitle)
+        case .transferWaiting, .planNeedsUpdate, .manualTransferReady:
+            return String(localizable: .migrationNotificationActionNeededTitle)
+        case .migrationComplete:
+            return String(localizable: .migrationNotificationMigrationCompleteTitle)
+        }
+    }
+
+    /// §4.4 matrix copy verbatim. `remaining` renders via `Zatoshi.decimalString()`;
+    /// `nextInHours` is the armed-window interval rounded to hours (caller-computed).
+    var body: String {
+        switch self {
+        case let .transferComplete(number, total, nextInHours, remaining):
+            return String(
+                localizable: .migrationNotificationTransferCompleteBody(
+                    number,
+                    total,
+                    nextInHours,
+                    remaining.decimalString()
+                )
+            )
+        case let .transferWaiting(number):
+            return String(localizable: .migrationNotificationTransferWaitingBody(number))
+        case .planNeedsUpdate:
+            return String(localizable: .migrationNotificationPlanNeedsUpdateBody)
+        case let .manualTransferReady(number):
+            return String(localizable: .migrationNotificationManualTransferReadyBody(number))
+        case .migrationComplete:
+            return String(localizable: .migrationNotificationMigrationCompleteBody)
+        }
+    }
+}

--- a/secant/Sources/Dependencies/UserNotifications/UserNotificationsInterface.swift
+++ b/secant/Sources/Dependencies/UserNotifications/UserNotificationsInterface.swift
@@ -1,0 +1,24 @@
+//
+//  UserNotificationsInterface.swift
+//  Zashi
+//
+//  Authorization-only seam over `UNUserNotificationCenter` for the Orchard -> Ironwood
+//  migration's Notifications permission screen (MOB-1466). MOB-1467 extends this client with
+//  local-notification scheduling (§4.4 matrix) — do not add those members here yet.
+//
+
+import UserNotifications
+import ComposableArchitecture
+
+extension DependencyValues {
+    var userNotifications: UserNotificationsClient {
+        get { self[UserNotificationsClient.self] }
+        set { self[UserNotificationsClient.self] = newValue }
+    }
+}
+
+@DependencyClient
+struct UserNotificationsClient: Sendable {
+    var authorizationStatus: @Sendable () async -> UNAuthorizationStatus = { .notDetermined }
+    var requestAuthorization: @Sendable () async -> Bool = { false }   // .alert, .sound, .badge
+}

--- a/secant/Sources/Dependencies/UserNotifications/UserNotificationsInterface.swift
+++ b/secant/Sources/Dependencies/UserNotifications/UserNotificationsInterface.swift
@@ -2,9 +2,9 @@
 //  UserNotificationsInterface.swift
 //  Zashi
 //
-//  Authorization-only seam over `UNUserNotificationCenter` for the Orchard -> Ironwood
-//  migration's Notifications permission screen (MOB-1466). MOB-1467 extends this client with
-//  local-notification scheduling (§4.4 matrix) — do not add those members here yet.
+//  Seam over `UNUserNotificationCenter` for the Orchard -> Ironwood migration: authorization
+//  (MOB-1466's Notifications permission screen) plus local-notification scheduling (MOB-1467,
+//  §4.4 matrix).
 //
 
 import UserNotifications
@@ -21,4 +21,10 @@ extension DependencyValues {
 struct UserNotificationsClient: Sendable {
     var authorizationStatus: @Sendable () async -> UNAuthorizationStatus = { .notDetermined }
     var requestAuthorization: @Sendable () async -> Bool = { false }   // .alert, .sound, .badge
+    // nil date = deliver now
+    var scheduleMigrationNotification: @Sendable (MigrationNotification, Date?) async -> Void
+    // pending + delivered, "migration." prefix
+    var cancelMigrationNotifications: @Sendable () async -> Void
+    // delivered ONLY — pending (manual ready reminder) must survive
+    var clearDeliveredMigrationNotifications: @Sendable () async -> Void
 }

--- a/secant/Sources/Dependencies/UserNotifications/UserNotificationsLiveKey.swift
+++ b/secant/Sources/Dependencies/UserNotifications/UserNotificationsLiveKey.swift
@@ -1,0 +1,28 @@
+//
+//  UserNotificationsLiveKey.swift
+//  Zashi
+//
+
+import UserNotifications
+import ComposableArchitecture
+
+extension UserNotificationsClient: DependencyKey {
+    static let liveValue: UserNotificationsClient = Self.live()
+
+    static func live() -> Self {
+        UserNotificationsClient(
+            authorizationStatus: {
+                await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+            },
+            requestAuthorization: {
+                do {
+                    return try await UNUserNotificationCenter.current().requestAuthorization(
+                        options: [.alert, .sound, .badge]
+                    )
+                } catch {
+                    return false
+                }
+            }
+        )
+    }
+}

--- a/secant/Sources/Dependencies/UserNotifications/UserNotificationsLiveKey.swift
+++ b/secant/Sources/Dependencies/UserNotifications/UserNotificationsLiveKey.swift
@@ -2,6 +2,10 @@
 //  UserNotificationsLiveKey.swift
 //  Zashi
 //
+//  LiveKey itself is untested (system framework) — everything decision-shaped (which
+//  `MigrationNotification` case, which date) lives in the pure layer / reducer that calls these
+//  members, per MOB-1467.
+//
 
 import UserNotifications
 import ComposableArchitecture
@@ -22,6 +26,50 @@ extension UserNotificationsClient: DependencyKey {
                 } catch {
                     return false
                 }
+            },
+            scheduleMigrationNotification: { notification, date in
+                let content = UNMutableNotificationContent()
+                content.title = notification.title
+                content.body = notification.body
+                content.sound = .default
+
+                let trigger: UNTimeIntervalNotificationTrigger?
+                if let date {
+                    // Immediate delivery (nil date) needs no trigger; otherwise fire at the
+                    // interval between now and the target date, floored at a hair above zero so
+                    // a past/imminent date still delivers rather than being rejected.
+                    let interval = max(date.timeIntervalSinceNow, 0.1)
+                    trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
+                } else {
+                    trigger = nil
+                }
+
+                let request = UNNotificationRequest(
+                    identifier: notification.identifier,
+                    content: content,
+                    trigger: trigger
+                )
+
+                try? await UNUserNotificationCenter.current().add(request)
+            },
+            cancelMigrationNotifications: {
+                let center = UNUserNotificationCenter.current()
+                let pendingIds = await center.pendingNotificationRequests()
+                    .map { $0.identifier }
+                    .filter { $0.hasPrefix(MigrationNotification.identifierPrefix) }
+                center.removePendingNotificationRequests(withIdentifiers: pendingIds)
+
+                let deliveredIds = await center.deliveredNotifications()
+                    .map { $0.request.identifier }
+                    .filter { $0.hasPrefix(MigrationNotification.identifierPrefix) }
+                center.removeDeliveredNotifications(withIdentifiers: deliveredIds)
+            },
+            clearDeliveredMigrationNotifications: {
+                let center = UNUserNotificationCenter.current()
+                let deliveredIds = await center.deliveredNotifications()
+                    .map { $0.request.identifier }
+                    .filter { $0.hasPrefix(MigrationNotification.identifierPrefix) }
+                center.removeDeliveredNotifications(withIdentifiers: deliveredIds)
             }
         )
     }

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -105,7 +105,7 @@ extension MigrationCoordFlow {
                 if state.mode == .immediate {
                     state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
                 } else {
-                    state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+                    state.path.append(.transferPlan(MigrationTransferPlan.State(variant: freshPlanVariant())))
                 }
                 return .none
 
@@ -290,9 +290,15 @@ extension MigrationCoordFlow {
         }
 
         return MigrationCoordFlow.PermissionStepResult(
-            pathState: .transferPlan(MigrationTransferPlan.State(variant: .scheduled)),
+            pathState: .transferPlan(MigrationTransferPlan.State(variant: freshPlanVariant())),
             forcedUseTor: true
         )
+    }
+
+    /// Fresh-entry plan variant: manual delivery (background delivery declined) shows the manual
+    /// copy and its confirm sends the first transfer now (§6.3); otherwise the scheduled variant.
+    private func freshPlanVariant() -> MigrationTransferPlan.State.Variant {
+        migrationManager.isManualDelivery() ? .manual : .scheduled
     }
 
     // MARK: - Reschedule / Recovery: TransferPlan hydration

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -122,8 +122,6 @@ extension MigrationCoordFlow {
                     return .send(.flowFinished)
                 }
 
-                migrationBGScheduler.scheduleFirstWindow()
-
                 switch planState.variant {
                 case .scheduled, .recreated:
                     state.path.append(.scheduled(MigrationScheduled.State()))
@@ -132,7 +130,7 @@ extension MigrationCoordFlow {
                     sendingState.networkPrivacyOptions = state.networkPrivacyOptions
                     state.path.append(.sending(sendingState))
                 }
-                return .none
+                return .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleFirstWindow() }
 
                 // MARK: - ReviewTransfer
 
@@ -201,7 +199,7 @@ extension MigrationCoordFlow {
                 }
                 return .run { [migrationBGScheduler, sdkSynchronizer] send in
                     await sdkSynchronizer.rescheduleStalledMigrationTransfer()
-                    migrationBGScheduler.scheduleFirstWindow()
+                    await migrationBGScheduler.scheduleFirstWindow()
                     let rows = sdkSynchronizer.migrationTransfers()
                     let planState = rescheduledPlanState(rows: rows)
                     await send(.pushHydratedPathState(.transferPlan(planState)))

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -1,0 +1,402 @@
+//
+//  MigrationCoordFlowCoordinator.swift
+//  Zashi
+//
+//  Routing brain for `MigrationCoordFlow` (MOB-1466): re-entry (`.onAppear`), the chaining table
+//  from Entry through Complete, and the shared permission-step helper (BackgroundDelivery ->
+//  Notifications -> NetworkPrivacy -> TransferPlan). See the MOB-1466 implementation spec's
+//  `MigrationCoordFlow` section for the full chaining table this mirrors row by row.
+//
+
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+extension MigrationCoordFlow {
+    func coordinatorReduce() -> Reduce<MigrationCoordFlow.State, MigrationCoordFlow.Action> {
+        Reduce { state, action in
+            switch action {
+                // MARK: - Self: onAppear (re-entry)
+
+            case .onAppear:
+                guard state.path.isEmpty else { return .none }
+                return .run { send in
+                    let pathState = await reentryPathState()
+                    await send(.pushNextPermissionStep(PermissionStepResult(pathState: pathState)))
+                }
+
+            case .pushNextPermissionStep(let result):
+                if result.forcedUseTor {
+                    state.networkPrivacyOptions.useTor = true
+                }
+                if let pathState = result.pathState {
+                    state.path.append(pathState)
+                }
+                return .none
+
+                // MARK: - Entry
+
+            case .entry(.delegate(.chose(let mode))):
+                state.mode = mode
+                migrationManager.setMigrationMode(mode)
+                sdkSynchronizer.selectMigrationMode(mode)
+
+                switch mode {
+                case .immediate:
+                    // Skip Network Privacy (S5) iff the app-wide Tor setup flag is on — in that
+                    // case `useTor` is implicitly `true` and Review is pushed directly; otherwise
+                    // Network Privacy is shown so the user can opt in explicitly. Both checks here
+                    // are synchronous SDK/dependency reads, so no effect is needed.
+                    if walletStorage.exportTorSetupFlag() == true {
+                        state.networkPrivacyOptions.useTor = true
+                        state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+                    } else {
+                        state.path.append(.networkPrivacy(MigrationNetworkPrivacy.State(variant: .immediate)))
+                    }
+                    return .none
+
+                case .privateScheduled:
+                    if sdkSynchronizer.isNoteSplitNeeded() {
+                        state.path.append(.noteSplit(MigrationNoteSplit.State()))
+                        return .none
+                    }
+                    return .run { send in
+                        await send(.pushNextPermissionStep(await nextPermissionStepResult()))
+                    }
+                }
+
+                // MARK: - NoteSplit
+
+            case .path(.element(id: let id, action: .noteSplit(.delegate(.continued)))):
+                // NoteSplit's `closeTapped` (flow-root back, splitting phase) and `continueTapped`
+                // (normal chain progression, confirmed phase) both emit the same `.continued`
+                // delegate value — `isFlowRoot` on the element disambiguates them, since only the
+                // flow-root splitting re-entry root can reach `closeTapped` at all.
+                if case .noteSplit(let noteSplitState) = state.path[id: id], noteSplitState.isFlowRoot {
+                    return .send(.flowFinished)
+                }
+                return .run { send in
+                    await send(.pushNextPermissionStep(await nextPermissionStepResult()))
+                }
+
+                // MARK: - BackgroundDelivery
+
+            case .path(.element(id: _, action: .backgroundDelivery(.delegate(.continued(let backgroundAllowed))))):
+                if !backgroundAllowed {
+                    migrationManager.setManualDelivery(true)
+                }
+                return .run { send in
+                    await send(.pushNextPermissionStep(await nextPermissionStepResult()))
+                }
+
+                // MARK: - Notifications
+
+            case .path(.element(id: _, action: .notifications(.delegate(.continued)))):
+                return .run { send in
+                    await send(.pushNextPermissionStep(await nextPermissionStepResult()))
+                }
+
+                // MARK: - NetworkPrivacy
+
+            case .path(.element(id: _, action: .networkPrivacy(.delegate(.confirmed(let options))))):
+                migrationManager.setNetworkPrivacyOptions(options)
+                state.networkPrivacyOptions = options
+
+                if state.mode == .immediate {
+                    state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+                } else {
+                    state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+                }
+                return .none
+
+                // MARK: - TransferPlan
+
+            case .path(.element(id: _, action: .transferPlan(.delegate(.confirmed)))):
+                guard case let .transferPlan(planState) = state.path.last else { return .none }
+
+                // Rescheduled variant (`requiresSigning == false`): its confirm is a plain
+                // acknowledgment of an already-committed reschedule (`scheduleFirstWindow()` ran
+                // once already, at reschedule-initiation) — no re-sign, no terminal `.scheduled`
+                // screen, straight to `.flowFinished` ("Got-it" per the spec).
+                guard planState.requiresSigning else {
+                    return .send(.flowFinished)
+                }
+
+                migrationBGScheduler.scheduleFirstWindow()
+
+                switch planState.variant {
+                case .scheduled, .recreated:
+                    state.path.append(.scheduled(MigrationScheduled.State()))
+                case .manual:
+                    var sendingState = MigrationSending.State(totalCount: 1)
+                    sendingState.networkPrivacyOptions = state.networkPrivacyOptions
+                    state.path.append(.sending(sendingState))
+                }
+                return .none
+
+                // MARK: - ReviewTransfer
+
+            case .path(.element(id: _, action: .reviewTransfer(.delegate(.confirmed)))):
+                var sendingState = MigrationSending.State(totalCount: 1)
+                sendingState.networkPrivacyOptions = state.networkPrivacyOptions
+                state.path.append(.sending(sendingState))
+                return .none
+
+                // MARK: - Sending
+
+            case .path(.element(id: _, action: .sending(.delegate(.closed)))):
+                if state.mode == .immediate {
+                    migrationManager.acknowledgeComplete()
+                    return .send(.flowFinished)
+                }
+
+                let hasStatusBeneath = state.path.contains { $0.is(\.status) }
+                if hasStatusBeneath {
+                    return .run { [sdkSynchronizer] send in
+                        await send(.sendNowCompleted(rows: sdkSynchronizer.migrationTransfers()))
+                    }
+                }
+
+                // Manual-first-transfer path: no `.status` yet on the path — push a fresh one.
+                return .run { send in
+                    await send(.pushHydratedStatus(await statusProgressState(isFlowRoot: false)))
+                }
+
+                // MARK: - Self: pushHydratedStatus / pushHydratedPathState / sendNowCompleted
+
+            case .pushHydratedStatus(let statusState):
+                state.path.append(.status(statusState))
+                return .none
+
+            case .pushHydratedPathState(let pathState):
+                state.path.append(pathState)
+                return .none
+
+            case .sendNowCompleted(let rows):
+                // Pop the Sending element and refresh the `.status` element now on top.
+                let _ = state.path.popLast()
+                guard let statusId = state.path.ids.last, case .status(var statusState) = state.path.last else {
+                    return .none
+                }
+                statusState.rows = IdentifiedArrayOf(uniqueElements: rows)
+                state.path[id: statusId] = .status(statusState)
+                return .none
+
+                // MARK: - Status
+
+            case .path(.element(id: _, action: .status(.delegate(.sendNow)))):
+                let networkPrivacyOptions = state.networkPrivacyOptions
+                return .run { [sdkSynchronizer] send in
+                    let rows = sdkSynchronizer.migrationTransfers()
+                    let overdueCount = rows.filter { $0.status == MigrationTransferRow.Status.overdue }.count
+                    var sendingState = MigrationSending.State(totalCount: max(overdueCount, 1))
+                    sendingState.networkPrivacyOptions = networkPrivacyOptions
+                    await send(.pushHydratedPathState(.sending(sendingState)))
+                }
+
+            case .path(.element(id: let id, action: .status(.delegate(.reschedule)))):
+                if case .status(var statusState) = state.path[id: id] {
+                    statusState.isRescheduling = true
+                    state.path[id: id] = .status(statusState)
+                }
+                return .run { [migrationBGScheduler, sdkSynchronizer] send in
+                    await sdkSynchronizer.rescheduleStalledMigrationTransfer()
+                    migrationBGScheduler.scheduleFirstWindow()
+                    let rows = sdkSynchronizer.migrationTransfers()
+                    let planState = rescheduledPlanState(rows: rows)
+                    await send(.pushHydratedPathState(.transferPlan(planState)))
+                }
+
+                // MARK: - Recovery
+
+            case .path(.element(id: _, action: .recovery(.delegate(.recreate)))):
+                return .run { [sdkSynchronizer] send in
+                    let schedule = await sdkSynchronizer.restartCurrentMigrationStep()
+                    let planState = recreatedPlanState(schedule: schedule)
+                    await send(.pushHydratedPathState(.transferPlan(planState)))
+                }
+
+                // MARK: - Flow-root closes / terminal delegates -> .flowFinished
+
+            case .path(.element(id: _, action: .complete(.delegate(.done)))):
+                migrationManager.acknowledgeComplete()
+                return .send(.flowFinished)
+
+            case .path(.element(id: _, action: .status(.delegate(.done)))),
+                 .path(.element(id: _, action: .scheduled(.delegate(.done)))),
+                 .path(.element(id: _, action: .recovery(.delegate(.close)))),
+                 .path(.element(id: _, action: .reviewTransfer(.delegate(.closed)))):
+                return .send(.flowFinished)
+
+            default: return .none
+            }
+        }
+    }
+
+    // MARK: - Re-entry
+
+    /// Maps `manager.reentryRoute()` onto the flow-root screen State to append, hydrated from SDK
+    /// members per the MOB-1466 spec's re-entry table. `.entry` appends nothing (Entry is the
+    /// coordinator's own root screen, already showing).
+    private func reentryPathState() async -> MigrationCoordFlow.Path.State? {
+        switch migrationManager.reentryRoute() {
+        case .recovery(let isExpired):
+            return .recovery(recoveryState(isExpired: isExpired, isFlowRoot: true))
+
+        case .statusResume:
+            return .status(await statusResumeState(isFlowRoot: true))
+
+        case .statusProgress:
+            return .status(await statusProgressState(isFlowRoot: true))
+
+        case .complete:
+            return .complete(completeState(isFlowRoot: true))
+
+        case .noteSplitProgress:
+            return .noteSplit(MigrationNoteSplit.State(phase: .splitting, isFlowRoot: true))
+
+        case .reviewManual(let step, let total):
+            return .reviewTransfer(await reviewManualState(step: step, total: total, isFlowRoot: true))
+
+        case .entry:
+            return nil
+        }
+    }
+
+    // MARK: - Permission-step routing
+
+    /// Shared helper (used after Entry-scheduled-no-split, NoteSplit-continued, and each
+    /// permission screen's continue/skip): computes the next needed screen in order —
+    /// `backgroundDelivery` iff background refresh isn't `.available` -> `notifications` iff
+    /// authorization is still `.notDetermined` (granted/denied both skip, per §5 S4) ->
+    /// `networkPrivacy` iff the app-wide Tor setup flag isn't on -> `transferPlan`. When S5 is
+    /// skipped because Tor is already on, `forcedUseTor` tells the reducer to set
+    /// `networkPrivacyOptions.useTor = true` before the plan screen is reached.
+    private func nextPermissionStepResult() async -> MigrationCoordFlow.PermissionStepResult {
+        if await migrationBGScheduler.backgroundRefreshStatus() != .available {
+            return MigrationCoordFlow.PermissionStepResult(pathState: .backgroundDelivery(MigrationBackgroundDelivery.State()))
+        }
+
+        if await userNotifications.authorizationStatus() == .notDetermined {
+            return MigrationCoordFlow.PermissionStepResult(pathState: .notifications(MigrationNotifications.State()))
+        }
+
+        if walletStorage.exportTorSetupFlag() != true {
+            let transferCount = sdkSynchronizer.migrationTransfers().count
+            let variant = MigrationNetworkPrivacy.State.Variant.scheduled(transferCount: transferCount)
+            return MigrationCoordFlow.PermissionStepResult(
+                pathState: .networkPrivacy(MigrationNetworkPrivacy.State(variant: variant))
+            )
+        }
+
+        return MigrationCoordFlow.PermissionStepResult(
+            pathState: .transferPlan(MigrationTransferPlan.State(variant: .scheduled)),
+            forcedUseTor: true
+        )
+    }
+
+    // MARK: - Reschedule / Recovery: TransferPlan hydration
+
+    /// Status `.reschedule`'s follow-up plan screen: `rescheduleStalledMigrationTransfer()`
+    /// returns `Void` (no schedule), so `rows` are built directly from a fresh
+    /// `migrationTransfers()` read rather than via `injectedSchedule`. `requiresSigning: false`
+    /// marks this variant's confirm as a plain acknowledgment (transfers are already signed).
+    private func rescheduledPlanState(rows: [MigrationTransferRow]) -> MigrationTransferPlan.State {
+        MigrationTransferPlan.State(
+            variant: .scheduled,
+            rows: IdentifiedArrayOf(uniqueElements: rows),
+            totalDurationHours: sdkSynchronizer.migrationSummary().estimatedDurationHours,
+            requiresSigning: false
+        )
+    }
+
+    /// Recovery `.recreate`'s follow-up plan screen: `restartCurrentMigrationStep()` returns a
+    /// fresh `MigrationSchedule`, injected via `injectedSchedule` so the screen's own `onAppear`
+    /// populates rows (no coordinator-side duplication of that row-building logic). This variant
+    /// DOES sign — `requiresSigning` stays at its default `true`.
+    private func recreatedPlanState(schedule: MigrationSchedule) -> MigrationTransferPlan.State {
+        var state = MigrationTransferPlan.State(variant: .recreated)
+        state.injectedSchedule = schedule
+        return state
+    }
+
+    private func recoveryState(isExpired: Bool, isFlowRoot: Bool) -> MigrationRecovery.State {
+        let rows = sdkSynchronizer.migrationTransfers()
+        let (first, last) = expiredOrInvalidBounds(rows: rows)
+        return MigrationRecovery.State(
+            reason: isExpired ? .expired : .notesSpent,
+            firstTransfer: first,
+            lastTransfer: last,
+            isFlowRoot: isFlowRoot
+        )
+    }
+
+    private func statusResumeState(isFlowRoot: Bool) async -> MigrationStatus.State {
+        let rows = sdkSynchronizer.migrationTransfers()
+        let summary = sdkSynchronizer.migrationSummary()
+        let stalledRow = rows.first { $0.status == MigrationTransferRow.Status.overdue }
+        var state = MigrationStatus.State(
+            presentation: .resume,
+            rows: IdentifiedArrayOf(uniqueElements: rows),
+            totalDurationHours: summary.estimatedDurationHours,
+            stalledNumber: (stalledRow?.index ?? 0) + 1,
+            stalledHoursAgo: stalledRow?.hoursFromNow ?? 0,
+            isFlowRoot: isFlowRoot
+        )
+        state.isSendNowDisabled = migrationManager.sendGate() != MigrationSendGate.allowed
+        return state
+    }
+
+    private func statusProgressState(isFlowRoot: Bool) async -> MigrationStatus.State {
+        let rows = sdkSynchronizer.migrationTransfers()
+        let summary = sdkSynchronizer.migrationSummary()
+        var state = MigrationStatus.State(
+            presentation: .progress,
+            rows: IdentifiedArrayOf(uniqueElements: rows),
+            totalDurationHours: summary.estimatedDurationHours,
+            isFlowRoot: isFlowRoot
+        )
+        state.isSendNowDisabled = migrationManager.sendGate() != MigrationSendGate.allowed
+        return state
+    }
+
+    private func completeState(isFlowRoot: Bool) -> MigrationComplete.State {
+        let summary = sdkSynchronizer.migrationSummary()
+        return MigrationComplete.State(
+            totalTransferred: summary.transferred,
+            dust: summary.dust,
+            transfersSent: summary.transfersSent,
+            transfersTotal: summary.transfersTotal,
+            durationHours: summary.estimatedDurationHours,
+            isFlowRoot: isFlowRoot
+        )
+    }
+
+    private func reviewManualState(step: Int, total: Int, isFlowRoot: Bool) async -> MigrationReviewTransfer.State {
+        let rows = sdkSynchronizer.migrationTransfers()
+        let nextRow = rows.first { $0.status == MigrationTransferRow.Status.active }
+            ?? rows.first { $0.status == MigrationTransferRow.Status.overdue }
+        return MigrationReviewTransfer.State(
+            mode: .manualStep(number: step, total: total),
+            amount: nextRow?.amount ?? Zatoshi.zero,
+            // Standard ZIP-317 marginal fee (`MigrationReviewTransfer.State.standardFee`'s value —
+            // that constant is `fileprivate` to its own file, so it's mirrored here literally).
+            fee: Zatoshi(100_000),
+            isFlowRoot: isFlowRoot
+        )
+    }
+
+    /// 1-based `(first, last)` bounds among rows flagged `.expired` or `.invalid`; falls back to
+    /// `(1, total)` when none match (mirrors `MigrationDerivations.expiredBounds`'s fallback shape).
+    private func expiredOrInvalidBounds(rows: [MigrationTransferRow]) -> (first: Int, last: Int) {
+        let flaggedIndexes = rows
+            .filter { $0.status == MigrationTransferRow.Status.expired || $0.status == MigrationTransferRow.Status.invalid }
+            .map { $0.index + 1 }
+
+        guard let first = flaggedIndexes.min(), let last = flaggedIndexes.max() else {
+            return (1, rows.count)
+        }
+
+        return (first, last)
+    }
+}

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
@@ -1,0 +1,98 @@
+//
+//  MigrationCoordFlowStore.swift
+//  Zashi
+//
+//  Coordinator for the Orchard -> Ironwood migration flow (MOB-1466). Chains the visual-only
+//  migration screens (MOB-1460...1464) into a live, state-driven flow: re-entry routing, mode/
+//  network-privacy persistence, permission-step sequencing, and the scheduled/manual/immediate
+//  chaining table. `MigrationEntry` is the flow's root screen (mirroring `SendCoordFlow`'s
+//  `sendFormState`); every other screen lives in `path`. Everything here runs against the inert
+//  SDK stubs — it goes live when the real SDK (MOB-1455) fills them in.
+//
+
+import SwiftUI
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationCoordFlow {
+    @Reducer(state: .equatable)
+    enum Path {
+        case backgroundDelivery(MigrationBackgroundDelivery)
+        case complete(MigrationComplete)
+        case networkPrivacy(MigrationNetworkPrivacy)
+        case noteSplit(MigrationNoteSplit)
+        case notifications(MigrationNotifications)
+        case recovery(MigrationRecovery)
+        case reviewTransfer(MigrationReviewTransfer)
+        case scheduled(MigrationScheduled)
+        case sending(MigrationSending)
+        case status(MigrationStatus)
+        case transferPlan(MigrationTransferPlan)
+    }
+
+    @ObservableState
+    struct State: Equatable {
+        var path = StackState<Path.State>()
+        var entryState = MigrationEntry.State()
+        /// Persisted via `manager.setMigrationMode` once chosen; held here too so later hops in
+        /// the same run (e.g. immediate's Tor-skip) don't need to re-read the dependency.
+        var mode: MigrationMode?
+        /// Held here once confirmed on the Network Privacy screen (or defaulted when S5 is
+        /// skipped) so Sending's coordinator-configured state can inject it.
+        var networkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+
+        init() { }
+    }
+
+    /// Result of the async permission-step helper (`nextPermissionStepPathState()`): the screen
+    /// to push (`nil` once every permission step is satisfied and the flow can proceed straight to
+    /// the plan/review screen the caller already knows to push), plus whether Network Privacy (S5)
+    /// was skipped because the app-wide Tor setup flag is already on — in which case the
+    /// coordinator force-sets `networkPrivacyOptions.useTor = true` before proceeding.
+    struct PermissionStepResult: Equatable {
+        var pathState: Path.State?
+        var forcedUseTor = false
+    }
+
+    enum Action {
+        case entry(MigrationEntry.Action)
+        case flowFinished
+        case onAppear
+        case path(StackActionOf<Path>)
+        /// Internal: the async re-entry/permission-step helper resolved the next screen to push
+        /// (or `nil` when nothing needs appending — the `.entry` re-entry route).
+        case pushNextPermissionStep(PermissionStepResult)
+        /// Internal: a fresh `MigrationStatus.State` (already hydrated) to push — used by Sending's
+        /// manual-first-transfer close (no `.status` beneath yet). A dedicated case (rather than
+        /// reusing `pushHydratedPathState`) so its `isFlowRoot: false` (mid-flow push) stays
+        /// visibly distinct in the reducer from the re-entry root's `isFlowRoot: true` status push.
+        case pushHydratedStatus(MigrationStatus.State)
+        /// Internal: a fresh `Path.State` (already hydrated) to push — used by Status `.sendNow`'s
+        /// overdue-batch Sending screen, Status `.reschedule`'s rescheduled plan, and Recovery
+        /// `.recreate`'s re-created plan.
+        case pushHydratedPathState(Path.State)
+        /// Internal: sendNow's Sending screen finished (`.closed`) — refresh the `.status` element
+        /// beneath with freshly-read rows and pop back to it.
+        case sendNowCompleted(rows: [MigrationTransferRow])
+    }
+
+    @Dependency(\.migrationBGScheduler) var migrationBGScheduler
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+    @Dependency(\.userNotifications) var userNotifications
+    @Dependency(\.walletStorage) var walletStorage
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        coordinatorReduce()
+
+        Scope(state: \.entryState, action: \.entry) {
+            MigrationEntry()
+        }
+
+        Reduce { _, _ in .none }
+            .forEach(\.path, action: \.path)
+    }
+}

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowView.swift
@@ -1,0 +1,81 @@
+//
+//  MigrationCoordFlowView.swift
+//  Zashi
+//
+//  NavigationStack for the Orchard -> Ironwood migration flow (MOB-1466). `MigrationEntry` is the
+//  root screen; every other migration screen is pushed onto `path` by the coordinator.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct MigrationCoordFlowView: View {
+    @Perception.Bindable var store: StoreOf<MigrationCoordFlow>
+
+    init(store: StoreOf<MigrationCoordFlow>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+                MigrationEntryView(
+                    store:
+                        store.scope(
+                            state: \.entryState,
+                            action: \.entry
+                        )
+                )
+            } destination: { store in
+                switch store.case {
+                case let .backgroundDelivery(store):
+                    MigrationBackgroundDeliveryView(store: store)
+                case let .complete(store):
+                    MigrationCompleteView(store: store)
+                case let .networkPrivacy(store):
+                    MigrationNetworkPrivacyView(store: store)
+                case let .noteSplit(store):
+                    MigrationNoteSplitView(store: store)
+                case let .notifications(store):
+                    MigrationNotificationsView(store: store)
+                case let .recovery(store):
+                    MigrationRecoveryView(store: store)
+                case let .reviewTransfer(store):
+                    MigrationReviewTransferView(store: store)
+                case let .scheduled(store):
+                    MigrationScheduledView(store: store)
+                case let .sending(store):
+                    MigrationSendingView(store: store)
+                case let .status(store):
+                    MigrationStatusView(store: store)
+                case let .transferPlan(store):
+                    MigrationTransferPlanView(store: store)
+                }
+            }
+        }
+        .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
+    }
+}
+
+// MARK: - Placeholders
+
+extension MigrationCoordFlow.State {
+    static var initial: MigrationCoordFlow.State { MigrationCoordFlow.State() }
+}
+
+extension MigrationCoordFlow {
+    @MainActor static let placeholder = StoreOf<MigrationCoordFlow>(
+        initialState: .initial
+    ) {
+        MigrationCoordFlow()
+    }
+}
+
+#Preview {
+    NavigationView {
+        MigrationCoordFlowView(store: MigrationCoordFlow.placeholder)
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift
@@ -7,7 +7,7 @@
 //  the Settings deep-link from the view (`@Environment(\.openURL)`) — the action here is just the
 //  tap signal. `scenePhaseActive` re-checks Background App Refresh on return and auto-advances via
 //  `.continued(backgroundAllowed: true)` once it becomes available (MOB-1466). The `skipTapped`
-//  delegate is emitted but consumed by nobody yet — chaining is the coordinator's job (phase 3).
+//  delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift
@@ -3,10 +3,11 @@
 //  zodl
 //
 //  "Allow Background Delivery" screen (MOB-1462, Figma S3 · 2840:4480). Explains why ZODL needs
-//  Background App Refresh to send migration transfers at their scheduled times. Visual-only:
-//  `allowTapped` (opening the Settings deep-link) and `scenePhaseActive` (re-checking BAR on
-//  return) are declared but inert — wiring them up is MOB-1466's job. The `skipTapped` delegate is
-//  emitted but consumed by nobody yet.
+//  Background App Refresh to send migration transfers at their scheduled times. `allowTapped` opens
+//  the Settings deep-link from the view (`@Environment(\.openURL)`) — the action here is just the
+//  tap signal. `scenePhaseActive` re-checks Background App Refresh on return and auto-advances via
+//  `.continued(backgroundAllowed: true)` once it becomes available (MOB-1466). The `skipTapped`
+//  delegate is emitted but consumed by nobody yet — chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -18,10 +19,10 @@ struct MigrationBackgroundDelivery {
     }
 
     enum Action: Equatable {
-        /// Inert now — MOB-1466 opens the Settings deep-link.
+        /// The Settings deep-link opens from the view; this action is just the tap signal.
         case allowTapped
         case delegate(Delegate)
-        /// Declared for MOB-1466 (re-check Background App Refresh on return) — inert.
+        /// Re-checks Background App Refresh on return; auto-advances when it becomes available.
         case scenePhaseActive
         case skipTapped
 
@@ -29,6 +30,8 @@ struct MigrationBackgroundDelivery {
             case continued(backgroundAllowed: Bool)
         }
     }
+
+    @Dependency(\.migrationBGScheduler) var migrationBGScheduler
 
     init() { }
 
@@ -42,7 +45,11 @@ struct MigrationBackgroundDelivery {
                 return .none
 
             case .scenePhaseActive:
-                return .none
+                return .run { send in
+                    let status = await migrationBGScheduler.backgroundRefreshStatus()
+                    guard status == .available else { return }
+                    await send(.delegate(.continued(backgroundAllowed: true)))
+                }
 
             case .skipTapped:
                 return .send(.delegate(.continued(backgroundAllowed: false)))

--- a/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryView.swift
+++ b/secant/Sources/Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryView.swift
@@ -2,16 +2,18 @@
 //  MigrationBackgroundDeliveryView.swift
 //  zodl
 //
-//  "Allow Background Delivery" screen (MOB-1462, Figma S3 · 2840:4480). Visually complete per
-//  Figma; `allowTapped` (Settings deep-link) and `scenePhaseActive` (BAR re-check) are declared but
-//  inert — wiring them up lands in MOB-1466. The `skipTapped` delegate is emitted but consumed by
-//  nobody yet.
+//  "Allow Background Delivery" screen (MOB-1462, Figma S3 · 2840:4480). `allowTapped` opens the
+//  Settings deep-link; `scenePhaseActive` re-checks Background App Refresh on return and the store
+//  auto-advances once it's available (MOB-1466). The `skipTapped` delegate is emitted but consumed
+//  by nobody yet — chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
 import SwiftUI
 
 struct MigrationBackgroundDeliveryView: View {
+    @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
     @Perception.Bindable var store: StoreOf<MigrationBackgroundDelivery>
 
     init(store: StoreOf<MigrationBackgroundDelivery>) {
@@ -49,6 +51,9 @@ struct MigrationBackgroundDeliveryView: View {
 
                 ZashiButton(String(localizable: .migrationAllow)) {
                     store.send(.allowTapped)
+                    if let settingsUrl = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(settingsUrl)
+                    }
                 }
                 .padding(.bottom, 24)
             }
@@ -56,6 +61,11 @@ struct MigrationBackgroundDeliveryView: View {
             .zashiBack()
         }
         .applyScreenBackground()
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .active {
+                store.send(.scenePhaseActive)
+            }
+        }
     }
 
     // MARK: - Bullet rows

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
@@ -2,9 +2,12 @@
 //  MigrationCompleteStore.swift
 //  zodl
 //
-//  "Migration Complete" screen (MOB-1464, Figma S12 · 2696:7267). Visually complete per Figma; all
-//  summary fields are placeholders — wiring the real data lands in MOB-1466. The `gotItTapped`
-//  delegate is emitted but consumed by nobody yet.
+//  "Migration Complete" screen (MOB-1464, Figma S12 · 2696:7267). Display-only summary fields are
+//  injected by the coordinator (MOB-1466). This screen has no back control at all
+//  (`.navigationBarBackButtonHidden()`); `isFlowRoot` is carried in State for coordinator-injection
+//  consistency with the other re-entry roots even though there's no back-control behavior to gate
+//  here. The `gotItTapped` delegate is emitted but consumed by nobody yet — wiring is the
+//  coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -19,6 +22,9 @@ struct MigrationComplete {
         var transfersSent = 0
         var transfersTotal = 0
         var durationHours = 0
+        /// Carried for consistency with the other re-entry-root screens; this screen has no back
+        /// control to gate (`.navigationBarBackButtonHidden()`, no custom leading toolbar item).
+        var isFlowRoot = false
 
         var hasDust: Bool {
             dust.amount > 0
@@ -29,13 +35,15 @@ struct MigrationComplete {
             dust: Zatoshi = .zero,
             transfersSent: Int = 0,
             transfersTotal: Int = 0,
-            durationHours: Int = 0
+            durationHours: Int = 0,
+            isFlowRoot: Bool = false
         ) {
             self.totalTransferred = totalTransferred
             self.dust = dust
             self.transfersSent = transfersSent
             self.transfersTotal = transfersTotal
             self.durationHours = durationHours
+            self.isFlowRoot = isFlowRoot
         }
     }
 

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
@@ -6,8 +6,7 @@
 //  injected by the coordinator (MOB-1466). This screen has no back control at all
 //  (`.navigationBarBackButtonHidden()`); `isFlowRoot` is carried in State for coordinator-injection
 //  consistency with the other re-entry roots even though there's no back-control behavior to gate
-//  here. The `gotItTapped` delegate is emitted but consumed by nobody yet — wiring is the
-//  coordinator's job (phase 3).
+//  here. The `gotItTapped` delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
@@ -5,8 +5,7 @@
 //  "Move to Ironwood" entry screen (MOB-1460, Figma S1 · 2867:10445 / 2867:5641 / 2867:5731). Lets
 //  the user pick between migrating with privacy (scheduled, split transfers) or immediately (single
 //  transfer, less privacy). `onAppear` loads the orchard-balance-to-migrate for the selected account
-//  (MOB-1466); chaining `nextTapped`'s delegate into the rest of the migration flow is the
-//  coordinator's job (MOB-1466 phase 3).
+//  (MOB-1466); `nextTapped`'s delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
@@ -4,8 +4,9 @@
 //
 //  "Move to Ironwood" entry screen (MOB-1460, Figma S1 · 2867:10445 / 2867:5641 / 2867:5731). Lets
 //  the user pick between migrating with privacy (scheduled, split transfers) or immediately (single
-//  transfer, less privacy). The delegate is emitted but consumed by nobody yet — chaining into the
-//  rest of the migration flow lands in MOB-1466.
+//  transfer, less privacy). `onAppear` loads the orchard-balance-to-migrate for the selected account
+//  (MOB-1466); chaining `nextTapped`'s delegate into the rest of the migration flow is the
+//  coordinator's job (MOB-1466 phase 3).
 //
 
 import ComposableArchitecture
@@ -16,10 +17,10 @@ struct MigrationEntry {
     @ObservableState
     struct State: Equatable {
         var selectedMode = MigrationMode.privateScheduled
-        /// Placeholder; real balance data lands in MOB-1466.
         var orchardBalance = Zatoshi.zero
         /// e.g. `"$4,832.86"`; `nil` omits the parenthesized fiat amount.
         var fiatText: String?
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
 
         var isDisclaimerVisible: Bool {
             selectedMode == .immediate
@@ -37,22 +38,31 @@ struct MigrationEntry {
     }
 
     enum Action: Equatable {
+        /// The orchard balance to migrate for the selected account, loaded on `onAppear`.
+        case balanceLoaded(Zatoshi)
         case delegate(Delegate)
         /// Inert for now; the "Find out more" destination (O-7) is undecided.
         case findOutMoreTapped
         case modeTapped(MigrationMode)
         case nextTapped
+        case onAppear
 
         enum Delegate: Equatable {
             case chose(MigrationMode)
         }
     }
 
+    @Dependency(\.migrationManager) var migrationManager
+
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .balanceLoaded(let balance):
+                state.orchardBalance = balance
+                return .none
+
             case .delegate:
                 return .none
 
@@ -65,6 +75,13 @@ struct MigrationEntry {
 
             case .nextTapped:
                 return .send(.delegate(.chose(state.selectedMode)))
+
+            case .onAppear:
+                let accountUUID = state.selectedWalletAccount?.id
+                return .run { send in
+                    let balance = await migrationManager.orchardBalanceToMigrate(accountUUID)
+                    await send(.balanceLoaded(balance))
+                }
             }
         }
     }

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
@@ -67,6 +67,9 @@ struct MigrationEntryView: View {
             .zashiBack()
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Description

--- a/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNetworkPrivacy/MigrationNetworkPrivacyStore.swift
@@ -3,8 +3,8 @@
 //  zodl
 //
 //  "Network Privacy" screen (MOB-1460, Figma S5 · 2867:5801 immediate / 2867:10835 scheduled).
-//  Lets the user opt in to routing migration transfer submission via Tor. The delegate is emitted
-//  but consumed by nobody yet — chaining into the rest of the migration flow lands in MOB-1466.
+//  Lets the user opt in to routing migration transfer submission via Tor. The `confirmed` delegate
+//  is consumed by MigrationCoordFlowCoordinator (MOB-1466), which persists the chosen options.
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
@@ -5,11 +5,14 @@
 //  "Split Your Wallet Funds" screen (MOB-1461, Figma S2 · 2867:10535 explainer / 2867:10741
 //  progress / 2867:10645 success / 2670:15570 failure sheet). One screen, three phases (explainer
 //  -> splitting -> confirmed) plus a failure bottom sheet presented over the splitting phase.
-//  Visual-only: SDK-driven actions (`splitConfirmed`, `splitResult`) are declared but inert, and the
-//  screen never transitions phases itself — wiring that up against the SDK is MOB-1466's job. The
-//  `continueTapped` delegate is emitted but consumed by nobody yet.
+//  `onAppear` resumes an already-pending split or prepares a fresh one; `confirmTapped`/`retryTapped`
+//  submit it; a `migrationStateStream()` subscription advances `.splitting` -> `.confirmed` once the
+//  SDK reports `.readyToPropose`. When the splitting phase is a flow re-entry root (`isFlowRoot`),
+//  its back control closes the flow (`closeTapped` -> `.delegate(.continued)`) instead of popping
+//  (MOB-1466). Chaining into the rest of the migration flow is the coordinator's job (phase 3).
 //
 
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
@@ -24,13 +27,18 @@ struct MigrationNoteSplit {
         }
 
         var phase = Phase.explainer
-        /// Placeholder; real proposal data lands in MOB-1466.
         var amount = Zatoshi.zero
         var fee = Zatoshi.zero
         /// Shown from the splitting phase on.
         var txId = ""
         /// Failure sheet presented over the splitting phase.
         var isFailurePresented = false
+        /// The prepared split proposal, held so `retryTapped` can re-submit without re-preparing.
+        var proposal: NoteSplitProposal?
+        var CancelStateStreamId = UUID()
+        /// True when the splitting phase is the coordinator's re-entry root — its back control then
+        /// closes the flow instead of popping.
+        var isFlowRoot = false
         @Shared(.inMemory(.toast)) var toast: Toast.Edge? = nil
 
         init(
@@ -38,13 +46,15 @@ struct MigrationNoteSplit {
             amount: Zatoshi = Zatoshi.zero,
             fee: Zatoshi = Zatoshi.zero,
             txId: String = "",
-            isFailurePresented: Bool = false
+            isFailurePresented: Bool = false,
+            isFlowRoot: Bool = false
         ) {
             self.phase = phase
             self.amount = amount
             self.fee = fee
             self.txId = txId
             self.isFailurePresented = isFailurePresented
+            self.isFlowRoot = isFlowRoot
         }
     }
 
@@ -52,17 +62,21 @@ struct MigrationNoteSplit {
         case binding(BindingAction<State>)
         /// Failure sheet: dismiss (stay on screen).
         case cancelTapped
-        /// Explainer CTA — inert now; MOB-1466 submits the split.
+        /// Flow-root back control (splitting phase only): closes the flow instead of popping.
+        case closeTapped
+        /// Explainer CTA — submits the prepared split.
         case confirmTapped
         /// Confirmed CTA.
         case continueTapped
         case copyTxIdTapped
         case delegate(Delegate)
-        /// Failure sheet: dismiss — inert re-submit (MOB-1466).
+        /// `prepareNoteSplit()` result — populates amount/fee and stores the proposal for submission.
+        case noteSplitPrepared(NoteSplitProposal)
+        case onAppear
+        /// Failure sheet: dismiss, then re-submit the stored proposal.
         case retryTapped
-        /// Declared for MOB-1466 (SDK-driven) — inert.
+        /// `migrationStateStream()` reported `.readyToPropose` while splitting.
         case splitConfirmed
-        /// Declared for MOB-1466 (SDK-driven) — inert.
         case splitResult(TransferResult)
 
         enum Delegate: Equatable {
@@ -71,6 +85,7 @@ struct MigrationNoteSplit {
     }
 
     @Dependency(\.pasteboard) var pasteboard
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
 
     init() { }
 
@@ -86,8 +101,12 @@ struct MigrationNoteSplit {
                 state.isFailurePresented = false
                 return .none
 
+            case .closeTapped:
+                return .send(.delegate(.continued))
+
             case .confirmTapped:
-                return .none
+                state.phase = .splitting
+                return submitNoteSplit(state.proposal)
 
             case .continueTapped:
                 return .send(.delegate(.continued))
@@ -100,16 +119,67 @@ struct MigrationNoteSplit {
             case .delegate:
                 return .none
 
+            case .noteSplitPrepared(let proposal):
+                state.proposal = proposal
+                state.amount = Zatoshi(proposal.outputNotes.reduce(0) { $0 + $1.amount })
+                state.fee = proposal.fee
+                return .none
+
+            case .onAppear:
+                let isPendingConfirmation = sdkSynchronizer.getMigrationState() == .splitPendingConfirmation
+                if isPendingConfirmation {
+                    state.phase = .splitting
+                }
+
+                return .merge(
+                    subscribeToMigrationState(cancelId: state.CancelStateStreamId),
+                    isPendingConfirmation ? .none : prepareNoteSplit()
+                )
+
             case .retryTapped:
                 state.isFailurePresented = false
-                return .none
+                return submitNoteSplit(state.proposal)
 
             case .splitConfirmed:
+                state.phase = .confirmed
                 return .none
 
-            case .splitResult:
+            case .splitResult(let result):
+                switch result {
+                case .success(let txId):
+                    state.txId = txId
+                    state.isFailurePresented = false
+                case .networkError, .invalidNote, .expired:
+                    state.isFailurePresented = true
+                }
                 return .none
             }
         }
+    }
+
+    private func prepareNoteSplit() -> Effect<Action> {
+        .run { send in
+            let proposal = await sdkSynchronizer.prepareNoteSplit()
+            await send(.noteSplitPrepared(proposal))
+        }
+    }
+
+    private func submitNoteSplit(_ proposal: NoteSplitProposal?) -> Effect<Action> {
+        guard let proposal else { return .none }
+
+        return .run { send in
+            let result = await sdkSynchronizer.submitNoteSplit(proposal)
+            await send(.splitResult(result))
+        }
+    }
+
+    private func subscribeToMigrationState(cancelId: UUID) -> Effect<Action> {
+        .publisher {
+            sdkSynchronizer.migrationStateStream()
+                .compactMap { state -> Action? in
+                    state == .readyToPropose ? Action.splitConfirmed : nil
+                }
+        }
+        .cancellable(id: cancelId, cancelInFlight: true)
     }
 }

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
@@ -9,7 +9,7 @@
 //  submit it; a `migrationStateStream()` subscription advances `.splitting` -> `.confirmed` once the
 //  SDK reports `.readyToPropose`. When the splitting phase is a flow re-entry root (`isFlowRoot`),
 //  its back control closes the flow (`closeTapped` -> `.delegate(.continued)`) instead of popping
-//  (MOB-1466). Chaining into the rest of the migration flow is the coordinator's job (phase 3).
+//  (MOB-1466). The `.continued` delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import Foundation
@@ -35,7 +35,7 @@ struct MigrationNoteSplit {
         var isFailurePresented = false
         /// The prepared split proposal, held so `retryTapped` can re-submit without re-preparing.
         var proposal: NoteSplitProposal?
-        var CancelStateStreamId = UUID()
+        var cancelStateStreamId = UUID()
         /// True when the splitting phase is the coordinator's re-entry root — its back control then
         /// closes the flow instead of popping.
         var isFlowRoot = false
@@ -132,7 +132,7 @@ struct MigrationNoteSplit {
                 }
 
                 return .merge(
-                    subscribeToMigrationState(cancelId: state.CancelStateStreamId),
+                    subscribeToMigrationState(cancelId: state.cancelStateStreamId),
                     isPendingConfirmation ? .none : prepareNoteSplit()
                 )
 

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
@@ -3,9 +3,10 @@
 //  zodl
 //
 //  "Split Your Wallet Funds" screen (MOB-1461, Figma S2 · 2867:10535 explainer / 2867:10741
-//  progress / 2867:10645 success / 2670:15570 failure sheet). Visually complete per Figma; phase
-//  transitions and the SDK-driven split submission are declared but inert — wiring them up lands in
-//  MOB-1466. The `continueTapped` delegate is emitted but consumed by nobody yet.
+//  progress / 2867:10645 success / 2670:15570 failure sheet). `onAppear` loads/resumes the split
+//  live via the store (MOB-1466); when the splitting phase is a flow re-entry root (`isFlowRoot`),
+//  its back control closes the flow instead of popping. The `continueTapped` delegate is emitted
+//  but consumed by nobody yet — chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -66,12 +67,15 @@ struct MigrationNoteSplitView: View {
                 footer
             }
             .screenHorizontalPadding()
-            .zashiBack()
+            .applyPresentationModifier(store: store)
             .zashiSheet(isPresented: $store.isFailurePresented) {
                 failureSheetContent
             }
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Header badge
@@ -272,6 +276,22 @@ struct MigrationNoteSplitView: View {
                 store.send(.retryTapped)
             }
             .padding(.bottom, Design.Spacing.sheetBottomSpace)
+        }
+    }
+}
+
+// MARK: - Presentation modifier
+
+private extension View {
+    /// Only the splitting phase can be a re-entry root — explainer/confirmed are always reached via
+    /// normal push, so a plain pop stands there regardless of `isFlowRoot`.
+    @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationNoteSplit>) -> some View {
+        if store.phase == .splitting && store.isFlowRoot {
+            zashiBackV2 {
+                store.send(.closeTapped)
+            }
+        } else {
+            zashiBack()
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift
@@ -6,8 +6,8 @@
 //  Explains what migration-related notifications the user will get, with copy that differs by
 //  `variant` (scheduled vs. manual send cadence). `allowTapped` requests `UNUserNotificationCenter`
 //  authorization; either outcome continues the flow — permission is a nice-to-have, not a blocker
-//  (MOB-1466). The `skipTapped`/`.continued` delegate is emitted but consumed by nobody yet —
-//  chaining is the coordinator's job (phase 3).
+//  (MOB-1466). The `skipTapped`/`.continued` delegate is consumed by `MigrationCoordFlowCoordinator`
+//  (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift
@@ -4,10 +4,10 @@
 //
 //  "Allow Notifications" screen (MOB-1462, Figma S4 scheduled · 2840:4728 / manual · 2867:1921).
 //  Explains what migration-related notifications the user will get, with copy that differs by
-//  `variant` (scheduled vs. manual send cadence). Visual-only: `allowTapped` (requesting
-//  `UNUserNotificationCenter` authorization) and `authorizationResult` are declared but inert —
-//  wiring them up is MOB-1466's job. The `skipTapped` delegate is emitted but consumed by nobody
-//  yet.
+//  `variant` (scheduled vs. manual send cadence). `allowTapped` requests `UNUserNotificationCenter`
+//  authorization; either outcome continues the flow — permission is a nice-to-have, not a blocker
+//  (MOB-1466). The `skipTapped`/`.continued` delegate is emitted but consumed by nobody yet —
+//  chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -29,9 +29,9 @@ struct MigrationNotifications {
     }
 
     enum Action: Equatable {
-        /// Inert now — MOB-1466 requests notification authorization.
+        /// Requests notification authorization.
         case allowTapped
-        /// Declared for MOB-1466 — inert.
+        /// `requestAuthorization()` result — either outcome continues the flow.
         case authorizationResult(Bool)
         case delegate(Delegate)
         case skipTapped
@@ -41,16 +41,21 @@ struct MigrationNotifications {
         }
     }
 
+    @Dependency(\.userNotifications) var userNotifications
+
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
             case .allowTapped:
-                return .none
+                return .run { send in
+                    let isAuthorized = await userNotifications.requestAuthorization()
+                    await send(.authorizationResult(isAuthorized))
+                }
 
             case .authorizationResult:
-                return .none
+                return .send(.delegate(.continued))
 
             case .delegate:
                 return .none

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
@@ -3,8 +3,10 @@
 //  zodl
 //
 //  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
-//  2696:5626 / expired 2973:5698). Visually complete per Figma; the `continueTapped` delegate is
-//  emitted but consumed by nobody yet — wiring the real plan-recreation flow lands in MOB-1466.
+//  2696:5626 / expired 2973:5698). When this screen is the coordinator's re-entry root
+//  (`isFlowRoot`), its back control closes the flow (`closeTapped` -> `.delegate(.close)`) instead
+//  of popping (MOB-1466). The `continueTapped` delegate is emitted but consumed by nobody yet —
+//  wiring the real plan-recreation flow is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -22,19 +24,31 @@ struct MigrationRecovery {
         /// "Transfers {a}–{b}" range in copy.
         var firstTransfer = 3
         var lastTransfer = 5
+        /// True when this screen is the coordinator's re-entry root — its back control then closes
+        /// the flow instead of popping.
+        var isFlowRoot = false
 
-        init(reason: Reason = .notesSpent, firstTransfer: Int = 3, lastTransfer: Int = 5) {
+        init(
+            reason: Reason = .notesSpent,
+            firstTransfer: Int = 3,
+            lastTransfer: Int = 5,
+            isFlowRoot: Bool = false
+        ) {
             self.reason = reason
             self.firstTransfer = firstTransfer
             self.lastTransfer = lastTransfer
+            self.isFlowRoot = isFlowRoot
         }
     }
 
     enum Action: Equatable {
+        /// Flow-root back control: closes the flow instead of popping.
+        case closeTapped
         case continueTapped
         case delegate(Delegate)
 
         enum Delegate: Equatable {
+            case close
             case recreate
         }
     }
@@ -44,6 +58,9 @@ struct MigrationRecovery {
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .closeTapped:
+                return .send(.delegate(.close))
+
             case .continueTapped:
                 return .send(.delegate(.recreate))
 

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift
@@ -5,8 +5,8 @@
 //  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
 //  2696:5626 / expired 2973:5698). When this screen is the coordinator's re-entry root
 //  (`isFlowRoot`), its back control closes the flow (`closeTapped` -> `.delegate(.close)`) instead
-//  of popping (MOB-1466). The `continueTapped` delegate is emitted but consumed by nobody yet —
-//  wiring the real plan-recreation flow is the coordinator's job (phase 3).
+//  of popping (MOB-1466). The `continueTapped` delegate (plan-recreation) is consumed by
+//  `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryView.swift
+++ b/secant/Sources/Features/Migration/MigrationRecovery/MigrationRecoveryView.swift
@@ -3,8 +3,9 @@
 //  zodl
 //
 //  "Reschedule Transfers" / "Transfers No Longer Valid" screen (MOB-1464, Figma S11 · spent
-//  2696:5626 / expired 2973:5698). Visually complete per Figma; the `continueTapped` delegate is
-//  emitted but consumed by nobody yet — wiring the real plan-recreation flow lands in MOB-1466.
+//  2696:5626 / expired 2973:5698). When `isFlowRoot` is set, the back control closes the flow
+//  instead of popping (MOB-1466). The `continueTapped` delegate is emitted but consumed by nobody
+//  yet — wiring the real plan-recreation flow is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -49,7 +50,7 @@ struct MigrationRecoveryView: View {
                 .padding(.bottom, 24)
             }
             .screenHorizontalPadding()
-            .zashiBack()
+            .applyPresentationModifier(store: store)
         }
         .applyScreenBackground()
     }
@@ -122,6 +123,20 @@ struct MigrationRecoveryView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 2)
                 .padding(.bottom, 12)
+        }
+    }
+}
+
+// MARK: - Presentation modifier
+
+private extension View {
+    @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationRecovery>) -> some View {
+        if store.isFlowRoot {
+            zashiBackV2 {
+                store.send(.closeTapped)
+            }
+        } else {
+            zashiBack()
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
@@ -10,8 +10,8 @@
 //  coordinator (no propose) and confirm delegates directly — the transfer was already signed at plan
 //  commit. When the manual-step variant is a flow re-entry root (`isFlowRoot`), its back control
 //  closes the flow via a new `.closed` delegate instead of popping — reusing `.confirmed` for a
-//  back-tap would incorrectly signal the transfer was confirmed (MOB-1466). Chaining is the
-//  coordinator's job (phase 3).
+//  back-tap would incorrectly signal the transfer was confirmed (MOB-1466). Both delegates are
+//  consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
@@ -5,9 +5,13 @@
 //  "Review Transfer" screen (MOB-1463, Figma S7 · immediate 2867:5924 / manual "3 of 5" 2729:8544,
 //  equivalent to frame 2712:7779 which fails to render via MCP). Final confirmation before a
 //  migration transfer is sent — either the single immediate transfer, or one step of a scheduled
-//  plan. Visual-only: `amount`/`fee` are placeholders and `sendResult` is declared but inert —
-//  submitting the transfer lands in MOB-1466. The `confirmTapped` delegate is emitted but consumed
-//  by nobody yet.
+//  plan. Immediate mode proposes its own single-transfer schedule on `onAppear` (for Amount/Fee) and
+//  signs+stores it on confirm before delegating; manual step has its data injected by the
+//  coordinator (no propose) and confirm delegates directly — the transfer was already signed at plan
+//  commit. When the manual-step variant is a flow re-entry root (`isFlowRoot`), its back control
+//  closes the flow via a new `.closed` delegate instead of popping — reusing `.confirmed` for a
+//  back-tap would incorrectly signal the transfer was confirmed (MOB-1466). Chaining is the
+//  coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -22,46 +26,91 @@ struct MigrationReviewTransfer {
             case manualStep(number: Int, total: Int)
         }
 
+        /// Standard ZIP-317 marginal fee shown throughout the app (`Zatoshi(100_000)` precedent —
+        /// migration schedules don't carry a fee field of their own).
+        fileprivate static let standardFee = Zatoshi(100_000)
+
         var mode = Mode.immediate
-        /// Placeholder; real proposal data lands in MOB-1466.
         var amount = Zatoshi.zero
         var fee = Zatoshi.zero
+        /// Immediate mode: the single-transfer schedule proposed on `onAppear`, signed+stored on
+        /// confirm. `nil` in manual-step mode (nothing to propose or sign here).
+        var schedule: MigrationSchedule?
+        /// True when the manual-step variant is the coordinator's re-entry root — its back control
+        /// then closes the flow instead of popping.
+        var isFlowRoot = false
 
         init(
             mode: Mode = .immediate,
             amount: Zatoshi = Zatoshi.zero,
-            fee: Zatoshi = Zatoshi.zero
+            fee: Zatoshi = Zatoshi.zero,
+            isFlowRoot: Bool = false
         ) {
             self.mode = mode
             self.amount = amount
             self.fee = fee
+            self.isFlowRoot = isFlowRoot
         }
     }
 
     enum Action: Equatable {
-        /// Inert now; MOB-1466 submits the transfer.
+        /// Flow-root back control (manual step only): closes the flow instead of popping.
+        case closeTapped
+        /// Immediate mode signs+stores the schedule then delegates; manual step delegates directly.
         case confirmTapped
         case delegate(Delegate)
-        /// Declared for MOB-1466 (SDK-driven) — inert.
-        case sendResult(TransferResult)
+        /// Immediate mode only: proposes a single-transfer schedule for Amount/Fee display.
+        case onAppear
+        /// `signAndStoreMigrationSchedule` completed (immediate mode only).
+        case scheduleSigned
+        /// `proposeMigrationTransfers()` result (immediate mode only).
+        case transferProposed(MigrationSchedule)
 
         enum Delegate: Equatable {
+            case closed
             case confirmed
         }
     }
+
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
 
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .closeTapped:
+                return .send(.delegate(.closed))
+
             case .confirmTapped:
-                return .send(.delegate(.confirmed))
+                guard case .immediate = state.mode, let schedule = state.schedule else {
+                    // Manual step: the transfer was already signed at plan commit — delegate directly.
+                    return .send(.delegate(.confirmed))
+                }
+
+                return .run { send in
+                    await sdkSynchronizer.signAndStoreMigrationSchedule(schedule)
+                    await send(.scheduleSigned)
+                }
 
             case .delegate:
                 return .none
 
-            case .sendResult:
+            case .onAppear:
+                guard case .immediate = state.mode else { return .none }
+
+                return .run { send in
+                    let schedule = await sdkSynchronizer.proposeMigrationTransfers()
+                    await send(.transferProposed(schedule))
+                }
+
+            case .scheduleSigned:
+                return .send(.delegate(.confirmed))
+
+            case .transferProposed(let schedule):
+                state.schedule = schedule
+                state.amount = schedule.transfers.first?.amount ?? Zatoshi.zero
+                state.fee = State.standardFee
                 return .none
             }
         }

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferView.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferView.swift
@@ -3,8 +3,10 @@
 //  zodl
 //
 //  "Review Transfer" screen (MOB-1463, Figma S7 · immediate 2867:5924 / manual "3 of 5"
-//  2729:8544). Visually complete per Figma; `sendResult` is declared but inert — submitting the
-//  transfer lands in MOB-1466. The `confirmTapped` delegate is emitted but consumed by nobody yet.
+//  2729:8544). `onAppear` loads Amount/Fee live (immediate mode) via the store; when the manual-step
+//  variant is a flow re-entry root (`isFlowRoot`), its back control closes the flow instead of
+//  popping (MOB-1466). The `confirmTapped` delegate is emitted but consumed by nobody yet —
+//  chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -50,9 +52,12 @@ struct MigrationReviewTransferView: View {
                 .padding(.bottom, 24)
             }
             .screenHorizontalPadding()
-            .zashiBack()
+            .applyPresentationModifier(store: store)
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Header
@@ -96,6 +101,22 @@ struct MigrationReviewTransferView: View {
                 value: "\(store.fee.decimalString()) ZEC",
                 rowAppereance: .bottom
             )
+        }
+    }
+}
+
+// MARK: - Presentation modifier
+
+private extension View {
+    /// Only the manual-step variant can be a re-entry root — immediate mode is always reached via
+    /// normal push, so a plain pop stands there regardless of `isFlowRoot`.
+    @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationReviewTransfer>) -> some View {
+        if store.mode != .immediate && store.isFlowRoot {
+            zashiBackV2 {
+                store.send(.closeTapped)
+            }
+        } else {
+            zashiBack()
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledStore.swift
+++ b/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledStore.swift
@@ -4,8 +4,8 @@
 //
 //  "Migration Scheduled" screen (MOB-1463, Figma S9 · 2630:11282). Terminal success screen shown
 //  once a scheduled migration plan has been confirmed: a summary card of what's being transferred
-//  and over how long. Visual-only: all fields are placeholders — the real summary data lands in
-//  MOB-1466. The `doneTapped` delegate is emitted but consumed by nobody yet.
+//  and over how long. The coordinator hydrates the summary fields and consumes the `doneTapped`
+//  delegate (MigrationCoordFlowCoordinator, MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
@@ -3,10 +3,13 @@
 //  zodl
 //
 //  "Sending" / "Sent" screen (MOB-1463, Figma S8 · sending 2618:6858 / sent 2618:6895). Shown while
-//  a migration transfer broadcasts, then flips to a success state. Visual-only: `txId` is a
-//  placeholder and `result` is declared but inert — resubmitting after a failure and wiring the
-//  real broadcast result land in MOB-1466. The `closeTapped` / `viewTransactionTapped` delegates
-//  are emitted but consumed by nobody yet.
+//  migration transfers broadcast — one for immediate/manual/plan-first sends, or a sequential batch
+//  for "send now" — then flips to a success state once every transfer in `totalCount` has been
+//  executed. `onAppear` runs `executeNextPendingMigrationTransfer` strictly in sequence, recording a
+//  broadcast and scheduling the next background window after each success; a failure/`nil` result
+//  stops the sequence and presents the failure sheet, and `retryTapped` re-runs only the failed step
+//  (MOB-1466). The `closeTapped` / `viewTransactionTapped` delegates are emitted but consumed by
+//  nobody yet — chaining is the coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -24,30 +27,46 @@ struct MigrationSending {
         var phase = Phase.sending
         /// Failure sheet presented over the sending phase.
         var isFailurePresented = false
-        /// Placeholder; real tx id lands in MOB-1466 (wires up View Transaction).
+        /// The most recently broadcast transfer's tx id (wires up View Transaction).
         var txId = ""
+        /// How many transfers this screen instance is responsible for: 1 for immediate/manual/
+        /// plan-first sends, N for a sequential "send now" batch. Coordinator-configured.
+        var totalCount = 1
+        /// How many of `totalCount` have been successfully broadcast so far.
+        var sentCount = 0
+        /// Submission options for `executeNextPendingMigrationTransfer`, injected by the coordinator.
+        var networkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
 
         init(
             phase: Phase = .sending,
             isFailurePresented: Bool = false,
-            txId: String = ""
+            txId: String = "",
+            totalCount: Int = 1,
+            sentCount: Int = 0,
+            networkPrivacyOptions: NetworkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
         ) {
             self.phase = phase
             self.isFailurePresented = isFailurePresented
             self.txId = txId
+            self.totalCount = totalCount
+            self.sentCount = sentCount
+            self.networkPrivacyOptions = networkPrivacyOptions
         }
     }
 
     enum Action: BindableAction, Equatable {
+        /// All `totalCount` transfers have been successfully broadcast.
+        case allTransfersSent
         case binding(BindingAction<State>)
         /// Failure sheet: dismiss (stay on screen).
         case cancelTapped
         case closeTapped
         case delegate(Delegate)
-        /// Declared for MOB-1466 (SDK-driven) — inert.
-        case result(TransferResult)
-        /// Failure sheet: dismiss — inert re-submit (MOB-1466).
+        case onAppear
+        /// Failure sheet: dismiss, then re-run the failed step.
         case retryTapped
+        /// `executeNextPendingMigrationTransfer` result for the current step; `nil` on a stub/no-op.
+        case transferResult(TransferResult?)
         case viewTransactionTapped
 
         enum Delegate: Equatable {
@@ -56,6 +75,10 @@ struct MigrationSending {
         }
     }
 
+    @Dependency(\.migrationBGScheduler) var migrationBGScheduler
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+
     init() { }
 
     var body: some Reducer<State, Action> {
@@ -63,6 +86,10 @@ struct MigrationSending {
 
         Reduce { state, action in
             switch action {
+            case .allTransfersSent:
+                state.phase = .success
+                return .none
+
             case .binding:
                 return .none
 
@@ -76,16 +103,41 @@ struct MigrationSending {
             case .delegate:
                 return .none
 
-            case .result:
-                return .none
+            case .onAppear:
+                return executeNextTransfer(options: state.networkPrivacyOptions)
 
             case .retryTapped:
                 state.isFailurePresented = false
-                return .none
+                return executeNextTransfer(options: state.networkPrivacyOptions)
+
+            case .transferResult(let result):
+                switch result {
+                case .success(let txId):
+                    state.txId = txId
+                    state.sentCount += 1
+                    // Both are synchronous, non-throwing dependency closures — no effect needed.
+                    migrationManager.recordMigrationBroadcast()
+                    migrationBGScheduler.scheduleNextWindow()
+
+                    return state.sentCount >= state.totalCount
+                        ? .send(.allTransfersSent)
+                        : executeNextTransfer(options: state.networkPrivacyOptions)
+
+                case .networkError, .invalidNote, .expired, nil:
+                    state.isFailurePresented = true
+                    return .none
+                }
 
             case .viewTransactionTapped:
                 return .send(.delegate(.viewTransaction))
             }
+        }
+    }
+
+    private func executeNextTransfer(options: NetworkPrivacyOptions) -> Effect<Action> {
+        .run { send in
+            let result = await sdkSynchronizer.executeNextPendingMigrationTransfer(options)
+            await send(.transferResult(result))
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
@@ -8,8 +8,8 @@
 //  executed. `onAppear` runs `executeNextPendingMigrationTransfer` strictly in sequence, recording a
 //  broadcast and scheduling the next background window after each success; a failure/`nil` result
 //  stops the sequence and presents the failure sheet, and `retryTapped` re-runs only the failed step
-//  (MOB-1466). The `closeTapped` / `viewTransactionTapped` delegates are emitted but consumed by
-//  nobody yet — chaining is the coordinator's job (phase 3).
+//  (MOB-1466). The `closeTapped` / `viewTransactionTapped` delegates are consumed by
+//  `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
@@ -115,13 +115,21 @@ struct MigrationSending {
                 case .success(let txId):
                     state.txId = txId
                     state.sentCount += 1
-                    // Both are synchronous, non-throwing dependency closures — no effect needed.
+                    // Synchronous, non-throwing dependency closure — no effect needed.
                     migrationManager.recordMigrationBroadcast()
-                    migrationBGScheduler.scheduleNextWindow()
 
-                    return state.sentCount >= state.totalCount
+                    let nextEffect: Effect<Action> = state.sentCount >= state.totalCount
                         ? .send(.allTransfersSent)
                         : executeNextTransfer(options: state.networkPrivacyOptions)
+
+                    // scheduleNextWindow() is async (MOB-1467) — concatenated ahead of the
+                    // follow-up effect so it still runs to completion before the next transfer
+                    // kicks off (or before .allTransfersSent), matching the previous synchronous
+                    // call-then-continue ordering.
+                    return .concatenate(
+                        .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleNextWindow() },
+                        nextEffect
+                    )
 
                 case .networkError, .invalidNote, .expired, nil:
                     state.isFailurePresented = true

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingView.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingView.swift
@@ -2,10 +2,10 @@
 //  MigrationSendingView.swift
 //  zodl
 //
-//  "Sending" / "Sent" screen (MOB-1463, Figma S8 · sending 2618:6858 / sent 2618:6895). Visually
-//  complete per Figma; `result` is declared but inert — wiring the real broadcast result and
-//  resubmission after a failure lands in MOB-1466. The `closeTapped` / `viewTransactionTapped`
-//  delegates are emitted but consumed by nobody yet.
+//  "Sending" / "Sent" screen (MOB-1463, Figma S8 · sending 2618:6858 / sent 2618:6895). `onAppear`
+//  drives the store's sequential transfer execution (MOB-1466). The `closeTapped` /
+//  `viewTransactionTapped` delegates are emitted but consumed by nobody yet — chaining is the
+//  coordinator's job (phase 3).
 //
 
 import ComposableArchitecture
@@ -34,6 +34,9 @@ struct MigrationSendingView: View {
                 .zashiSheet(isPresented: $store.isFailurePresented) {
                     failureSheetContent
                 }
+        }
+        .onAppear {
+            store.send(.onAppear)
         }
     }
 

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
@@ -7,8 +7,8 @@
 //  via `migrationTransfers()`/`migrationSummary()`, derives `isSendNowDisabled` from
 //  `manager.sendGate()`, and subscribes `migrationStateStream()` to refresh rows live (MOB-1466).
 //  When this screen is a flow re-entry root (`isFlowRoot`), its back control closes the flow
-//  (`.done`) instead of popping — every other delegate is emitted but consumed by nobody yet;
-//  chaining is the coordinator's job (phase 3).
+//  (`.done`) instead of popping — every other delegate is consumed by
+//  `MigrationCoordFlowCoordinator` (MOB-1466).
 //
 
 import Foundation
@@ -37,7 +37,7 @@ struct MigrationStatus {
         var isFlowRoot = false
         /// Send-now CTA disabled per `manager.sendGate()` (`.syncRequired`/`.waitUntil` -> disabled).
         var isSendNowDisabled = false
-        var CancelStateStreamId = UUID()
+        var cancelStateStreamId = UUID()
 
         var remainingCount: Int {
             rows.filter { $0.status != .sent }.count
@@ -110,7 +110,7 @@ struct MigrationStatus {
                         sdkSynchronizer.migrationStateStream()
                             .map { _ in Action.migrationStateChanged }
                     }
-                    .cancellable(id: state.CancelStateStreamId, cancelInFlight: true)
+                    .cancellable(id: state.cancelStateStreamId, cancelInFlight: true)
                 )
 
             case .rescheduleTapped:

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusStore.swift
@@ -3,12 +3,15 @@
 //  zodl
 //
 //  "Migration Progress" / "Resume Migration" / "Re-scheduling…" screen (MOB-1464, Figma S10 ·
-//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). Visually complete per Figma;
-//  `rows` is a placeholder and every delegate is emitted but consumed by nobody yet — wiring the
-//  real reschedule/send-now behavior and chaining into the rest of the migration flow lands in
-//  MOB-1466.
+//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). `onAppear` loads rows/summary
+//  via `migrationTransfers()`/`migrationSummary()`, derives `isSendNowDisabled` from
+//  `manager.sendGate()`, and subscribes `migrationStateStream()` to refresh rows live (MOB-1466).
+//  When this screen is a flow re-entry root (`isFlowRoot`), its back control closes the flow
+//  (`.done`) instead of popping — every other delegate is emitted but consumed by nobody yet;
+//  chaining is the coordinator's job (phase 3).
 //
 
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
@@ -22,7 +25,6 @@ struct MigrationStatus {
         }
 
         var presentation = Presentation.progress
-        /// Placeholder; real proposal data lands in MOB-1466.
         var rows: IdentifiedArrayOf<MigrationTransferRow> = []
         var totalDurationHours = 0
         /// Resume header: "Transfer {n} of {m} …".
@@ -30,6 +32,12 @@ struct MigrationStatus {
         var stalledHoursAgo = 0
         /// Visual-only: skeleton captions + disabled spinner button on the resume presentation.
         var isRescheduling = false
+        /// True when this screen is the coordinator's re-entry root (both presentations) — its back
+        /// control then closes the flow instead of popping.
+        var isFlowRoot = false
+        /// Send-now CTA disabled per `manager.sendGate()` (`.syncRequired`/`.waitUntil` -> disabled).
+        var isSendNowDisabled = false
+        var CancelStateStreamId = UUID()
 
         var remainingCount: Int {
             rows.filter { $0.status != .sent }.count
@@ -41,7 +49,8 @@ struct MigrationStatus {
             totalDurationHours: Int = 0,
             stalledNumber: Int = 0,
             stalledHoursAgo: Int = 0,
-            isRescheduling: Bool = false
+            isRescheduling: Bool = false,
+            isFlowRoot: Bool = false
         ) {
             self.presentation = presentation
             self.rows = rows
@@ -49,15 +58,23 @@ struct MigrationStatus {
             self.stalledNumber = stalledNumber
             self.stalledHoursAgo = stalledHoursAgo
             self.isRescheduling = isRescheduling
+            self.isFlowRoot = isFlowRoot
         }
     }
 
     enum Action: Equatable {
+        /// Flow-root back control: closes the flow instead of popping.
+        case closeTapped
         /// Progress CTA and the X close.
         case gotItTapped
         case delegate(Delegate)
+        /// `migrationStateStream()` ticked — reloads rows/summary/gate.
+        case migrationStateChanged
+        case onAppear
         case rescheduleTapped
         case sendNowTapped
+        /// `migrationTransfers()` + `migrationSummary()` + `manager.sendGate()` result.
+        case statusLoaded(rows: [MigrationTransferRow], totalDurationHours: Int, isSendNowDisabled: Bool)
 
         enum Delegate: Equatable {
             case done
@@ -66,13 +83,35 @@ struct MigrationStatus {
         }
     }
 
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .closeTapped:
+                return .send(.delegate(.done))
+
             case .gotItTapped:
                 return .send(.delegate(.done))
+
+            case .delegate:
+                return .none
+
+            case .migrationStateChanged:
+                return loadStatus()
+
+            case .onAppear:
+                return .merge(
+                    loadStatus(),
+                    .publisher {
+                        sdkSynchronizer.migrationStateStream()
+                            .map { _ in Action.migrationStateChanged }
+                    }
+                    .cancellable(id: state.CancelStateStreamId, cancelInFlight: true)
+                )
 
             case .rescheduleTapped:
                 state.isRescheduling = true
@@ -81,9 +120,27 @@ struct MigrationStatus {
             case .sendNowTapped:
                 return .send(.delegate(.sendNow))
 
-            case .delegate:
+            case .statusLoaded(let rows, let totalDurationHours, let isSendNowDisabled):
+                state.rows = IdentifiedArrayOf(uniqueElements: rows)
+                state.totalDurationHours = totalDurationHours
+                state.isSendNowDisabled = isSendNowDisabled
                 return .none
             }
+        }
+    }
+
+    private func loadStatus() -> Effect<Action> {
+        .run { send in
+            let rows = sdkSynchronizer.migrationTransfers()
+            let summary = sdkSynchronizer.migrationSummary()
+            let isSendNowDisabled = migrationManager.sendGate() != MigrationSendGate.allowed
+            await send(
+                .statusLoaded(
+                    rows: rows,
+                    totalDurationHours: summary.estimatedDurationHours,
+                    isSendNowDisabled: isSendNowDisabled
+                )
+            )
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
+++ b/secant/Sources/Features/Migration/MigrationStatus/MigrationStatusView.swift
@@ -3,9 +3,10 @@
 //  zodl
 //
 //  "Migration Progress" / "Resume Migration" / "Re-scheduling…" screen (MOB-1464, Figma S10 ·
-//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). Visually complete per Figma;
-//  every delegate emitted here is consumed by nobody yet — wiring the real reschedule/send-now
-//  behavior and chaining into the rest of the migration flow lands in MOB-1466.
+//  progress 2709:3350 / resume 2696:7133 / re-scheduling 2840:3656). `onAppear` loads live rows via
+//  the store; every other delegate emitted here is consumed by nobody yet — chaining is the
+//  coordinator's job (phase 3). When `isFlowRoot` is set, the back control closes the flow instead
+//  of popping (MOB-1466).
 //
 
 import ComposableArchitecture
@@ -56,6 +57,9 @@ struct MigrationStatusView: View {
             .applyPresentationModifier(store: store)
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Title + description
@@ -145,6 +149,7 @@ struct MigrationStatusView: View {
                 ZashiButton(String(localizable: .migrationStatusSendNow)) {
                     store.send(.sendNowTapped)
                 }
+                .disabled(store.isSendNowDisabled)
             }
         }
     }
@@ -153,10 +158,18 @@ struct MigrationStatusView: View {
 // MARK: - Presentation modifier
 
 private extension View {
+    /// `.progress`'s back was already close-like (`zashiBackV2` sending `.gotItTapped`) before
+    /// `isFlowRoot` existed — that stands unconditionally. `.resume`'s back is a plain pop unless
+    /// this screen is the coordinator's re-entry root, in which case it closes the flow instead
+    /// (MOB-1466 back-semantics: "when `isFlowRoot == false`, current behavior stands").
     @ViewBuilder func applyPresentationModifier(store: StoreOf<MigrationStatus>) -> some View {
         if store.presentation == .progress {
             zashiBackV2 {
                 store.send(.gotItTapped)
+            }
+        } else if store.isFlowRoot {
+            zashiBackV2 {
+                store.send(.closeTapped)
             }
         } else {
             zashiBack()

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -98,6 +98,12 @@ struct MigrationTransferPlan {
                     return .none
                 }
 
+                // Coordinator-hydrated rows (the rescheduled variant — no schedule object exists
+                // for it) must not be overwritten by a fresh proposal.
+                if !state.rows.isEmpty {
+                    return .none
+                }
+
                 return .run { send in
                     let schedule = await sdkSynchronizer.proposeMigrationTransfers()
                     await send(.transfersProposed(schedule))

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -4,11 +4,15 @@
 //
 //  "Transfer Plan" screen (MOB-1463, Figma S6 · scheduled 2867:10211 / manual 2867:2198 /
 //  re-created 2709:3519). One-time review of the migration schedule before signing: a timeline of
-//  transfer rows, each showing its amount, status, and ETA. Visual-only: `rows` is a placeholder —
-//  the real proposal (and signing/storing it) lands in MOB-1466. The `confirmTapped` delegate is
-//  emitted but consumed by nobody yet.
+//  transfer rows, each showing its amount, status, and ETA. A fresh entry proposes its own schedule
+//  on `onAppear`; a recovery/reschedule variant instead has its schedule injected by the coordinator
+//  (`injectedSchedule`) and must not re-propose. `confirmTapped` signs and stores whichever schedule
+//  is active, unless `requiresSigning == false` (the rescheduled variant, whose transfers are
+//  already signed), in which case it's a plain acknowledgment (MOB-1466). Chaining the
+//  `confirmTapped` delegate into the rest of the flow is `MigrationCoordFlow`'s job.
 //
 
+import Foundation
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
@@ -23,31 +27,50 @@ struct MigrationTransferPlan {
         }
 
         var variant = Variant.scheduled
-        /// Placeholder; real proposal data lands in MOB-1466.
         var rows: IdentifiedArrayOf<MigrationTransferRow> = []
         var totalDurationHours = 0
         @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion?
+        /// Coordinator-injected schedule for recovery/reschedule variants — when set, `onAppear`
+        /// populates rows from it directly instead of calling `proposeMigrationTransfers()`.
+        var injectedSchedule: MigrationSchedule?
+        /// The schedule currently backing `rows` (either `injectedSchedule` or a freshly proposed
+        /// one) — what `confirmTapped` signs and stores.
+        var schedule: MigrationSchedule?
+        /// `false` for the rescheduled variant only (MOB-1466): its transfers are already signed at
+        /// the original plan commit, so `confirmTapped` is a plain acknowledgment — `false` skips
+        /// `signAndStoreMigrationSchedule` and delegates `.confirmed` directly. The re-created
+        /// (recovery) variant signs a fresh schedule, so it keeps the default `true`.
+        var requiresSigning = true
 
         init(
             variant: Variant = .scheduled,
             rows: IdentifiedArrayOf<MigrationTransferRow> = [],
-            totalDurationHours: Int = 0
+            totalDurationHours: Int = 0,
+            requiresSigning: Bool = true
         ) {
             self.variant = variant
             self.rows = rows
             self.totalDurationHours = totalDurationHours
+            self.requiresSigning = requiresSigning
         }
     }
 
     enum Action: Equatable {
-        /// Inert now; MOB-1466 signs and stores the schedule.
+        /// Signs and stores the active schedule.
         case confirmTapped
         case delegate(Delegate)
+        case onAppear
+        /// `signAndStoreMigrationSchedule` completed.
+        case scheduleSigned
+        /// `proposeMigrationTransfers()` result — populates rows/duration for a fresh entry.
+        case transfersProposed(MigrationSchedule)
 
         enum Delegate: Equatable {
             case confirmed
         }
     }
+
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
 
     init() { }
 
@@ -55,11 +78,65 @@ struct MigrationTransferPlan {
         Reduce { state, action in
             switch action {
             case .confirmTapped:
-                return .send(.delegate(.confirmed))
+                guard state.requiresSigning else {
+                    // Rescheduled variant: transfers are already signed — this is acknowledgment.
+                    return .send(.delegate(.confirmed))
+                }
+
+                let schedule = state.schedule ?? MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+                return .run { send in
+                    await sdkSynchronizer.signAndStoreMigrationSchedule(schedule)
+                    await send(.scheduleSigned)
+                }
 
             case .delegate:
                 return .none
+
+            case .onAppear:
+                if let injectedSchedule = state.injectedSchedule {
+                    apply(injectedSchedule, to: &state)
+                    return .none
+                }
+
+                return .run { send in
+                    let schedule = await sdkSynchronizer.proposeMigrationTransfers()
+                    await send(.transfersProposed(schedule))
+                }
+
+            case .scheduleSigned:
+                return .send(.delegate(.confirmed))
+
+            case .transfersProposed(let schedule):
+                apply(schedule, to: &state)
+                return .none
             }
         }
+    }
+
+    /// Populates `rows`/`totalDurationHours`/`schedule` from a `MigrationSchedule`, whether it was
+    /// freshly proposed or injected by the coordinator. The first transfer is `.active` (ready now);
+    /// the rest are `.pending`. `hoursFromNow` comes from `estimateTimestamp` where the SDK can
+    /// resolve a height to a timestamp; unresolved (incl. the inert stub) defaults to `0`.
+    private func apply(_ schedule: MigrationSchedule, to state: inout State) {
+        state.rows = IdentifiedArrayOf(
+            uniqueElements: schedule.transfers.enumerated().map { index, transfer in
+                MigrationTransferRow(
+                    id: transfer.id,
+                    index: index,
+                    amount: transfer.amount,
+                    status: index == 0 ? .active : .pending,
+                    hoursFromNow: hoursFromNow(forHeightReadyAt: transfer.nextExecutableAfterHeight)
+                )
+            }
+        )
+        state.totalDurationHours = schedule.estimatedDurationHours
+        state.schedule = schedule
+    }
+
+    private func hoursFromNow(forHeightReadyAt height: BlockHeight) -> Int {
+        guard let readyTimestamp = sdkSynchronizer.estimateTimestamp(height) else { return 0 }
+
+        let seconds = Date(timeIntervalSince1970: readyTimestamp).timeIntervalSinceNow
+        return max(0, Int(seconds / 3_600))
     }
 }

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
@@ -3,9 +3,9 @@
 //  zodl
 //
 //  "Transfer Plan" screen (MOB-1463, Figma S6 · scheduled 2867:10211 / manual 2867:2198 /
-//  re-created 2709:3519). Visually complete per Figma; `rows` is a placeholder and the
-//  `confirmTapped` delegate is emitted but consumed by nobody yet — wiring the real proposal and
-//  chaining into the rest of the migration flow lands in MOB-1466.
+//  re-created 2709:3519). `onAppear` loads a fresh proposal (or leaves an injected schedule alone)
+//  via the store; the `confirmTapped` delegate is emitted but consumed by nobody yet — chaining
+//  into the rest of the migration flow is the coordinator's job (MOB-1466 phase 3).
 //
 
 import ComposableArchitecture
@@ -49,6 +49,9 @@ struct MigrationTransferPlanView: View {
             .zashiBack()
         }
         .applyScreenBackground()
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
 
     // MARK: - Title + description

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -246,10 +246,36 @@ extension Root {
                 state.walletBackupCoordFlowState = .initial
                 state.path = .walletBackup
                 return .none
-                
+
             case .home(.smartBanner(.serverSwitchRequested)):
                 state.serverSetupState = .initial
                 state.path = .serverSwitch
+                return .none
+
+                // MARK: - Migration Coord Flow
+
+            case .home(.smartBanner(.migrationScreenRequested)):
+                state.migrationCoordFlowState = MigrationCoordFlow.State.initial
+                state.path = .migrationCoordFlow
+                return .none
+
+            case .migrationCoordFlow(.flowFinished):
+                state.path = nil
+                return .none
+
+            case .migrationCoordFlow(
+                .path(.element(id: _, action: .sending(.delegate(.viewTransaction))))
+            ):
+                // The migration Sending delegate carries only a bare stub `txId: String`
+                // (`MigrationSending.State.txId`), never a real `TransactionState` — but
+                // `TransactionsCoordFlow`'s existing open-a-transaction plumbing (mirrored from
+                // `.home(.transactionList(.transactionTapped))` above) requires a non-optional
+                // `TransactionState` looked up from `state.transactions`, which a synthetic
+                // migration txid will never be a member of. Until the real SDK (MOB-1455) fills
+                // in migration transfers with transactions the rest of the app can see, treat
+                // View Transaction as a flow close rather than a broken/empty detail screen.
+                // TODO: [MOB-1458] route to transaction detail once real txids exist
+                state.path = nil
                 return .none
 
                 // MARK: - Keystone

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -7,7 +7,43 @@
 
 import ComposableArchitecture
 import Foundation
+@preconcurrency import BackgroundTasks
 @preconcurrency import ZcashLightClientKit
+
+/// Wraps a `BGProcessingTask` for the migration BG session decision tree (MOB-1467). A bare
+/// `BGProcessingTask` cannot be instantiated in unit tests, so the AppDelegate-facing
+/// `.migrationBackgroundTask(BGProcessingTask)` action is immediately wrapped into this handle
+/// and forwarded to `.migrationBackgroundSession`, the action the reducer's tree — and every
+/// `RootMigrationBackgroundTests` case — actually drives. `rawTask` is `nil` in tests (spy
+/// handles); `complete` is always a real, observable closure (`LockIsolated` spy in tests, real
+/// `task.setTaskCompleted(success:)` in production via the AppDelegate-side `live` initializer).
+/// `@unchecked Sendable`: `BGProcessingTask` (a system framework type, `@preconcurrency`-imported
+/// above) is safe to hand across the effect boundary here the same way the existing
+/// `power_wifi_sync`/`scheduler` tasks already are (`Root.State.bgTask`, `AppDelegate`'s
+/// `task.expirationHandler`) — it is only ever read or completed, never mutated concurrently.
+struct MigrationBGSessionHandle: @unchecked Sendable {
+    let rawTask: BGProcessingTask?
+    let complete: @Sendable (Bool) -> Void
+
+    init(rawTask: BGProcessingTask?, complete: @escaping @Sendable (Bool) -> Void) {
+        self.rawTask = rawTask
+        self.complete = complete
+    }
+
+    /// Production convenience: wraps a live task, completing it via its own
+    /// `setTaskCompleted(success:)` when the session decides it's done.
+    static func live(_ task: BGProcessingTask) -> MigrationBGSessionHandle {
+        MigrationBGSessionHandle(rawTask: task, complete: { task.setTaskCompleted(success: $0) })
+    }
+}
+
+extension MigrationBGSessionHandle: Equatable {
+    /// `complete` is a closure and can't be compared — identity of the wrapped task (or "both
+    /// nil", the spy-handle shape every test uses) is the only meaningful equality here.
+    static func == (lhs: MigrationBGSessionHandle, rhs: MigrationBGSessionHandle) -> Bool {
+        lhs.rawTask === rhs.rawTask
+    }
+}
 
 /// In this file is a collection of helpers that control all state and action related operations
 /// for the `Root` with a connection to the app/wallet initialization and erasure of the wallet.
@@ -30,6 +66,7 @@ extension Root {
         case initializationFailed(ZcashError)
         case initializationSuccessfullyDone
         case loadedWalletAccounts([WalletAccount])
+        case migrationBackgroundSession(MigrationBGSessionHandle)
         case resetZashi
         case resetZashiRequest(Bool)
         case resetZashiRequestCanceled
@@ -72,10 +109,16 @@ extension Root {
                 // freshness itself stays reactive (SmartBanner's own subscription + walk) — this
                 // is deliberately the minimal Root-side hook the spec calls for.
                 let reconcileEffect: Effect<Action> = .run { [migrationManager] _ in migrationManager.reconcile() }
+                // MOB-1467: opening the app clears stale migration notifications from Notification
+                // Center — the banner/re-entry route now carries the current state. Delivered ONLY:
+                // a pending manual-mode "ready to send" reminder must survive foreground entry.
+                let clearDeliveredEffect: Effect<Action> = .run { [userNotifications] _ in
+                    await userNotifications.clearDeliveredMigrationNotifications()
+                }
                 if state.isLockedInKeychainUnavailableState || !sdkSynchronizer.latestState().syncStatus.isPrepared {
-                    return .merge(reconcileEffect, .send(.initialization(.initialSetups)))
+                    return .merge(reconcileEffect, clearDeliveredEffect, .send(.initialization(.initialSetups)))
                 } else {
-                    return .merge(reconcileEffect, .send(.initialization(.retryStart)))
+                    return .merge(reconcileEffect, clearDeliveredEffect, .send(.initialization(.retryStart)))
                 }
                 
             case .initialization(.appDelegate(.didEnterBackground)):
@@ -108,7 +151,40 @@ extension Root {
                         await send(.initialization(.retryStart))
                     }
                 }
-                
+
+            case .initialization(.appDelegate(.migrationBackgroundTask(let task))):
+                // Immediately wrapped so the decision tree below (`.migrationBackgroundSession`)
+                // never touches a raw `BGProcessingTask` directly — that type can't be
+                // instantiated in unit tests, so `RootMigrationBackgroundTests` drives
+                // `.migrationBackgroundSession` with spy handles instead (`rawTask: nil`).
+                return .send(.initialization(.migrationBackgroundSession(MigrationBGSessionHandle.live(task))))
+
+            case .initialization(.migrationBackgroundSession(let handle)):
+                return migrationBackgroundSessionEffect(state: &state, handle: handle)
+
+            case .initialization(.appDelegate(.migrationBackgroundTaskExpired)):
+                // Mirror `didEnterBackground`'s expiration handling for the existing
+                // `power_wifi_sync` task: stop the synchronizer and release `state.bgTask` (a
+                // sync-only session may have set it), then re-arm — an expired session must never
+                // orphan the wakeup chain. Re-submitting with the same identifier REPLACES the
+                // pending request, so this is safe even if branch 2's up-front re-arm already ran
+                // in this same session.
+                sdkSynchronizer.stop()
+                state.bgTask?.setTaskCompleted(success: false)
+                state.bgTask = nil
+                return .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleNextWindow() }
+
+            case .initialization(.appDelegate(.migrationNotificationTapped)):
+                // Same gate as `checkBackupPhraseValidation` uses for `isAtDeeplinkWarningScreen`:
+                // `.initialized` is set exactly once, at that checkpoint, so it doubles as "Home
+                // is up" here. If we're not there yet (cold start still in flight), stash the
+                // request — `checkBackupPhraseValidation` fires it once initialization completes.
+                guard state.appInitializationState == .initialized else {
+                    state.pendingMigrationDeepLink = true
+                    return .none
+                }
+                return migrationNotificationTappedRoutingEffect(state: &state)
+
             case .synchronizerStateChanged(let latestState):
                 let snapshot = SyncStatusSnapshot.snapshotFor(state: latestState.data.syncStatus)
 
@@ -480,11 +556,21 @@ extension Root {
                 state.appInitializationState = .initialized
                 let isAtDeeplinkWarningScreen = state.destinationState.destination == .deeplinkWarning
 
+                // MOB-1467: this is the checkpoint that already knows "we just reached Home from
+                // cold start" — mirrors `isAtDeeplinkWarningScreen` immediately above: snapshot +
+                // clear the pending flag now, fire its routing in the same delayed effect that
+                // sends Home, right alongside it.
+                let hasPendingMigrationDeepLink = state.pendingMigrationDeepLink
+                state.pendingMigrationDeepLink = false
+
                 return .run { send in
                     // Delay the splash overlay dismissal
                     try await mainQueue.sleep(for: .seconds(0.5))
                     if !isAtDeeplinkWarningScreen {
                         await send(.destination(.updateDestination(Root.DestinationState.Destination.home)))
+                    }
+                    if hasPendingMigrationDeepLink {
+                        await send(.initialization(.appDelegate(.migrationNotificationTapped)))
                     }
                 }
                 .cancellable(id: state.CancelId, cancelInFlight: true)
@@ -758,5 +844,121 @@ extension Root {
             return true
         default: return false
         }
+    }
+
+    // MARK: - MOB-1467: Migration BG session decision tree
+
+    /// The migration BG session's decision tree (spec "Root: BG session decision tree"), checked
+    /// in this exact order:
+    /// 1. Plan broken (invalid transfer, or expired-attention state) — notify, do NOT re-arm.
+    /// 2. Sync required before the next transfer — either skip (deferred-after-broadcast) or run a
+    ///    sync-only session that never broadcasts, reusing the existing `power_wifi_sync` sync-kick
+    ///    machinery verbatim (`state.bgTask` + `.retryStart`; `synchronizerStateChanged` completes
+    ///    the task on `.upToDate`/`.stopped`/`.error`).
+    /// 3. Otherwise, send: `executeNextPendingMigrationTransfer` and notify/re-arm per outcome.
+    /// Every branch except the sync-only session completes `handle` itself (that session's
+    /// completion is the existing `synchronizerStateChanged` machinery, exactly like the
+    /// `power_wifi_sync` task it mirrors).
+    private func migrationBackgroundSessionEffect(
+        state: inout Root.State,
+        handle: MigrationBGSessionHandle
+    ) -> Effect<Root.Action> {
+        let migrationState = sdkSynchronizer.getMigrationState()
+        let isPlanBroken = sdkSynchronizer.hasInvalidMigrationTransfers()
+            || migrationState == MigrationState.requiresAttention(AttentionReason.transferExpired)
+
+        if isPlanBroken {
+            return .run { [userNotifications] _ in
+                await userNotifications.scheduleMigrationNotification(MigrationNotification.planNeedsUpdate, nil)
+                handle.complete(true)
+            }
+        }
+
+        if sdkSynchronizer.isSyncRequiredBeforeNextMigrationTransfer() {
+            if migrationManager.isSyncDeferredAfterBroadcast() {
+                return .run { [migrationBGScheduler] _ in
+                    await migrationBGScheduler.scheduleNextWindow()
+                    handle.complete(true)
+                }
+            }
+
+            // Sync-only session: never broadcasts. Re-arm up front, then reuse the
+            // `power_wifi_sync` handler's own sync-kick verbatim (`state.bgTask` + `.retryStart`) —
+            // `synchronizerStateChanged` completes `state.bgTask` on `.upToDate`/`.stopped`/`.error`
+            // exactly as it does for that task. `handle.rawTask` may be `nil` in tests (spy
+            // handles); that completion is then a no-op, which is acceptable — this branch is
+            // asserted on the arm + kick + stash, not on task completion.
+            state.bgTask = handle.rawTask
+            return .concatenate(
+                .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleNextWindow() },
+                .send(.initialization(.retryStart))
+            )
+        }
+
+        return .run { [migrationManager, sdkSynchronizer, migrationBGScheduler, userNotifications] _ in
+            let options = migrationManager.networkPrivacyOptions()
+            let result = await sdkSynchronizer.executeNextPendingMigrationTransfer(options)
+
+            switch result {
+            case .success:
+                migrationManager.recordMigrationBroadcast()
+
+                if sdkSynchronizer.getMigrationState() == MigrationState.complete {
+                    await userNotifications.scheduleMigrationNotification(MigrationNotification.migrationComplete, nil)
+                    await migrationBGScheduler.cancelAll()
+                } else {
+                    let notification = Self.transferCompleteNotification(sdkSynchronizer: sdkSynchronizer)
+                    await userNotifications.scheduleMigrationNotification(notification, nil)
+                    await migrationBGScheduler.scheduleNextWindow()
+                }
+
+            case .networkError, .invalidNote, .expired:
+                let nextNumber = (sdkSynchronizer.getMigrationProgress()?.completedTransfers ?? 0) + 1
+                await userNotifications.scheduleMigrationNotification(MigrationNotification.transferWaiting(number: nextNumber), nil)
+                await migrationBGScheduler.scheduleNextWindow()
+
+            case nil:
+                await migrationBGScheduler.scheduleNextWindow()
+            }
+
+            handle.complete(true)
+        }
+    }
+
+    /// Builds the `.transferComplete` notification payload from the freshly-updated migration
+    /// state: `number`/`total`/`remaining` from `getMigrationProgress()`, `nextInHours` from the
+    /// same cadence-window derivation `MigrationBGSchedulerClient`'s `arm(margin:)` uses (§8.3's
+    /// next-window margin, `estimateTimestamp` as the preferred source), rounded to hours.
+    private static func transferCompleteNotification(sdkSynchronizer: SDKSynchronizerClient) -> MigrationNotification {
+        let progress = sdkSynchronizer.getMigrationProgress()
+        let preferredExecutableAt = progress?.nextTransferReadyAtHeight.flatMap { height in
+            sdkSynchronizer.estimateTimestamp(height).map { Date(timeIntervalSince1970: $0) }
+        }
+        let now = Date()
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.nextWindowMargin,
+            preferredExecutableAt: preferredExecutableAt,
+            now: now
+        )
+        let nextInHours = Int((window.timeIntervalSince(now) / 3600).rounded())
+
+        return MigrationNotification.transferComplete(
+            number: progress?.completedTransfers ?? 0,
+            total: progress?.totalTransfers ?? 0,
+            nextInHours: nextInHours,
+            remaining: progress?.remainingOrchard ?? Zatoshi.zero
+        )
+    }
+
+    // MARK: - MOB-1467: Migration notification-tap deep link
+
+    /// Exactly the SmartBanner-tap routing (`RootCoordinator`'s
+    /// `.home(.smartBanner(.migrationScreenRequested))`): fresh flow state, open the migration
+    /// path. Shared by the immediate (Home already up) and deferred (fired from
+    /// `checkBackupPhraseValidation` once initialization reaches Home) call sites.
+    private func migrationNotificationTappedRoutingEffect(state: inout Root.State) -> Effect<Root.Action> {
+        state.migrationCoordFlowState = MigrationCoordFlow.State.initial
+        state.path = Root.State.Path.migrationCoordFlow
+        return .none
     }
 }

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -66,10 +66,16 @@ extension Root {
                     }
                 }
                 state.appStartState = .willEnterForeground
+                // MOB-1466: reconcile migration state on every foreground entry (idempotent
+                // `initializeMigrationPostUpgrade()` + the stale-acknowledge reset) so a banner/
+                // re-entry route that changed while backgrounded is picked up promptly. Banner
+                // freshness itself stays reactive (SmartBanner's own subscription + walk) — this
+                // is deliberately the minimal Root-side hook the spec calls for.
+                let reconcileEffect: Effect<Action> = .run { [migrationManager] _ in migrationManager.reconcile() }
                 if state.isLockedInKeychainUnavailableState || !sdkSynchronizer.latestState().syncStatus.isPrepared {
-                    return .send(.initialization(.initialSetups))
+                    return .merge(reconcileEffect, .send(.initialization(.initialSetups)))
                 } else {
-                    return .send(.initialization(.retryStart))
+                    return .merge(reconcileEffect, .send(.initialization(.retryStart)))
                 }
                 
             case .initialization(.appDelegate(.didEnterBackground)):
@@ -253,7 +259,13 @@ extension Root {
                 // TODO: [#524] finish all the wallet events according to definition, https://github.com/Electric-Coin-Company/zashi-ios/issues/524
                 LoggerProxy.event(".appDelegate(.didFinishLaunching)")
                 /// We need to fetch data from keychain, in order to be 100% sure the keychain can be read we delay the check a bit
-                return .send(.initialization(.checkWalletInitialization))
+                return .merge(
+                    // MOB-1466: reconcile migration state once per launch — off the hot path
+                    // (`initializeMigrationPostUpgrade()` is idempotent), so it never blocks or
+                    // reorders the existing wallet-initialization sequence below.
+                    .run { [migrationManager] _ in migrationManager.reconcile() },
+                    .send(.initialization(.checkWalletInitialization))
+                )
 
                 /// Evaluate the wallet's state based on keychain keys and database files presence
             case .initialization(.checkWalletInitialization):

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -16,6 +16,7 @@ struct Root {
         enum Path {
             case addKeystoneHWWalletCoordFlow
             case currencyConversionSetup
+            case migrationCoordFlow
             case receive
             case requestZecCoordFlow
             case scanCoordFlow
@@ -101,6 +102,7 @@ struct Root {
 
         var addKeystoneHWWalletCoordFlowState = AddKeystoneHWWalletCoordFlow.State.initial
         var currencyConversionSetupState = CurrencyConversionSetup.State.initial
+        var migrationCoordFlowState = MigrationCoordFlow.State.initial
         var receiveState = Receive.State.initial
         var requestZecCoordFlowState = RequestZecCoordFlow.State.initial
         var scanCoordFlowState = ScanCoordFlow.State.initial
@@ -137,7 +139,7 @@ struct Root {
             // it; if voting ever gets its own `Path` case, move the sensitivity there.
             case .settings:
                 return true
-            case .sendCoordFlow, .scanCoordFlow, .swapAndPayCoordFlow, .transactionsCoordFlow:
+            case .migrationCoordFlow, .sendCoordFlow, .scanCoordFlow, .swapAndPayCoordFlow, .transactionsCoordFlow:
                 return true
             case .addKeystoneHWWalletCoordFlow, .currencyConversionSetup, .receive,
                  .requestZecCoordFlow, .serverSwitch, .torSetup, .walletBackup:
@@ -216,6 +218,7 @@ struct Root {
 
         case addKeystoneHWWalletCoordFlow(AddKeystoneHWWalletCoordFlow.Action)
         case currencyConversionSetup(CurrencyConversionSetup.Action)
+        case migrationCoordFlow(MigrationCoordFlow.Action)
         case receive(Receive.Action)
         case requestZecCoordFlow(RequestZecCoordFlow.Action)
         case scanCoordFlow(ScanCoordFlow.Action)
@@ -290,6 +293,7 @@ struct Root {
     @Dependency(\.flexaHandler) var flexaHandler
     @Dependency(\.localAuthentication) var localAuthentication
     @Dependency(\.mainQueue) var mainQueue
+    @Dependency(\.migrationManager) var migrationManager
     @Dependency(\.mnemonic) var mnemonic
     @Dependency(\.numberFormatter) var numberFormatter
     @Dependency(\.pasteboard) var pasteboard
@@ -371,6 +375,10 @@ struct Root {
         
         Scope(state: \.addKeystoneHWWalletCoordFlowState, action: \.addKeystoneHWWalletCoordFlow) {
             AddKeystoneHWWalletCoordFlow()
+        }
+
+        Scope(state: \.migrationCoordFlowState, action: \.migrationCoordFlow) {
+            MigrationCoordFlow()
         }
 
         Scope(state: \.transactionsCoordFlowState, action: \.transactionsCoordFlow) {

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -74,6 +74,12 @@ struct Root {
         var onboardingState: RestoreWalletCoordFlow.State
         var osStatusErrorState: OSStatusError.State
         var path: Path? = nil
+        /// Set by `.migrationNotificationTapped` when it arrives before the app has reached Home
+        /// (`appInitializationState != .initialized`) — mirrors `RootDestination`'s
+        /// `isAtDeeplinkWarningScreen` gating: the routing itself is deferred rather than dropped,
+        /// and fires from `checkBackupPhraseValidation`'s existing "did we just reach Home"
+        /// checkpoint once initialization completes. Cleared immediately after firing.
+        var pendingMigrationDeepLink = false
         var pendingServerCandidate: PendingServerCandidate?
         var phraseDisplayState: RecoveryPhraseDisplay.State
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
@@ -293,6 +299,7 @@ struct Root {
     @Dependency(\.flexaHandler) var flexaHandler
     @Dependency(\.localAuthentication) var localAuthentication
     @Dependency(\.mainQueue) var mainQueue
+    @Dependency(\.migrationBGScheduler) var migrationBGScheduler
     @Dependency(\.migrationManager) var migrationManager
     @Dependency(\.mnemonic) var mnemonic
     @Dependency(\.numberFormatter) var numberFormatter
@@ -304,6 +311,7 @@ struct Root {
     @Dependency(\.uriParser) var uriParser
     @Dependency(\.userDefaults) var userDefaults
     @Dependency(\.userMetadataProvider) var userMetadataProvider
+    @Dependency(\.userNotifications) var userNotifications
     @Dependency(\.userStoredPreferences) var userStoredPreferences
     @Dependency(\.votingMetadata) var votingMetadata
     @Dependency(\.walletConfigProvider) var walletConfigProvider

--- a/secant/Sources/Features/Root/RootView.swift
+++ b/secant/Sources/Features/Root/RootView.swift
@@ -202,6 +202,15 @@ private extension RootView {
                                 )
                                 .transition(.move(edge: .trailing))
                                 .zIndex(1)
+                            } else if path == .migrationCoordFlow {
+                                MigrationCoordFlowView(
+                                    store:
+                                        store.scope(
+                                            state: \.migrationCoordFlowState,
+                                            action: \.migrationCoordFlow)
+                                )
+                                .transition(.move(edge: .trailing))
+                                .zIndex(1)
                             } else if path == .currencyConversionSetup {
                                 NavigationStack {
                                     CurrencyConversionSetupView(

--- a/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerMigrationContent.swift
@@ -2,11 +2,10 @@
 //  SmartBannerMigrationContent.swift
 //  zodl
 //
-//  Ironwood migration content for the SmartBanner's `priorityMigration` case (MOB-1464). Visual-only:
-//  the case can never be requested by the running evaluator chain yet — wiring the real
-//  triggering/evaluators/routing is MOB-1466's job. `MigrationBannerVariant` is a pure, testable
-//  mapping (see MigrationBannerVariantTests); `migrationContent()` mirrors `shieldingContent()`'s
-//  structure.
+//  Ironwood migration content for the SmartBanner's `priorityMigration` case (MOB-1464), triggered
+//  live via the `.evaluatePriorityMigration` walk step and the `migrationStateStream()` subscription
+//  (MOB-1466 — see SmartBannerStore.swift). `MigrationBannerVariant` is a pure, testable mapping
+//  (see MigrationBannerVariantTests); `migrationContent()` mirrors `shieldingContent()`'s structure.
 //
 
 import SwiftUI
@@ -93,8 +92,10 @@ extension SmartBannerView {
 /// `MigrationBannerVariant` without hosting a live `SmartBannerView` (whose `onAppear` starts real
 /// dependency subscriptions). Tints use the Gray ramp (`utility-gray-50`/`-200`), matching the
 /// Figma migration-banner tokens — deliberately NOT `SmartBannerView.titleStyle()`/`infoStyle()`,
-/// which still use the pre-rebrand Purple ramp. When MOB-1466 hosts this content inside the live
-/// banner, the shared banner gradient (Purple._700 → ._950) likely needs the same Gray swap.
+/// which still use the pre-rebrand Purple ramp. Resolved by MOB-1466 (per-priority gradient, not an
+/// app-wide restyle): `SmartBannerView`'s background `LinearGradient` swaps to this same Gray._700
+/// → ._950 pair only while `store.priorityContent == .priorityMigration`; every other banner keeps
+/// the Purple._700 → ._950 pair unchanged.
 struct MigrationBannerContentView: View {
     let variant: MigrationBannerVariant
     let onButtonTap: () -> Void

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -35,7 +35,7 @@ struct SmartBanner {
             case priority75 // tor
             case priority8 // currency conversion
             case priority9 // auto-shielding
-            case priorityMigration = -1 // ironwood migration (MOB-1464; not triggered yet — MOB-1466)
+            case priorityMigration = -1 // ironwood migration (MOB-1464; triggered — MOB-1466)
 
             func next() -> PriorityContent {
                 // `priorityMigration` (-1) sits outside the walk-down chain — it is only ever
@@ -43,10 +43,15 @@ struct SmartBanner {
                 guard rawValue > 0 else { return .priority9 }
                 return PriorityContent(rawValue: rawValue - 1) ?? .priority9
             }
+
+            /// Display rank — lower wins. `priorityMigration` slots between `priority2` (sync error)
+            /// and `priority3` (restoring): operational alerts outrank migration; migration outranks the rest.
+            var rank: Double { self == .priorityMigration ? 1.5 : Double(rawValue) }
         }
         
         var CancelNetworkMonitorId = UUID()
         var CancelStateStreamId = UUID()
+        var CancelMigrationStateStreamId = UUID()
         var CancelShieldingProcessorId = UUID()
 
         var isScanProgressComplete = false
@@ -118,6 +123,7 @@ struct SmartBanner {
         case onDisappear
         case evaluatePriority1
         case evaluatePriority2
+        case evaluatePriorityMigration
         case evaluatePriority3
         case evaluatePriority4
         case evaluatePriority45
@@ -127,6 +133,9 @@ struct SmartBanner {
         case evaluatePriority75
         case evaluatePriority8
         case evaluatePriority9
+        case migrationStateChanged(MigrationState)
+        case migrationVariantLoaded(MigrationBannerVariant?)
+        case migrationVariantUpdated(MigrationBannerVariant?)
         case networkMonitorChanged(Bool)
         case openBanner
         case openBannerRequest
@@ -146,6 +155,7 @@ struct SmartBanner {
         case autoShieldingTapped
         case currencyConversionScreenRequested
         case currencyConversionTapped
+        case migrationScreenRequested
         case serverSwitchRequested
         case shieldFundsTapped
         case torSettingsRequested
@@ -155,6 +165,7 @@ struct SmartBanner {
     }
 
     @Dependency(\.mainQueue) var mainQueue
+    @Dependency(\.migrationManager) var migrationManager
     @Dependency(\.networkMonitor) var networkMonitor
     @Dependency(\.sdkSynchronizer) var sdkSynchronizer
     @Dependency(\.shieldingProcessor) var shieldingProcessor
@@ -195,6 +206,12 @@ struct SmartBanner {
                     }
                     .cancellable(id: state.CancelStateStreamId, cancelInFlight: true),
                     .publisher {
+                        sdkSynchronizer.migrationStateStream()
+                            .throttle(for: .seconds(0.2), scheduler: mainQueue, latest: true)
+                            .map(Action.migrationStateChanged)
+                    }
+                    .cancellable(id: state.CancelMigrationStateStreamId, cancelInFlight: true),
+                    .publisher {
                         shieldingProcessor.observe()
                             .map(Action.shieldingProcessorStateChanged)
                     }
@@ -206,6 +223,7 @@ struct SmartBanner {
                 return .merge(
                     .cancel(id: state.CancelNetworkMonitorId),
                     .cancel(id: state.CancelStateStreamId),
+                    .cancel(id: state.CancelMigrationStateStreamId),
                     .cancel(id: state.CancelShieldingProcessorId)
                 )
 
@@ -300,6 +318,8 @@ struct SmartBanner {
                     return .send(.torSetupScreenRequested)
                 } else if state.priorityContent == .priority8 {
                     return .send(.currencyConversionScreenRequested)
+                } else if state.priorityContent == .priorityMigration {
+                    return .send(.migrationScreenRequested)
                 } else if state.isSyncTimedOut {
                     state.isSyncTimedOutSheetPresented = true
                     return .none
@@ -411,7 +431,11 @@ struct SmartBanner {
                     }
                     
                     // return of restoring/syncing
-                    let isSyncingHigherPriority = (state.priorityContent?.rawValue ?? 0) > State.PriorityContent.priority4.rawValue
+                    // `rank` (not `rawValue`) so `priorityMigration`'s rank (1.5, between priority2
+                    // and priority3) correctly keeps this branch from replacing a showing migration
+                    // banner with priority3/priority4 — `rawValue` (-1) would give the same numeric
+                    // answer here today only by coincidence.
+                    let isSyncingHigherPriority = (state.priorityContent?.rank ?? 0) > State.PriorityContent.priority4.rank
                     if isSyncing && (state.priorityContent == nil || isSyncingHigherPriority) {
                         if state.walletStatus == .resyncing {
                             //return .send(.triggerPriority(.priority45))
@@ -425,13 +449,51 @@ struct SmartBanner {
 
                 return .none
 
+            case .migrationStateChanged:
+                // The stream only tells us migration state changed, not what it resolved to — the
+                // manager owns the state->variant derivation (balances, persistence, transfer rows),
+                // so recompute the same way the walk step does, via `migrationManager.bannerVariant`.
+                return .run { [accountUUID = state.selectedWalletAccount?.id] send in
+                    await send(.migrationVariantUpdated(migrationManager.bannerVariant(accountUUID)))
+                }
+
+            case .migrationVariantUpdated(let variant):
+                if let variant {
+                    state.migrationBannerVariant = variant
+                    if state.priorityContent != .priorityMigration {
+                        return .send(.triggerPriority(.priorityMigration))
+                    }
+                    // Already showing migration — content re-renders from the updated variant
+                    // alone; re-triggering would just be rejected by the `openBannerRequest`
+                    // rank guard anyway (equal rank), so skip the round trip.
+                    return .none
+                }
+                if state.priorityContent == .priorityMigration {
+                    // Send `.closeBanner(true)` directly rather than `.closeAndCleanupBanner` —
+                    // the latter wraps its send in its own `.run`, which only schedules that
+                    // nested effect rather than awaiting it, so a second `await send(...)` right
+                    // after it would race the close instead of running after it settles (the same
+                    // reason `.walletAccountChanged` above sends `.closeBanner(true)` directly).
+                    return .run { send in
+                        await send(.closeBanner(true), animation: .easeInOut(duration: Constants.easeInOutDuration))
+                        await send(.evaluatePriority1)
+                    }
+                }
+                return .none
+
                 // disconnected
             case .evaluatePriority1:
                 return .send(.evaluatePriority2)
 
                 // syncing error
             case .evaluatePriority2:
-                return .send(.evaluatePriority3)
+                return .send(.evaluatePriorityMigration)
+
+                // ironwood migration
+            case .evaluatePriorityMigration:
+                return .run { [accountUUID = state.selectedWalletAccount?.id] send in
+                    await send(.migrationVariantLoaded(migrationManager.bannerVariant(accountUUID)))
+                }
 
                 // restoring
             case .evaluatePriority3:
@@ -541,7 +603,14 @@ struct SmartBanner {
                 // auto-shielding
             case .evaluatePriority9:
                 return .none
-                
+
+            case .migrationVariantLoaded(let variant):
+                guard let variant else {
+                    return .send(.evaluatePriority3)
+                }
+                state.migrationBannerVariant = variant
+                return .send(.triggerPriority(.priorityMigration))
+
             case .triggerPriority(let priority):
                 state.priorityContentRequested = priority
                 return .send(.openBannerRequest)
@@ -554,7 +623,7 @@ struct SmartBanner {
                 guard let priorityContentRequested = state.priorityContentRequested else {
                     return .none
                 }
-                if let priorityContent = state.priorityContent, priorityContentRequested.rawValue >= priorityContent.rawValue {
+                if let priorityContent = state.priorityContent, priorityContentRequested.rank >= priorityContent.rank {
                     return .none
                 }
                 if state.isOpen {
@@ -596,6 +665,12 @@ struct SmartBanner {
                 
             case .currencyConversionTapped:
                 return .send(.smartBannerContentTapped)
+
+            case .migrationScreenRequested:
+                // No state change here — Root intercepts this leaf action to open
+                // `MigrationCoordFlow` (MOB-1466 phase 5), the same shape as
+                // `currencyConversionScreenRequested` / `torSetupScreenRequested` above.
+                return .none
 
             case .torSetupScreenRequested:
                 return .none

--- a/secant/Sources/Features/SmartBanner/SmartBannerView.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerView.swift
@@ -81,7 +81,12 @@ struct SmartBannerView: View {
                         .frame(height: 2)
                         .frame(maxWidth: .infinity)
                     LinearGradient(
-                        stops: [
+                        stops: store.priorityContent == .priorityMigration
+                        ? [
+                            Gradient.Stop(color: Design.Utility.Gray._700.color(.light), location: 0.00),
+                            Gradient.Stop(color: Design.Utility.Gray._950.color(.light), location: 1.00)
+                        ]
+                        : [
                             Gradient.Stop(color: Design.Utility.Purple._700.color(.light), location: 0.00),
                             Gradient.Stop(color: Design.Utility.Purple._950.color(.light), location: 1.00)
                         ],

--- a/secant/Sources/Generated/SharedStateKeys.swift
+++ b/secant/Sources/Generated/SharedStateKeys.swift
@@ -27,4 +27,10 @@ public extension String {
     static let hasSeenHowToVoteKeystone = "sharedStateKey_hasSeenHowToVoteKeystone"
     static let votingConfigOverrideURL = "sharedStateKey_votingConfigOverrideURL"
     static let votingCustomChains = "sharedStateKey_votingCustomChains"
+    static let migrationMode = "sharedStateKey_migrationMode"
+    static let migrationManualDelivery = "sharedStateKey_migrationManualDelivery"
+    static let migrationNetworkPrivacyOptions = "sharedStateKey_migrationNetworkPrivacyOptions"
+    static let migrationCompleteAcknowledged = "sharedStateKey_migrationCompleteAcknowledged"
+    static let migrationLastBroadcastAt = "sharedStateKey_migrationLastBroadcastAt"
+    static let migrationSyncGateUntil = "sharedStateKey_migrationSyncGateUntil"
 }

--- a/secant/Sources/Models/AppDelegateAction.swift
+++ b/secant/Sources/Models/AppDelegateAction.swift
@@ -13,4 +13,7 @@ enum AppDelegateAction: Equatable {
     case didEnterBackground
     case willEnterForeground
     case backgroundTask(BGProcessingTask)
+    case migrationBackgroundTask(BGProcessingTask)
+    case migrationBackgroundTaskExpired
+    case migrationNotificationTapped
 }

--- a/secant/secant-mainnet-Info.plist
+++ b/secant/secant-mainnet-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/secant/secant-testnet-Info.plist
+++ b/secant/secant-testnet-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/secant/zashi-testnet-Info.plist
+++ b/secant/zashi-testnet-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/zashi-internal-Info.plist
+++ b/zashi-internal-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/zodlTests/MigrationTests/MigrationBGSchedulerTests.swift
+++ b/zodlTests/MigrationTests/MigrationBGSchedulerTests.swift
@@ -1,0 +1,202 @@
+//
+//  MigrationBGSchedulerTests.swift
+//  zodlTests
+//
+//  Covers the pure `WakeupAction.decide` decision function
+//  (Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift) for MOB-1467: the
+//  (state, isManualDelivery, window, nextTransferNumber) table — scheduled mode submits a BG
+//  task, manual mode schedules the "ready" notification, and `.complete` always wins with
+//  `.cancelAll` regardless of delivery mode. Pure enum/function, no SDK or framework touched
+//  (never `BGTaskScheduler`/`UNUserNotificationCenter` in this file) -> no shared state ->
+//  no `.serialized`.
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationBGSchedulerTests {
+    private static let window = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Non-complete states x scheduled/manual
+
+    @Test func scheduledModeSubmitsTaskWithTheGivenWindow() {
+        let action = WakeupAction.decide(
+            state: MigrationState.notStarted,
+            isManualDelivery: false,
+            window: Self.window,
+            nextTransferNumber: 1
+        )
+
+        #expect(action == WakeupAction.submitTask(earliestBeginDate: Self.window))
+    }
+
+    @Test func manualModeSchedulesReadyNotificationWithGivenWindowAndNumber() {
+        let action = WakeupAction.decide(
+            state: MigrationState.notStarted,
+            isManualDelivery: true,
+            window: Self.window,
+            nextTransferNumber: 3
+        )
+
+        #expect(action == WakeupAction.scheduleReadyNotification(number: 3, at: Self.window))
+    }
+
+    @Test func inProgressScheduledModeSubmitsTask() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let action = WakeupAction.decide(
+            state: MigrationState.inProgress(progress),
+            isManualDelivery: false,
+            window: Self.window,
+            nextTransferNumber: 3
+        )
+
+        #expect(action == WakeupAction.submitTask(earliestBeginDate: Self.window))
+    }
+
+    @Test func inProgressManualModeSchedulesReadyNotification() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let action = WakeupAction.decide(
+            state: MigrationState.inProgress(progress),
+            isManualDelivery: true,
+            window: Self.window,
+            nextTransferNumber: 3
+        )
+
+        #expect(action == WakeupAction.scheduleReadyNotification(number: 3, at: Self.window))
+    }
+
+    @Test func requiresAttentionScheduledModeSubmitsTask() {
+        let action = WakeupAction.decide(
+            state: MigrationState.requiresAttention(AttentionReason.transferStalled(transferNumber: 2)),
+            isManualDelivery: false,
+            window: Self.window,
+            nextTransferNumber: 2
+        )
+
+        #expect(action == WakeupAction.submitTask(earliestBeginDate: Self.window))
+    }
+
+    @Test func requiresAttentionManualModeSchedulesReadyNotification() {
+        let action = WakeupAction.decide(
+            state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+            isManualDelivery: true,
+            window: Self.window,
+            nextTransferNumber: 1
+        )
+
+        #expect(action == WakeupAction.scheduleReadyNotification(number: 1, at: Self.window))
+    }
+
+    // MARK: - .complete always wins, regardless of mode
+
+    @Test func completeStateCancelsAllInScheduledMode() {
+        let action = WakeupAction.decide(
+            state: MigrationState.complete,
+            isManualDelivery: false,
+            window: Self.window,
+            nextTransferNumber: 1
+        )
+
+        #expect(action == WakeupAction.cancelAll)
+    }
+
+    @Test func completeStateCancelsAllInManualMode() {
+        let action = WakeupAction.decide(
+            state: MigrationState.complete,
+            isManualDelivery: true,
+            window: Self.window,
+            nextTransferNumber: 1
+        )
+
+        #expect(action == WakeupAction.cancelAll)
+    }
+
+    // MARK: - Full table
+
+    @Test func decisionTable() {
+        struct Row {
+            let name: String
+            let state: MigrationState
+            let isManualDelivery: Bool
+            let nextTransferNumber: Int
+            let expected: WakeupAction
+        }
+
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 4,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 50
+        )
+
+        let rows: [Row] = [
+            Row(
+                name: "notStarted/scheduled",
+                state: MigrationState.notStarted,
+                isManualDelivery: false,
+                nextTransferNumber: 1,
+                expected: WakeupAction.submitTask(earliestBeginDate: Self.window)
+            ),
+            Row(
+                name: "notStarted/manual",
+                state: MigrationState.notStarted,
+                isManualDelivery: true,
+                nextTransferNumber: 1,
+                expected: WakeupAction.scheduleReadyNotification(number: 1, at: Self.window)
+            ),
+            Row(
+                name: "inProgress/scheduled",
+                state: MigrationState.inProgress(progress),
+                isManualDelivery: false,
+                nextTransferNumber: 2,
+                expected: WakeupAction.submitTask(earliestBeginDate: Self.window)
+            ),
+            Row(
+                name: "inProgress/manual",
+                state: MigrationState.inProgress(progress),
+                isManualDelivery: true,
+                nextTransferNumber: 2,
+                expected: WakeupAction.scheduleReadyNotification(number: 2, at: Self.window)
+            ),
+            Row(
+                name: "complete/scheduled",
+                state: MigrationState.complete,
+                isManualDelivery: false,
+                nextTransferNumber: 5,
+                expected: WakeupAction.cancelAll
+            ),
+            Row(
+                name: "complete/manual",
+                state: MigrationState.complete,
+                isManualDelivery: true,
+                nextTransferNumber: 5,
+                expected: WakeupAction.cancelAll
+            )
+        ]
+
+        for row in rows {
+            let action = WakeupAction.decide(
+                state: row.state,
+                isManualDelivery: row.isManualDelivery,
+                window: Self.window,
+                nextTransferNumber: row.nextTransferNumber
+            )
+
+            #expect(action == row.expected, "Row \(row.name) expected \(row.expected) but got \(action)")
+        }
+    }
+}

--- a/zodlTests/MigrationTests/MigrationBackgroundDeliveryTests.swift
+++ b/zodlTests/MigrationTests/MigrationBackgroundDeliveryTests.swift
@@ -4,13 +4,16 @@
 //
 //  Covers the MigrationBackgroundDelivery reducer
 //  (Features/Migration/MigrationBackgroundDelivery/MigrationBackgroundDeliveryStore.swift) for
-//  MOB-1462: the `skipTapped` delegate contract, and that `allowTapped` / `scenePhaseActive` are
-//  no-ops for now — the Settings deep-link and BAR re-check land in MOB-1466. No shared/global
-//  state -> no `.serialized`.
+//  MOB-1462/1466: the `skipTapped` delegate contract, that `allowTapped` produces no state/effects
+//  (the Settings deep-link opens from the view via `@Environment(\.openURL)`), and (MOB-1466)
+//  `scenePhaseActive` re-checking `MigrationBGSchedulerClient.backgroundRefreshStatus()` and
+//  auto-advancing via `.continued(backgroundAllowed: true)` once it becomes `.available`. No
+//  shared/global state -> no `.serialized`.
 //
 
 import Testing
 import Foundation
+import UIKit
 import ComposableArchitecture
 @testable import zodl_internal
 
@@ -32,19 +35,42 @@ import ComposableArchitecture
         await store.send(.allowTapped)
     }
 
-    @MainActor @Test func scenePhaseActiveProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
-            MigrationBackgroundDelivery()
-        }
-
-        await store.send(.scenePhaseActive)
-    }
-
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
         let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
             MigrationBackgroundDelivery()
         }
 
         await store.send(.delegate(.continued(backgroundAllowed: false)))
+    }
+
+    @MainActor @Test func scenePhaseActiveWithAvailableStatusEmitsDelegateContinuedAllowed() async {
+        let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
+            MigrationBackgroundDelivery()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+        }
+
+        await store.send(.scenePhaseActive)
+        await store.receive(.delegate(.continued(backgroundAllowed: true)))
+    }
+
+    @MainActor @Test func scenePhaseActiveWithDeniedStatusProducesNoDelegate() async {
+        let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
+            MigrationBackgroundDelivery()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .denied }
+        }
+
+        await store.send(.scenePhaseActive)
+    }
+
+    @MainActor @Test func scenePhaseActiveWithRestrictedStatusProducesNoDelegate() async {
+        let store = TestStore(initialState: MigrationBackgroundDelivery.State()) {
+            MigrationBackgroundDelivery()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .restricted }
+        }
+
+        await store.send(.scenePhaseActive)
     }
 }

--- a/zodlTests/MigrationTests/MigrationCadenceTests.swift
+++ b/zodlTests/MigrationTests/MigrationCadenceTests.swift
@@ -1,0 +1,176 @@
+//
+//  MigrationCadenceTests.swift
+//  zodlTests
+//
+//  Covers `MigrationCadence` (Dependencies/MigrationBGScheduler/MigrationCadence.swift) for
+//  MOB-1467: the margin constants (§8.3: 30 min / 6.5 h) and the `window(margin:
+//  preferredExecutableAt:now:)` max rule — the SDK's preferred executable time wins when it is
+//  later than the margin floor, the margin floor wins when the SDK preference is earlier (or
+//  nil, as against the current stubs). Pure math, no shared state -> no `.serialized`.
+//
+//  `preferredExecutableAt`/`window` inputs and expectations are expressed relative to a fixed
+//  `now` so every row is self-contained and doesn't depend on wall-clock time.
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct MigrationCadenceTests {
+    private static let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Margin constants
+
+    @Test func firstWindowMarginIsThirtyMinutes() {
+        #expect(MigrationCadence.firstWindowMargin == 30 * 60)
+    }
+
+    @Test func nextWindowMarginIsSixAndAHalfHours() {
+        #expect(MigrationCadence.nextWindowMargin == 6.5 * 60 * 60)
+    }
+
+    // MARK: - window(margin:preferredExecutableAt:now:) — max rule
+
+    @Test func nilPreferredFallsBackToMarginFloorForFirstWindow() {
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.firstWindowMargin,
+            preferredExecutableAt: nil,
+            now: Self.now
+        )
+
+        #expect(window == Self.now.addingTimeInterval(MigrationCadence.firstWindowMargin))
+    }
+
+    @Test func nilPreferredFallsBackToMarginFloorForNextWindow() {
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.nextWindowMargin,
+            preferredExecutableAt: nil,
+            now: Self.now
+        )
+
+        #expect(window == Self.now.addingTimeInterval(MigrationCadence.nextWindowMargin))
+    }
+
+    @Test func preferredLaterThanMarginFloorWins() {
+        // SDK preference (2 hours out) is later than the 30-minute margin floor -> SDK wins.
+        let preferred = Self.now.addingTimeInterval(2 * 60 * 60)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.firstWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == preferred)
+    }
+
+    @Test func preferredEarlierThanMarginFloorFallsBackToMargin() {
+        // SDK preference (10 minutes out) is earlier than the 30-minute margin floor -> margin wins.
+        let preferred = Self.now.addingTimeInterval(10 * 60)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.firstWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == Self.now.addingTimeInterval(MigrationCadence.firstWindowMargin))
+    }
+
+    @Test func preferredExactlyAtMarginFloorUsesThatMoment() {
+        // Boundary: preferred == margin floor exactly -> `max` picks either (they're equal).
+        let preferred = Self.now.addingTimeInterval(MigrationCadence.firstWindowMargin)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.firstWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == preferred)
+    }
+
+    @Test func preferredInThePastFallsBackToMargin() {
+        // A stale/past SDK preference must never win over the margin floor (never wake "now").
+        let preferred = Self.now.addingTimeInterval(-3600)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.nextWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == Self.now.addingTimeInterval(MigrationCadence.nextWindowMargin))
+    }
+
+    @Test func preferredLaterThanNextWindowMarginWins() {
+        // SDK preference (7 hours out) is later than the 6.5-hour next-window margin -> SDK wins.
+        let preferred = Self.now.addingTimeInterval(7 * 60 * 60)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.nextWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == preferred)
+    }
+
+    // MARK: - Full table (both margins x nil/earlier/later), one assertion per row
+
+    @Test func windowTable() {
+        struct Row {
+            let name: String
+            let margin: TimeInterval
+            let preferredOffset: TimeInterval?   // relative to `now`; nil = no SDK preference
+            let expectedOffset: TimeInterval      // relative to `now`
+        }
+
+        let rows: [Row] = [
+            Row(
+                name: "first/nil",
+                margin: MigrationCadence.firstWindowMargin,
+                preferredOffset: nil,
+                expectedOffset: MigrationCadence.firstWindowMargin
+            ),
+            Row(
+                name: "first/earlier",
+                margin: MigrationCadence.firstWindowMargin,
+                preferredOffset: 60,
+                expectedOffset: MigrationCadence.firstWindowMargin
+            ),
+            Row(
+                name: "first/later",
+                margin: MigrationCadence.firstWindowMargin,
+                preferredOffset: 3600,
+                expectedOffset: 3600
+            ),
+            Row(
+                name: "next/nil",
+                margin: MigrationCadence.nextWindowMargin,
+                preferredOffset: nil,
+                expectedOffset: MigrationCadence.nextWindowMargin
+            ),
+            Row(
+                name: "next/earlier",
+                margin: MigrationCadence.nextWindowMargin,
+                preferredOffset: 3600,
+                expectedOffset: MigrationCadence.nextWindowMargin
+            ),
+            Row(
+                name: "next/later",
+                margin: MigrationCadence.nextWindowMargin,
+                preferredOffset: 8 * 60 * 60,
+                expectedOffset: 8 * 60 * 60
+            )
+        ]
+
+        for row in rows {
+            let preferred = row.preferredOffset.map { Self.now.addingTimeInterval($0) }
+            let window = MigrationCadence.window(margin: row.margin, preferredExecutableAt: preferred, now: Self.now)
+            let expected = Self.now.addingTimeInterval(row.expectedOffset)
+
+            #expect(window == expected, "Row \(row.name) expected \(expected) but got \(window)")
+        }
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCompleteTests.swift
+++ b/zodlTests/MigrationTests/MigrationCompleteTests.swift
@@ -3,9 +3,12 @@
 //  zodlTests
 //
 //  Covers the MigrationComplete reducer
-//  (Features/Migration/MigrationComplete/MigrationCompleteStore.swift) for MOB-1464: the `hasDust`
-//  derivation at zero/nonzero dust, and the `gotItTapped` delegate contract. Visual-only screen —
-//  no SDK calls, no navigation. No shared/global state -> no `.serialized`.
+//  (Features/Migration/MigrationComplete/MigrationCompleteStore.swift) for MOB-1464/1466: the
+//  `hasDust` derivation at zero/nonzero dust, and the `gotItTapped` delegate contract. This screen
+//  has no back control at all (`.navigationBarBackButtonHidden()`, no custom leading toolbar item)
+//  — `isFlowRoot` is added to State for coordinator-injection consistency with the other re-entry
+//  roots, but there is no back-control behavior to gate here. No SDK calls, no navigation. No
+//  shared/global state -> no `.serialized`.
 //
 
 import Testing
@@ -24,6 +27,7 @@ import ComposableArchitecture
         #expect(state.transfersTotal == 0)
         #expect(state.durationHours == 0)
         #expect(state.hasDust == false)
+        #expect(state.isFlowRoot == false)
     }
 
     @MainActor @Test func hasDustIsFalseWhenDustIsZero() async {

--- a/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
@@ -1,0 +1,865 @@
+//
+//  MigrationCoordFlowTests.swift
+//  zodlTests
+//
+//  Covers `MigrationCoordFlow` (Features/CoordFlows/MigrationCoordFlow{Store,Coordinator}.swift)
+//  for MOB-1466: re-entry routing (`.onAppear`), the chaining table from Entry through Complete
+//  for all three modes (immediate/scheduled/manual), the permission-step helper's skip logic,
+//  sendNow/reschedule/recovery orchestration, and every flow-root close path's `.flowFinished`
+//  emission. `.serialized`: every `MigrationCoordFlow.State()` carries a `MigrationEntry.State`
+//  (`entryState`), which reads the process-global `@Shared(.inMemory(.selectedWalletAccount))` on
+//  init — matching the precedent in `MigrationEntryTests`, which mutates the same key directly.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) struct MigrationCoordFlowTests {
+    // MARK: - Re-entry: .onAppear with empty path
+
+    @MainActor @Test func onAppearWithEntryRouteAppendsNothing() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .entry }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        #expect(store.state.path.isEmpty)
+    }
+
+    @MainActor @Test func onAppearWithStatusProgressRouteAppendsFlowRootStatusScreen() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)
+        ]
+        let summary = MigrationSummary(
+            transferred: Zatoshi.zero,
+            dust: Zatoshi.zero,
+            transfersSent: 0,
+            transfersTotal: 1,
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .statusProgress }
+            $0.migrationManager.sendGate = { .allowed }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.sdkSynchronizer.migrationSummary = { summary }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        #expect(store.state.path.count == 1)
+        guard case let .status(statusState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .status as the only path element")
+            return
+        }
+        #expect(statusState.presentation == MigrationStatus.State.Presentation.progress)
+        #expect(statusState.isFlowRoot == true)
+        #expect(statusState.rows == IdentifiedArrayOf(uniqueElements: rows))
+        #expect(statusState.totalDurationHours == 24)
+    }
+
+    @MainActor @Test func onAppearWithRecoveryNotExpiredRouteAppendsFlowRootRecoveryScreen() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .invalid, hoursFromNow: 0),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(1_000), status: .invalid, hoursFromNow: 0)
+        ]
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .recovery(isExpired: false) }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .recovery(recoveryState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .recovery on the path")
+            return
+        }
+        #expect(recoveryState.reason == MigrationRecovery.State.Reason.notesSpent)
+        #expect(recoveryState.isFlowRoot == true)
+        #expect(recoveryState.firstTransfer == 2)
+        #expect(recoveryState.lastTransfer == 3)
+    }
+
+    @MainActor @Test func onAppearWithRecoveryExpiredRouteAppendsFlowRootRecoveryScreenWithExpiredReason() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .recovery(isExpired: true) }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { [] }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .recovery(recoveryState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .recovery on the path")
+            return
+        }
+        #expect(recoveryState.reason == MigrationRecovery.State.Reason.expired)
+        #expect(recoveryState.isFlowRoot == true)
+    }
+
+    @MainActor @Test func onAppearWithStatusResumeRouteAppendsFlowRootStatusScreenInResumePresentation() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .overdue, hoursFromNow: 5)
+        ]
+        let summary = MigrationSummary(
+            transferred: Zatoshi.zero,
+            dust: Zatoshi.zero,
+            transfersSent: 1,
+            transfersTotal: 2,
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .statusResume }
+            $0.migrationManager.sendGate = { .syncRequired }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.sdkSynchronizer.migrationSummary = { summary }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .status(statusState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .status on the path")
+            return
+        }
+        #expect(statusState.presentation == MigrationStatus.State.Presentation.resume)
+        #expect(statusState.isFlowRoot == true)
+        #expect(statusState.stalledNumber == 2)
+        #expect(statusState.stalledHoursAgo == 5)
+        #expect(statusState.isSendNowDisabled == true)
+    }
+
+    @MainActor @Test func onAppearWithCompleteRouteAppendsFlowRootCompleteScreen() async {
+        let summary = MigrationSummary(
+            transferred: Zatoshi(1_245_800_000),
+            dust: Zatoshi(31_000),
+            transfersSent: 5,
+            transfersTotal: 5,
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .complete }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationSummary = { summary }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .complete(completeState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .complete on the path")
+            return
+        }
+        #expect(completeState.isFlowRoot == true)
+        #expect(completeState.totalTransferred == Zatoshi(1_245_800_000))
+        #expect(completeState.dust == Zatoshi(31_000))
+        #expect(completeState.transfersSent == 5)
+        #expect(completeState.transfersTotal == 5)
+        #expect(completeState.durationHours == 24)
+    }
+
+    @MainActor @Test func onAppearWithNoteSplitProgressRouteAppendsFlowRootSplittingScreen() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .noteSplitProgress }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .noteSplit(noteSplitState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .noteSplit on the path")
+            return
+        }
+        #expect(noteSplitState.phase == MigrationNoteSplit.State.Phase.splitting)
+        #expect(noteSplitState.isFlowRoot == true)
+    }
+
+    @MainActor @Test func onAppearWithReviewManualRouteAppendsFlowRootManualStepReviewScreen() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(2_000), status: .active, hoursFromNow: 0)
+        ]
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.reentryRoute = { .reviewManual(step: 2, total: 5) }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .reviewTransfer(reviewState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .reviewTransfer on the path")
+            return
+        }
+        #expect(reviewState.mode == MigrationReviewTransfer.State.Mode.manualStep(number: 2, total: 5))
+        #expect(reviewState.isFlowRoot == true)
+        #expect(reviewState.amount == Zatoshi(2_000))
+        #expect(reviewState.fee == Zatoshi(100_000))
+    }
+
+    // MARK: - Immediate flow (§6.1)
+
+    @MainActor @Test func entryChoseImmediateWithTorFlagOnSkipsNetworkPrivacyAndPushesReview() async {
+        let setMigrationModeCalls = LockIsolated<[MigrationMode]>([])
+        let selectMigrationModeCalls = LockIsolated<[MigrationMode]>([])
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setMigrationMode = { mode in setMigrationModeCalls.withValue { $0.append(mode) } }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.selectMigrationMode = { mode in selectMigrationModeCalls.withValue { $0.append(mode) } }
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { true }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.entry(.delegate(.chose(.immediate))))
+
+        #expect(store.state.mode == MigrationMode.immediate)
+        #expect(setMigrationModeCalls.value == [MigrationMode.immediate])
+        #expect(selectMigrationModeCalls.value == [MigrationMode.immediate])
+        #expect(store.state.networkPrivacyOptions.useTor == true)
+        guard case let .reviewTransfer(reviewState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .reviewTransfer on the path (NetworkPrivacy skipped)")
+            return
+        }
+        #expect(reviewState.mode == MigrationReviewTransfer.State.Mode.immediate)
+    }
+
+    @MainActor @Test func entryChoseImmediateWithTorFlagOffShowsNetworkPrivacy() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setMigrationMode = { _ in }
+            $0.sdkSynchronizer = .noOp
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { false }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.entry(.delegate(.chose(.immediate))))
+
+        guard case let .networkPrivacy(networkPrivacyState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .networkPrivacy on the path (Tor flag off)")
+            return
+        }
+        #expect(networkPrivacyState.variant == MigrationNetworkPrivacy.State.Variant.immediate)
+    }
+
+    @MainActor @Test func networkPrivacyConfirmedInImmediateModePushesReviewTransferImmediate() async {
+        let setOptionsCalls = LockIsolated<[NetworkPrivacyOptions]>([])
+        var state = MigrationCoordFlow.State()
+        state.mode = .immediate
+        state.path.append(.networkPrivacy(MigrationNetworkPrivacy.State(variant: .immediate)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setNetworkPrivacyOptions = { options in setOptionsCalls.withValue { $0.append(options) } }
+        }
+        store.exhaustivity = .off
+
+        let options = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        await store.send(.path(.element(id: 0, action: .networkPrivacy(.delegate(.confirmed(options))))))
+
+        #expect(setOptionsCalls.value == [options])
+        #expect(store.state.networkPrivacyOptions == options)
+        guard case let .reviewTransfer(reviewState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .reviewTransfer pushed on top")
+            return
+        }
+        #expect(reviewState.mode == MigrationReviewTransfer.State.Mode.immediate)
+    }
+
+    @MainActor @Test func networkPrivacyConfirmedInScheduledModePushesTransferPlan() async {
+        var state = MigrationCoordFlow.State()
+        state.mode = .privateScheduled
+        state.path.append(.networkPrivacy(MigrationNetworkPrivacy.State(variant: .scheduled(transferCount: 5))))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setNetworkPrivacyOptions = { _ in }
+        }
+        store.exhaustivity = .off
+
+        let options = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        await store.send(.path(.element(id: 0, action: .networkPrivacy(.delegate(.confirmed(options))))))
+
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan pushed on top")
+            return
+        }
+        #expect(planState.variant == MigrationTransferPlan.State.Variant.scheduled)
+    }
+
+    @MainActor @Test func reviewTransferConfirmedPushesSending() async {
+        var state = MigrationCoordFlow.State()
+        state.mode = .immediate
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .reviewTransfer(.delegate(.confirmed)))))
+
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed on top")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
+        #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    @MainActor @Test func sendingClosedInImmediateModeAcknowledgesCompleteAndFinishesFlow() async {
+        let acknowledgeCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.mode = .immediate
+        state.path.append(.sending(MigrationSending.State(phase: .success)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.acknowledgeComplete = { acknowledgeCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .sending(.delegate(.closed)))))
+        await store.receive(\.flowFinished)
+
+        #expect(acknowledgeCalls.value == 1)
+    }
+
+    // MARK: - Scheduled flow (§6.2): note-split skip
+
+    @MainActor @Test func entryChoseScheduledWithNoteSplitNeededPushesNoteSplit() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setMigrationMode = { _ in }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.isNoteSplitNeeded = { true }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.entry(.delegate(.chose(.privateScheduled))))
+
+        guard case .noteSplit = try? #require(store.state.path.last) else {
+            Issue.record("Expected .noteSplit pushed (note split needed)")
+            return
+        }
+    }
+
+    @MainActor @Test func entryChoseScheduledWithoutNoteSplitNeededGoesStraightToPermissionSteps() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State()) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+            $0.userNotifications.authorizationStatus = { .authorized }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.isNoteSplitNeeded = { false }
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { true }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.entry(.delegate(.chose(.privateScheduled))))
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan pushed (all permission steps skipped)")
+            return
+        }
+        #expect(planState.variant == MigrationTransferPlan.State.Variant.scheduled)
+        #expect(store.state.networkPrivacyOptions.useTor == true)
+    }
+
+    // MARK: - Scheduled flow (§6.2): permission-step skip combinations
+
+    @MainActor @Test func noteSplitContinuedWithAllPermissionStepsNeededPushesBackgroundDelivery() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .confirmed)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .denied }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .noteSplit(.delegate(.continued)))))
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case .backgroundDelivery = try? #require(store.state.path.last) else {
+            Issue.record("Expected .backgroundDelivery pushed (background refresh not available)")
+            return
+        }
+    }
+
+    @MainActor @Test func noteSplitFlowRootCloseFinishesFlowInsteadOfContinuingPermissionSteps() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .splitting, isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        // Same `.continued` delegate value as a normal continue, but `closeTapped` on a flow-root
+        // splitting screen — must finish the flow, not proceed to permission-step routing.
+        await store.send(.path(.element(id: 0, action: .noteSplit(.delegate(.continued)))))
+        await store.receive(\.flowFinished)
+    }
+
+    @MainActor @Test func backgroundDeliveryDeclinedSetsManualDeliveryAndContinuesToNotifications() async {
+        let setManualDeliveryCalls = LockIsolated<[Bool]>([])
+        var state = MigrationCoordFlow.State()
+        state.path.append(.backgroundDelivery(MigrationBackgroundDelivery.State()))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setManualDelivery = { allowed in setManualDeliveryCalls.withValue { $0.append(allowed) } }
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+            $0.userNotifications.authorizationStatus = { .notDetermined }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .backgroundDelivery(.delegate(.continued(backgroundAllowed: false))))))
+        await store.receive(\.pushNextPermissionStep)
+
+        #expect(setManualDeliveryCalls.value == [true])
+        guard case .notifications = try? #require(store.state.path.last) else {
+            Issue.record("Expected .notifications pushed (authorization not determined)")
+            return
+        }
+    }
+
+    @MainActor @Test func notificationsContinuedWithTorFlagOffPushesNetworkPrivacyScheduledVariant() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .pending, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .pending, hoursFromNow: 0)
+        ]
+        var state = MigrationCoordFlow.State()
+        state.path.append(.notifications(MigrationNotifications.State()))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+            $0.userNotifications.authorizationStatus = { .authorized }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { false }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .notifications(.delegate(.continued)))))
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case let .networkPrivacy(networkPrivacyState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .networkPrivacy pushed (Tor flag off)")
+            return
+        }
+        #expect(networkPrivacyState.variant == MigrationNetworkPrivacy.State.Variant.scheduled(transferCount: 2))
+    }
+
+    @MainActor @Test func allPermissionStepsSkippedGoesStraightToTransferPlanWithForcedTor() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.notifications(MigrationNotifications.State()))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
+            $0.userNotifications.authorizationStatus = { .denied }
+            $0.sdkSynchronizer = .noOp
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportTorSetupFlag = { true }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .notifications(.delegate(.continued)))))
+        await store.receive(\.pushNextPermissionStep)
+
+        guard case .transferPlan = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan pushed (all permission steps skipped)")
+            return
+        }
+        #expect(store.state.networkPrivacyOptions.useTor == true)
+    }
+
+    // MARK: - Scheduled flow (§6.2): plan confirm -> Scheduled
+
+    @MainActor @Test func transferPlanConfirmedInScheduledVariantSchedulesFirstWindowAndPushesScheduled() async {
+        let scheduleFirstWindowCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.scheduleFirstWindow = { scheduleFirstWindowCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.confirmed)))))
+
+        #expect(scheduleFirstWindowCalls.value == 1)
+        guard case .scheduled = try? #require(store.state.path.last) else {
+            Issue.record("Expected .scheduled pushed")
+            return
+        }
+    }
+
+    @MainActor @Test func scheduledDoneFinishesFlow() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.scheduled(MigrationScheduled.State()))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .scheduled(.delegate(.done)))))
+        await store.receive(\.flowFinished)
+    }
+
+    // MARK: - Manual flow (§6.3)
+
+    @MainActor @Test func transferPlanConfirmedInManualVariantSchedulesFirstWindowAndPushesSendingWithTotalCountOne() async {
+        let scheduleFirstWindowCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .manual)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.scheduleFirstWindow = { scheduleFirstWindowCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.confirmed)))))
+
+        #expect(scheduleFirstWindowCalls.value == 1)
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
+        #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    @MainActor @Test func sendingClosedInManualModeWithNoStatusBeneathPushesFreshStatus() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0)
+        ]
+        let summary = MigrationSummary(
+            transferred: Zatoshi(1_000),
+            dust: Zatoshi.zero,
+            transfersSent: 1,
+            transfersTotal: 1,
+            estimatedDurationHours: 24
+        )
+        var state = MigrationCoordFlow.State()
+        state.mode = .privateScheduled
+        state.path.append(.sending(MigrationSending.State(phase: .success)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.sendGate = { .allowed }
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.sdkSynchronizer.migrationSummary = { summary }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .sending(.delegate(.closed)))))
+        await store.receive(\.pushHydratedStatus)
+
+        #expect(store.state.path.count == 2)
+        guard case let .status(statusState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .status pushed on top of the (still-present) .sending element")
+            return
+        }
+        #expect(statusState.presentation == MigrationStatus.State.Presentation.progress)
+        #expect(statusState.isFlowRoot == false)
+    }
+
+    // MARK: - sendNow: overdue count drives Sending totalCount, completion returns to Status
+
+    @MainActor @Test func statusSendNowPushesSendingConfiguredForOverdueCount() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .overdue, hoursFromNow: 5),
+            MigrationTransferRow(id: "2", index: 2, amount: Zatoshi(1_000), status: .overdue, hoursFromNow: 3)
+        ]
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.path.append(.status(MigrationStatus.State(presentation: .resume, isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .status(.delegate(.sendNow)))))
+        await store.receive(\.pushHydratedPathState)
+
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed")
+            return
+        }
+        #expect(sendingState.totalCount == 2)
+        #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    @MainActor @Test func sendingClosedAfterSendNowPopsBackToStatusWithRefreshedRows() async {
+        let refreshedRows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0)
+        ]
+        var state = MigrationCoordFlow.State()
+        state.path.append(.status(MigrationStatus.State(presentation: .resume, isFlowRoot: true)))
+        state.path.append(.sending(MigrationSending.State(phase: .success, totalCount: 2)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { refreshedRows }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 1, action: .sending(.delegate(.closed)))))
+        await store.receive(\.sendNowCompleted)
+
+        #expect(store.state.path.count == 1)
+        guard case let .status(statusState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending popped, .status remaining on top")
+            return
+        }
+        #expect(statusState.rows == IdentifiedArrayOf(uniqueElements: refreshedRows))
+        #expect(statusState.isFlowRoot == true)
+    }
+
+    // MARK: - Reschedule: SDK + scheduler spies called in order, rescheduled plan pushed
+
+    @MainActor @Test func statusRescheduleSetsIsReschedulingCallsSDKAndSchedulerThenPushesPlan() async {
+        let callOrder = LockIsolated<[String]>([])
+        let refreshedRows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)
+        ]
+        var state = MigrationCoordFlow.State()
+        state.path.append(.status(MigrationStatus.State(presentation: .resume, isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.rescheduleStalledMigrationTransfer = {
+                callOrder.withValue { $0.append("reschedule") }
+            }
+            $0.sdkSynchronizer.migrationTransfers = { refreshedRows }
+            $0.migrationBGScheduler.scheduleFirstWindow = { callOrder.withValue { $0.append("scheduleFirstWindow") } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .status(.delegate(.reschedule)))))
+        await store.receive(\.pushHydratedPathState)
+
+        #expect(callOrder.value == ["reschedule", "scheduleFirstWindow"])
+        guard case let .status(statusState) = try? #require(store.state.path[id: 0]) else {
+            Issue.record("Expected .status still at the bottom of the path with isRescheduling set")
+            return
+        }
+        #expect(statusState.isRescheduling == true)
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan (rescheduled) pushed")
+            return
+        }
+        #expect(planState.requiresSigning == false)
+        #expect(planState.rows == IdentifiedArrayOf(uniqueElements: refreshedRows))
+    }
+
+    @MainActor @Test func rescheduledPlanConfirmDoesNotSignAndFinishesFlow() async {
+        let signCalls = LockIsolated<Int>(0)
+        var planState = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: false)
+        planState.rows = [MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)]
+        let store = TestStore(initialState: planState) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in signCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signCalls.value == 0)
+    }
+
+    @MainActor @Test func rescheduledPlanConfirmedInCoordinatorFinishesFlowWithoutPushingScheduled() async {
+        let scheduleFirstWindowCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled, requiresSigning: false)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.scheduleFirstWindow = { scheduleFirstWindowCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.confirmed)))))
+        await store.receive(\.flowFinished)
+
+        #expect(scheduleFirstWindowCalls.value == 0)
+    }
+
+    // MARK: - Recovery: restartCurrentMigrationStep spy, re-created plan injected, its confirm DOES sign
+
+    @MainActor @Test func recoveryRecreateCallsRestartAndPushesRecreatedPlanWithInjectedSchedule() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        let restartCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.path.append(.recovery(MigrationRecovery.State(isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.restartCurrentMigrationStep = {
+                restartCalls.withValue { $0 += 1 }
+                return schedule
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .recovery(.delegate(.recreate)))))
+        await store.receive(\.pushHydratedPathState)
+
+        #expect(restartCalls.value == 1)
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan (re-created) pushed")
+            return
+        }
+        #expect(planState.variant == MigrationTransferPlan.State.Variant.recreated)
+        #expect(planState.injectedSchedule == schedule)
+        #expect(planState.requiresSigning == true)
+    }
+
+    @MainActor @Test func recreatedPlanConfirmDoesSign() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        var planState = MigrationTransferPlan.State(variant: .recreated)
+        planState.schedule = schedule
+        let signedSchedule = LockIsolated<MigrationSchedule?>(nil)
+        let store = TestStore(initialState: planState) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { signedSchedule.setValue($0) }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signedSchedule.value == schedule)
+    }
+
+    // MARK: - Every flow-root back -> .flowFinished
+
+    @MainActor @Test func statusDoneFinishesFlow() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.status(MigrationStatus.State(isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .status(.delegate(.done)))))
+        await store.receive(\.flowFinished)
+    }
+
+    @MainActor @Test func recoveryCloseFinishesFlow() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.recovery(MigrationRecovery.State(isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .recovery(.delegate(.close)))))
+        await store.receive(\.flowFinished)
+    }
+
+    @MainActor @Test func reviewTransferClosedFinishesFlow() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(
+            .reviewTransfer(MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5), isFlowRoot: true))
+        )
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .reviewTransfer(.delegate(.closed)))))
+        await store.receive(\.flowFinished)
+    }
+
+    @MainActor @Test func completeDoneAcknowledgesCompleteAndFinishesFlow() async {
+        let acknowledgeCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.path.append(.complete(MigrationComplete.State(isFlowRoot: true)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.acknowledgeComplete = { acknowledgeCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .complete(.delegate(.done)))))
+        await store.receive(\.flowFinished)
+
+        #expect(acknowledgeCalls.value == 1)
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
@@ -327,6 +327,28 @@ import ComposableArchitecture
         #expect(planState.variant == MigrationTransferPlan.State.Variant.scheduled)
     }
 
+    @MainActor @Test func manualDeliveryFreshPlanUsesManualVariant() async {
+        var state = MigrationCoordFlow.State()
+        state.mode = .privateScheduled
+        state.path.append(.networkPrivacy(MigrationNetworkPrivacy.State(variant: .scheduled(transferCount: 5))))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationManager.setNetworkPrivacyOptions = { _ in }
+            $0.migrationManager.isManualDelivery = { true }
+        }
+        store.exhaustivity = .off
+
+        let options = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        await store.send(.path(.element(id: 0, action: .networkPrivacy(.delegate(.confirmed(options))))))
+
+        guard case let .transferPlan(planState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .transferPlan pushed on top")
+            return
+        }
+        #expect(planState.variant == MigrationTransferPlan.State.Variant.manual)
+    }
+
     @MainActor @Test func reviewTransferConfirmedPushesSending() async {
         var state = MigrationCoordFlow.State()
         state.mode = .immediate
@@ -505,6 +527,7 @@ import ComposableArchitecture
         } withDependencies: {
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .denied }
+            $0.migrationManager.isManualDelivery = { false }
             $0.sdkSynchronizer = .noOp
             $0.walletStorage = .noOp
             $0.walletStorage.exportTorSetupFlag = { true }
@@ -578,6 +601,34 @@ import ComposableArchitecture
         }
         #expect(sendingState.totalCount == 1)
         #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    @MainActor @Test func manualPlanConfirmPushesSendingWithSingleTransfer() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        var planState = MigrationTransferPlan.State(variant: .manual, requiresSigning: true)
+        planState.schedule = schedule
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.path.append(.transferPlan(planState))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.migrationBGScheduler.scheduleFirstWindow = { }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.confirmed)))))
+
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
     }
 
     @MainActor @Test func sendingClosedInManualModeWithNoStatusBeneathPushesFreshStatus() async {

--- a/zodlTests/MigrationTests/MigrationEntryTests.swift
+++ b/zodlTests/MigrationTests/MigrationEntryTests.swift
@@ -3,22 +3,40 @@
 //  zodlTests
 //
 //  Covers the MigrationEntry reducer (Features/Migration/MigrationEntry/MigrationEntryStore.swift)
-//  for MOB-1460: mode selection, the disclaimer-visibility derivation, and the `nextTapped` delegate
-//  contract. No SDK calls, no navigation — chaining lands in MOB-1466. No shared/global state ->
-//  no `.serialized`.
+//  for MOB-1460/1466: mode selection, the disclaimer-visibility derivation, the `nextTapped`
+//  delegate contract, and (MOB-1466) `onAppear` loading the orchard-balance-to-migrate amount for
+//  the selected account via `MigrationManagerClient`. `.serialized`: state mutates the
+//  process-global `@Shared(.inMemory(.selectedWalletAccount))`.
 //
 
 import Testing
 import Foundation
 import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite struct MigrationEntryTests {
+@Suite(.serialized) struct MigrationEntryTests {
+    private func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
     @MainActor @Test func defaultStateIsPrivateScheduledWithNoDisclaimer() async {
         let state = MigrationEntry.State()
 
         #expect(state.selectedMode == MigrationMode.privateScheduled)
         #expect(state.isDisclaimerVisible == false)
+        #expect(state.orchardBalance == Zatoshi.zero)
+        #expect(state.selectedWalletAccount == nil)
     }
 
     @MainActor @Test func modeTappedImmediateSelectsModeAndRevealsDisclaimer() async {
@@ -85,5 +103,42 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.chose(.immediate)))
+    }
+
+    @MainActor @Test func onAppearWithNoSelectedAccountLoadsZeroBalance() async {
+        var state = MigrationEntry.State()
+        state.$selectedWalletAccount.withLock { $0 = nil }
+        let store = TestStore(initialState: state) {
+            MigrationEntry()
+        } withDependencies: {
+            $0.migrationManager.orchardBalanceToMigrate = { accountUUID in
+                #expect(accountUUID == nil)
+                return Zatoshi(999)
+            }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.balanceLoaded) {
+            $0.orchardBalance = Zatoshi(999)
+        }
+    }
+
+    @MainActor @Test func onAppearWithSelectedAccountLoadsOrchardBalanceToMigrate() async {
+        let account = walletAccount(idByte: 7)
+        var state = MigrationEntry.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+        let store = TestStore(initialState: state) {
+            MigrationEntry()
+        } withDependencies: {
+            $0.migrationManager.orchardBalanceToMigrate = { accountUUID in
+                #expect(accountUUID == account.id)
+                return Zatoshi(1_245_800_000)
+            }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.balanceLoaded) {
+            $0.orchardBalance = Zatoshi(1_245_800_000)
+        }
     }
 }

--- a/zodlTests/MigrationTests/MigrationManagerTests.swift
+++ b/zodlTests/MigrationTests/MigrationManagerTests.swift
@@ -10,6 +10,7 @@
 
 import Testing
 import Foundation
+import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
@@ -305,8 +306,9 @@ struct MigrationManagerTests {
     @Test func acknowledgedFlagIsIgnoredOutsideCompleteState() {
         // The acknowledged flag is only consulted while state is `.complete` — a `notStarted`
         // state with a positive balance must still show `.required` even if `isCompleteAcknowledged`
-        // is stale-true from a previous migration (that reset is `reconcile()`'s job, exercised
-        // separately below via `MigrationGateStorage`/manager-level tests, not this pure table).
+        // is stale-true from a previous migration (that reset is `reconcile()`'s job, exercised by
+        // `reconcileClearsAcknowledgedFlagWhenStateIsNotComplete` /
+        // `reconcileKeepsAcknowledgedFlagWhenStateIsComplete` below, not this pure table).
         let variant = MigrationDerivations.bannerVariant(
             state: MigrationState.notStarted,
             hasInvalid: false,
@@ -885,5 +887,62 @@ struct MigrationManagerTests {
 
         storage.clearAcknowledgedComplete()
         #expect(storage.isCompleteAcknowledged() == false)
+    }
+
+    // MARK: - reconcile(): stale-acknowledge reset
+    //
+    // These two exercise the real `MigrationManagerImpl.reconcile()` (MigrationManagerLiveKey.swift)
+    // against an isolated `UserDefaults` suite via the Impl's injectable `gateStorage` seam, with
+    // `getMigrationState` stubbed through `withDependencies` — the stale-acknowledge reset must
+    // clear the flag for any non-`.complete` state and preserve it while `.complete`.
+
+    @Test func reconcileClearsAcknowledgedFlagWhenStateIsNotComplete() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testReconcileClearsAcknowledgedFlagWhenStateIsNotComplete"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: "testReconcileClearsAcknowledgedFlagWhenStateIsNotComplete")
+        }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        storage.acknowledgeComplete()
+        #expect(storage.isCompleteAcknowledged() == true)
+
+        withDependencies {
+            $0.sdkSynchronizer = SDKSynchronizerClient.noOp
+            $0.sdkSynchronizer.getMigrationState = {
+                MigrationState.inProgress(
+                    MigrationProgress(completedTransfers: 1, totalTransfers: 5, remainingOrchard: Zatoshi(1), nextTransferReadyAtHeight: nil)
+                )
+            }
+        } operation: {
+            let impl = MigrationManagerImpl(gateStorage: storage)
+            impl.reconcile()
+        }
+
+        #expect(storage.isCompleteAcknowledged() == false)
+    }
+
+    @Test func reconcileKeepsAcknowledgedFlagWhenStateIsComplete() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testReconcileKeepsAcknowledgedFlagWhenStateIsComplete"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testReconcileKeepsAcknowledgedFlagWhenStateIsComplete") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        storage.acknowledgeComplete()
+        #expect(storage.isCompleteAcknowledged() == true)
+
+        withDependencies {
+            $0.sdkSynchronizer = SDKSynchronizerClient.noOp
+            $0.sdkSynchronizer.getMigrationState = { MigrationState.complete }
+        } operation: {
+            let impl = MigrationManagerImpl(gateStorage: storage)
+            impl.reconcile()
+        }
+
+        #expect(storage.isCompleteAcknowledged() == true)
     }
 }

--- a/zodlTests/MigrationTests/MigrationManagerTests.swift
+++ b/zodlTests/MigrationTests/MigrationManagerTests.swift
@@ -1,0 +1,889 @@
+//
+//  MigrationManagerTests.swift
+//  zodlTests
+//
+//  Covers `MigrationManagerClient`'s pure derivations (Dependencies/MigrationManager/) for
+//  MOB-1466: `MigrationDerivations.bannerVariant`/`reentryRoute` tables, the 10-minute
+//  sync<->send gate math (`MigrationGateStorage`), and every UserDefaults-backed persistence
+//  roundtrip. `.serialized` because every test shares the `UserDefaults` global.
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized)
+struct MigrationManagerTests {
+    // MARK: - bannerVariant
+
+    @Test func notStartedWithPositiveBalanceIsRequired() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi(1),
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.required)
+    }
+
+    @Test func notStartedWithZeroBalanceIsNil() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == nil)
+    }
+
+    @Test func readyToProposeWithPositiveBalanceIsRequired() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.readyToPropose,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi(500),
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.required)
+    }
+
+    @Test func readyToProposeWithZeroBalanceIsNil() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.readyToPropose,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == nil)
+    }
+
+    @Test func splitPendingConfirmationIsSplitting() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.splitPendingConfirmation,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.splitting)
+    }
+
+    @Test func inProgressManualAndDueIsTransferReady() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: true,
+            isNextTransferDue: true,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.transferReady(number: 3))
+    }
+
+    @Test func inProgressManualButNotDueIsPlainProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: true,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.inProgress(done: 2, total: 5))
+    }
+
+    @Test func inProgressNonManualIsPlainProgressEvenWhenDue() {
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 4,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: true,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.inProgress(done: 1, total: 4))
+    }
+
+    @Test func requiresAttentionSyncRequiredBeforeNextRendersAsPlainProgress() {
+        // The LiveKey normalizes `.requiresAttention(.syncRequiredBeforeNext)` into
+        // `.inProgress(progress)` using its own `getMigrationProgress()` snapshot before calling
+        // the pure function (`syncRequiredBeforeNext` itself carries no progress payload) — so at
+        // this layer it is indistinguishable from a plain `.inProgress` state.
+        let progress = MigrationProgress(
+            completedTransfers: 3,
+            totalTransfers: 6,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.inProgress(done: 3, total: 6))
+    }
+
+    @Test func requiresAttentionTransferStalledIsTransferWaiting() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.transferStalled(transferNumber: 3)),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.transferWaiting(number: 3))
+    }
+
+    @Test func requiresAttentionInvalidTransferIsUpdatePlan() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+            hasInvalid: true,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.updatePlan)
+    }
+
+    @Test func requiresAttentionTransferExpiredUsesExpiredRowBounds() {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "r0", index: 0, amount: Zatoshi(100), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "r1", index: 1, amount: Zatoshi(100), status: .expired, hoursFromNow: 0),
+            MigrationTransferRow(id: "r2", index: 2, amount: Zatoshi(100), status: .expired, hoursFromNow: 0),
+            MigrationTransferRow(id: "r3", index: 3, amount: Zatoshi(100), status: .expired, hoursFromNow: 0),
+            MigrationTransferRow(id: "r4", index: 4, amount: Zatoshi(100), status: .pending, hoursFromNow: 1)
+        ]
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.transferExpired),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: rows
+        )
+
+        #expect(variant == MigrationBannerVariant.transfersExpired(first: 2, last: 4))
+    }
+
+    @Test func requiresAttentionTransferExpiredFallsBackToOneAndTotalWhenNoRowsAreExpired() {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "r0", index: 0, amount: Zatoshi(100), status: .sent, hoursFromNow: 0),
+            MigrationTransferRow(id: "r1", index: 1, amount: Zatoshi(100), status: .pending, hoursFromNow: 1)
+        ]
+
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.transferExpired),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: rows
+        )
+
+        #expect(variant == MigrationBannerVariant.transfersExpired(first: 1, last: 2))
+    }
+
+    @Test func requiresAttentionTransferExpiredFallsBackToOneAndZeroWithNoRowsAtAll() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.requiresAttention(AttentionReason.transferExpired),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.transfersExpired(first: 1, last: 0))
+    }
+
+    @Test func completeUnacknowledgedIsComplete() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.complete)
+    }
+
+    @Test func completeAcknowledgedIsNil() {
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi.zero,
+            isCompleteAcknowledged: true,
+            transferRows: []
+        )
+
+        #expect(variant == nil)
+    }
+
+    @Test func acknowledgedFlagIsIgnoredOutsideCompleteState() {
+        // The acknowledged flag is only consulted while state is `.complete` — a `notStarted`
+        // state with a positive balance must still show `.required` even if `isCompleteAcknowledged`
+        // is stale-true from a previous migration (that reset is `reconcile()`'s job, exercised
+        // separately below via `MigrationGateStorage`/manager-level tests, not this pure table).
+        let variant = MigrationDerivations.bannerVariant(
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi(1),
+            isCompleteAcknowledged: true,
+            transferRows: []
+        )
+
+        #expect(variant == MigrationBannerVariant.required)
+    }
+
+    // MARK: - reentryRoute
+
+    @Test func hasInvalidTransfersWinsOverEverythingElse() {
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 2,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: nil
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.complete,
+            hasInvalid: true,
+            hasOverdue: true,
+            isManualDelivery: true,
+            isNextTransferDue: true,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.recovery(isExpired: false))
+    }
+
+    @Test func invalidTransferWithTransferExpiredAttentionReasonIsExpiredRecovery() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.requiresAttention(AttentionReason.transferExpired),
+            hasInvalid: true,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.recovery(isExpired: true))
+    }
+
+    @Test func invalidTransferWithOtherAttentionReasonIsNonExpiredRecovery() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+            hasInvalid: true,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.recovery(isExpired: false))
+    }
+
+    @Test func hasOverdueWinsOverInProgressAndComplete() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: true,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.statusResume)
+    }
+
+    @Test func manualDueWinsOverPlainInProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: 100
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: true,
+            isNextTransferDue: true,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.reviewManual(step: 3, total: 5))
+    }
+
+    @Test func manualButNotDueFallsThroughToPlainInProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: 100
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: true,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.statusProgress)
+    }
+
+    @Test func dueButNotManualFallsThroughToPlainInProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: 100
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: true,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.statusProgress)
+    }
+
+    @Test func plainInProgressIsStatusProgress() {
+        let progress = MigrationProgress(
+            completedTransfers: 0,
+            totalTransfers: 3,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: nil
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.inProgress(progress),
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.statusProgress)
+    }
+
+    @Test func completeUnacknowledgedIsCompleteRoute() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.complete)
+    }
+
+    @Test func completeAcknowledgedFallsThroughToEntry() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.complete,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: true,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.entry)
+    }
+
+    @Test func splitPendingConfirmationIsNoteSplitProgress() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.splitPendingConfirmation,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.noteSplitProgress)
+    }
+
+    @Test func notStartedIsEntry() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.entry)
+    }
+
+    @Test func readyToProposeIsEntry() {
+        let route = MigrationDerivations.reentryRoute(
+            state: MigrationState.readyToPropose,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            isCompleteAcknowledged: false,
+            progress: nil
+        )
+
+        #expect(route == MigrationReentryRoute.entry)
+    }
+
+    @Test func allSevenRoutesInPriorityOrder() {
+        // §4.3 priority order, verified as one table so a future reordering trips a single test.
+        struct Row {
+            let name: String
+            let hasInvalid: Bool
+            let hasOverdue: Bool
+            let isManualDelivery: Bool
+            let isNextTransferDue: Bool
+            let isCompleteAcknowledged: Bool
+            let state: MigrationState
+            let expected: MigrationReentryRoute
+        }
+
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 4,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: 100
+        )
+
+        let rows: [Row] = [
+            Row(
+                name: "1: recovery",
+                hasInvalid: true,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+                expected: MigrationReentryRoute.recovery(isExpired: false)
+            ),
+            Row(
+                name: "2: statusResume",
+                hasInvalid: false,
+                hasOverdue: true,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.inProgress(progress),
+                expected: MigrationReentryRoute.statusResume
+            ),
+            Row(
+                name: "3: reviewManual",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: true,
+                isNextTransferDue: true,
+                isCompleteAcknowledged: false,
+                state: MigrationState.inProgress(progress),
+                expected: MigrationReentryRoute.reviewManual(step: 2, total: 4)
+            ),
+            Row(
+                name: "4: statusProgress",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.inProgress(progress),
+                expected: MigrationReentryRoute.statusProgress
+            ),
+            Row(
+                name: "5: complete",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.complete,
+                expected: MigrationReentryRoute.complete
+            ),
+            Row(
+                name: "6: noteSplitProgress",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.splitPendingConfirmation,
+                expected: MigrationReentryRoute.noteSplitProgress
+            ),
+            Row(
+                name: "7: entry",
+                hasInvalid: false,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.notStarted,
+                expected: MigrationReentryRoute.entry
+            )
+        ]
+
+        for row in rows {
+            let route = MigrationDerivations.reentryRoute(
+                state: row.state,
+                hasInvalid: row.hasInvalid,
+                hasOverdue: row.hasOverdue,
+                isManualDelivery: row.isManualDelivery,
+                isNextTransferDue: row.isNextTransferDue,
+                isCompleteAcknowledged: row.isCompleteAcknowledged,
+                progress: progress
+            )
+
+            #expect(route == row.expected, "Row \(row.name) expected \(row.expected) but got \(route)")
+        }
+    }
+
+    // MARK: - Gate: MigrationGateStorage
+
+    @Test func gateAllowedByDefault() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateAllowedByDefault"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGateAllowedByDefault") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let now = Date(timeIntervalSince1970: 1_000_000)
+
+        #expect(storage.sendGate(now: now) == MigrationSendGate.allowed)
+    }
+
+    @Test func gateSyncRequiredWhilePending() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateSyncRequiredWhilePending"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGateSyncRequiredWhilePending") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let now = Date(timeIntervalSince1970: 1_000_000)
+
+        storage.markSyncRequired()
+
+        #expect(storage.sendGate(now: now) == MigrationSendGate.syncRequired)
+    }
+
+    @Test func gateWaitUntilTenMinutesAfterSyncCompletion() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateWaitUntilTenMinutesAfterSyncCompletion"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGateWaitUntilTenMinutesAfterSyncCompletion") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let syncCompletedAt = Date(timeIntervalSince1970: 1_000_000)
+
+        storage.markSyncRequired()
+        storage.recordSyncCompletion(at: syncCompletedAt)
+
+        let justAfterCompletion = syncCompletedAt.addingTimeInterval(1)
+        guard case let MigrationSendGate.waitUntil(gateUntil) = storage.sendGate(now: justAfterCompletion) else {
+            Issue.record("Expected .waitUntil right after sync completion")
+            return
+        }
+
+        #expect(gateUntil == syncCompletedAt.addingTimeInterval(10 * 60))
+    }
+
+    @Test func gateTransitionsToAllowedAfterTenMinutesElapse() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateTransitionsToAllowedAfterTenMinutesElapse"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: "testMigrationGateTransitionsToAllowedAfterTenMinutesElapse")
+        }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let syncCompletedAt = Date(timeIntervalSince1970: 1_000_000)
+
+        storage.markSyncRequired()
+        storage.recordSyncCompletion(at: syncCompletedAt)
+
+        let exactlyAtGate = syncCompletedAt.addingTimeInterval(10 * 60)
+        #expect(storage.sendGate(now: exactlyAtGate) == MigrationSendGate.allowed)
+
+        let wellAfterGate = syncCompletedAt.addingTimeInterval(20 * 60)
+        #expect(storage.sendGate(now: wellAfterGate) == MigrationSendGate.allowed)
+    }
+
+    @Test func gateFullSyncRequiredToWaitUntilToAllowedTransition() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGateFullTransition"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGateFullTransition") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let t0 = Date(timeIntervalSince1970: 2_000_000)
+
+        // Before any sync requirement is observed: allowed.
+        #expect(storage.sendGate(now: t0) == MigrationSendGate.allowed)
+
+        // Sync becomes required: CTA disabled outright.
+        storage.markSyncRequired()
+        #expect(storage.sendGate(now: t0) == MigrationSendGate.syncRequired)
+
+        // Sync completes: 10-minute countdown starts.
+        storage.recordSyncCompletion(at: t0)
+        guard case .waitUntil = storage.sendGate(now: t0.addingTimeInterval(60)) else {
+            Issue.record("Expected .waitUntil 1 minute after sync completion")
+            return
+        }
+
+        // 10 minutes elapse: allowed again.
+        #expect(storage.sendGate(now: t0.addingTimeInterval(10 * 60 + 1)) == MigrationSendGate.allowed)
+    }
+
+    @Test func gateStatePersistsAcrossStorageInstancesUsingTheSameSuite() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationGatePersistsAcrossInstances"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationGatePersistsAcrossInstances") }
+
+        let syncCompletedAt = Date(timeIntervalSince1970: 3_000_000)
+
+        let firstStorage = MigrationGateStorage(userDefaults: userDefaults)
+        firstStorage.markSyncRequired()
+        firstStorage.recordSyncCompletion(at: syncCompletedAt)
+
+        // A fresh instance over the same UserDefaults suite (simulating relaunch) must observe
+        // the persisted gate, not reset to `.allowed` — the whole point of persisting
+        // `migrationSyncGateUntil` is that a relaunch cannot dodge the send-side gate.
+        let secondStorage = MigrationGateStorage(userDefaults: userDefaults)
+        guard case let MigrationSendGate.waitUntil(gateUntil) = secondStorage.sendGate(
+            now: syncCompletedAt.addingTimeInterval(1)
+        ) else {
+            Issue.record("Expected persisted .waitUntil to survive a fresh MigrationGateStorage instance")
+            return
+        }
+
+        #expect(gateUntil == syncCompletedAt.addingTimeInterval(10 * 60))
+    }
+
+    @Test func recordMigrationBroadcastPersistsTimestamp() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testRecordMigrationBroadcastPersistsTimestamp"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testRecordMigrationBroadcastPersistsTimestamp") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let broadcastAt = Date(timeIntervalSince1970: 4_000_000)
+
+        storage.recordMigrationBroadcast(at: broadcastAt)
+
+        let stored = userDefaults.object(forKey: .migrationLastBroadcastAt) as? Double
+        #expect(stored == broadcastAt.timeIntervalSince1970)
+    }
+
+    @Test func syncDeferredForTenMinutesAfterBroadcast() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testSyncDeferredForTenMinutesAfterBroadcast"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testSyncDeferredForTenMinutesAfterBroadcast") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let broadcastAt = Date(timeIntervalSince1970: 4_000_000)
+
+        // No broadcast recorded yet -> never deferred.
+        #expect(storage.isSyncDeferredAfterBroadcast(now: broadcastAt) == false)
+
+        storage.recordMigrationBroadcast(at: broadcastAt)
+
+        // Deferred strictly within the 10-minute window after the broadcast, allowed at/after it
+        // (the sync side of the feature spec section 8.2 separation, consumed by MOB-1467).
+        #expect(storage.isSyncDeferredAfterBroadcast(now: broadcastAt.addingTimeInterval(1)) == true)
+        #expect(storage.isSyncDeferredAfterBroadcast(now: broadcastAt.addingTimeInterval(10 * 60 - 1)) == true)
+        #expect(storage.isSyncDeferredAfterBroadcast(now: broadcastAt.addingTimeInterval(10 * 60)) == false)
+    }
+
+    // MARK: - Persistence: mode / manual delivery / network privacy / acknowledge
+
+    @Test func migrationModePersistenceRoundTrip() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testMigrationModePersistenceRoundTrip"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testMigrationModePersistenceRoundTrip") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+
+        #expect(storage.migrationMode() == nil)
+
+        storage.setMigrationMode(MigrationMode.immediate)
+        #expect(storage.migrationMode() == MigrationMode.immediate)
+
+        storage.setMigrationMode(MigrationMode.privateScheduled)
+        #expect(storage.migrationMode() == MigrationMode.privateScheduled)
+    }
+
+    @Test func manualDeliveryPersistenceRoundTrip() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testManualDeliveryPersistenceRoundTrip"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testManualDeliveryPersistenceRoundTrip") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+
+        #expect(storage.isManualDelivery() == false)
+
+        storage.setManualDelivery(true)
+        #expect(storage.isManualDelivery() == true)
+
+        storage.setManualDelivery(false)
+        #expect(storage.isManualDelivery() == false)
+    }
+
+    @Test func networkPrivacyOptionsPersistenceRoundTrip() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testNetworkPrivacyOptionsPersistenceRoundTrip"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testNetworkPrivacyOptionsPersistenceRoundTrip") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+
+        #expect(storage.networkPrivacyOptions() == NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil))
+
+        let options = NetworkPrivacyOptions(useTor: true, submissionEndpoint: "https://example.com:9067")
+        storage.setNetworkPrivacyOptions(options)
+        #expect(storage.networkPrivacyOptions() == options)
+    }
+
+    @Test func completeAcknowledgedPersistenceRoundTrip() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testCompleteAcknowledgedPersistenceRoundTrip"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: "testCompleteAcknowledgedPersistenceRoundTrip") }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+
+        #expect(storage.isCompleteAcknowledged() == false)
+
+        storage.acknowledgeComplete()
+        #expect(storage.isCompleteAcknowledged() == true)
+
+        storage.clearAcknowledgedComplete()
+        #expect(storage.isCompleteAcknowledged() == false)
+    }
+}

--- a/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
+++ b/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
@@ -3,15 +3,17 @@
 //  zodlTests
 //
 //  Covers the MigrationNoteSplit reducer
-//  (Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift) for MOB-1461: the default
-//  phase/state, the txid pasteboard copy, the failure sheet dismissal (cancel/retry), and the
-//  `continueTapped` delegate contract. Phase transitions and SDK calls are inert/declared-only —
-//  wiring them up is MOB-1466's job. The copy action writes the shared toast (`@Shared` in-memory
-//  state) -> `.serialized` per the repo rule for suites mutating process-global state.
+//  (Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift) for MOB-1461/1466: the
+//  default phase/state, the txid pasteboard copy, the failure sheet dismissal (cancel/retry), the
+//  `continueTapped` delegate contract, and (MOB-1466) `onAppear` load/resume, `confirmTapped`
+//  submission, the `migrationStateStream()` subscription driving `.splitConfirmed`, and retry
+//  re-submission. The copy action writes the shared toast (`@Shared` in-memory state) ->
+//  `.serialized` per the repo rule for suites mutating process-global state.
 //
 
 import Testing
 import Foundation
+@preconcurrency import Combine
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
@@ -25,6 +27,16 @@ import ComposableArchitecture
         #expect(state.fee == Zatoshi.zero)
         #expect(state.txId == "")
         #expect(state.isFailurePresented == false)
+        #expect(state.isFlowRoot == false)
+    }
+
+    @MainActor @Test func closeTappedWhenFlowRootEmitsDelegateContinued() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting, isFlowRoot: true)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.continued))
     }
 
     @MainActor @Test func copyTxIdTappedCopiesTxIdToPasteboard() async {
@@ -56,18 +68,6 @@ import ComposableArchitecture
         }
     }
 
-    @MainActor @Test func retryTappedDismissesFailureSheet() async {
-        let store = TestStore(
-            initialState: MigrationNoteSplit.State(phase: .splitting, isFailurePresented: true)
-        ) {
-            MigrationNoteSplit()
-        }
-
-        await store.send(.retryTapped) {
-            $0.isFailurePresented = false
-        }
-    }
-
     @MainActor @Test func continueTappedEmitsDelegateContinued() async {
         let store = TestStore(initialState: MigrationNoteSplit.State(phase: .confirmed)) {
             MigrationNoteSplit()
@@ -77,28 +77,14 @@ import ComposableArchitecture
         await store.receive(.delegate(.continued))
     }
 
-    @MainActor @Test func confirmTappedProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationNoteSplit.State()) {
-            MigrationNoteSplit()
-        }
-
-        await store.send(.confirmTapped)
-    }
-
-    @MainActor @Test func splitConfirmedProducesNoStateChangeOrEffects() async {
+    @MainActor @Test func splitConfirmedSetsConfirmedPhase() async {
         let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
             MigrationNoteSplit()
         }
 
-        await store.send(.splitConfirmed)
-    }
-
-    @MainActor @Test func splitResultInvalidNoteProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
-            MigrationNoteSplit()
+        await store.send(.splitConfirmed) {
+            $0.phase = .confirmed
         }
-
-        await store.send(.splitResult(.invalidNote))
     }
 
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
@@ -107,5 +93,186 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.continued))
+    }
+
+    // MARK: - onAppear: fresh load vs. resume
+
+    @MainActor @Test func onAppearWhenNotPendingConfirmationPreparesNoteSplitAndPopulatesAmountFee() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let store = TestStore(initialState: MigrationNoteSplit.State()) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.getMigrationState = { .readyToPropose }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.prepareNoteSplit = {
+                NoteSplitProposal(outputNotes: [Zatoshi(500_000_000), Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+            }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.noteSplitPrepared) {
+            $0.proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000), Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+            $0.amount = Zatoshi(1_000_000_000)
+            $0.fee = Zatoshi(100_000)
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func onAppearWhenSplitPendingConfirmationJumpsToSplittingPhaseWithoutPreparing() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let prepareCalls = LockIsolated<Int>(0)
+        let store = TestStore(initialState: MigrationNoteSplit.State()) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.getMigrationState = { .splitPendingConfirmation }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.prepareNoteSplit = {
+                prepareCalls.withValue { $0 += 1 }
+                return NoteSplitProposal(outputNotes: [], fee: Zatoshi.zero)
+            }
+        }
+
+        await store.send(.onAppear) {
+            $0.phase = .splitting
+        }
+
+        #expect(prepareCalls.value == 0)
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func migrationStateStreamReadyToProposeAfterSplittingEmitsSplitConfirmed() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let store = TestStore(initialState: MigrationNoteSplit.State()) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.getMigrationState = { .splitPendingConfirmation }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+        }
+
+        await store.send(.onAppear) {
+            $0.phase = .splitting
+        }
+
+        stateStream.send(.readyToPropose)
+        await store.receive(\.splitConfirmed) {
+            $0.phase = .confirmed
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    // MARK: - confirmTapped / submission
+
+    @MainActor @Test func confirmTappedEntersSplittingPhaseAndSubmitsProposal() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let submittedProposal = LockIsolated<NoteSplitProposal?>(nil)
+        let proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+        var state = MigrationNoteSplit.State(phase: .explainer)
+        state.proposal = proposal
+        let store = TestStore(initialState: state) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.submitNoteSplit = { submitted in
+                submittedProposal.setValue(submitted)
+                return .success(txId: "e87f1234567890abcdef6f28b")
+            }
+        }
+
+        await store.send(.confirmTapped) {
+            $0.phase = .splitting
+        }
+        await store.receive(\.splitResult) {
+            $0.txId = "e87f1234567890abcdef6f28b"
+        }
+
+        #expect(submittedProposal.value == proposal)
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func splitResultSuccessStoresTxIdAndStaysInSplittingPhase() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.success(txId: "e87f1234567890abcdef6f28b"))) {
+            $0.txId = "e87f1234567890abcdef6f28b"
+        }
+
+        #expect(store.state.phase == .splitting)
+        #expect(store.state.isFailurePresented == false)
+    }
+
+    @MainActor @Test func splitResultNetworkErrorPresentsFailureSheet() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.networkError(retryable: true))) {
+            $0.isFailurePresented = true
+        }
+    }
+
+    @MainActor @Test func splitResultInvalidNotePresentsFailureSheet() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.invalidNote)) {
+            $0.isFailurePresented = true
+        }
+    }
+
+    @MainActor @Test func splitResultExpiredPresentsFailureSheet() async {
+        let store = TestStore(initialState: MigrationNoteSplit.State(phase: .splitting)) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitResult(.expired)) {
+            $0.isFailurePresented = true
+        }
+    }
+
+    // MARK: - retryTapped: dismiss + re-submit
+
+    @MainActor @Test func retryTappedDismissesFailureSheetAndResubmitsStoredProposal() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let submitCalls = LockIsolated<Int>(0)
+        let proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+        var state = MigrationNoteSplit.State(phase: .splitting, isFailurePresented: true)
+        state.proposal = proposal
+        let store = TestStore(initialState: state) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.submitNoteSplit = { _ in
+                submitCalls.withValue { $0 += 1 }
+                return .success(txId: "retried-tx-id")
+            }
+        }
+
+        await store.send(.retryTapped) {
+            $0.isFailurePresented = false
+        }
+        await store.receive(\.splitResult) {
+            $0.txId = "retried-tx-id"
+        }
+
+        #expect(submitCalls.value == 1)
+
+        stateStream.send(completion: .finished)
+        await store.finish()
     }
 }

--- a/zodlTests/MigrationTests/MigrationNotificationTests.swift
+++ b/zodlTests/MigrationTests/MigrationNotificationTests.swift
@@ -1,0 +1,178 @@
+//
+//  MigrationNotificationTests.swift
+//  zodlTests
+//
+//  Covers `MigrationNotification` (Dependencies/UserNotifications/MigrationNotification.swift)
+//  for MOB-1467: the stable "migration."-prefixed `identifier` per case, the localized `title`/
+//  `body` (§4.4 matrix copy verbatim), and format-arg rendering (transfer numbers, hour counts,
+//  the `Zatoshi.decimalString()` remaining-amount rendering). Pure enum, no shared state ->
+//  no `.serialized`.
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationNotificationTests {
+    // MARK: - identifier
+
+    @Test func identifierTable() {
+        struct Row {
+            let name: String
+            let notification: MigrationNotification
+            let expected: String
+        }
+
+        let rows: [Row] = [
+            Row(
+                name: "transferComplete",
+                notification: MigrationNotification.transferComplete(number: 1, total: 5, nextInHours: 6, remaining: Zatoshi(100)),
+                expected: "migration.transferComplete"
+            ),
+            Row(
+                name: "transferWaiting",
+                notification: MigrationNotification.transferWaiting(number: 2),
+                expected: "migration.transferWaiting"
+            ),
+            Row(
+                name: "planNeedsUpdate",
+                notification: MigrationNotification.planNeedsUpdate,
+                expected: "migration.planNeedsUpdate"
+            ),
+            Row(
+                name: "manualTransferReady",
+                notification: MigrationNotification.manualTransferReady(number: 3),
+                expected: "migration.manualTransferReady"
+            ),
+            Row(
+                name: "migrationComplete",
+                notification: MigrationNotification.migrationComplete,
+                expected: "migration.complete"
+            )
+        ]
+
+        for row in rows {
+            #expect(row.notification.identifier == row.expected, "Row \(row.name)")
+            #expect(row.notification.identifier.hasPrefix(MigrationNotification.identifierPrefix), "Row \(row.name) prefix")
+        }
+    }
+
+    @Test func identifiersAreAllUnique() {
+        let notifications: [MigrationNotification] = [
+            MigrationNotification.transferComplete(number: 1, total: 1, nextInHours: 1, remaining: Zatoshi.zero),
+            MigrationNotification.transferWaiting(number: 1),
+            MigrationNotification.planNeedsUpdate,
+            MigrationNotification.manualTransferReady(number: 1),
+            MigrationNotification.migrationComplete
+        ]
+
+        let identifiers = Set(notifications.map { $0.identifier })
+        #expect(identifiers.count == notifications.count)
+    }
+
+    // MARK: - title
+
+    @Test func titleTable() {
+        struct Row {
+            let name: String
+            let notification: MigrationNotification
+            let expected: String
+        }
+
+        let rows: [Row] = [
+            Row(
+                name: "transferComplete",
+                notification: MigrationNotification.transferComplete(number: 1, total: 5, nextInHours: 6, remaining: Zatoshi(100)),
+                expected: "Migration update"
+            ),
+            Row(
+                name: "transferWaiting",
+                notification: MigrationNotification.transferWaiting(number: 2),
+                expected: "Action needed"
+            ),
+            Row(
+                name: "planNeedsUpdate",
+                notification: MigrationNotification.planNeedsUpdate,
+                expected: "Action needed"
+            ),
+            Row(
+                name: "manualTransferReady",
+                notification: MigrationNotification.manualTransferReady(number: 3),
+                expected: "Action needed"
+            ),
+            Row(
+                name: "migrationComplete",
+                notification: MigrationNotification.migrationComplete,
+                expected: "Migration complete"
+            )
+        ]
+
+        for row in rows {
+            #expect(row.notification.title == row.expected, "Row \(row.name)")
+        }
+    }
+
+    // MARK: - body — §4.4 matrix copy verbatim, incl. format-arg rendering
+
+    @Test func transferCompleteBodyRendersAllFourArgs() {
+        let notification = MigrationNotification.transferComplete(
+            number: 2,
+            total: 5,
+            nextInHours: 6,
+            remaining: Zatoshi(123_456_789)
+        )
+
+        let expected = "Transfer 2 of 5 complete — next send in ~6 hours. "
+            + "\(Zatoshi(123_456_789).decimalString()) ZEC remaining in Orchard."
+        #expect(notification.body == expected)
+    }
+
+    @Test func transferCompleteBodyRendersZeroRemaining() {
+        let notification = MigrationNotification.transferComplete(
+            number: 5,
+            total: 5,
+            nextInHours: 0,
+            remaining: Zatoshi.zero
+        )
+
+        let expected = "Transfer 5 of 5 complete — next send in ~0 hours. "
+            + "\(Zatoshi.zero.decimalString()) ZEC remaining in Orchard."
+        #expect(notification.body == expected)
+    }
+
+    @Test func transferWaitingBodyRendersNumber() {
+        let notification = MigrationNotification.transferWaiting(number: 3)
+
+        #expect(notification.body == "Transfer 3 waiting. Open ZODL to send or re-schedule.")
+    }
+
+    @Test func planNeedsUpdateBodyIsFixedCopy() {
+        let notification = MigrationNotification.planNeedsUpdate
+
+        #expect(notification.body == "Migration plan needs update. Open ZODL to review the details.")
+    }
+
+    @Test func manualTransferReadyBodyRendersNumber() {
+        let notification = MigrationNotification.manualTransferReady(number: 4)
+
+        #expect(notification.body == "Transfer 4 — ready to send. Open ZODL to review the details.")
+    }
+
+    @Test func migrationCompleteBodyIsFixedCopy() {
+        let notification = MigrationNotification.migrationComplete
+
+        #expect(notification.body == "Migration complete. Open ZODL to review the details.")
+    }
+
+    // MARK: - Equatable
+
+    @Test func transferCompleteIsEquatableByAllPayloadFields() {
+        let a = MigrationNotification.transferComplete(number: 1, total: 5, nextInHours: 6, remaining: Zatoshi(100))
+        let b = MigrationNotification.transferComplete(number: 1, total: 5, nextInHours: 6, remaining: Zatoshi(100))
+        let c = MigrationNotification.transferComplete(number: 2, total: 5, nextInHours: 6, remaining: Zatoshi(100))
+
+        #expect(a == b)
+        #expect(a != c)
+    }
+}

--- a/zodlTests/MigrationTests/MigrationNotificationsTests.swift
+++ b/zodlTests/MigrationTests/MigrationNotificationsTests.swift
@@ -3,10 +3,10 @@
 //  zodlTests
 //
 //  Covers the MigrationNotifications reducer
-//  (Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift) for MOB-1462: the
-//  default `variant`, the `skipTapped` delegate contract, and that `allowTapped` /
-//  `authorizationResult` are no-ops for now — the `UNUserNotificationCenter` request lands in
-//  MOB-1466. No shared/global state -> no `.serialized`.
+//  (Features/Migration/MigrationNotifications/MigrationNotificationsStore.swift) for MOB-1462/1466:
+//  the default `variant`, the `skipTapped` delegate contract, and (MOB-1466) `allowTapped`
+//  requesting `UserNotificationsClient` authorization and `authorizationResult` emitting
+//  `.delegate(.continued)` regardless of outcome. No shared/global state -> no `.serialized`.
 //
 
 import Testing
@@ -30,28 +30,46 @@ import ComposableArchitecture
         await store.receive(.delegate(.continued))
     }
 
-    @MainActor @Test func allowTappedProducesNoStateChangeOrEffects() async {
+    @MainActor @Test func allowTappedRequestsAuthorizationAndEmitsResultTrue() async {
         let store = TestStore(initialState: MigrationNotifications.State()) {
             MigrationNotifications()
+        } withDependencies: {
+            $0.userNotifications.requestAuthorization = { true }
         }
 
         await store.send(.allowTapped)
+        await store.receive(.authorizationResult(true))
+        await store.receive(.delegate(.continued))
     }
 
-    @MainActor @Test func authorizationResultTrueProducesNoStateChangeOrEffects() async {
+    @MainActor @Test func allowTappedRequestsAuthorizationAndEmitsResultFalse() async {
+        let store = TestStore(initialState: MigrationNotifications.State()) {
+            MigrationNotifications()
+        } withDependencies: {
+            $0.userNotifications.requestAuthorization = { false }
+        }
+
+        await store.send(.allowTapped)
+        await store.receive(.authorizationResult(false))
+        await store.receive(.delegate(.continued))
+    }
+
+    @MainActor @Test func authorizationResultTrueEmitsDelegateContinued() async {
         let store = TestStore(initialState: MigrationNotifications.State()) {
             MigrationNotifications()
         }
 
         await store.send(.authorizationResult(true))
+        await store.receive(.delegate(.continued))
     }
 
-    @MainActor @Test func authorizationResultFalseProducesNoStateChangeOrEffects() async {
+    @MainActor @Test func authorizationResultFalseEmitsDelegateContinued() async {
         let store = TestStore(initialState: MigrationNotifications.State()) {
             MigrationNotifications()
         }
 
         await store.send(.authorizationResult(false))
+        await store.receive(.delegate(.continued))
     }
 
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {

--- a/zodlTests/MigrationTests/MigrationRecoveryTests.swift
+++ b/zodlTests/MigrationTests/MigrationRecoveryTests.swift
@@ -3,9 +3,10 @@
 //  zodlTests
 //
 //  Covers the MigrationRecovery reducer
-//  (Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift) for MOB-1464: the default
-//  `.notesSpent` reason and the `continueTapped` delegate contract. Visual-only screen — no SDK
-//  calls, no navigation. No shared/global state -> no `.serialized`.
+//  (Features/Migration/MigrationRecovery/MigrationRecoveryStore.swift) for MOB-1464/1466: the
+//  default `.notesSpent` reason, the `continueTapped` delegate contract, and (MOB-1466) the
+//  `isFlowRoot`-gated back control — `closeTapped` emits the new `.delegate(.close)` case when this
+//  screen is the coordinator's re-entry root. No shared/global state -> no `.serialized`.
 //
 
 import Testing
@@ -20,6 +21,7 @@ import ComposableArchitecture
         #expect(state.reason == MigrationRecovery.State.Reason.notesSpent)
         #expect(state.firstTransfer == 3)
         #expect(state.lastTransfer == 5)
+        #expect(state.isFlowRoot == false)
     }
 
     @MainActor @Test func expiredReasonIsPreservedInState() async {
@@ -52,5 +54,22 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.recreate))
+    }
+
+    @MainActor @Test func closeTappedEmitsDelegateClose() async {
+        let store = TestStore(initialState: MigrationRecovery.State(isFlowRoot: true)) {
+            MigrationRecovery()
+        }
+
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.close))
+    }
+
+    @MainActor @Test func delegateCloseActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationRecovery.State()) {
+            MigrationRecovery()
+        }
+
+        await store.send(.delegate(.close))
     }
 }

--- a/zodlTests/MigrationTests/MigrationReviewTransferTests.swift
+++ b/zodlTests/MigrationTests/MigrationReviewTransferTests.swift
@@ -3,9 +3,15 @@
 //  zodlTests
 //
 //  Covers the MigrationReviewTransfer reducer
-//  (Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift) for MOB-1463:
-//  the default `mode`, the `confirmTapped` delegate contract, and that `sendResult` is a no-op for
-//  now — submitting the transfer is MOB-1466's job. No shared/global state -> no `.serialized`.
+//  (Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift) for MOB-1463/1466:
+//  the default `mode`, and (MOB-1466) two divergent `onAppear`/`confirmTapped` paths keyed off
+//  `mode` — immediate proposes a single-transfer schedule via `proposeMigrationTransfers()` for
+//  Amount/Fee and signs+stores it on confirm before delegating; manual step has its data injected by
+//  the coordinator (no propose) and confirm delegates directly (the transfer was already signed at
+//  plan commit). Also covers the `isFlowRoot`-gated back control for the manual-step variant: a new
+//  `Delegate.closed` case (reusing `.confirmed` for a back-tap would be a correctness bug — that
+//  case means "user confirmed the transfer", not "user backed out"). No shared/global state ->
+//  no `.serialized`.
 //
 
 import Testing
@@ -21,26 +27,26 @@ import ComposableArchitecture
         #expect(state.mode == MigrationReviewTransfer.State.Mode.immediate)
         #expect(state.amount == Zatoshi.zero)
         #expect(state.fee == Zatoshi.zero)
+        #expect(state.isFlowRoot == false)
     }
 
-    @MainActor @Test func confirmTappedEmitsDelegateConfirmed() async {
-        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
-            MigrationReviewTransfer()
-        }
-
-        await store.send(.confirmTapped)
-        await store.receive(.delegate(.confirmed))
-    }
-
-    @MainActor @Test func confirmTappedEmitsDelegateConfirmedForManualStepMode() async {
+    @MainActor @Test func closeTappedWhenFlowRootEmitsDelegateClosed() async {
         let store = TestStore(
-            initialState: MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5))
+            initialState: MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5), isFlowRoot: true)
         ) {
             MigrationReviewTransfer()
         }
 
-        await store.send(.confirmTapped)
-        await store.receive(.delegate(.confirmed))
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.closed))
+    }
+
+    @MainActor @Test func delegateClosedActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
+            MigrationReviewTransfer()
+        }
+
+        await store.send(.delegate(.closed))
     }
 
     @MainActor @Test func manualStepModeIsPreservedInState() async {
@@ -49,19 +55,100 @@ import ComposableArchitecture
         #expect(state.mode == .manualStep(number: 3, total: 5))
     }
 
-    @MainActor @Test func sendResultExpiredProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationReviewTransfer.State()) {
-            MigrationReviewTransfer()
-        }
-
-        await store.send(.sendResult(.expired))
-    }
-
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
         let store = TestStore(initialState: MigrationReviewTransfer.State()) {
             MigrationReviewTransfer()
         }
 
         await store.send(.delegate(.confirmed))
+    }
+
+    // MARK: - Immediate mode: onAppear proposes, confirm signs+stores then delegates
+
+    @MainActor @Test func onAppearInImmediateModeProposesSingleTransferScheduleForAmountFee() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(1_245_800_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 0
+        )
+        let store = TestStore(initialState: MigrationReviewTransfer.State(mode: .immediate)) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = { schedule }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferProposed) {
+            $0.amount = Zatoshi(1_245_800_000)
+            $0.fee = Zatoshi(100_000)
+            $0.schedule = schedule
+        }
+    }
+
+    @MainActor @Test func onAppearInManualStepModeDoesNotProposeAndLeavesInjectedDataAlone() async {
+        let proposeCalls = LockIsolated<Int>(0)
+        let store = TestStore(
+            initialState: MigrationReviewTransfer.State(
+                mode: .manualStep(number: 3, total: 5),
+                amount: Zatoshi(243_100_000),
+                fee: Zatoshi(100_000)
+            )
+        ) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = {
+                proposeCalls.withValue { $0 += 1 }
+                return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+            }
+        }
+
+        await store.send(.onAppear)
+
+        #expect(proposeCalls.value == 0)
+        #expect(store.state.amount == Zatoshi(243_100_000))
+    }
+
+    @MainActor @Test func confirmTappedInImmediateModeSignsAndStoresScheduleThenDelegatesConfirmed() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(1_245_800_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 0
+        )
+        let signedSchedule = LockIsolated<MigrationSchedule?>(nil)
+        var state = MigrationReviewTransfer.State(mode: .immediate)
+        state.schedule = schedule
+        let store = TestStore(initialState: state) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { signedSchedule.setValue($0) }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signedSchedule.value == schedule)
+    }
+
+    @MainActor @Test func confirmTappedInManualStepModeDelegatesConfirmedDirectlyWithoutSigning() async {
+        let signCalls = LockIsolated<Int>(0)
+        let store = TestStore(
+            initialState: MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5))
+        ) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in signCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signCalls.value == 0)
     }
 }

--- a/zodlTests/MigrationTests/MigrationSendingTests.swift
+++ b/zodlTests/MigrationTests/MigrationSendingTests.swift
@@ -3,10 +3,13 @@
 //  zodlTests
 //
 //  Covers the MigrationSending reducer
-//  (Features/Migration/MigrationSending/MigrationSendingStore.swift) for MOB-1463: the default
+//  (Features/Migration/MigrationSending/MigrationSendingStore.swift) for MOB-1463/1466: the default
 //  phase/state, the `closeTapped` / `viewTransactionTapped` delegate contracts, the failure sheet
-//  dismissal (cancel/retry), and that `result` is a no-op for now — resubmitting the transfer is
-//  MOB-1466's job. No shared/global state -> no `.serialized`.
+//  dismissal (cancel/retry), and (MOB-1466) `onAppear` executing `totalCount` transfers strictly in
+//  sequence via `executeNextPendingMigrationTransfer`, recording a broadcast +
+//  scheduling the next background window after each success, presenting the failure sheet on
+//  failure/`nil`, and retry re-running only the failed step. No shared/global state ->
+//  no `.serialized`.
 //
 
 import Testing
@@ -22,6 +25,8 @@ import ComposableArchitecture
         #expect(state.phase == MigrationSending.State.Phase.sending)
         #expect(state.isFailurePresented == false)
         #expect(state.txId == "")
+        #expect(state.totalCount == 1)
+        #expect(state.sentCount == 0)
     }
 
     @MainActor @Test func closeTappedEmitsDelegateClosed() async {
@@ -52,29 +57,176 @@ import ComposableArchitecture
         }
     }
 
-    @MainActor @Test func retryTappedDismissesFailureSheet() async {
-        let store = TestStore(initialState: MigrationSending.State(isFailurePresented: true)) {
-            MigrationSending()
-        }
-
-        await store.send(.retryTapped) {
-            $0.isFailurePresented = false
-        }
-    }
-
-    @MainActor @Test func resultNetworkErrorRetryableProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationSending.State()) {
-            MigrationSending()
-        }
-
-        await store.send(.result(.networkError(retryable: true)))
-    }
-
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
         let store = TestStore(initialState: MigrationSending.State()) {
             MigrationSending()
         }
 
         await store.send(.delegate(.closed))
+    }
+
+    // MARK: - onAppear: single transfer (immediate/manual/plan-first)
+
+    @MainActor @Test func onAppearWithSingleTransferSucceedsAndReachesSentPhase() async {
+        let recordBroadcastCalls = LockIsolated<Int>(0)
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 1)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in .success(txId: "tx-0") }
+            $0.migrationManager.recordMigrationBroadcast = { recordBroadcastCalls.withValue { $0 += 1 } }
+            $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.sentCount = 1
+            $0.txId = "tx-0"
+        }
+        await store.receive(\.allTransfersSent) {
+            $0.phase = .success
+        }
+
+        #expect(recordBroadcastCalls.value == 1)
+        #expect(scheduleNextWindowCalls.value == 1)
+    }
+
+    // MARK: - onAppear: sequential N transfers (send-now)
+
+    @MainActor @Test func onAppearWithMultipleTransfersExecutesStrictlyInSequence() async {
+        let executedCount = LockIsolated<Int>(0)
+        let recordBroadcastCalls = LockIsolated<Int>(0)
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 3)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in
+                let callIndex = executedCount.withValue { count -> Int in
+                    count += 1
+                    return count
+                }
+                return .success(txId: "tx-\(callIndex)")
+            }
+            $0.migrationManager.recordMigrationBroadcast = { recordBroadcastCalls.withValue { $0 += 1 } }
+            $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.sentCount = 1
+            $0.txId = "tx-1"
+        }
+        await store.receive(\.transferResult) {
+            $0.sentCount = 2
+            $0.txId = "tx-2"
+        }
+        await store.receive(\.transferResult) {
+            $0.sentCount = 3
+            $0.txId = "tx-3"
+        }
+        await store.receive(\.allTransfersSent) {
+            $0.phase = .success
+        }
+
+        #expect(executedCount.value == 3)
+        #expect(recordBroadcastCalls.value == 3)
+        #expect(scheduleNextWindowCalls.value == 3)
+    }
+
+    @MainActor @Test func onAppearPassesInjectedNetworkPrivacyOptionsToExecute() async {
+        let capturedOptions = LockIsolated<NetworkPrivacyOptions?>(nil)
+        let options = NetworkPrivacyOptions(useTor: true, submissionEndpoint: "https://example.com:9067")
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 1, networkPrivacyOptions: options)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { passedOptions in
+                capturedOptions.setValue(passedOptions)
+                return .success(txId: "tx-0")
+            }
+            $0.migrationManager.recordMigrationBroadcast = { }
+            $0.migrationBGScheduler.scheduleNextWindow = { }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.sentCount = 1
+            $0.txId = "tx-0"
+        }
+        await store.receive(\.allTransfersSent) {
+            $0.phase = .success
+        }
+
+        #expect(capturedOptions.value == options)
+    }
+
+    // MARK: - Failure / nil result: presents failure sheet, stops the sequence
+
+    @MainActor @Test func onAppearWithFailureResultPresentsFailureSheetAndStopsSequence() async {
+        let executedCount = LockIsolated<Int>(0)
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 3)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in
+                executedCount.withValue { $0 += 1 }
+                return .networkError(retryable: true)
+            }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.isFailurePresented = true
+        }
+
+        #expect(executedCount.value == 1)
+        #expect(store.state.sentCount == 0)
+    }
+
+    @MainActor @Test func onAppearWithNilResultPresentsFailureSheet() async {
+        let store = TestStore(initialState: MigrationSending.State(totalCount: 1)) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in nil }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transferResult) {
+            $0.isFailurePresented = true
+        }
+    }
+
+    // MARK: - retryTapped: re-runs only the failed step
+
+    @MainActor @Test func retryTappedDismissesFailureSheetAndReRunsFailedStep() async {
+        let executedCount = LockIsolated<Int>(0)
+        let state = MigrationSending.State(isFailurePresented: true, totalCount: 2, sentCount: 1)
+        let store = TestStore(initialState: state) {
+            MigrationSending()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in
+                executedCount.withValue { $0 += 1 }
+                return .success(txId: "retried-tx")
+            }
+            $0.migrationManager.recordMigrationBroadcast = { }
+            $0.migrationBGScheduler.scheduleNextWindow = { }
+        }
+
+        await store.send(.retryTapped) {
+            $0.isFailurePresented = false
+        }
+        await store.receive(\.transferResult) {
+            $0.sentCount = 2
+            $0.txId = "retried-tx"
+        }
+        await store.receive(\.allTransfersSent) {
+            $0.phase = .success
+        }
+
+        #expect(executedCount.value == 1)
     }
 }

--- a/zodlTests/MigrationTests/MigrationStatusTests.swift
+++ b/zodlTests/MigrationTests/MigrationStatusTests.swift
@@ -3,13 +3,17 @@
 //  zodlTests
 //
 //  Covers the MigrationStatus reducer (Features/Migration/MigrationStatus/MigrationStatusStore.swift)
-//  for MOB-1464: the default `.progress` presentation, the `gotItTapped`/`sendNowTapped`/
-//  `rescheduleTapped` delegate contracts, and the `remainingCount` derivation over a mixed row set.
-//  Visual-only screen — no SDK calls, no navigation. No shared/global state -> no `.serialized`.
+//  for MOB-1464/1466: the default `.progress` presentation, the `gotItTapped`/`sendNowTapped`/
+//  `rescheduleTapped` delegate contracts, the `remainingCount` derivation over a mixed row set, and
+//  (MOB-1466) `onAppear` loading rows/summary via `migrationTransfers()`/`migrationSummary()`,
+//  subscribing `migrationStateStream()` to refresh rows on change, the `isSendNowDisabled`
+//  derivation from `manager.sendGate()`, and the `isFlowRoot`-gated close-instead-of-pop back
+//  action. No shared/global state -> no `.serialized`.
 //
 
 import Testing
 import Foundation
+@preconcurrency import Combine
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
@@ -24,6 +28,8 @@ import ComposableArchitecture
         #expect(state.stalledNumber == 0)
         #expect(state.stalledHoursAgo == 0)
         #expect(state.isRescheduling == false)
+        #expect(state.isFlowRoot == false)
+        #expect(state.isSendNowDisabled == false)
     }
 
     @MainActor @Test func gotItTappedEmitsDelegateDone() async {
@@ -84,5 +90,130 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.done))
+    }
+
+    // MARK: - onAppear: load rows/summary + sendGate, subscribe to state stream
+
+    @MainActor @Test func onAppearLoadsRowsSummaryAndSendGate() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(351_220_000), status: .sent, hoursFromNow: 6),
+            MigrationTransferRow(id: "1", index: 1, amount: Zatoshi(287_410_000), status: .active, hoursFromNow: 0)
+        ]
+        let summary = MigrationSummary(
+            transferred: Zatoshi(351_220_000),
+            dust: Zatoshi.zero,
+            transfersSent: 1,
+            transfersTotal: 2,
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationStatus.State()) {
+            MigrationStatus()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { rows }
+            $0.sdkSynchronizer.migrationSummary = { summary }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.migrationManager.sendGate = { .allowed }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.statusLoaded) {
+            $0.rows = IdentifiedArrayOf(uniqueElements: rows)
+            $0.totalDurationHours = 24
+            $0.isSendNowDisabled = false
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func onAppearWithSyncRequiredGateDisablesSendNow() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
+            MigrationStatus()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.migrationManager.sendGate = { .syncRequired }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.statusLoaded) {
+            $0.isSendNowDisabled = true
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func onAppearWithWaitUntilGateDisablesSendNow() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
+            MigrationStatus()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.migrationManager.sendGate = { .waitUntil(Date(timeIntervalSince1970: 1_000_000)) }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.statusLoaded) {
+            $0.isSendNowDisabled = true
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func migrationStateStreamChangeRefreshesRows() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let initialRows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)
+        ]
+        let refreshedRows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .sent, hoursFromNow: 0)
+        ]
+        let currentRows = LockIsolated(initialRows)
+        let store = TestStore(initialState: MigrationStatus.State()) {
+            MigrationStatus()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationTransfers = { currentRows.value }
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.migrationManager.sendGate = { .allowed }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.statusLoaded) {
+            $0.rows = IdentifiedArrayOf(uniqueElements: initialRows)
+        }
+
+        currentRows.setValue(refreshedRows)
+        let tickProgress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 1,
+            remainingOrchard: .zero,
+            nextTransferReadyAtHeight: nil
+        )
+        stateStream.send(.inProgress(tickProgress))
+        await store.receive(\.migrationStateChanged)
+        await store.receive(\.statusLoaded) {
+            $0.rows = IdentifiedArrayOf(uniqueElements: refreshedRows)
+        }
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    // MARK: - isFlowRoot: close-instead-of-pop back
+
+    @MainActor @Test func closeTappedWhenFlowRootEmitsDelegateDone() async {
+        let store = TestStore(initialState: MigrationStatus.State(isFlowRoot: true)) {
+            MigrationStatus()
+        }
+
+        await store.send(.closeTapped)
+        await store.receive(.delegate(.done))
     }
 }

--- a/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
@@ -3,10 +3,13 @@
 //  zodlTests
 //
 //  Covers the MigrationTransferPlan reducer
-//  (Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift) for MOB-1463: the
-//  default `variant`, and the `confirmTapped` delegate contract. Signing and storing the schedule
-//  is inert for now — wiring it up is MOB-1466's job. State carries the shared exchange rate but
-//  only reads it — nothing here mutates process-global state -> no `.serialized`.
+//  (Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift) for MOB-1463/1466:
+//  the default `variant`, the `confirmTapped` delegate contract, and (MOB-1466) `onAppear` — a
+//  fresh entry proposes transfers via `proposeMigrationTransfers()` and populates rows/duration,
+//  while an injected schedule (recovery/reschedule variants) is left untouched (no re-propose) —
+//  plus `confirmTapped` signing and storing the schedule via `signAndStoreMigrationSchedule`.
+//  State carries the shared exchange rate but only reads it — nothing here mutates process-global
+//  state -> no `.serialized`.
 //
 
 import Testing
@@ -22,24 +25,7 @@ import ComposableArchitecture
         #expect(state.variant == MigrationTransferPlan.State.Variant.scheduled)
         #expect(state.rows.isEmpty)
         #expect(state.totalDurationHours == 0)
-    }
-
-    @MainActor @Test func confirmTappedEmitsDelegateConfirmed() async {
-        let store = TestStore(initialState: MigrationTransferPlan.State()) {
-            MigrationTransferPlan()
-        }
-
-        await store.send(.confirmTapped)
-        await store.receive(.delegate(.confirmed))
-    }
-
-    @MainActor @Test func confirmTappedEmitsDelegateConfirmedForManualVariant() async {
-        let store = TestStore(initialState: MigrationTransferPlan.State(variant: .manual)) {
-            MigrationTransferPlan()
-        }
-
-        await store.send(.confirmTapped)
-        await store.receive(.delegate(.confirmed))
+        #expect(state.injectedSchedule == nil)
     }
 
     @MainActor @Test func recreatedVariantIsPreservedInState() async {
@@ -54,5 +40,105 @@ import ComposableArchitecture
         }
 
         await store.send(.delegate(.confirmed))
+    }
+
+    // MARK: - onAppear: fresh propose vs. injected schedule
+
+    @MainActor @Test func onAppearWithNoInjectedScheduleProposesTransfersAndPopulatesRows() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200),
+                TransferProposal(id: "t1", amount: Zatoshi(300_000_000), anchorHeight: 100, nextExecutableAfterHeight: 150, expiryHeight: 250)
+            ],
+            estimatedDurationHours: 24
+        )
+        let store = TestStore(initialState: MigrationTransferPlan.State(variant: .scheduled)) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = { schedule }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.transfersProposed) {
+            $0.rows = [
+                MigrationTransferRow(id: "t0", index: 0, amount: Zatoshi(500_000_000), status: .active, hoursFromNow: 0),
+                MigrationTransferRow(id: "t1", index: 1, amount: Zatoshi(300_000_000), status: .pending, hoursFromNow: 0)
+            ]
+            $0.totalDurationHours = 24
+            $0.schedule = schedule
+        }
+    }
+
+    @MainActor @Test func onAppearWithInjectedScheduleDoesNotReProposeAndPopulatesRowsDirectly() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(200_000_000), anchorHeight: 50, nextExecutableAfterHeight: 50, expiryHeight: 150)
+            ],
+            estimatedDurationHours: 12
+        )
+        let proposeCalls = LockIsolated<Int>(0)
+        var state = MigrationTransferPlan.State(variant: .recreated)
+        state.injectedSchedule = schedule
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = {
+                proposeCalls.withValue { $0 += 1 }
+                return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+            }
+        }
+
+        await store.send(.onAppear) {
+            $0.rows = [
+                MigrationTransferRow(id: "t0", index: 0, amount: Zatoshi(200_000_000), status: .active, hoursFromNow: 0)
+            ]
+            $0.totalDurationHours = 12
+            $0.schedule = schedule
+        }
+
+        #expect(proposeCalls.value == 0)
+    }
+
+    // MARK: - confirmTapped: sign + store, then delegate
+
+    @MainActor @Test func confirmTappedSignsAndStoresScheduleThenEmitsDelegateConfirmed() async {
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        let signedSchedule = LockIsolated<MigrationSchedule?>(nil)
+        var state = MigrationTransferPlan.State()
+        state.schedule = schedule
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { signedSchedule.setValue($0) }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(signedSchedule.value == schedule)
+    }
+
+    @MainActor @Test func confirmTappedForManualVariantSignsAndStoresScheduleThenEmitsDelegateConfirmed() async {
+        let schedule = MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+        var state = MigrationTransferPlan.State(variant: .manual)
+        state.schedule = schedule
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
     }
 }

--- a/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
@@ -101,6 +101,32 @@ import ComposableArchitecture
         #expect(proposeCalls.value == 0)
     }
 
+    @MainActor @Test func onAppearWithCoordinatorHydratedRowsDoesNotRePropose() async {
+        let rows: [MigrationTransferRow] = [
+            MigrationTransferRow(id: "0", index: 0, amount: Zatoshi(1_000), status: .active, hoursFromNow: 0)
+        ]
+        let state = MigrationTransferPlan.State(
+            variant: .scheduled,
+            rows: IdentifiedArrayOf(uniqueElements: rows),
+            totalDurationHours: 12,
+            requiresSigning: false
+        )
+        let called = LockIsolated<Bool>(false)
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationTransfers = {
+                called.setValue(true)
+                return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+            }
+        }
+
+        await store.send(.onAppear)
+
+        #expect(called.value == false)
+    }
+
     // MARK: - confirmTapped: sign + store, then delegate
 
     @MainActor @Test func confirmTappedSignsAndStoresScheduleThenEmitsDelegateConfirmed() async {

--- a/zodlTests/MigrationTests/RootMigrationBackgroundTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationBackgroundTests.swift
@@ -1,0 +1,423 @@
+//
+//  RootMigrationBackgroundTests.swift
+//  zodlTests
+//
+//  Covers MOB-1467's Root-level migration BG session decision tree
+//  (Features/Root/RootInitialization.swift, `.initialization(.migrationBackgroundSession)` and
+//  `.appDelegate(.migrationBackgroundTaskExpired)`): every branch of the spec's ordered tree —
+//  plan-broken, sync-required (deferred and not), send (success/success-to-complete/failure/nil),
+//  and session expiration — driven with spy `MigrationBGSessionHandle`s (`rawTask: nil`, since a
+//  bare `BGProcessingTask` cannot be instantiated in unit tests; see that type's doc comment).
+//
+//  `.serialized`: same precedent as `RootMigrationRoutingTests` — constructing `Root.State` builds
+//  `migrationCoordFlowState = MigrationCoordFlow.State.initial`, which reads the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` key. Uses a plain `Store` (not `TestStore`) with
+//  `withDependencies` overrides and `LockIsolated` spies + polling, mirroring
+//  `RootMigrationRoutingTests`/`FlexaSecurityTests`.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct RootMigrationBackgroundTests {
+    // MARK: - Branch 1: Plan broken
+
+    /// `hasInvalidMigrationTransfers() == true` must post `.planNeedsUpdate` immediately (nil
+    /// date), never re-arm (`scheduleNextWindow`/`scheduleFirstWindow` untouched), and complete
+    /// the session successfully — recovery's own `scheduleFirstWindow` re-arms after the user
+    /// re-creates the plan, not this session.
+    @Test func planBrokenViaInvalidTransfersNotifiesWithoutRearming() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.hasInvalidMigrationTransfers = { true }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, date in
+                    notifications.withValue { $0.append(notification) }
+                    #expect(date == nil)
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 } == [MigrationNotification.planNeedsUpdate])
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 0)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// Same branch, reached via the state shape instead: `.requiresAttention(.transferExpired)`
+    /// must also count as "plan broken", independent of `hasInvalidMigrationTransfers`.
+    @Test func planBrokenViaTransferExpiredStateNotifiesWithoutRearming() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.hasInvalidMigrationTransfers = { false }
+                $0.sdkSynchronizer.getMigrationState = { MigrationState.requiresAttention(AttentionReason.transferExpired) }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 } == [MigrationNotification.planNeedsUpdate])
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 0)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    // MARK: - Branch 2: Sync required
+
+    /// Within 10 min of a foreground broadcast (`isSyncDeferredAfterBroadcast() == true`): skip
+    /// even the sync — re-arm only, complete the session. `state.bgTask` must NOT be touched (no
+    /// sync-only session runs).
+    @Test func syncRequiredButDeferredAfterBroadcastOnlyRearms() async {
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.isSyncRequiredBeforeNextMigrationTransfer = { true }
+                $0.migrationManager.isSyncDeferredAfterBroadcast = { true }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(completeCalls.withValue { $0 } == [true])
+            #expect(store.state.bgTask == nil)
+        }
+    }
+
+    /// Not deferred: a sync-only session. Re-arms up front, stashes `state.bgTask =
+    /// handle.rawTask`, and kicks the same sync path `power_wifi_sync` uses (`.retryStart`) —
+    /// asserted here by actually observing `sdkSynchronizer.start` fire (past `.retryStart`'s
+    /// disk-space guard — overridden true, `RootMigrationRoutingTests`' `initialSetupsInvoke
+    /// MigrationReconcile` precedent — and its own `latestState().syncStatus.isPrepared` guard,
+    /// opened via a mutated `SynchronizerState.zero` with `.upToDate` status). This branch never
+    /// completes `handle` itself — that's the existing `synchronizerStateChanged` machinery's job,
+    /// exactly as for the `power_wifi_sync` task it mirrors — so `completeCalls` stays empty here.
+    @Test func syncRequiredNotDeferredRearmsAndStashesBgTaskForSyncOnlySession() async {
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let startCalls = LockIsolated<[Bool]>([])
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        let preparedState: SynchronizerState = {
+            var state = SynchronizerState.zero
+            state.syncStatus = SyncStatus.upToDate
+            return state
+        }()
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                // `latestState`/`start` are non-`@DependencyClient` `let` fields on
+                // `SDKSynchronizerClient` (no per-field override) — replace the whole client via
+                // its `.mocked(...)` builder (same defaults as `.noOp` for every other field), then
+                // layer the ordinary `var` overrides below on top.
+                $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                    latestState: { preparedState },
+                    start: { _ in startCalls.withValue { $0.append(true) } }
+                )
+                $0.sdkSynchronizer.isSyncRequiredBeforeNextMigrationTransfer = { true }
+                $0.migrationManager.isSyncDeferredAfterBroadcast = { false }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { startCalls.withValue { !$0.isEmpty } }
+
+            // Arm.
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            // Stash: `state.bgTask` takes on `handle.rawTask` (`nil` here — the spy handle shape).
+            #expect(store.state.bgTask == nil)
+            // Kick: `.retryStart` ran all the way to `sdkSynchronizer.start(true)`.
+            #expect(startCalls.withValue { $0 } == [true])
+            // This branch does not itself complete the handle.
+            #expect(completeCalls.withValue { $0 }.isEmpty)
+        }
+    }
+
+    // MARK: - Branch 3: Send
+
+    /// A successful broadcast that does NOT complete the migration: records the broadcast, posts
+    /// `.transferComplete` (never `.migrationComplete`), re-arms, and completes the session.
+    @Test func sendSuccessNotCompleteNotifiesTransferCompleteAndRearms() async {
+        let recordBroadcastCalls = LockIsolated<Int>(0)
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let cancelAllCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(12_345),
+            nextTransferReadyAtHeight: nil
+        )
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in TransferResult.success(txId: "tx-1") }
+                $0.sdkSynchronizer.getMigrationState = { MigrationState.inProgress(progress) }
+                $0.sdkSynchronizer.getMigrationProgress = { progress }
+                $0.migrationManager.recordMigrationBroadcast = { recordBroadcastCalls.withValue { $0 += 1 } }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.migrationBGScheduler.cancelAll = { cancelAllCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, date in
+                    notifications.withValue { $0.append(notification) }
+                    #expect(date == nil)
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(recordBroadcastCalls.withValue { $0 } == 1)
+            #expect(notifications.withValue { $0 }.count == 1)
+            if case let MigrationNotification.transferComplete(number, total, _, remaining)? = notifications.withValue({ $0 }).first {
+                #expect(number == 2)
+                #expect(total == 5)
+                #expect(remaining == Zatoshi(12_345))
+            } else {
+                Issue.record("Expected a .transferComplete notification, got \(notifications.withValue { $0 })")
+            }
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(cancelAllCalls.withValue { $0 } == 0)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// A successful broadcast that DOES complete the migration: posts `.migrationComplete`
+    /// (never `.transferComplete`), cancels everything instead of re-arming, and completes the
+    /// session.
+    @Test func sendSuccessToCompleteNotifiesMigrationCompleteAndCancelsAll() async {
+        let recordBroadcastCalls = LockIsolated<Int>(0)
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let cancelAllCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in TransferResult.success(txId: "tx-final") }
+                $0.sdkSynchronizer.getMigrationState = { MigrationState.complete }
+                $0.migrationManager.recordMigrationBroadcast = { recordBroadcastCalls.withValue { $0 += 1 } }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.migrationBGScheduler.cancelAll = { cancelAllCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(recordBroadcastCalls.withValue { $0 } == 1)
+            #expect(notifications.withValue { $0 } == [MigrationNotification.migrationComplete])
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 0)
+            #expect(cancelAllCalls.withValue { $0 } == 1)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// A failed send (`.networkError`) posts `.transferWaiting(number:)` — 1-based, derived from
+    /// `getMigrationProgress()?.completedTransfers ?? 0` + 1 — and re-arms.
+    @Test func sendFailureNotifiesTransferWaitingAndRearms() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        let progress = MigrationProgress(
+            completedTransfers: 3,
+            totalTransfers: 6,
+            remainingOrchard: Zatoshi(500),
+            nextTransferReadyAtHeight: nil
+        )
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in TransferResult.networkError(retryable: true) }
+                $0.sdkSynchronizer.getMigrationProgress = { progress }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 } == [MigrationNotification.transferWaiting(number: 4)])
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// Nothing pending (`nil` result): re-arm only, no notification, complete the session. (The
+    /// LiveKey's own complete-check choke point is what converts a stray re-arm into `cancelAll`
+    /// once the migration is actually done — this test only asserts the Root-level tree calls
+    /// `scheduleNextWindow`, not what that call internally decides.)
+    @Test func nilPendingTransferOnlyRearms() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in nil }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 }.isEmpty)
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    // MARK: - Expiration
+
+    /// `.migrationBackgroundTaskExpired` must re-arm — an expired session must never orphan the
+    /// wakeup chain (re-submitting with the same identifier REPLACES the pending request, so this
+    /// is safe even stacked after branch 2's own up-front re-arm).
+    @Test func expiredSessionRearms() async {
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+            }
+
+            store.send(.initialization(.appDelegate(.migrationBackgroundTaskExpired)))
+            await waitForRootStore { scheduleNextWindowCalls.withValue { $0 } == 1 }
+
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(store.state.bgTask == nil)
+        }
+    }
+}
+
+// MARK: - Shared dependency baseline (mirrors RootMigrationRoutingTests.swift)
+
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mainQueue = .immediate
+    values.mnemonic = .mock
+    values.migrationBGScheduler.backgroundRefreshStatus = { .available }
+    values.migrationBGScheduler.scheduleFirstWindow = { }
+    values.migrationBGScheduler.scheduleNextWindow = { }
+    values.migrationBGScheduler.cancelAll = { }
+    values.migrationManager.bannerVariant = { _ in nil }
+    values.migrationManager.reentryRoute = { .entry }
+    values.migrationManager.migrationMode = { nil }
+    values.migrationManager.setMigrationMode = { _ in }
+    values.migrationManager.setManualDelivery = { _ in }
+    values.migrationManager.setNetworkPrivacyOptions = { _ in }
+    values.migrationManager.acknowledgeComplete = { }
+    values.migrationManager.recordMigrationBroadcast = { }
+    values.migrationManager.reconcile = { }
+    values.migrationManager.isSyncDeferredAfterBroadcast = { false }
+    values.migrationManager.networkPrivacyOptions = { NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil) }
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.load = { _ in }
+    values.userNotifications.authorizationStatus = { .notDetermined }
+    values.userNotifications.requestAuthorization = { false }
+    values.userNotifications.scheduleMigrationNotification = { _, _ in }
+    values.userNotifications.cancelMigrationNotifications = { }
+    values.userNotifications.clearDeliveredMigrationNotifications = { }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}
+
+@MainActor
+private func waitForRootStore(
+    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for migration-background Root store state", sourceLocation: sourceLocation)
+}

--- a/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
@@ -1,0 +1,232 @@
+//
+//  RootMigrationRoutingTests.swift
+//  zodlTests
+//
+//  Covers MOB-1466 phase 5's Root-level wiring for the migration flow
+//  (Features/Root/{RootStore,RootCoordinator,RootInitialization}.swift): the SmartBanner-tap ->
+//  `.migrationCoordFlow` route (with flow-state reset), `isSensitiveFlowActive` classifying the new
+//  `Path` case, `flowFinished` closing the path, launch/foreground reconciliation invoking
+//  `migrationManager.reconcile()`, and the Sending `.viewTransaction` delegate's Root-level handling
+//  (v1: treated as a flow close — see the `RootCoordinator` doc comment at that case for why).
+//
+//  `.serialized`: constructing `Root.State` builds `migrationCoordFlowState = MigrationCoordFlow
+//  .State.initial`, which itself builds a `MigrationEntry.State` reading the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` key — same precedent as `MigrationCoordFlowTests`.
+//  Uses a plain `Store` (not `TestStore`) with heavy `withDependencies` overrides, mirroring
+//  `FlexaTests/FlexaSecurityTests.swift`: Root's init effects are too heavy for exhaustive
+//  `TestStore` assertion, so behavior is observed via `LockIsolated` spies and polling.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct RootMigrationRoutingTests {
+    // MARK: - Banner tap -> .migrationCoordFlow
+
+    /// Tapping the migration banner (`.home(.smartBanner(.migrationScreenRequested))`) must open
+    /// `.migrationCoordFlow` and reset its flow state fresh — same shape as `.walletBackupTapped`
+    /// opening `.walletBackup`.
+    @Test func migrationScreenRequestedOpensMigrationCoordFlowWithFreshState() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            // Poison the pre-existing flow state so a reset is actually observable.
+            initialState.migrationCoordFlowState.mode = MigrationMode.immediate
+            initialState.migrationCoordFlowState.path.append(.complete(MigrationComplete.State()))
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            store.send(.home(.smartBanner(.migrationScreenRequested)))
+            await waitForRootStore { store.state.path == Root.State.Path.migrationCoordFlow }
+
+            #expect(store.state.path == Root.State.Path.migrationCoordFlow)
+            #expect(store.state.migrationCoordFlowState.mode == nil)
+            #expect(store.state.migrationCoordFlowState.path.isEmpty)
+        }
+    }
+
+    // MARK: - flowFinished -> path == nil
+
+    /// `MigrationCoordFlow`'s `.flowFinished` (every flow-root close / terminal delegate) must
+    /// close the migration path back to Home.
+    @Test func migrationCoordFlowFinishedClosesPath() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.path = Root.State.Path.migrationCoordFlow
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            store.send(.migrationCoordFlow(.flowFinished))
+            await waitForRootStore { store.state.path == nil }
+
+            #expect(store.state.path == nil)
+        }
+    }
+
+    // MARK: - isSensitiveFlowActive
+
+    /// Pure computed-property check: `.migrationCoordFlow` must classify as sensitive, alongside
+    /// send/scan/swap/transactions — the exhaustive switch forces this classification by design.
+    @Test func isSensitiveFlowActiveIsTrueForMigrationCoordFlow() {
+        var state = Root.State.initial
+        state.path = Root.State.Path.migrationCoordFlow
+
+        #expect(state.isSensitiveFlowActive == true)
+    }
+
+    // MARK: - Reconciliation: willEnterForeground
+
+    /// Every foreground entry must invoke `migrationManager.reconcile()`, regardless of the
+    /// keychain/sync-status branch taken afterward.
+    @Test func willEnterForegroundInvokesMigrationReconcile() async {
+        let reconcileCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.migrationManager.reconcile = { reconcileCalls.withValue { $0 += 1 } }
+            }
+
+            store.send(.initialization(.appDelegate(.willEnterForeground)))
+            await waitForRootStore { reconcileCalls.withValue { $0 } == 1 }
+
+            #expect(reconcileCalls.withValue { $0 } == 1)
+        }
+    }
+
+    // MARK: - Reconciliation: launch (initialSetups)
+
+    /// The launch path (`initialSetups`, past the disk-space guard) must also invoke
+    /// `migrationManager.reconcile()`, independent of `willEnterForeground`'s own hook.
+    @Test func initialSetupsInvokesMigrationReconcile() async {
+        let reconcileCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.migrationManager.reconcile = { reconcileCalls.withValue { $0 += 1 } }
+                $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+            }
+
+            store.send(.initialization(.initialSetups))
+            await waitForRootStore { reconcileCalls.withValue { $0 } == 1 }
+
+            #expect(reconcileCalls.withValue { $0 } == 1)
+        }
+    }
+
+    // MARK: - View Transaction (Sending delegate)
+
+    /// The migration Sending screen's `.viewTransaction` delegate carries only a bare stub
+    /// `txId: String` — never a real `TransactionState` the existing transaction-detail plumbing
+    /// (`TransactionDetails.State.transaction`, non-optional) could open. Root's v1 handling (see
+    /// the doc comment on this case in `RootCoordinator.swift`) treats it as a flow close rather
+    /// than opening a broken/empty detail screen, pending real txids from the SDK (MOB-1455).
+    @Test func sendingViewTransactionDelegateClosesMigrationFlow() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.path = Root.State.Path.migrationCoordFlow
+            let sendingState = MigrationSending.State(phase: .success, txId: "stub-tx-id")
+            initialState.migrationCoordFlowState.path.append(.sending(sendingState))
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            let sendingId = try? #require(initialState.migrationCoordFlowState.path.ids.last)
+            guard let sendingId else {
+                Issue.record("Expected a sending element id on the migration path")
+                return
+            }
+
+            store.send(
+                .migrationCoordFlow(
+                    .path(.element(id: sendingId, action: .sending(.delegate(.viewTransaction))))
+                )
+            )
+            await waitForRootStore { store.state.path == nil }
+
+            #expect(store.state.path == nil)
+        }
+    }
+}
+
+// MARK: - Shared dependency baseline
+
+/// Base override set for driving a full `Root` `Store` without its heavy init effects crashing on
+/// unimplemented dependency defaults — mirrors `FlexaSecurityTests`' override set, plus the
+/// migration-specific clients and the `.initialization(...)` launch-path dependencies (`
+/// databaseFiles`, `diskSpaceChecker`) this suite's reconciliation tests additionally traverse.
+/// `diskSpaceChecker` defaults to "full disk" (`hasEnoughFreeSpaceForSync == false`) so a bare
+/// `.willEnterForeground` send — which can itself fall through to `.initialSetups` — doesn't
+/// also run `initialSetups`'s own reconcile effect and double-count the spy; tests that need the
+/// `initialSetups` continuation (past the disk-space guard) override it back to `true` locally.
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mainQueue = .immediate
+    values.mnemonic = .mock
+    values.migrationBGScheduler.backgroundRefreshStatus = { .available }
+    values.migrationBGScheduler.scheduleFirstWindow = { }
+    values.migrationBGScheduler.scheduleNextWindow = { }
+    values.migrationBGScheduler.cancelAll = { }
+    values.migrationManager.bannerVariant = { _ in nil }
+    values.migrationManager.reentryRoute = { .entry }
+    values.migrationManager.migrationMode = { nil }
+    values.migrationManager.setMigrationMode = { _ in }
+    values.migrationManager.setManualDelivery = { _ in }
+    values.migrationManager.setNetworkPrivacyOptions = { _ in }
+    values.migrationManager.acknowledgeComplete = { }
+    values.migrationManager.recordMigrationBroadcast = { }
+    values.migrationManager.reconcile = { }
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.load = { _ in }
+    values.userNotifications.authorizationStatus = { .notDetermined }
+    values.userNotifications.requestAuthorization = { false }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}
+
+@MainActor
+private func waitForRootStore(
+    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for migration-routing Root store state", sourceLocation: sourceLocation)
+}

--- a/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
@@ -9,6 +9,12 @@
 //  `migrationManager.reconcile()`, and the Sending `.viewTransaction` delegate's Root-level handling
 //  (v1: treated as a flow close — see the `RootCoordinator` doc comment at that case for why).
 //
+//  Also covers MOB-1467's notification-tap deep link (`.appDelegate(.migrationNotificationTapped)`):
+//  immediate routing once Home/initialized, versus the deferred `pendingMigrationDeepLink` path that
+//  mirrors `RootDestination`'s `isAtDeeplinkWarningScreen` gating and fires from
+//  `checkBackupPhraseValidation`'s "just reached Home" checkpoint — plus the `willEnterForeground`
+//  delivered-notifications clear.
+//
 //  `.serialized`: constructing `Root.State` builds `migrationCoordFlowState = MigrationCoordFlow
 //  .State.initial`, which itself builds a `MigrationEntry.State` reading the process-global
 //  `@Shared(.inMemory(.selectedWalletAccount))` key — same precedent as `MigrationCoordFlowTests`.
@@ -173,6 +179,97 @@ import ComposableArchitecture
             await waitForRootStore { store.state.path == nil }
 
             #expect(store.state.path == nil)
+        }
+    }
+
+    // MARK: - MOB-1467: Notification-tap deep link
+
+    /// Tapping a migration notification while Home is already up/initialized must route
+    /// immediately — exactly the SmartBanner-tap routing (fresh flow state, `.migrationCoordFlow`).
+    @Test func migrationNotificationTappedOnInitializedStateRoutesImmediately() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.appInitializationState = InitializationState.initialized
+            // Poison the pre-existing flow state so a reset is actually observable, same as the
+            // banner-tap test above.
+            initialState.migrationCoordFlowState.mode = MigrationMode.immediate
+            initialState.migrationCoordFlowState.path.append(.complete(MigrationComplete.State()))
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            store.send(.initialization(.appDelegate(.migrationNotificationTapped)))
+            await waitForRootStore { store.state.path == Root.State.Path.migrationCoordFlow }
+
+            #expect(store.state.path == Root.State.Path.migrationCoordFlow)
+            #expect(store.state.migrationCoordFlowState.mode == nil)
+            #expect(store.state.migrationCoordFlowState.path.isEmpty)
+            #expect(store.state.pendingMigrationDeepLink == false)
+        }
+    }
+
+    /// Tapping a migration notification BEFORE the app has reached Home (cold start still in
+    /// flight) must stash the request rather than drop it — mirrors `RootDestination`'s
+    /// `isAtDeeplinkWarningScreen` gating. It then fires once `checkBackupPhraseValidation` (the
+    /// checkpoint that sets `appInitializationState = .initialized`) runs, exactly like a deferred
+    /// deep link is released there.
+    @Test func migrationNotificationTappedBeforeInitializedStashesThenFiresAtCheckBackupPhraseValidation() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.appInitializationState = InitializationState.uninitialized
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            store.send(.initialization(.appDelegate(.migrationNotificationTapped)))
+            await waitForRootStore { store.state.pendingMigrationDeepLink == true }
+
+            #expect(store.state.pendingMigrationDeepLink == true)
+            #expect(store.state.path == nil)
+
+            store.send(.initialization(.checkBackupPhraseValidation))
+            await waitForRootStore { store.state.path == Root.State.Path.migrationCoordFlow }
+
+            #expect(store.state.path == Root.State.Path.migrationCoordFlow)
+            #expect(store.state.pendingMigrationDeepLink == false)
+        }
+    }
+
+    // MARK: - MOB-1467: Foreground-clear of delivered migration notifications
+
+    /// Every foreground entry must clear DELIVERED migration notifications (the banner/re-entry
+    /// route now carries the current state) — but must not cancel PENDING ones (a manual-mode
+    /// "ready to send" reminder must survive), so this only asserts the delivered-clear spy, never
+    /// `cancelMigrationNotifications`.
+    @Test func willEnterForegroundClearsDeliveredMigrationNotifications() async {
+        let clearDeliveredCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.userNotifications.clearDeliveredMigrationNotifications = {
+                    clearDeliveredCalls.withValue { $0 += 1 }
+                }
+            }
+
+            store.send(.initialization(.appDelegate(.willEnterForeground)))
+            await waitForRootStore { clearDeliveredCalls.withValue { $0 } == 1 }
+
+            #expect(clearDeliveredCalls.withValue { $0 } == 1)
         }
     }
 }

--- a/zodlTests/SmartBannerTests/SmartBannerMigrationTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerMigrationTests.swift
@@ -1,0 +1,361 @@
+//
+//  SmartBannerMigrationTests.swift
+//  zodlTests
+//
+//  MOB-1466: covers the `priorityMigration` wiring added to `SmartBannerStore.swift` — the
+//  `PriorityContent.rank` ordering (below priority1/priority2, above everything else), the
+//  `.evaluatePriorityMigration` walk step slotted between priority2 and priority3, the
+//  `migrationStateStream()` reactive trigger (`.migrationStateChanged`/`.migrationVariantUpdated`),
+//  and the `.migrationScreenRequested` tap leaf action. `.serialized`: state touches the
+//  process-global `@Shared(.inMemory(.selectedWalletAccount))`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) struct SmartBannerMigrationTests {
+    private func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    // MARK: - Rank interplay
+
+    @MainActor @Test func migrationRequestIsRejectedWhilePriority1Shows() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority1
+        state.priorityContentRequested = .priority1
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.triggerPriority(.priorityMigration)) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        // Guard rejects: priorityMigration.rank (1.5) >= priority1.rank (0) — no further effects.
+        await store.receive(\.openBannerRequest)
+    }
+
+    @MainActor @Test func migrationRequestIsRejectedWhilePriority2Shows() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority2
+        state.priorityContentRequested = .priority2
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.triggerPriority(.priorityMigration)) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        // Guard rejects: priorityMigration.rank (1.5) >= priority2.rank (1) — no further effects.
+        await store.receive(\.openBannerRequest)
+    }
+
+    @MainActor @Test func priority1RequestReplacesAShowingMigrationBanner() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.triggerPriority(.priority1)) {
+            $0.priorityContentRequested = .priority1
+        }
+        // priority1.rank (0) < priorityMigration.rank (1.5) — allowed; banner is open, so it closes
+        // (non-clean) first, then re-requests, then re-opens with the new priority.
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priority1
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    @MainActor @Test func migrationRequestReplacesAShowingPriority3Banner() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority3
+        state.priorityContentRequested = .priority3
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.triggerPriority(.priorityMigration)) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        // priorityMigration.rank (1.5) < priority3.rank (2) — allowed.
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    @MainActor @Test func migrationRequestReplacesAShowingPriority9Banner() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority9
+        state.priorityContentRequested = .priority9
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.triggerPriority(.priorityMigration)) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        // priorityMigration.rank (1.5) < priority9.rank (10) — allowed.
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    @MainActor @Test func priority3RequestIsRejectedWhileMigrationShows() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.triggerPriority(.priority3)) {
+            $0.priorityContentRequested = .priority3
+        }
+        // Guard rejects: priority3.rank (2) >= priorityMigration.rank (1.5) — no further effects.
+        await store.receive(\.openBannerRequest)
+    }
+
+    @MainActor @Test func priority9RequestIsRejectedWhileMigrationShows() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.triggerPriority(.priority9)) {
+            $0.priorityContentRequested = .priority9
+        }
+        // Guard rejects: priority9.rank (10) >= priorityMigration.rank (1.5) — no further effects.
+        await store.receive(\.openBannerRequest)
+    }
+
+    // MARK: - Walk step
+
+    @MainActor @Test func priority2WalkDownReachesEvaluatePriorityMigration() async {
+        let store = TestStore(initialState: SmartBanner.State()) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+        // A nil variant lets the walk continue all the way to priority9 (untouched, unrelated
+        // steps) — only priority2 -> evaluatePriorityMigration -> priority3 is under test here.
+        store.exhaustivity = .off
+
+        await store.send(.evaluatePriority2)
+        await store.receive(\.evaluatePriorityMigration)
+        // Falls through with a nil variant — verified in detail below; here we only assert the
+        // walk actually reaches the new step rather than jumping straight to priority3.
+        await store.receive(\.migrationVariantLoaded)
+        await store.receive(\.evaluatePriority3)
+    }
+
+    @MainActor @Test func evaluatePriorityMigrationWithNonNilVariantTriggersMigration() async {
+        let account = walletAccount(idByte: 3)
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { accountUUID in
+                #expect(accountUUID == account.id)
+                return MigrationBannerVariant.complete
+            }
+        }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.evaluatePriorityMigration)
+        await store.receive(\.migrationVariantLoaded) {
+            // `.complete`, not the `State()` default (`.required`), so the assignment is an
+            // observable change — proves the loaded variant actually lands in state.
+            $0.migrationBannerVariant = MigrationBannerVariant.complete
+        }
+        await store.receive(\.triggerPriority) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    @MainActor @Test func evaluatePriorityMigrationWithNilVariantFallsThroughToPriority3() async {
+        let store = TestStore(initialState: SmartBanner.State()) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+        // A nil variant lets the walk continue all the way to priority9 (untouched, unrelated
+        // steps) — only the migration -> priority3 hop is under test here.
+        store.exhaustivity = .off
+
+        await store.send(.evaluatePriorityMigration)
+        await store.receive(\.migrationVariantLoaded)
+        await store.receive(\.evaluatePriority3)
+        // walletStatus defaults to `.none` — priority3 (restoring) itself is a no-op walk-through.
+        await store.receive(\.evaluatePriority4)
+    }
+
+    // MARK: - Reactive trigger: variant-only update while showing
+
+    @MainActor @Test func migrationStateChangedWithNonNilVariantWhileShowingOnlyUpdatesState() async {
+        let account = walletAccount(idByte: 5)
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        state.migrationBannerVariant = MigrationBannerVariant.inProgress(done: 2, total: 5)
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { accountUUID in
+                #expect(accountUUID == account.id)
+                return MigrationBannerVariant.inProgress(done: 3, total: 5)
+            }
+        }
+
+        await store.send(.migrationStateChanged(MigrationState.inProgress(
+            MigrationProgress(
+                completedTransfers: 3,
+                totalTransfers: 5,
+                remainingOrchard: Zatoshi.zero,
+                nextTransferReadyAtHeight: nil
+            )
+        )))
+        await store.receive(\.migrationVariantUpdated) {
+            $0.migrationBannerVariant = MigrationBannerVariant.inProgress(done: 3, total: 5)
+        }
+        // No `.triggerPriority`/`.closeAndCleanupBanner` follow-up — content re-renders live from
+        // the state mutation alone, banner stays open on the same priority.
+        #expect(store.state.priorityContent == .priorityMigration)
+        #expect(store.state.isOpen)
+    }
+
+    @MainActor @Test func migrationStateChangedWithNonNilVariantWhileNotShowingTriggers() async {
+        let store = TestStore(initialState: SmartBanner.State()) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in MigrationBannerVariant.complete }
+        }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.migrationStateChanged(MigrationState.notStarted))
+        await store.receive(\.migrationVariantUpdated) {
+            // `.complete`, not the `State()` default (`.required`) — see the analogous comment in
+            // `evaluatePriorityMigrationWithNonNilVariantTriggersMigration` above.
+            $0.migrationBannerVariant = MigrationBannerVariant.complete
+        }
+        await store.receive(\.triggerPriority) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    // MARK: - Reactive trigger: variant nil while migration showing
+
+    @MainActor @Test func migrationStateChangedWithNilVariantWhileMigrationShowingClosesAndRewalks() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.migrationStateChanged(MigrationState.complete))
+        await store.receive(\.migrationVariantUpdated)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+            $0.priorityContentRequested = nil
+            $0.priorityContent = nil
+        }
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.evaluatePriority1)
+        // The re-walk continues (evaluatePriority2 -> evaluatePriorityMigration -> ...); with the
+        // same `nil`-returning override it walks all the way down without re-triggering migration.
+        #expect(store.state.priorityContent == nil)
+    }
+
+    @MainActor @Test func migrationStateChangedWithNilVariantWhileNotShowingIsANoOp() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priority6
+        state.priorityContentRequested = .priority6
+        state.isOpen = true
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+
+        await store.send(.migrationStateChanged(MigrationState.complete))
+        await store.receive(\.migrationVariantUpdated)
+        // Nil while some other priority (not migration) is showing: nothing else happens.
+        #expect(store.state.priorityContent == .priority6)
+        #expect(store.state.isOpen)
+    }
+
+    // MARK: - Tap
+
+    @MainActor @Test func smartBannerContentTappedWithMigrationShowingRequestsMigrationScreen() async {
+        var state = SmartBanner.State()
+        state.priorityContent = .priorityMigration
+        let store = TestStore(initialState: state) { SmartBanner() }
+
+        await store.send(.smartBannerContentTapped)
+        await store.receive(\.migrationScreenRequested)
+    }
+
+    @MainActor @Test func migrationScreenRequestedProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: SmartBanner.State()) { SmartBanner() }
+
+        await store.send(.migrationScreenRequested)
+    }
+}


### PR DESCRIPTION
Implements [MOB-1467](https://linear.app/zodl/issue/MOB-1467/ironwood-migration-background-scheduling-local-notifications) — the full spec lives in the ticket description. Stacked on #1885 (MOB-1466).

Fills the MOB-1466 seams with real background execution and notifications. Everything still runs against the inert SDK stubs — sessions no-op gracefully; goes live with MOB-1455.

## What's here

- **`MigrationBGSchedulerClient` LiveKey**: `BGProcessingTask` `co.electriccoin.migration_transfer` (network required, power not) with the §8.3 cadence — SDK per-transfer time preferred, 30 min / 6.5 h margins as floor+fallback (`MigrationCadence`, table-tested). **Unified wakeup semantics**: in manual-delivery mode the same calls pre-schedule the "Transfer n — ready to send" reminder instead of a BG task. A **complete-check choke point** converts any arm request into `cancelAll` once the migration is `.complete` (prevents an infinite chain of no-op wakeups after immediate-mode/manual completion).
- **BG session decision tree** (Root, house pattern — task forwarded from AppDelegate as an action): plan-broken → "plan needs update" notification, no re-arm · sync-required → **sync-only session** riding the existing `power_wifi_sync` completion machinery (`state.bgTask` + `synchronizerStateChanged`), re-armed up front · sync-deferred (within 10 min of a foreground broadcast) → re-arm only · otherwise send via `executeNextPendingMigrationTransfer` (transaction-guarded in its LiveKey) → success/complete/failure notifications + re-arm. Never syncs and broadcasts in one session. Expiration re-arms (same-id resubmission replaces, so no double-scheduling).
- **Notification matrix** (§4.4): pure `MigrationNotification` enum (5 cases; stable `migration.*` identifiers so re-posts replace) + `UserNotificationsClient` scheduling/cancel/clear-delivered members. Per user decisions: **success notifications ON**; **no pre-scheduled missed-window safety net** (live sessions only — the banner + Resume routing cover silent misses); **manual-mode ready reminders ARE pre-scheduled** (no BG sessions exist in manual mode; the S4 copy promises them). Opening the app clears delivered migration notifications; pending manual reminders survive. 8 new localized strings (EN+ES).
- **Deep links** (greenfield): `UNUserNotificationCenterDelegate` adapter in AppDelegate (set synchronously at launch for cold-start taps) → migration-prefixed taps route into the migration flow via the banner-tap path, deferred until initialization completes (same release point as `RootDestination`'s deep-link gating). Foreground migration notifications are suppressed — the SmartBanner carries live state.
- New task id registered in AppDelegate + added to **all five** Info.plists (the ticket said four; exploration found five). Existing `power_wifi_sync` / `scheduler` tasks untouched.

## Flagged

- **Notification titles** ("Migration update" / "Action needed" / "Migration complete") are new copy — §4.4 pins bodies only; please confirm titles against the Figma lock screens.
- `UNTimeIntervalNotificationTrigger` requires a strictly positive interval → 0.1 s floor on past/imminent target dates (Apple API constraint).
- Device-side check that the task fires: run on device, background the app, then in the debugger
  `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"co.electriccoin.migration_transfer"]`.

## Verification

- Full `zodlTests` target on `zodl-internal` (iPhone 17 Pro sim, `-skipMacroValidation`): **885 tests / 126 suites, all green** (+41 vs. the MOB-1466 base; 1 pre-existing unrelated known issue). New suites: `MigrationCadenceTests` (10), `MigrationNotificationTests` (10), `MigrationBGSchedulerTests` (9), `RootMigrationBackgroundTests` (9); `RootMigrationRoutingTests` +3 (deep-link + foreground-clear).
- Full build green. Added Swift lines ≤ 150 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)