### PR TITLE
[MOB-1468] Keystone signing path for the Ironwood migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1465] Internal DEBUG-only gallery of all Ironwood migration screens (long-press the balance on Home). Not present in release builds.
 - [MOB-1466] Ironwood migration screens are wired into a complete guided flow (entry, scheduling, status, recovery) driven by migration state, with a Home banner entry point — dormant until the migration SDK ships.
 - [MOB-1467] Scheduled Ironwood migration transfers can now send from background tasks, with local notifications for progress, required actions, and manual-mode send reminders — dormant until the migration SDK ships.
+- [MOB-1468] Keystone hardware-wallet accounts can complete the Ironwood migration — transfers are signed by QR in a single batched session — dormant until the migration SDK and Keystone batch support ship.
 
 ## 3.7.2 build 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1464] Ironwood migration screens: progress status, plan recovery, migration complete, and the home widget states. Not reachable in the app yet.
 - [MOB-1465] Internal DEBUG-only gallery of all Ironwood migration screens (long-press the balance on Home). Not present in release builds.
 - [MOB-1466] Ironwood migration screens are wired into a complete guided flow (entry, scheduling, status, recovery) driven by migration state, with a Home banner entry point — dormant until the migration SDK ships.
+- [MOB-1467] Scheduled Ironwood migration transfers can now send from background tasks, with local notifications for progress, required actions, and manual-mode send reminders — dormant until the migration SDK ships.
 
 ## 3.7.2 build 1
 

--- a/secant-distrib-Info.plist
+++ b/secant-distrib-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -19434,6 +19434,142 @@
         }
       }
     },
+    "migrationNotification.transferCompleteTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration update"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualización de la migración"
+          }
+        }
+      }
+    },
+    "migrationNotification.transferCompleteBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld of %2$lld complete — next send in ~%3$lld hours. %4$@ ZEC remaining in Orchard."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld de %2$lld completada — el próximo envío será en ~%3$lld horas. Quedan %4$@ ZEC en Orchard."
+          }
+        }
+      }
+    },
+    "migrationNotification.actionNeededTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Action needed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acción necesaria"
+          }
+        }
+      }
+    },
+    "migrationNotification.transferWaitingBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld waiting. Open ZODL to send or re-schedule."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld en espera. Abre ZODL para enviarla o reprogramarla."
+          }
+        }
+      }
+    },
+    "migrationNotification.planNeedsUpdateBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration plan needs update. Open ZODL to review the details."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El plan de migración necesita una actualización. Abre ZODL para revisar los detalles."
+          }
+        }
+      }
+    },
+    "migrationNotification.manualTransferReadyBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer %1$lld — ready to send. Open ZODL to review the details."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia %1$lld — lista para enviar. Abre ZODL para revisar los detalles."
+          }
+        }
+      }
+    },
+    "migrationNotification.migrationCompleteTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migración completada"
+          }
+        }
+      }
+    },
+    "migrationNotification.migrationCompleteBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration complete. Open ZODL to review the details."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migración completada. Abre ZODL para revisar los detalles."
+          }
+        }
+      }
+    },
     "migrationNotifications.title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/AppDelegate.swift
+++ b/secant/Sources/AppDelegate.swift
@@ -22,6 +22,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     private let workerQueue = DispatchQueue(label: "Monitor")
     private let isConnectedToWifi = ManagedAtomic(false)
 
+    // Owned strongly so it outlives this method scope — `UNUserNotificationCenter.current()`
+    // only holds its delegate weakly.
+    private let notificationDelegate = MigrationNotificationCenterDelegate()
+
     let rootStore = StoreOf<Root>(
         initialState: .initial
     ) {
@@ -40,9 +44,14 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 #endif
         handleBackgroundTask()
 
+        // Synchronous, before anything else touches notifications — required to catch cold-start
+        // taps (the app can be launched directly by a notification tap).
+        notificationDelegate.rootStore = rootStore
+        UNUserNotificationCenter.current().delegate = notificationDelegate
+
         // set the default behavior for the NSDecimalNumber
         NSDecimalNumber.defaultBehavior = Zatoshi.decimalHandler
-        
+
         rootStore.send(.initialization(.appDelegate(.didFinishLaunching)))
 
         return true
@@ -97,11 +106,41 @@ extension AppDelegate {
 
             scheduleSchedulerBackgroundTask()
             scheduleBackgroundTask()
-            
+
             task.setTaskCompleted(success: true)
         }
-        
+
         LoggerProxy.event("BGTask SCHEDULER registered \(bcgSchedulerTaskResult)")
+
+        let bcgMigrationTaskResult = BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: MigrationBGTask.identifier,
+            using: DispatchQueue.main
+        ) { [self] task in
+            LoggerProxy.event("BGTask BGTaskScheduler.shared.register MIGRATION called")
+            guard let task = task as? BGProcessingTask else {
+                return
+            }
+
+            startMigrationBackgroundTask(task)
+        }
+
+        LoggerProxy.event("BGTask MIGRATION registered \(bcgMigrationTaskResult)")
+    }
+
+    /// Unlike `startBackgroundTask` (the `power_wifi_sync` handler above), there is deliberately
+    /// NO WiFi gate here: migration's `BGProcessingTaskRequest.requiresNetworkConnectivity` already
+    /// covers the network requirement, and migration must not additionally demand WiFi/power.
+    private func startMigrationBackgroundTask(_ task: BGProcessingTask) {
+        LoggerProxy.event("BGTask startMigrationBackgroundTask called")
+
+        rootStore.send(.initialization(.appDelegate(.migrationBackgroundTask(task))))
+
+        task.expirationHandler = { [rootStore] in
+            LoggerProxy.event("BGTask startMigrationBackgroundTask expirationHandler called")
+            DispatchQueue.main.async {
+                rootStore.send(.initialization(.appDelegate(.migrationBackgroundTaskExpired)))
+            }
+        }
     }
     
     private func startBackgroundTask(_ task: BGProcessingTask) {
@@ -180,6 +219,47 @@ extension AppDelegate {
             LoggerProxy.event("BGTask scheduleSchedulerBackgroundTask succeeded to submit")
         } catch {
             LoggerProxy.event("BGTask scheduleSchedulerBackgroundTask failed to submit, error: \(error)")
+        }
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate (MOB-1467)
+
+/// Routes migration notification taps into the app (`.migrationNotificationTapped`) and controls
+/// foreground presentation of migration notifications (the SmartBanner already covers live state,
+/// so migration notifications present nothing while the app is in the foreground). `rootStore` is
+/// injected by `AppDelegate` rather than held here at construction time, since this delegate is
+/// set on `UNUserNotificationCenter.current()` synchronously in `didFinishLaunching`, before
+/// `AppDelegate`'s own `rootStore` would otherwise be considered "ready" — it's a stored property
+/// on `AppDelegate` either way, so both are initialized together in practice.
+final class MigrationNotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate {
+    var rootStore: StoreOf<Root>?
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if response.notification.request.identifier.hasPrefix(MigrationNotification.identifierPrefix) {
+            let rootStore = self.rootStore
+            DispatchQueue.main.async {
+                rootStore?.send(.initialization(.appDelegate(.migrationNotificationTapped)))
+            }
+        }
+
+        completionHandler()
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        if notification.request.identifier.hasPrefix(MigrationNotification.identifierPrefix) {
+            // The SmartBanner already covers live migration state while the app is foregrounded.
+            completionHandler([])
+        } else {
+            completionHandler([.banner, .list, .sound])
         }
     }
 }

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerInterface.swift
@@ -2,10 +2,10 @@
 //  MigrationBGSchedulerInterface.swift
 //  Zashi
 //
-//  Background-refresh status check + scheduling seams for the Orchard -> Ironwood migration's
-//  background execution (MOB-1467). Only `backgroundRefreshStatus` is live in this ticket
-//  (MOB-1466); the scheduling members are inert stubs the coordinator calls at the right cadence
-//  points so MOB-1467 only has to fill the `LiveKey`, never touch call sites.
+//  Background-refresh status check + scheduling seam for the Orchard -> Ironwood migration's
+//  background execution (MOB-1467): the `co.electriccoin.migration_transfer` `BGProcessingTask`
+//  cadence (§8.3) in scheduled mode, or a pre-scheduled "ready to send" local notification in
+//  manual mode — see `MigrationBGSchedulerLiveKey`'s `WakeupAction` decision function.
 //
 
 import UIKit
@@ -21,10 +21,20 @@ extension DependencyValues {
 @DependencyClient
 struct MigrationBGSchedulerClient: Sendable {
     var backgroundRefreshStatus: @Sendable () async -> UIBackgroundRefreshStatus = { .available }
-    // +30 min rule — no-op until MOB-1467
-    var scheduleFirstWindow: @Sendable () -> Void
-    // +6.5 h rule — no-op until MOB-1467
-    var scheduleNextWindow: @Sendable () -> Void
-    // no-op until MOB-1467
-    var cancelAll: @Sendable () -> Void
+    // Arms the next wakeup (+30 min rule): BG task request in scheduled mode, pre-scheduled
+    // "ready to send" notification in manual mode. First-check: no-ops (cancels) if migration is
+    // already `.complete`.
+    var scheduleFirstWindow: @Sendable () async -> Void
+    // Arms the next wakeup (+6.5 h rule), same branching as scheduleFirstWindow. Also the reset
+    // point after a manual/immediate foreground send.
+    var scheduleNextWindow: @Sendable () async -> Void
+    // Cancels the pending BG task request and every migration-prefixed notification (pending +
+    // delivered).
+    var cancelAll: @Sendable () async -> Void
+}
+
+/// Background-task identifier for the migration transfer wakeup (AppDelegate registers with it;
+/// prototype precedent).
+enum MigrationBGTask {
+    static let identifier = "co.electriccoin.migration_transfer"
 }

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
@@ -2,32 +2,121 @@
 //  MigrationBGSchedulerLiveKey.swift
 //  Zashi
 //
+//  Live implementation of `MigrationBGSchedulerClient`. The branch decision (submit a BG task vs.
+//  schedule a manual-mode "ready" notification vs. cancel everything because the migration is
+//  done) is factored into the pure, table-testable `WakeupAction.decide` (mirroring
+//  `MigrationDerivations` in MigrationManagerLiveKey.swift) so `MigrationBGSchedulerTests` can
+//  exercise every row without touching `BGTaskScheduler` or `UNUserNotificationCenter`; this file
+//  only computes the inputs and executes the resulting action.
+//
 
+@preconcurrency import BackgroundTasks
 import UIKit
 import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
 
 extension MigrationBGSchedulerClient: DependencyKey {
     static let liveValue: MigrationBGSchedulerClient = Self.live()
 
     static func live() -> Self {
-        MigrationBGSchedulerClient(
+        let impl = MigrationBGSchedulerImpl()
+
+        return MigrationBGSchedulerClient(
             backgroundRefreshStatus: {
                 await MainActor.run {
                     UIApplication.shared.backgroundRefreshStatus
                 }
             },
-            // TODO: [MOB-1467] Schedule the first background-refresh window ~30 minutes after a
-            // migration plan is committed (or re-committed via reschedule/recreate). Call sites in
-            // MOB-1466 already invoke this at every cadence-reset point (plan committed; reschedule
-            // confirmed; recovery recreate confirmed) — this only has to start honoring it.
-            scheduleFirstWindow: { },
-            // TODO: [MOB-1467] Schedule the next background-refresh window ~6.5 hours after the
-            // previous one fired (§8.3 cadence), or after a manual/immediate foreground send
-            // resets the cadence per the coordinator's call sites.
-            scheduleNextWindow: { },
-            // TODO: [MOB-1467] Cancel every pending background-refresh window (migration complete,
-            // user backed out, etc).
-            cancelAll: { }
+            scheduleFirstWindow: { await impl.arm(margin: MigrationCadence.firstWindowMargin) },
+            scheduleNextWindow: { await impl.arm(margin: MigrationCadence.nextWindowMargin) },
+            cancelAll: { await impl.cancelAll() }
         )
+    }
+}
+
+/// Composes `migrationManager` + `sdkSynchronizer` + `userNotifications` and turns their current
+/// readings into a `WakeupAction`, then executes it. `@unchecked Sendable`: holds no mutable state
+/// of its own — every dependency it wraps is itself `Sendable`.
+private final class MigrationBGSchedulerImpl: @unchecked Sendable {
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+    @Dependency(\.userNotifications) var userNotifications
+
+    /// Shared by `scheduleFirstWindow`/`scheduleNextWindow` — only the margin differs. The
+    /// complete-check choke point lives inside `WakeupAction.decide`, so both call sites uniformly
+    /// no-op (cancel) once the migration is done, without duplicating that check here.
+    func arm(margin: TimeInterval) async {
+        let progress = sdkSynchronizer.getMigrationProgress()
+        let preferredExecutableAt = progress?.nextTransferReadyAtHeight.flatMap { height in
+            sdkSynchronizer.estimateTimestamp(height).map { Date(timeIntervalSince1970: $0) }
+        }
+        let window = MigrationCadence.window(
+            margin: margin,
+            preferredExecutableAt: preferredExecutableAt,
+            now: Date()
+        )
+
+        let action = WakeupAction.decide(
+            state: sdkSynchronizer.getMigrationState(),
+            isManualDelivery: migrationManager.isManualDelivery(),
+            window: window,
+            nextTransferNumber: (progress?.completedTransfers ?? 0) + 1
+        )
+
+        await execute(action)
+    }
+
+    func cancelAll() async {
+        await execute(WakeupAction.cancelAll)
+    }
+
+    private func execute(_ action: WakeupAction) async {
+        switch action {
+        case let .submitTask(earliestBeginDate):
+            let request = BGProcessingTaskRequest(identifier: MigrationBGTask.identifier)
+            request.earliestBeginDate = earliestBeginDate
+            request.requiresNetworkConnectivity = true
+            request.requiresExternalPower = false
+            try? BGTaskScheduler.shared.submit(request)
+
+        case let .scheduleReadyNotification(number, at):
+            await userNotifications.scheduleMigrationNotification(.manualTransferReady(number: number), at)
+
+        case .cancelAll:
+            BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: MigrationBGTask.identifier)
+            await userNotifications.cancelMigrationNotifications()
+        }
+    }
+}
+
+// MARK: - Pure decision (table-testable, no SDK/framework dependency)
+
+/// What to do when arming the next migration wakeup. Scheduled mode submits a `BGProcessingTask`
+/// request; manual mode pre-schedules the "ready to send" notification (§4.4 approved decision 3
+/// — manual mode has no BG sessions, so its reminder is time-scheduled up front rather than
+/// posted live from a session). Either branch is skipped in favor of `.cancelAll` once the
+/// migration is `.complete` — the choke point that prevents an infinite +6.5 h no-op chain.
+enum WakeupAction: Equatable {
+    case submitTask(earliestBeginDate: Date)
+    case scheduleReadyNotification(number: Int, at: Date)
+    case cancelAll
+
+    /// `state` gates everything: `.complete` always wins, regardless of `isManualDelivery`.
+    /// Otherwise: manual -> `.scheduleReadyNotification`, scheduled -> `.submitTask`.
+    static func decide(
+        state: MigrationState,
+        isManualDelivery: Bool,
+        window: Date,
+        nextTransferNumber: Int
+    ) -> WakeupAction {
+        guard state != MigrationState.complete else {
+            return WakeupAction.cancelAll
+        }
+
+        if isManualDelivery {
+            return WakeupAction.scheduleReadyNotification(number: nextTransferNumber, at: window)
+        }
+
+        return WakeupAction.submitTask(earliestBeginDate: window)
     }
 }

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationCadence.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationCadence.swift
@@ -1,0 +1,25 @@
+//
+//  MigrationCadence.swift
+//  Zashi
+//
+//  Pure background-wakeup timing math for the Orchard -> Ironwood migration (MOB-1467, §8.3).
+//  `window(margin:preferredExecutableAt:now:)` is the single formula both `scheduleFirstWindow`
+//  and `scheduleNextWindow` use in the `MigrationBGSchedulerClient` LiveKey — only the margin
+//  constant differs between them. Table-tested directly, no SDK dependency (see
+//  MigrationCadenceTests).
+//
+
+import Foundation
+
+enum MigrationCadence {
+    static let firstWindowMargin: TimeInterval = 30 * 60          // §8.3
+    static let nextWindowMargin: TimeInterval = 6.5 * 60 * 60     // §8.3
+
+    /// earliestBeginDate for the next wakeup. The SDK's per-transfer executable time is
+    /// authoritative when known; the app margin is both the fallback (stubs return nil) and a
+    /// floor (never wake before the margin — §8.3's 30 min/6.5 h cushions over the SDK's
+    /// ~10 min/~6 h expectations).
+    static func window(margin: TimeInterval, preferredExecutableAt: Date?, now: Date) -> Date {
+        max(preferredExecutableAt ?? Date.distantPast, now.addingTimeInterval(margin))
+    }
+}

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
@@ -157,6 +157,16 @@ struct SDKSynchronizerClient: Sendable {
     var proposeNoteSplitPCZT: @Sendable () async -> Pczt = { Pczt() }                                         // [ext]
     var proposeMigrationPCZTs: @Sendable (MigrationSchedule) async -> [Pczt] = { _ in [] }                    // [ext]
     var storeSignedMigrationTransactions: @Sendable ([Pczt]) async -> Void = { _ in }                         // [ext]
+    // Keystone note-split broadcast — [ext]: symmetric with submitNoteSplit; SDK must treat this
+    // broadcast as the migration note split (state -> splitPendingConfirmation).
+    var submitSignedNoteSplit: @Sendable (Pczt) async -> TransferResult = { _ in TransferResult.success(txId: "") }
+    // Batch UR encoding of N migration PCZTs into ONE animated-QR session — [ext]: JOINT SDK +
+    // Keystone-team ask; device support unvalidated (feature-spec §14 risk). Stub: nil (screen dormant).
+    var urEncoderForMigrationPCZTBatch: @Sendable ([Pczt]) -> UREncoder? = { _ in nil }
+    // Batch parse of the scanned signed session back into N signed PCZTs — [ext], same ask. Input type
+    // matches the scan-checker plumbing (the accumulated UR; prefer a Data/cbor-based signature if the
+    // URKit type isn't Sendable-friendly — implementer resolves against ScanChecker.swift's shapes).
+    var parseMigrationPCZTBatch: @Sendable (Data) -> [Pczt]? = { _ in nil }
     // Lifecycle — Kotlin: initializePostUpgrade
     var initializeMigrationPostUpgrade: @Sendable () -> Void = { }                                            // [draft]
 }

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -292,13 +292,16 @@ extension SDKSynchronizerClient: DependencyKey {
             },
             // Migration (Orchard → Ironwood) — STUB: the SDK API does not exist yet (MOB-1455).
             // These compile the app against the expected contract and do nothing. When the real
-            // SDK lands, replace these closures here. The two broadcast-path stubs
-            // (`submitNoteSplit`, `executeNextPendingMigrationTransfer`) already acquire the
-            // transaction guard below — same `withSubmission` pattern as
+            // SDK lands, replace these closures here. The three broadcast-path stubs
+            // (`submitNoteSplit`, `executeNextPendingMigrationTransfer`, `submitSignedNoteSplit`)
+            // already acquire the transaction guard below — same `withSubmission` pattern as
             // `createAndSubmitProposedTransactions` — so they are correct-by-construction once
             // real broadcasting lands; every other migration stub here is read-only/non-broadcast
-            // and stays unguarded. `storeSignedMigrationTransactions` (Keystone/PCZT path,
-            // MOB-1468) only stores locally — it is not a broadcast and must stay unguarded.
+            // and stays unguarded. `storeSignedMigrationTransactions` (Keystone/PCZT path) is
+            // local storage, not a broadcast, so it stays unguarded too — MOB-1468. The two batch
+            // members (`urEncoderForMigrationPCZTBatch`, `parseMigrationPCZTBatch`) are plain
+            // inert stubs — their real implementations belong to KeystoneSDK/the Zcash SDK when
+            // the batch UR format exists (joint SDK + Keystone-team ask, unvalidated).
             getMigrationState: { .notStarted },
             migrationStateStream: { Just(MigrationState.notStarted).eraseToAnyPublisher() },
             getMigrationProgress: { nil },
@@ -339,6 +342,18 @@ extension SDKSynchronizerClient: DependencyKey {
             proposeNoteSplitPCZT: { Pczt() },
             proposeMigrationPCZTs: { _ in [] },
             storeSignedMigrationTransactions: { _ in },
+            submitSignedNoteSplit: { _ in
+                @Dependency(\.transactionGuard) var transactionGuard
+                do {
+                    return try await transactionGuard.withSubmission {
+                        TransferResult.success(txId: "")
+                    }
+                } catch {
+                    return TransferResult.networkError(retryable: true)
+                }
+            },
+            urEncoderForMigrationPCZTBatch: { _ in nil },
+            parseMigrationPCZTBatch: { _ in nil },
             initializeMigrationPostUpgrade: { }
         )
     }

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
@@ -111,6 +111,9 @@ extension SDKSynchronizerClient: TestDependencyKey {
         proposeNoteSplitPCZT: unimplemented("\(Self.self).proposeNoteSplitPCZT", placeholder: Pczt()),
         proposeMigrationPCZTs: unimplemented("\(Self.self).proposeMigrationPCZTs", placeholder: []),
         storeSignedMigrationTransactions: unimplemented("\(Self.self).storeSignedMigrationTransactions", placeholder: {}()),
+        submitSignedNoteSplit: unimplemented("\(Self.self).submitSignedNoteSplit", placeholder: .success(txId: "")),
+        urEncoderForMigrationPCZTBatch: unimplemented("\(Self.self).urEncoderForMigrationPCZTBatch", placeholder: nil),
+        parseMigrationPCZTBatch: unimplemented("\(Self.self).parseMigrationPCZTBatch", placeholder: nil),
         initializeMigrationPostUpgrade: unimplemented("\(Self.self).initializeMigrationPostUpgrade", placeholder: {}())
     )
 }
@@ -190,6 +193,9 @@ extension SDKSynchronizerClient {
         proposeNoteSplitPCZT: { Pczt() },
         proposeMigrationPCZTs: { _ in [] },
         storeSignedMigrationTransactions: { _ in },
+        submitSignedNoteSplit: { _ in TransferResult.success(txId: "") },
+        urEncoderForMigrationPCZTBatch: { _ in nil },
+        parseMigrationPCZTBatch: { _ in nil },
         initializeMigrationPostUpgrade: { }
     )
 
@@ -318,7 +324,10 @@ extension SDKSynchronizerClient {
         updateTransparentAddressTransactions: @escaping @Sendable (String) async throws -> TransparentAddressCheckResult = { _ in .notFound },
         fetchUTXOsByAddress: @escaping @Sendable (String, AccountUUID) async throws -> TransparentAddressCheckResult = { _, _ in .notFound },
         enhanceTransactionBy: @escaping @Sendable (String) async throws -> Void = { _ in },
-        getTreeState: @escaping @Sendable (UInt64) async throws -> Data = { _ in Data() }
+        getTreeState: @escaping @Sendable (UInt64) async throws -> Data = { _ in Data() },
+        submitSignedNoteSplit: @escaping @Sendable (Pczt) async -> TransferResult = { _ in TransferResult.success(txId: "") },
+        urEncoderForMigrationPCZTBatch: @escaping @Sendable ([Pczt]) -> UREncoder? = { _ in nil },
+        parseMigrationPCZTBatch: @escaping @Sendable (Data) -> [Pczt]? = { _ in nil }
     ) -> SDKSynchronizerClient {
         SDKSynchronizerClient(
             stateStream: stateStream,
@@ -394,6 +403,9 @@ extension SDKSynchronizerClient {
             proposeNoteSplitPCZT: { Pczt() },
             proposeMigrationPCZTs: { _ in [] },
             storeSignedMigrationTransactions: { _ in },
+            submitSignedNoteSplit: submitSignedNoteSplit,
+            urEncoderForMigrationPCZTBatch: urEncoderForMigrationPCZTBatch,
+            parseMigrationPCZTBatch: parseMigrationPCZTBatch,
             initializeMigrationPostUpgrade: { }
         )
     }

--- a/secant/Sources/Dependencies/UserNotifications/MigrationNotification.swift
+++ b/secant/Sources/Dependencies/UserNotifications/MigrationNotification.swift
@@ -1,0 +1,82 @@
+//
+//  MigrationNotification.swift
+//  Zashi
+//
+//  Pure mapping from a migration background event onto the local notification's identifier/
+//  title/body (MOB-1467, feature spec §4.4). `MigrationBannerVariant`-style: no SDK dependency,
+//  no I/O — `MigrationBGSchedulerLiveKey` and `RootInitialization`'s BG session decision tree
+//  construct a case and hand it to `userNotifications.scheduleMigrationNotification(_:at:)`.
+//  Table-tested directly (see MigrationNotificationTests).
+//
+//  Titles are short new copy ("Migration update" / "Action needed" / "Migration complete") —
+//  §4.4 only pins the bodies verbatim; PR flags these for design confirmation against the Figma
+//  lock-screen mocks.
+//
+
+@preconcurrency import ZcashLightClientKit
+
+enum MigrationNotification: Equatable, Sendable {
+    /// Stable prefix shared by every identifier below — phase 2's tap-routing (matching a
+    /// delivered notification's identifier) and `cancelMigrationNotifications`/
+    /// `clearDeliveredMigrationNotifications` (filtering pending/delivered requests) both key off
+    /// this constant rather than restating the literal.
+    static let identifierPrefix = "migration."
+
+    case transferComplete(number: Int, total: Int, nextInHours: Int, remaining: Zatoshi)
+    case transferWaiting(number: Int)
+    case planNeedsUpdate                 // covers BOTH matrix rows 3+4 (identical copy)
+    case manualTransferReady(number: Int)
+    case migrationComplete
+
+    /// Stable, "migration."-prefixed — re-posting the same case replaces the previous pending/
+    /// delivered notification (no dedup marker needed elsewhere).
+    var identifier: String {
+        switch self {
+        case .transferComplete:
+            return "\(Self.identifierPrefix)transferComplete"
+        case .transferWaiting:
+            return "\(Self.identifierPrefix)transferWaiting"
+        case .planNeedsUpdate:
+            return "\(Self.identifierPrefix)planNeedsUpdate"
+        case .manualTransferReady:
+            return "\(Self.identifierPrefix)manualTransferReady"
+        case .migrationComplete:
+            return "\(Self.identifierPrefix)complete"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .transferComplete:
+            return String(localizable: .migrationNotificationTransferCompleteTitle)
+        case .transferWaiting, .planNeedsUpdate, .manualTransferReady:
+            return String(localizable: .migrationNotificationActionNeededTitle)
+        case .migrationComplete:
+            return String(localizable: .migrationNotificationMigrationCompleteTitle)
+        }
+    }
+
+    /// §4.4 matrix copy verbatim. `remaining` renders via `Zatoshi.decimalString()`;
+    /// `nextInHours` is the armed-window interval rounded to hours (caller-computed).
+    var body: String {
+        switch self {
+        case let .transferComplete(number, total, nextInHours, remaining):
+            return String(
+                localizable: .migrationNotificationTransferCompleteBody(
+                    number,
+                    total,
+                    nextInHours,
+                    remaining.decimalString()
+                )
+            )
+        case let .transferWaiting(number):
+            return String(localizable: .migrationNotificationTransferWaitingBody(number))
+        case .planNeedsUpdate:
+            return String(localizable: .migrationNotificationPlanNeedsUpdateBody)
+        case let .manualTransferReady(number):
+            return String(localizable: .migrationNotificationManualTransferReadyBody(number))
+        case .migrationComplete:
+            return String(localizable: .migrationNotificationMigrationCompleteBody)
+        }
+    }
+}

--- a/secant/Sources/Dependencies/UserNotifications/UserNotificationsInterface.swift
+++ b/secant/Sources/Dependencies/UserNotifications/UserNotificationsInterface.swift
@@ -2,9 +2,9 @@
 //  UserNotificationsInterface.swift
 //  Zashi
 //
-//  Authorization-only seam over `UNUserNotificationCenter` for the Orchard -> Ironwood
-//  migration's Notifications permission screen (MOB-1466). MOB-1467 extends this client with
-//  local-notification scheduling (§4.4 matrix) — do not add those members here yet.
+//  Seam over `UNUserNotificationCenter` for the Orchard -> Ironwood migration: authorization
+//  (MOB-1466's Notifications permission screen) plus local-notification scheduling (MOB-1467,
+//  §4.4 matrix).
 //
 
 import UserNotifications
@@ -21,4 +21,10 @@ extension DependencyValues {
 struct UserNotificationsClient: Sendable {
     var authorizationStatus: @Sendable () async -> UNAuthorizationStatus = { .notDetermined }
     var requestAuthorization: @Sendable () async -> Bool = { false }   // .alert, .sound, .badge
+    // nil date = deliver now
+    var scheduleMigrationNotification: @Sendable (MigrationNotification, Date?) async -> Void
+    // pending + delivered, "migration." prefix
+    var cancelMigrationNotifications: @Sendable () async -> Void
+    // delivered ONLY — pending (manual ready reminder) must survive
+    var clearDeliveredMigrationNotifications: @Sendable () async -> Void
 }

--- a/secant/Sources/Dependencies/UserNotifications/UserNotificationsLiveKey.swift
+++ b/secant/Sources/Dependencies/UserNotifications/UserNotificationsLiveKey.swift
@@ -2,6 +2,10 @@
 //  UserNotificationsLiveKey.swift
 //  Zashi
 //
+//  LiveKey itself is untested (system framework) — everything decision-shaped (which
+//  `MigrationNotification` case, which date) lives in the pure layer / reducer that calls these
+//  members, per MOB-1467.
+//
 
 import UserNotifications
 import ComposableArchitecture
@@ -22,6 +26,50 @@ extension UserNotificationsClient: DependencyKey {
                 } catch {
                     return false
                 }
+            },
+            scheduleMigrationNotification: { notification, date in
+                let content = UNMutableNotificationContent()
+                content.title = notification.title
+                content.body = notification.body
+                content.sound = .default
+
+                let trigger: UNTimeIntervalNotificationTrigger?
+                if let date {
+                    // Immediate delivery (nil date) needs no trigger; otherwise fire at the
+                    // interval between now and the target date, floored at a hair above zero so
+                    // a past/imminent date still delivers rather than being rejected.
+                    let interval = max(date.timeIntervalSinceNow, 0.1)
+                    trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
+                } else {
+                    trigger = nil
+                }
+
+                let request = UNNotificationRequest(
+                    identifier: notification.identifier,
+                    content: content,
+                    trigger: trigger
+                )
+
+                try? await UNUserNotificationCenter.current().add(request)
+            },
+            cancelMigrationNotifications: {
+                let center = UNUserNotificationCenter.current()
+                let pendingIds = await center.pendingNotificationRequests()
+                    .map { $0.identifier }
+                    .filter { $0.hasPrefix(MigrationNotification.identifierPrefix) }
+                center.removePendingNotificationRequests(withIdentifiers: pendingIds)
+
+                let deliveredIds = await center.deliveredNotifications()
+                    .map { $0.request.identifier }
+                    .filter { $0.hasPrefix(MigrationNotification.identifierPrefix) }
+                center.removeDeliveredNotifications(withIdentifiers: deliveredIds)
+            },
+            clearDeliveredMigrationNotifications: {
+                let center = UNUserNotificationCenter.current()
+                let deliveredIds = await center.deliveredNotifications()
+                    .map { $0.request.identifier }
+                    .filter { $0.hasPrefix(MigrationNotification.identifierPrefix) }
+                center.removeDeliveredNotifications(withIdentifiers: deliveredIds)
             }
         )
     }

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -168,30 +168,21 @@ extension MigrationCoordFlow {
             case .path(.element(id: _, action: .scan(.foundPCZTBatch(let signed)))):
                 guard let context = state.pendingKeystoneSigning else { return .none }
 
+                // Empty batch: nothing decoded to a usable signed PCZT — in EVERY context this
+                // abandons the signing session like a rejection (deferred pop of scan + sign back
+                // to the initiating screen, context cleared) and never submits or stores anything
+                // (no-partial-storage invariant). The user re-initiates from the confirm button.
+                guard !signed.isEmpty else { return .send(.keystoneScanAbandoned) }
+
                 switch context {
                 case .noteSplit:
-                    // Empty batch: nothing decoded to a usable signed PCZT — treat it as a failure
-                    // the same way an unparseable/rejected QR does elsewhere, without ever calling
-                    // `submitSignedNoteSplit` (no-partial-storage invariant).
-                    guard let pczt = signed.first else {
-                        return .send(
-                            .keystoneSigningSubmitted(
-                                context: .noteSplit,
-                                result: .networkError(retryable: true),
-                                signedPczt: nil
-                            )
-                        )
-                    }
+                    guard let pczt = signed.first else { return .none }
                     return .run { [sdkSynchronizer] send in
                         let result = await sdkSynchronizer.submitSignedNoteSplit(pczt)
                         await send(.keystoneSigningSubmitted(context: .noteSplit, result: result, signedPczt: pczt))
                     }
 
                 case .planCommit, .immediateReview:
-                    // Empty batch: nothing to store — no-partial-storage invariant (never call
-                    // `storeSignedMigrationTransactions` with an incomplete/empty set).
-                    guard !signed.isEmpty else { return .none }
-
                     return .run { [sdkSynchronizer] send in
                         await sdkSynchronizer.storeSignedMigrationTransactions(signed)
                         await send(.keystoneSigningSubmitted(context: context, result: nil, signedPczt: nil))
@@ -213,6 +204,12 @@ extension MigrationCoordFlow {
 
             case .keystoneSignRejected:
                 state.pendingKeystoneSigning = nil
+                let _ = state.path.popLast()
+                return .none
+
+            case .keystoneScanAbandoned:
+                state.pendingKeystoneSigning = nil
+                let _ = state.path.popLast()
                 let _ = state.path.popLast()
                 return .none
 

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -122,8 +122,6 @@ extension MigrationCoordFlow {
                     return .send(.flowFinished)
                 }
 
-                migrationBGScheduler.scheduleFirstWindow()
-
                 switch planState.variant {
                 case .scheduled, .recreated:
                     state.path.append(.scheduled(MigrationScheduled.State()))
@@ -132,7 +130,7 @@ extension MigrationCoordFlow {
                     sendingState.networkPrivacyOptions = state.networkPrivacyOptions
                     state.path.append(.sending(sendingState))
                 }
-                return .none
+                return .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleFirstWindow() }
 
                 // MARK: - ReviewTransfer
 
@@ -201,7 +199,7 @@ extension MigrationCoordFlow {
                 }
                 return .run { [migrationBGScheduler, sdkSynchronizer] send in
                     await sdkSynchronizer.rescheduleStalledMigrationTransfer()
-                    migrationBGScheduler.scheduleFirstWindow()
+                    await migrationBGScheduler.scheduleFirstWindow()
                     let rows = sdkSynchronizer.migrationTransfers()
                     let planState = rescheduledPlanState(rows: rows)
                     await send(.pushHydratedPathState(.transferPlan(planState)))

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -7,6 +7,16 @@
 //  Notifications -> NetworkPrivacy -> TransferPlan). See the MOB-1466 implementation spec's
 //  `MigrationCoordFlow` section for the full chaining table this mirrors row by row.
 //
+//  MOB-1468 (Keystone) adds a QR sign/scan round-trip ahead of the three signing sources
+//  (NoteSplit/TransferPlan/ReviewTransfer): each delegates `.keystoneSignRequested(pczts)` instead
+//  of signing locally, which sets `pendingKeystoneSigning` and pushes `keystoneSign`;
+//  `keystoneSign(.delegate(.getSignature))` pushes `scan` configured with the migration batch
+//  checker; `scan(.foundPCZTBatch(signed))` switches on `pendingKeystoneSigning` to submit/store the
+//  signed PCZTs and resume whichever chain the source represents, popping both pushed elements and
+//  clearing the context. `keystoneSign(.delegate(.rejected))` pops back to the signing source with
+//  its state untouched (no partial storage ever happens on that path). See the "Keystone signing"
+//  section below.
+//
 
 import Foundation
 import ComposableArchitecture
@@ -122,15 +132,7 @@ extension MigrationCoordFlow {
                     return .send(.flowFinished)
                 }
 
-                switch planState.variant {
-                case .scheduled, .recreated:
-                    state.path.append(.scheduled(MigrationScheduled.State()))
-                case .manual:
-                    var sendingState = MigrationSending.State(totalCount: 1)
-                    sendingState.networkPrivacyOptions = state.networkPrivacyOptions
-                    state.path.append(.sending(sendingState))
-                }
-                return .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleFirstWindow() }
+                return transferPlanPostConfirmChain(variant: planState.variant, state: &state)
 
                 // MARK: - ReviewTransfer
 
@@ -138,6 +140,80 @@ extension MigrationCoordFlow {
                 var sendingState = MigrationSending.State(totalCount: 1)
                 sendingState.networkPrivacyOptions = state.networkPrivacyOptions
                 state.path.append(.sending(sendingState))
+                return .none
+
+                // MARK: - Keystone signing (MOB-1468)
+
+            case .path(.element(id: _, action: .noteSplit(.delegate(.keystoneSignRequested(let pczts))))):
+                state.pendingKeystoneSigning = .noteSplit
+                state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: pczts)))
+                return .none
+
+            case .path(.element(id: _, action: .transferPlan(.delegate(.keystoneSignRequested(let pczts))))):
+                state.pendingKeystoneSigning = .planCommit
+                state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: pczts)))
+                return .none
+
+            case .path(.element(id: _, action: .reviewTransfer(.delegate(.keystoneSignRequested(let pczts))))):
+                state.pendingKeystoneSigning = .immediateReview
+                state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: pczts)))
+                return .none
+
+            case .path(.element(id: _, action: .keystoneSign(.delegate(.getSignature)))):
+                var scanState = Scan.State.initial
+                scanState.checkers = [.keystoneMigrationBatchScanChecker]
+                state.path.append(.scan(scanState))
+                return .none
+
+            case .path(.element(id: _, action: .scan(.foundPCZTBatch(let signed)))):
+                guard let context = state.pendingKeystoneSigning else { return .none }
+
+                switch context {
+                case .noteSplit:
+                    // Empty batch: nothing decoded to a usable signed PCZT — treat it as a failure
+                    // the same way an unparseable/rejected QR does elsewhere, without ever calling
+                    // `submitSignedNoteSplit` (no-partial-storage invariant).
+                    guard let pczt = signed.first else {
+                        return .send(
+                            .keystoneSigningSubmitted(
+                                context: .noteSplit,
+                                result: .networkError(retryable: true),
+                                signedPczt: nil
+                            )
+                        )
+                    }
+                    return .run { [sdkSynchronizer] send in
+                        let result = await sdkSynchronizer.submitSignedNoteSplit(pczt)
+                        await send(.keystoneSigningSubmitted(context: .noteSplit, result: result, signedPczt: pczt))
+                    }
+
+                case .planCommit, .immediateReview:
+                    // Empty batch: nothing to store — no-partial-storage invariant (never call
+                    // `storeSignedMigrationTransactions` with an incomplete/empty set).
+                    guard !signed.isEmpty else { return .none }
+
+                    return .run { [sdkSynchronizer] send in
+                        await sdkSynchronizer.storeSignedMigrationTransactions(signed)
+                        await send(.keystoneSigningSubmitted(context: context, result: nil, signedPczt: nil))
+                    }
+                }
+
+            case .keystoneSigningSubmitted(let context, let result, let signedPczt):
+                return resumeAfterKeystoneSigning(context: context, result: result, signedPczt: signedPczt, state: &state)
+
+            case .path(.element(id: _, action: .keystoneSign(.delegate(.rejected)))):
+                // No-partial-storage invariant: nothing was submitted/stored — just pop back to the
+                // signing source with its state untouched (NoteSplit still explainer, plan/review
+                // still unsigned) and clear the context. The pop is deferred to a follow-up
+                // self-action (mirrors `sendNowCompleted`'s deferred pop) rather than done inline
+                // here: `.forEach(\.path, action:)` still needs to deliver this SAME action to the
+                // `keystoneSign` element after this case returns, and popping it first would leave
+                // `.forEach` with no element to deliver to (a TCA "missing element" runtime error).
+                return .send(.keystoneSignRejected)
+
+            case .keystoneSignRejected:
+                state.pendingKeystoneSigning = nil
+                let _ = state.path.popLast()
                 return .none
 
                 // MARK: - Sending
@@ -228,6 +304,84 @@ extension MigrationCoordFlow {
 
             default: return .none
             }
+        }
+    }
+
+    // MARK: - TransferPlan: shared post-confirm chain (software `.confirmed` + Keystone `planCommit`)
+
+    /// Scheduled/recreated push `.scheduled`; manual pushes `.sending` (totalCount 1, current
+    /// network-privacy options) — then schedules the first background window either way. Shared by
+    /// the software `TransferPlan.delegate(.confirmed)` row and the Keystone `planCommit` resume
+    /// (`resumeAfterKeystoneSigning`), which both reach this point with a signed+stored schedule.
+    private func transferPlanPostConfirmChain(
+        variant: MigrationTransferPlan.State.Variant,
+        state: inout MigrationCoordFlow.State
+    ) -> Effect<MigrationCoordFlow.Action> {
+        switch variant {
+        case .scheduled, .recreated:
+            state.path.append(.scheduled(MigrationScheduled.State()))
+        case .manual:
+            var sendingState = MigrationSending.State(totalCount: 1)
+            sendingState.networkPrivacyOptions = state.networkPrivacyOptions
+            state.path.append(.sending(sendingState))
+        }
+        return .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleFirstWindow() }
+    }
+
+    // MARK: - Keystone signing (MOB-1468): resume after submit/store
+
+    /// Pops `scan`+`keystoneSign` (the two elements the QR round-trip pushed) and resumes whichever
+    /// chain `context` represents, mirroring how the equivalent software `.confirmed` row would
+    /// proceed from the now-topmost signing-source element:
+    /// - `.noteSplit`: mutates the `noteSplit` element now on top in place (the `isRescheduling`
+    ///   precedent) — `phase = .splitting`, `signedNoteSplitPczt` set to the PCZT that was
+    ///   submitted — then applies `result` exactly like that element's own `.splitResult` handling
+    ///   (success sets `txId`; failure presents the failure sheet).
+    /// - `.planCommit`: the `transferPlan` element now on top never re-signs again — resumes via
+    ///   `transferPlanPostConfirmChain(variant:state:)`, identical to the software `.confirmed` row.
+    /// - `.immediateReview`: pushes `.sending`, identical to the software `reviewTransfer.confirmed`
+    ///   row.
+    ///
+    /// Clears `pendingKeystoneSigning` in every case.
+    private func resumeAfterKeystoneSigning(
+        context: MigrationCoordFlow.KeystoneSigningContext,
+        result: TransferResult?,
+        signedPczt: Pczt?,
+        state: inout MigrationCoordFlow.State
+    ) -> Effect<MigrationCoordFlow.Action> {
+        state.pendingKeystoneSigning = nil
+        state.path.removeLast(2)
+
+        switch context {
+        case .noteSplit:
+            guard
+                let noteSplitId = state.path.ids.last,
+                case .noteSplit(var noteSplitState) = state.path[id: noteSplitId]
+            else {
+                return .none
+            }
+
+            noteSplitState.phase = .splitting
+            noteSplitState.signedNoteSplitPczt = signedPczt
+            switch result {
+            case .success(let txId):
+                noteSplitState.txId = txId
+                noteSplitState.isFailurePresented = false
+            case .networkError, .invalidNote, .expired, .none:
+                noteSplitState.isFailurePresented = true
+            }
+            state.path[id: noteSplitId] = .noteSplit(noteSplitState)
+            return .none
+
+        case .planCommit:
+            guard case let .transferPlan(planState) = state.path.last else { return .none }
+            return transferPlanPostConfirmChain(variant: planState.variant, state: &state)
+
+        case .immediateReview:
+            var sendingState = MigrationSending.State(totalCount: 1)
+            sendingState.networkPrivacyOptions = state.networkPrivacyOptions
+            state.path.append(.sending(sendingState))
+            return .none
         }
     }
 

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
@@ -109,6 +109,10 @@ struct MigrationCoordFlow {
         /// `keystoneSign` element inline in the `.path(.element(...))` case would race
         /// `.forEach(\.path, action:)`'s delivery of that same action to the (then-missing) element.
         case keystoneSignRejected
+        /// Internal: an empty scanned batch abandons the signing session — pops BOTH the `scan`
+        /// and `keystoneSign` elements back to the initiating screen (deferred like
+        /// `keystoneSignRejected`, since `scan` is the acting element) and clears the context.
+        case keystoneScanAbandoned
     }
 
     @Dependency(\.migrationBGScheduler) var migrationBGScheduler

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
@@ -9,6 +9,12 @@
 //  `sendFormState`); every other screen lives in `path`. Everything here runs against the inert
 //  SDK stubs — it goes live when the real SDK (MOB-1455) fills them in.
 //
+//  MOB-1468 (Keystone) adds `keystoneSign`/`scan` path elements and `pendingKeystoneSigning`: the
+//  three signing sources (NoteSplit/TransferPlan/ReviewTransfer) delegate `.keystoneSignRequested`
+//  instead of signing locally, the coordinator routes through a QR sign/scan round-trip, then
+//  resumes whichever chain the source represents. See `MigrationCoordFlowCoordinator.swift`'s
+//  Keystone rows for the routing table.
+//
 
 import SwiftUI
 import ComposableArchitecture
@@ -16,15 +22,27 @@ import ComposableArchitecture
 
 @Reducer
 struct MigrationCoordFlow {
+    /// MOB-1468 (Keystone): which signing source is awaiting/mid QR round-trip, so
+    /// `scan(.foundPCZTBatch)` knows which chain to resume once the signed PCZTs come back.
+    enum KeystoneSigningContext: Equatable {
+        case noteSplit
+        /// Fresh + re-created plans (`requiresSigning == true`) — the rescheduled variant never
+        /// re-signs, so it never reaches this context.
+        case planCommit
+        case immediateReview
+    }
+
     @Reducer(state: .equatable)
     enum Path {
         case backgroundDelivery(MigrationBackgroundDelivery)
         case complete(MigrationComplete)
+        case keystoneSign(MigrationKeystoneSign)
         case networkPrivacy(MigrationNetworkPrivacy)
         case noteSplit(MigrationNoteSplit)
         case notifications(MigrationNotifications)
         case recovery(MigrationRecovery)
         case reviewTransfer(MigrationReviewTransfer)
+        case scan(Scan)
         case scheduled(MigrationScheduled)
         case sending(MigrationSending)
         case status(MigrationStatus)
@@ -41,6 +59,10 @@ struct MigrationCoordFlow {
         /// Held here once confirmed on the Network Privacy screen (or defaulted when S5 is
         /// skipped) so Sending's coordinator-configured state can inject it.
         var networkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        /// MOB-1468 (Keystone): set when a `.keystoneSignRequested` delegate pushes `keystoneSign`,
+        /// cleared once the QR round-trip resolves (either resumed via `foundPCZTBatch` or backed
+        /// out via `.rejected`).
+        var pendingKeystoneSigning: KeystoneSigningContext?
 
         init() { }
     }
@@ -75,6 +97,18 @@ struct MigrationCoordFlow {
         /// Internal: sendNow's Sending screen finished (`.closed`) — refresh the `.status` element
         /// beneath with freshly-read rows and pop back to it.
         case sendNowCompleted(rows: [MigrationTransferRow])
+        /// Internal: MOB-1468 Keystone `scan(.foundPCZTBatch)` finished submitting (noteSplit) or
+        /// storing (planCommit/immediateReview) the signed PCZTs — pops `scan`+`keystoneSign` and
+        /// resumes the chain `context` represents. `result` carries the noteSplit broadcast outcome
+        /// (mirrors the software `.splitResult` handling) and `signedPczt` the PCZT that was
+        /// submitted (so the mutated `noteSplit` element can hold it for `retryTapped`); both `nil`
+        /// for the other two contexts, whose `storeSignedMigrationTransactions` call returns `Void`.
+        case keystoneSigningSubmitted(context: KeystoneSigningContext, result: TransferResult?, signedPczt: Pczt?)
+        /// Internal: MOB-1468 `keystoneSign(.delegate(.rejected))`'s pop, deferred to a follow-up
+        /// self-action for the same reason `sendNowCompleted` defers its pop — popping the
+        /// `keystoneSign` element inline in the `.path(.element(...))` case would race
+        /// `.forEach(\.path, action:)`'s delivery of that same action to the (then-missing) element.
+        case keystoneSignRejected
     }
 
     @Dependency(\.migrationBGScheduler) var migrationBGScheduler

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowView.swift
@@ -32,6 +32,8 @@ struct MigrationCoordFlowView: View {
                     MigrationBackgroundDeliveryView(store: store)
                 case let .complete(store):
                     MigrationCompleteView(store: store)
+                case let .keystoneSign(store):
+                    MigrationKeystoneSignView(store: store)
                 case let .networkPrivacy(store):
                     MigrationNetworkPrivacyView(store: store)
                 case let .noteSplit(store):
@@ -42,6 +44,8 @@ struct MigrationCoordFlowView: View {
                     MigrationRecoveryView(store: store)
                 case let .reviewTransfer(store):
                     MigrationReviewTransferView(store: store)
+                case let .scan(store):
+                    ScanView(store: store)
                 case let .scheduled(store):
                     MigrationScheduledView(store: store)
                 case let .sending(store):

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryView.swift
@@ -25,7 +25,7 @@ struct MigrationEntryView: View {
             VStack(spacing: 0) {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
-                        MigrationPairedIcons()
+                        MigrationPairedIcons(vendor: store.selectedWalletAccount?.vendor ?? .zcash)
                             .padding(.bottom, 16)
 
                         Text(localizable: .migrationEntryTitle)

--- a/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignStore.swift
+++ b/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignStore.swift
@@ -1,0 +1,65 @@
+//
+//  MigrationKeystoneSignStore.swift
+//  zodl
+//
+//  Migration-owned Keystone signing screen (MOB-1468, Figma sign frame 2867:11861). Visually
+//  mirrors `SignWithKeystoneView`'s composition exactly (SendConfirmation cannot host this — its
+//  PCZT pipeline is single-PCZT and proposal-centric). Batched single-session signing: this screen
+//  always carries the full `[Pczt]` for the current signing context (note split / plan commit /
+//  immediate review are all sessions of 1..N, uniformly). The `UREncoder` is computed live in the
+//  view via `sdkSynchronizer.urEncoderForMigrationPCZTBatch(pczts)` — never cached in `State` (the
+//  same approach `SignWithKeystoneView` uses for `urEncoderForPCZT`), since `UREncoder` is a
+//  non-`Equatable`, non-`Sendable` class that cannot live in an `@ObservableState` `Equatable`
+//  struct. Stubbed today: the batch encoder returns `nil`, so the QR area renders the same
+//  empty/loading treatment `SignWithKeystoneView` shows while `pcztForUI == nil` — dormant, by
+//  design, until the SDK + Keystone batch support land (MOB-1455). Coordinator wiring
+//  (`.getSignature` -> scan -> submit/store) is MOB-1468 phase 2's job.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationKeystoneSign {
+    @ObservableState
+    struct State: Equatable {
+        var pczts: [Pczt] = []
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+
+        init(pczts: [Pczt] = []) {
+            self.pczts = pczts
+        }
+    }
+
+    enum Action: Equatable {
+        case delegate(Delegate)
+        case getSignatureTapped
+        case onAppear
+        case rejectTapped
+
+        enum Delegate: Equatable {
+            case getSignature
+            case rejected
+        }
+    }
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        Reduce { _, action in
+            switch action {
+            case .delegate:
+                return .none
+
+            case .getSignatureTapped:
+                return .send(.delegate(.getSignature))
+
+            case .onAppear:
+                return .none
+
+            case .rejectTapped:
+                return .send(.delegate(.rejected))
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignStore.swift
+++ b/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignStore.swift
@@ -12,8 +12,8 @@
 //  non-`Equatable`, non-`Sendable` class that cannot live in an `@ObservableState` `Equatable`
 //  struct. Stubbed today: the batch encoder returns `nil`, so the QR area renders the same
 //  empty/loading treatment `SignWithKeystoneView` shows while `pcztForUI == nil` — dormant, by
-//  design, until the SDK + Keystone batch support land (MOB-1455). Coordinator wiring
-//  (`.getSignature` -> scan -> submit/store) is MOB-1468 phase 2's job.
+//  design, until the SDK + Keystone batch support land (MOB-1455). The coordinator consumes both
+//  delegates (`.getSignature` -> scan -> submit/store, `.rejected` -> deferred pop) — MOB-1468.
 //
 
 import ComposableArchitecture

--- a/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignView.swift
+++ b/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignView.swift
@@ -1,0 +1,173 @@
+//
+//  MigrationKeystoneSignView.swift
+//  zodl
+//
+//  Migration-owned Keystone signing screen (MOB-1468, Figma sign frame 2867:11861). Visually
+//  mirrors `SignWithKeystoneView`'s composition exactly: account card with Keystone logo +
+//  truncated ZIP-316 address + "Hardware" badge, `AnimatedQRCode` (or the same empty/loading
+//  treatment while the batch encoder is nil), "Scan with your Keystone wallet" copy, Reject
+//  (secondary/destructive) / Get Signature (primary). Reuses `SignWithKeystoneView`'s existing
+//  localized keys — zero new strings.
+//
+
+import SwiftUI
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+struct MigrationKeystoneSignView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @Perception.Bindable var store: StoreOf<MigrationKeystoneSign>
+
+    @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+
+    init(store: StoreOf<MigrationKeystoneSign>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        accountCard
+                            .padding(.top, 40)
+
+                        qrArea
+                            .padding(.top, 32)
+
+                        Text(localizable: .keystoneSignWithTitle)
+                            .zFont(.medium, size: 16, style: Design.Text.primary)
+                            .padding(.top, 32)
+
+                        Text(localizable: .keystoneSignWithDesc)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .screenHorizontalPadding()
+                            .lineLimit(2)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.top, 4)
+                    }
+                }
+
+                Spacer()
+
+                ZashiButton(
+                    String(localizable: .keystoneSignWithReject),
+                    type: .destructive1
+                ) {
+                    store.send(.rejectTapped)
+                }
+                .padding(.bottom, 8)
+
+                ZashiButton(
+                    String(localizable: .keystoneSignWithGetSignature)
+                ) {
+                    store.send(.getSignatureTapped)
+                }
+                .padding(.bottom, 24)
+            }
+            .onAppear {
+                store.send(.onAppear)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 20)
+        }
+        .screenHorizontalPadding()
+        .applyScreenBackground()
+        .navigationBarBackButtonHidden(true)
+        .navigationBarTitleDisplayMode(.inline)
+        .screenTitle(String(localizable: .keystoneSignWithSignTransaction))
+    }
+
+    // MARK: - Account card
+
+    @ViewBuilder private var accountCard: some View {
+        HStack(spacing: 0) {
+            Asset.Assets.Partners.keystoneLogo.image
+                .resizable()
+                .frame(width: 24, height: 24)
+                .padding(8)
+                .background {
+                    Circle()
+                        .fill(Design.Surfaces.bgAlt.color(colorScheme))
+                }
+                .padding(.trailing, 12)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(localizable: .accountsKeystone)
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                Text(store.selectedWalletAccount?.unifiedAddress?.zip316 ?? "")
+                    .zFont(fontFamily: .robotoMono, size: 12, style: Design.Text.tertiary)
+            }
+
+            Spacer()
+
+            Text(localizable: .keystoneSignWithHardware)
+                .zFont(.medium, size: 12, style: Design.Utility.HyperBlue._700)
+                .padding(.vertical, 2)
+                .padding(.horizontal, 8)
+                .background {
+                    RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                        .fill(Design.Utility.HyperBlue._50.color(colorScheme))
+                        .background {
+                            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                                .stroke(Design.Utility.HyperBlue._200.color(colorScheme))
+                        }
+                }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+        }
+    }
+
+    // MARK: - QR area
+
+    @ViewBuilder private var qrArea: some View {
+        if let encoder = sdkSynchronizer.urEncoderForMigrationPCZTBatch(store.pczts) {
+            AnimatedQRCode(urEncoder: encoder, size: 250)
+                .frame(width: 216, height: 216)
+                .padding(24)
+                .background {
+                    RoundedRectangle(cornerRadius: Design.Radius._xl)
+                        .fill(Asset.Colors.ZDesign.Base.bone.color)
+                        .background {
+                            RoundedRectangle(cornerRadius: Design.Radius._xl)
+                                .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+                        }
+                }
+        } else {
+            VStack {
+                ProgressView()
+            }
+            .frame(width: 216, height: 216)
+            .padding(24)
+            .background {
+                RoundedRectangle(cornerRadius: Design.Radius._xl)
+                    .fill(Asset.Colors.ZDesign.Base.bone.color)
+                    .background {
+                        RoundedRectangle(cornerRadius: Design.Radius._xl)
+                            .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+                    }
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Dormant (stub encoder)") {
+    NavigationView {
+        MigrationKeystoneSignView(
+            store: StoreOf<MigrationKeystoneSign>(
+                initialState: MigrationKeystoneSign.State(pczts: [Pczt()])
+            ) {
+                MigrationKeystoneSign()
+            }
+        )
+    }
+}

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
@@ -11,6 +11,14 @@
 //  its back control closes the flow (`closeTapped` -> `.delegate(.continued)`) instead of popping
 //  (MOB-1466). The `.continued` delegate is consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
+//  MOB-1468 (Keystone): a Keystone-vendor account forks `confirmTapped` — instead of submitting a
+//  proposal locally, it proposes the note-split PCZT (`proposeNoteSplitPCZT()`) and delegates
+//  `.keystoneSignRequested([pczt])` for the coordinator to route through `MigrationKeystoneSign` +
+//  `Scan`. The software (`.zcash`) path is unchanged. Once the coordinator completes the QR
+//  round-trip it mutates this element in place into `.splitting` phase with `signedNoteSplitPczt`
+//  set — `retryTapped` then forks too: a signed PCZT present means re-broadcast the SAME PCZT via
+//  `submitSignedNoteSplit` (never a new signing round); `nil` keeps the existing software retry.
+//
 
 import Foundation
 import ComposableArchitecture
@@ -39,7 +47,13 @@ struct MigrationNoteSplit {
         /// True when the splitting phase is the coordinator's re-entry root — its back control then
         /// closes the flow instead of popping.
         var isFlowRoot = false
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
         @Shared(.inMemory(.toast)) var toast: Toast.Edge? = nil
+        /// MOB-1468 (Keystone): set by the coordinator once the QR round-trip signs the note-split
+        /// PCZT, alongside mutating `phase` to `.splitting`. Non-`nil` forks `retryTapped` to
+        /// re-broadcast this SAME signed PCZT via `submitSignedNoteSplit` instead of re-preparing.
+        /// Cleared once `.splitConfirmed` lands.
+        var signedNoteSplitPczt: Pczt?
 
         init(
             phase: Phase = .explainer,
@@ -47,7 +61,8 @@ struct MigrationNoteSplit {
             fee: Zatoshi = Zatoshi.zero,
             txId: String = "",
             isFailurePresented: Bool = false,
-            isFlowRoot: Bool = false
+            isFlowRoot: Bool = false,
+            signedNoteSplitPczt: Pczt? = nil
         ) {
             self.phase = phase
             self.amount = amount
@@ -55,6 +70,7 @@ struct MigrationNoteSplit {
             self.txId = txId
             self.isFailurePresented = isFailurePresented
             self.isFlowRoot = isFlowRoot
+            self.signedNoteSplitPczt = signedNoteSplitPczt
         }
     }
 
@@ -81,6 +97,10 @@ struct MigrationNoteSplit {
 
         enum Delegate: Equatable {
             case continued
+            /// MOB-1468 (Keystone): the note-split PCZT was proposed and needs QR signing — a
+            /// single-element array (batched-session-of-1), the shared shape across all three
+            /// Keystone signing sources so the coordinator can treat them symmetrically.
+            case keystoneSignRequested([Pczt])
         }
     }
 
@@ -105,8 +125,11 @@ struct MigrationNoteSplit {
                 return .send(.delegate(.continued))
 
             case .confirmTapped:
-                state.phase = .splitting
-                return submitNoteSplit(state.proposal)
+                guard state.selectedWalletAccount?.vendor == .keystone else {
+                    state.phase = .splitting
+                    return submitNoteSplit(state.proposal)
+                }
+                return requestKeystoneNoteSplitSignature()
 
             case .continueTapped:
                 return .send(.delegate(.continued))
@@ -138,10 +161,14 @@ struct MigrationNoteSplit {
 
             case .retryTapped:
                 state.isFailurePresented = false
+                if let signedNoteSplitPczt = state.signedNoteSplitPczt {
+                    return resubmitSignedNoteSplit(signedNoteSplitPczt)
+                }
                 return submitNoteSplit(state.proposal)
 
             case .splitConfirmed:
                 state.phase = .confirmed
+                state.signedNoteSplitPczt = nil
                 return .none
 
             case .splitResult(let result):
@@ -169,6 +196,25 @@ struct MigrationNoteSplit {
 
         return .run { send in
             let result = await sdkSynchronizer.submitNoteSplit(proposal)
+            await send(.splitResult(result))
+        }
+    }
+
+    /// MOB-1468 (Keystone) `confirmTapped` fork: proposes the note-split PCZT and hands it to the
+    /// coordinator for QR signing. Does not touch `phase` — the coordinator flips it to `.splitting`
+    /// once the signed PCZT comes back from the scan.
+    private func requestKeystoneNoteSplitSignature() -> Effect<Action> {
+        .run { send in
+            let pczt = await sdkSynchronizer.proposeNoteSplitPCZT()
+            await send(.delegate(.keystoneSignRequested([pczt])))
+        }
+    }
+
+    /// MOB-1468 (Keystone) `retryTapped` fork: re-broadcasts the SAME already-signed PCZT — never a
+    /// new signing round.
+    private func resubmitSignedNoteSplit(_ pczt: Pczt) -> Effect<Action> {
+        .run { send in
+            let result = await sdkSynchronizer.submitSignedNoteSplit(pczt)
             await send(.splitResult(result))
         }
     }

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitView.swift
@@ -46,7 +46,7 @@ struct MigrationNoteSplitView: View {
             VStack(spacing: 0) {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
-                        MigrationPairedIcons(badge: headerBadge)
+                        MigrationPairedIcons(badge: headerBadge, vendor: store.selectedWalletAccount?.vendor ?? .zcash)
                             .padding(.bottom, 16)
 
                         Text(title)

--- a/secant/Sources/Features/Migration/MigrationPairedIcons.swift
+++ b/secant/Sources/Features/Migration/MigrationPairedIcons.swift
@@ -2,10 +2,13 @@
 //  MigrationPairedIcons.swift
 //  zodl
 //
-//  Shared header view for migration screens (MOB-1460): the ZODL account badge overlapped by a
+//  Shared header view for migration screens (MOB-1460): the account badge overlapped by a
 //  circular Ironwood ("coins-swap") mark. Used by MigrationEntry and reused by later migration
 //  screens. MOB-1461 parameterizes the trailing badge so MigrationNoteSplit can swap it per phase
 //  (spinner while splitting, success check once confirmed) while MigrationEntry keeps the default.
+//  MOB-1468 parameterizes the leading brandmark by account vendor: `.zcash` (default) keeps the
+//  ZODL brandmark every existing call site already renders; `.keystone` swaps in the Keystone
+//  brandmark `SignWithKeystoneView`'s account card uses — no new assets.
 //
 
 import SwiftUI
@@ -23,10 +26,11 @@ struct MigrationPairedIcons: View {
     @Environment(\.colorScheme) private var colorScheme
     var size: CGFloat = 48
     var badge: Badge = .coinsSwap
+    var vendor: WalletAccount.Vendor = .zcash
 
     var body: some View {
         HStack(spacing: -(size * 0.18)) {
-            Asset.Assets.zashiLogoWithBackground.image
+            leadingBrandmark
                 .resizable()
                 .scaledToFit()
                 .frame(width: size, height: size)
@@ -63,6 +67,18 @@ struct MigrationPairedIcons: View {
             return Design.Utility.SuccessGreen._100
         }
     }
+
+    /// Not `WalletAccount.Vendor.icon()` — that method's `.zcash` case returns a different asset
+    /// (`Icons.zashiLogoSq`) than this view's existing hardcoded brandmark, which would break every
+    /// current call site's pixel-identical `.zcash` default.
+    private var leadingBrandmark: Image {
+        switch vendor {
+        case .keystone:
+            return Asset.Assets.Partners.keystoneLogo.image
+        case .zcash:
+            return Asset.Assets.zashiLogoWithBackground.image
+        }
+    }
 }
 
 // MARK: - Previews
@@ -79,5 +95,10 @@ struct MigrationPairedIcons: View {
 
 #Preview("Success check") {
     MigrationPairedIcons(badge: .successCheck)
+        .padding()
+}
+
+#Preview("Keystone vendor") {
+    MigrationPairedIcons(vendor: .keystone)
         .padding()
 }

--- a/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
+++ b/secant/Sources/Features/Migration/MigrationReviewTransfer/MigrationReviewTransferStore.swift
@@ -13,6 +13,13 @@
 //  back-tap would incorrectly signal the transfer was confirmed (MOB-1466). Both delegates are
 //  consumed by `MigrationCoordFlowCoordinator` (MOB-1466).
 //
+//  MOB-1468 (Keystone): a Keystone-vendor account in immediate mode forks `confirmTapped` — instead
+//  of signing+storing `state.schedule` locally (the same schedule `onAppear` proposed via
+//  `proposeMigrationTransfers()` for Amount/Fee), it proposes that schedule's PCZT
+//  (`proposeMigrationPCZTs(schedule)`) and delegates `.keystoneSignRequested([pczt])` for the
+//  coordinator to route through `MigrationKeystoneSign` + `Scan`. The manual-step path (transfers
+//  already signed at plan commit) is unchanged — `signAndStoreMigrationSchedule` never runs there.
+//
 
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
@@ -39,6 +46,7 @@ struct MigrationReviewTransfer {
         /// True when the manual-step variant is the coordinator's re-entry root — its back control
         /// then closes the flow instead of popping.
         var isFlowRoot = false
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
 
         init(
             mode: Mode = .immediate,
@@ -69,6 +77,10 @@ struct MigrationReviewTransfer {
         enum Delegate: Equatable {
             case closed
             case confirmed
+            /// MOB-1468 (Keystone): the immediate-mode schedule's PCZT was proposed and needs QR
+            /// signing — a single-element array (batched-session-of-1), the shared shape across all
+            /// three Keystone signing sources so the coordinator can treat them symmetrically.
+            case keystoneSignRequested([Pczt])
         }
     }
 
@@ -88,10 +100,13 @@ struct MigrationReviewTransfer {
                     return .send(.delegate(.confirmed))
                 }
 
-                return .run { send in
-                    await sdkSynchronizer.signAndStoreMigrationSchedule(schedule)
-                    await send(.scheduleSigned)
+                guard state.selectedWalletAccount?.vendor == .keystone else {
+                    return .run { send in
+                        await sdkSynchronizer.signAndStoreMigrationSchedule(schedule)
+                        await send(.scheduleSigned)
+                    }
                 }
+                return requestKeystoneSignature(for: schedule)
 
             case .delegate:
                 return .none
@@ -113,6 +128,15 @@ struct MigrationReviewTransfer {
                 state.fee = State.standardFee
                 return .none
             }
+        }
+    }
+
+    /// MOB-1468 (Keystone) `confirmTapped` fork: proposes the immediate-mode schedule's PCZT and
+    /// hands it to the coordinator for QR signing.
+    private func requestKeystoneSignature(for schedule: MigrationSchedule) -> Effect<Action> {
+        .run { send in
+            let pczts = await sdkSynchronizer.proposeMigrationPCZTs(schedule)
+            await send(.delegate(.keystoneSignRequested(pczts)))
         }
     }
 }

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
@@ -115,13 +115,21 @@ struct MigrationSending {
                 case .success(let txId):
                     state.txId = txId
                     state.sentCount += 1
-                    // Both are synchronous, non-throwing dependency closures — no effect needed.
+                    // Synchronous, non-throwing dependency closure — no effect needed.
                     migrationManager.recordMigrationBroadcast()
-                    migrationBGScheduler.scheduleNextWindow()
 
-                    return state.sentCount >= state.totalCount
+                    let nextEffect: Effect<Action> = state.sentCount >= state.totalCount
                         ? .send(.allTransfersSent)
                         : executeNextTransfer(options: state.networkPrivacyOptions)
+
+                    // scheduleNextWindow() is async (MOB-1467) — concatenated ahead of the
+                    // follow-up effect so it still runs to completion before the next transfer
+                    // kicks off (or before .allTransfersSent), matching the previous synchronous
+                    // call-then-continue ordering.
+                    return .concatenate(
+                        .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleNextWindow() },
+                        nextEffect
+                    )
 
                 case .networkError, .invalidNote, .expired, nil:
                     state.isFailurePresented = true

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -11,6 +11,12 @@
 //  already signed), in which case it's a plain acknowledgment (MOB-1466). Chaining the
 //  `confirmTapped` delegate into the rest of the flow is `MigrationCoordFlow`'s job.
 //
+//  MOB-1468 (Keystone): a Keystone-vendor account with `requiresSigning == true` (fresh + re-created
+//  plans) forks `confirmTapped` — instead of signing+storing locally, it proposes the schedule's
+//  PCZTs (`proposeMigrationPCZTs(schedule)`) and delegates `.keystoneSignRequested(pczts)` for the
+//  coordinator to route through `MigrationKeystoneSign` + `Scan` in ONE batched session. The software
+//  path and the rescheduled `requiresSigning == false` variant (never re-signs) are unchanged.
+//
 
 import Foundation
 import ComposableArchitecture
@@ -41,6 +47,7 @@ struct MigrationTransferPlan {
         /// `signAndStoreMigrationSchedule` and delegates `.confirmed` directly. The re-created
         /// (recovery) variant signs a fresh schedule, so it keeps the default `true`.
         var requiresSigning = true
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
 
         init(
             variant: Variant = .scheduled,
@@ -67,6 +74,10 @@ struct MigrationTransferPlan {
 
         enum Delegate: Equatable {
             case confirmed
+            /// MOB-1468 (Keystone): the schedule's PCZTs (ALL N transfers) were proposed and need QR
+            /// signing in ONE batched session — the shared shape across all three Keystone signing
+            /// sources so the coordinator can treat them symmetrically.
+            case keystoneSignRequested([Pczt])
         }
     }
 
@@ -84,10 +95,14 @@ struct MigrationTransferPlan {
                 }
 
                 let schedule = state.schedule ?? MigrationSchedule(transfers: [], estimatedDurationHours: 0)
-                return .run { send in
-                    await sdkSynchronizer.signAndStoreMigrationSchedule(schedule)
-                    await send(.scheduleSigned)
+
+                guard state.selectedWalletAccount?.vendor == .keystone else {
+                    return .run { send in
+                        await sdkSynchronizer.signAndStoreMigrationSchedule(schedule)
+                        await send(.scheduleSigned)
+                    }
                 }
+                return requestKeystoneSignature(for: schedule)
 
             case .delegate:
                 return .none
@@ -116,6 +131,15 @@ struct MigrationTransferPlan {
                 apply(schedule, to: &state)
                 return .none
             }
+        }
+    }
+
+    /// MOB-1468 (Keystone) `confirmTapped` fork: proposes ALL of the schedule's PCZTs and hands them
+    /// to the coordinator for ONE batched QR-signing session.
+    private func requestKeystoneSignature(for schedule: MigrationSchedule) -> Effect<Action> {
+        .run { send in
+            let pczts = await sdkSynchronizer.proposeMigrationPCZTs(schedule)
+            await send(.delegate(.keystoneSignRequested(pczts)))
         }
     }
 

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -7,7 +7,43 @@
 
 import ComposableArchitecture
 import Foundation
+@preconcurrency import BackgroundTasks
 @preconcurrency import ZcashLightClientKit
+
+/// Wraps a `BGProcessingTask` for the migration BG session decision tree (MOB-1467). A bare
+/// `BGProcessingTask` cannot be instantiated in unit tests, so the AppDelegate-facing
+/// `.migrationBackgroundTask(BGProcessingTask)` action is immediately wrapped into this handle
+/// and forwarded to `.migrationBackgroundSession`, the action the reducer's tree — and every
+/// `RootMigrationBackgroundTests` case — actually drives. `rawTask` is `nil` in tests (spy
+/// handles); `complete` is always a real, observable closure (`LockIsolated` spy in tests, real
+/// `task.setTaskCompleted(success:)` in production via the AppDelegate-side `live` initializer).
+/// `@unchecked Sendable`: `BGProcessingTask` (a system framework type, `@preconcurrency`-imported
+/// above) is safe to hand across the effect boundary here the same way the existing
+/// `power_wifi_sync`/`scheduler` tasks already are (`Root.State.bgTask`, `AppDelegate`'s
+/// `task.expirationHandler`) — it is only ever read or completed, never mutated concurrently.
+struct MigrationBGSessionHandle: @unchecked Sendable {
+    let rawTask: BGProcessingTask?
+    let complete: @Sendable (Bool) -> Void
+
+    init(rawTask: BGProcessingTask?, complete: @escaping @Sendable (Bool) -> Void) {
+        self.rawTask = rawTask
+        self.complete = complete
+    }
+
+    /// Production convenience: wraps a live task, completing it via its own
+    /// `setTaskCompleted(success:)` when the session decides it's done.
+    static func live(_ task: BGProcessingTask) -> MigrationBGSessionHandle {
+        MigrationBGSessionHandle(rawTask: task, complete: { task.setTaskCompleted(success: $0) })
+    }
+}
+
+extension MigrationBGSessionHandle: Equatable {
+    /// `complete` is a closure and can't be compared — identity of the wrapped task (or "both
+    /// nil", the spy-handle shape every test uses) is the only meaningful equality here.
+    static func == (lhs: MigrationBGSessionHandle, rhs: MigrationBGSessionHandle) -> Bool {
+        lhs.rawTask === rhs.rawTask
+    }
+}
 
 /// In this file is a collection of helpers that control all state and action related operations
 /// for the `Root` with a connection to the app/wallet initialization and erasure of the wallet.
@@ -30,6 +66,7 @@ extension Root {
         case initializationFailed(ZcashError)
         case initializationSuccessfullyDone
         case loadedWalletAccounts([WalletAccount])
+        case migrationBackgroundSession(MigrationBGSessionHandle)
         case resetZashi
         case resetZashiRequest(Bool)
         case resetZashiRequestCanceled
@@ -72,10 +109,16 @@ extension Root {
                 // freshness itself stays reactive (SmartBanner's own subscription + walk) — this
                 // is deliberately the minimal Root-side hook the spec calls for.
                 let reconcileEffect: Effect<Action> = .run { [migrationManager] _ in migrationManager.reconcile() }
+                // MOB-1467: opening the app clears stale migration notifications from Notification
+                // Center — the banner/re-entry route now carries the current state. Delivered ONLY:
+                // a pending manual-mode "ready to send" reminder must survive foreground entry.
+                let clearDeliveredEffect: Effect<Action> = .run { [userNotifications] _ in
+                    await userNotifications.clearDeliveredMigrationNotifications()
+                }
                 if state.isLockedInKeychainUnavailableState || !sdkSynchronizer.latestState().syncStatus.isPrepared {
-                    return .merge(reconcileEffect, .send(.initialization(.initialSetups)))
+                    return .merge(reconcileEffect, clearDeliveredEffect, .send(.initialization(.initialSetups)))
                 } else {
-                    return .merge(reconcileEffect, .send(.initialization(.retryStart)))
+                    return .merge(reconcileEffect, clearDeliveredEffect, .send(.initialization(.retryStart)))
                 }
                 
             case .initialization(.appDelegate(.didEnterBackground)):
@@ -108,7 +151,40 @@ extension Root {
                         await send(.initialization(.retryStart))
                     }
                 }
-                
+
+            case .initialization(.appDelegate(.migrationBackgroundTask(let task))):
+                // Immediately wrapped so the decision tree below (`.migrationBackgroundSession`)
+                // never touches a raw `BGProcessingTask` directly — that type can't be
+                // instantiated in unit tests, so `RootMigrationBackgroundTests` drives
+                // `.migrationBackgroundSession` with spy handles instead (`rawTask: nil`).
+                return .send(.initialization(.migrationBackgroundSession(MigrationBGSessionHandle.live(task))))
+
+            case .initialization(.migrationBackgroundSession(let handle)):
+                return migrationBackgroundSessionEffect(state: &state, handle: handle)
+
+            case .initialization(.appDelegate(.migrationBackgroundTaskExpired)):
+                // Mirror `didEnterBackground`'s expiration handling for the existing
+                // `power_wifi_sync` task: stop the synchronizer and release `state.bgTask` (a
+                // sync-only session may have set it), then re-arm — an expired session must never
+                // orphan the wakeup chain. Re-submitting with the same identifier REPLACES the
+                // pending request, so this is safe even if branch 2's up-front re-arm already ran
+                // in this same session.
+                sdkSynchronizer.stop()
+                state.bgTask?.setTaskCompleted(success: false)
+                state.bgTask = nil
+                return .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleNextWindow() }
+
+            case .initialization(.appDelegate(.migrationNotificationTapped)):
+                // Same gate as `checkBackupPhraseValidation` uses for `isAtDeeplinkWarningScreen`:
+                // `.initialized` is set exactly once, at that checkpoint, so it doubles as "Home
+                // is up" here. If we're not there yet (cold start still in flight), stash the
+                // request — `checkBackupPhraseValidation` fires it once initialization completes.
+                guard state.appInitializationState == .initialized else {
+                    state.pendingMigrationDeepLink = true
+                    return .none
+                }
+                return migrationNotificationTappedRoutingEffect(state: &state)
+
             case .synchronizerStateChanged(let latestState):
                 let snapshot = SyncStatusSnapshot.snapshotFor(state: latestState.data.syncStatus)
 
@@ -480,11 +556,21 @@ extension Root {
                 state.appInitializationState = .initialized
                 let isAtDeeplinkWarningScreen = state.destinationState.destination == .deeplinkWarning
 
+                // MOB-1467: this is the checkpoint that already knows "we just reached Home from
+                // cold start" — mirrors `isAtDeeplinkWarningScreen` immediately above: snapshot +
+                // clear the pending flag now, fire its routing in the same delayed effect that
+                // sends Home, right alongside it.
+                let hasPendingMigrationDeepLink = state.pendingMigrationDeepLink
+                state.pendingMigrationDeepLink = false
+
                 return .run { send in
                     // Delay the splash overlay dismissal
                     try await mainQueue.sleep(for: .seconds(0.5))
                     if !isAtDeeplinkWarningScreen {
                         await send(.destination(.updateDestination(Root.DestinationState.Destination.home)))
+                    }
+                    if hasPendingMigrationDeepLink {
+                        await send(.initialization(.appDelegate(.migrationNotificationTapped)))
                     }
                 }
                 .cancellable(id: state.CancelId, cancelInFlight: true)
@@ -758,5 +844,121 @@ extension Root {
             return true
         default: return false
         }
+    }
+
+    // MARK: - MOB-1467: Migration BG session decision tree
+
+    /// The migration BG session's decision tree (spec "Root: BG session decision tree"), checked
+    /// in this exact order:
+    /// 1. Plan broken (invalid transfer, or expired-attention state) — notify, do NOT re-arm.
+    /// 2. Sync required before the next transfer — either skip (deferred-after-broadcast) or run a
+    ///    sync-only session that never broadcasts, reusing the existing `power_wifi_sync` sync-kick
+    ///    machinery verbatim (`state.bgTask` + `.retryStart`; `synchronizerStateChanged` completes
+    ///    the task on `.upToDate`/`.stopped`/`.error`).
+    /// 3. Otherwise, send: `executeNextPendingMigrationTransfer` and notify/re-arm per outcome.
+    /// Every branch except the sync-only session completes `handle` itself (that session's
+    /// completion is the existing `synchronizerStateChanged` machinery, exactly like the
+    /// `power_wifi_sync` task it mirrors).
+    private func migrationBackgroundSessionEffect(
+        state: inout Root.State,
+        handle: MigrationBGSessionHandle
+    ) -> Effect<Root.Action> {
+        let migrationState = sdkSynchronizer.getMigrationState()
+        let isPlanBroken = sdkSynchronizer.hasInvalidMigrationTransfers()
+            || migrationState == MigrationState.requiresAttention(AttentionReason.transferExpired)
+
+        if isPlanBroken {
+            return .run { [userNotifications] _ in
+                await userNotifications.scheduleMigrationNotification(MigrationNotification.planNeedsUpdate, nil)
+                handle.complete(true)
+            }
+        }
+
+        if sdkSynchronizer.isSyncRequiredBeforeNextMigrationTransfer() {
+            if migrationManager.isSyncDeferredAfterBroadcast() {
+                return .run { [migrationBGScheduler] _ in
+                    await migrationBGScheduler.scheduleNextWindow()
+                    handle.complete(true)
+                }
+            }
+
+            // Sync-only session: never broadcasts. Re-arm up front, then reuse the
+            // `power_wifi_sync` handler's own sync-kick verbatim (`state.bgTask` + `.retryStart`) —
+            // `synchronizerStateChanged` completes `state.bgTask` on `.upToDate`/`.stopped`/`.error`
+            // exactly as it does for that task. `handle.rawTask` may be `nil` in tests (spy
+            // handles); that completion is then a no-op, which is acceptable — this branch is
+            // asserted on the arm + kick + stash, not on task completion.
+            state.bgTask = handle.rawTask
+            return .concatenate(
+                .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleNextWindow() },
+                .send(.initialization(.retryStart))
+            )
+        }
+
+        return .run { [migrationManager, sdkSynchronizer, migrationBGScheduler, userNotifications] _ in
+            let options = migrationManager.networkPrivacyOptions()
+            let result = await sdkSynchronizer.executeNextPendingMigrationTransfer(options)
+
+            switch result {
+            case .success:
+                migrationManager.recordMigrationBroadcast()
+
+                if sdkSynchronizer.getMigrationState() == MigrationState.complete {
+                    await userNotifications.scheduleMigrationNotification(MigrationNotification.migrationComplete, nil)
+                    await migrationBGScheduler.cancelAll()
+                } else {
+                    let notification = Self.transferCompleteNotification(sdkSynchronizer: sdkSynchronizer)
+                    await userNotifications.scheduleMigrationNotification(notification, nil)
+                    await migrationBGScheduler.scheduleNextWindow()
+                }
+
+            case .networkError, .invalidNote, .expired:
+                let nextNumber = (sdkSynchronizer.getMigrationProgress()?.completedTransfers ?? 0) + 1
+                await userNotifications.scheduleMigrationNotification(MigrationNotification.transferWaiting(number: nextNumber), nil)
+                await migrationBGScheduler.scheduleNextWindow()
+
+            case nil:
+                await migrationBGScheduler.scheduleNextWindow()
+            }
+
+            handle.complete(true)
+        }
+    }
+
+    /// Builds the `.transferComplete` notification payload from the freshly-updated migration
+    /// state: `number`/`total`/`remaining` from `getMigrationProgress()`, `nextInHours` from the
+    /// same cadence-window derivation `MigrationBGSchedulerClient`'s `arm(margin:)` uses (§8.3's
+    /// next-window margin, `estimateTimestamp` as the preferred source), rounded to hours.
+    private static func transferCompleteNotification(sdkSynchronizer: SDKSynchronizerClient) -> MigrationNotification {
+        let progress = sdkSynchronizer.getMigrationProgress()
+        let preferredExecutableAt = progress?.nextTransferReadyAtHeight.flatMap { height in
+            sdkSynchronizer.estimateTimestamp(height).map { Date(timeIntervalSince1970: $0) }
+        }
+        let now = Date()
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.nextWindowMargin,
+            preferredExecutableAt: preferredExecutableAt,
+            now: now
+        )
+        let nextInHours = Int((window.timeIntervalSince(now) / 3600).rounded())
+
+        return MigrationNotification.transferComplete(
+            number: progress?.completedTransfers ?? 0,
+            total: progress?.totalTransfers ?? 0,
+            nextInHours: nextInHours,
+            remaining: progress?.remainingOrchard ?? Zatoshi.zero
+        )
+    }
+
+    // MARK: - MOB-1467: Migration notification-tap deep link
+
+    /// Exactly the SmartBanner-tap routing (`RootCoordinator`'s
+    /// `.home(.smartBanner(.migrationScreenRequested))`): fresh flow state, open the migration
+    /// path. Shared by the immediate (Home already up) and deferred (fired from
+    /// `checkBackupPhraseValidation` once initialization reaches Home) call sites.
+    private func migrationNotificationTappedRoutingEffect(state: inout Root.State) -> Effect<Root.Action> {
+        state.migrationCoordFlowState = MigrationCoordFlow.State.initial
+        state.path = Root.State.Path.migrationCoordFlow
+        return .none
     }
 }

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -74,6 +74,12 @@ struct Root {
         var onboardingState: RestoreWalletCoordFlow.State
         var osStatusErrorState: OSStatusError.State
         var path: Path? = nil
+        /// Set by `.migrationNotificationTapped` when it arrives before the app has reached Home
+        /// (`appInitializationState != .initialized`) — mirrors `RootDestination`'s
+        /// `isAtDeeplinkWarningScreen` gating: the routing itself is deferred rather than dropped,
+        /// and fires from `checkBackupPhraseValidation`'s existing "did we just reach Home"
+        /// checkpoint once initialization completes. Cleared immediately after firing.
+        var pendingMigrationDeepLink = false
         var pendingServerCandidate: PendingServerCandidate?
         var phraseDisplayState: RecoveryPhraseDisplay.State
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
@@ -293,6 +299,7 @@ struct Root {
     @Dependency(\.flexaHandler) var flexaHandler
     @Dependency(\.localAuthentication) var localAuthentication
     @Dependency(\.mainQueue) var mainQueue
+    @Dependency(\.migrationBGScheduler) var migrationBGScheduler
     @Dependency(\.migrationManager) var migrationManager
     @Dependency(\.mnemonic) var mnemonic
     @Dependency(\.numberFormatter) var numberFormatter
@@ -304,6 +311,7 @@ struct Root {
     @Dependency(\.uriParser) var uriParser
     @Dependency(\.userDefaults) var userDefaults
     @Dependency(\.userMetadataProvider) var userMetadataProvider
+    @Dependency(\.userNotifications) var userNotifications
     @Dependency(\.userStoredPreferences) var userStoredPreferences
     @Dependency(\.votingMetadata) var votingMetadata
     @Dependency(\.walletConfigProvider) var walletConfigProvider

--- a/secant/Sources/Features/Scan/ScanChecker.swift
+++ b/secant/Sources/Features/Scan/ScanChecker.swift
@@ -9,6 +9,7 @@ import ComposableArchitecture
 import ZcashPaymentURI
 
 @preconcurrency import KeystoneSDK
+import URKit
 
 protocol ScanChecker: Sendable, Equatable {
     var id: Int { get }
@@ -124,6 +125,39 @@ struct KeystoneVotingDelegationPcztScanChecker: ScanChecker, Equatable {
     }
 }
 
+/// Migration Keystone batch signing (MOB-1468) — mirrors `KeystonePcztScanChecker`'s accumulate-
+/// with-progress flow, but the completed UR parses via `sdkSynchronizer.parseMigrationPCZTBatch`
+/// rather than `KeystoneZcashSDK().parseZcashPczt(ur:)`: that call is the single-PCZT decoder (it
+/// invokes the Rust `parse_zcash_pczt` FFI entrypoint), which is the wrong shape for a batch UR
+/// whose CBOR format doesn't exist yet — the accumulated UR's raw cbor bytes (`resultUR.cbor
+/// .cborData`, the same accessor `KeystoneZcashSDK` uses internally) go straight to the [ext]
+/// batch-parse stub instead. Stub returns `nil` today, so a completed scan reports the same
+/// failure an unparseable QR gets, exactly like every other checker here when parsing fails.
+struct KeystoneMigrationBatchScanChecker: ScanChecker, Equatable {
+    let id = 6
+
+    func checkQRCode(_ qrCode: String) -> Scan.Action? {
+        @Dependency(\.keystoneHandler) var keystoneHandler
+        @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+
+        if let result = keystoneHandler.decodeQR(qrCode) {
+            if result.progress < 100 {
+                return ScanCheckerWrapper.reportCheck(qrCode, progress: result.progress)
+            }
+
+            if let resultUR = result.ur, result.progress == 100 {
+                if let pczts = sdkSynchronizer.parseMigrationPCZTBatch(resultUR.cbor.cborData) {
+                    return .foundPCZTBatch(pczts)
+                } else {
+                    return nil
+                }
+            }
+        }
+
+        return nil
+    }
+}
+
 struct ScanCheckerWrapper: Equatable, Sendable {
     let checker: any ScanChecker
 
@@ -133,6 +167,7 @@ struct ScanCheckerWrapper: Equatable, Sendable {
     static let keystonePCZTScanChecker = ScanCheckerWrapper(KeystonePcztScanChecker())
     static let swapStringScanChecker = ScanCheckerWrapper(SwapStringScanChecker())
     static let keystoneVotingDelegationPCZTScanChecker = ScanCheckerWrapper(KeystoneVotingDelegationPcztScanChecker())
+    static let keystoneMigrationBatchScanChecker = ScanCheckerWrapper(KeystoneMigrationBatchScanChecker())
 
     static func == (lhs: ScanCheckerWrapper, rhs: ScanCheckerWrapper) -> Bool {
         return lhs.checker.id == rhs.checker.id

--- a/secant/Sources/Features/Scan/ScanStore.swift
+++ b/secant/Sources/Features/Scan/ScanStore.swift
@@ -79,6 +79,10 @@ struct Scan {
         case foundAccounts(ZcashAccounts)
         case foundPCZT(Data)
         case foundVotingDelegationPCZT(Data)
+        /// Migration Keystone batch signing (MOB-1468) — the fully parsed set of signed PCZTs from
+        /// one scanned batch UR session. Additive to this shared Scan feature; the coordinator that
+        /// requested the scan is responsible for consuming it (MOB-1468 phase 2).
+        case foundPCZTBatch([Pczt])
         case animatedQRProgress(Int, Int?, Int?)
         case scanFailed(ScanImageResult)
         case scan(RedactableString)
@@ -146,7 +150,12 @@ struct Scan {
                 state.isAnythingFound = true
                 state.progress = nil
                 return .none
-                
+
+            case .foundPCZTBatch:
+                state.isAnythingFound = true
+                state.progress = nil
+                return .none
+
             case .foundString:
                 state.isAnythingFound = true
                 return .none

--- a/secant/Sources/Models/AppDelegateAction.swift
+++ b/secant/Sources/Models/AppDelegateAction.swift
@@ -13,4 +13,7 @@ enum AppDelegateAction: Equatable {
     case didEnterBackground
     case willEnterForeground
     case backgroundTask(BGProcessingTask)
+    case migrationBackgroundTask(BGProcessingTask)
+    case migrationBackgroundTaskExpired
+    case migrationNotificationTapped
 }

--- a/secant/secant-mainnet-Info.plist
+++ b/secant/secant-mainnet-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/secant/secant-testnet-Info.plist
+++ b/secant/secant-testnet-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/secant/zashi-testnet-Info.plist
+++ b/secant/zashi-testnet-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/zashi-internal-Info.plist
+++ b/zashi-internal-Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>co.electriccoin.power_wifi_sync</string>
 		<string>co.electriccoin.scheduler</string>
+		<string>co.electriccoin.migration_transfer</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/zodlTests/MigrationTests/MigrationBGSchedulerTests.swift
+++ b/zodlTests/MigrationTests/MigrationBGSchedulerTests.swift
@@ -1,0 +1,202 @@
+//
+//  MigrationBGSchedulerTests.swift
+//  zodlTests
+//
+//  Covers the pure `WakeupAction.decide` decision function
+//  (Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift) for MOB-1467: the
+//  (state, isManualDelivery, window, nextTransferNumber) table — scheduled mode submits a BG
+//  task, manual mode schedules the "ready" notification, and `.complete` always wins with
+//  `.cancelAll` regardless of delivery mode. Pure enum/function, no SDK or framework touched
+//  (never `BGTaskScheduler`/`UNUserNotificationCenter` in this file) -> no shared state ->
+//  no `.serialized`.
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationBGSchedulerTests {
+    private static let window = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Non-complete states x scheduled/manual
+
+    @Test func scheduledModeSubmitsTaskWithTheGivenWindow() {
+        let action = WakeupAction.decide(
+            state: MigrationState.notStarted,
+            isManualDelivery: false,
+            window: Self.window,
+            nextTransferNumber: 1
+        )
+
+        #expect(action == WakeupAction.submitTask(earliestBeginDate: Self.window))
+    }
+
+    @Test func manualModeSchedulesReadyNotificationWithGivenWindowAndNumber() {
+        let action = WakeupAction.decide(
+            state: MigrationState.notStarted,
+            isManualDelivery: true,
+            window: Self.window,
+            nextTransferNumber: 3
+        )
+
+        #expect(action == WakeupAction.scheduleReadyNotification(number: 3, at: Self.window))
+    }
+
+    @Test func inProgressScheduledModeSubmitsTask() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let action = WakeupAction.decide(
+            state: MigrationState.inProgress(progress),
+            isManualDelivery: false,
+            window: Self.window,
+            nextTransferNumber: 3
+        )
+
+        #expect(action == WakeupAction.submitTask(earliestBeginDate: Self.window))
+    }
+
+    @Test func inProgressManualModeSchedulesReadyNotification() {
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 100
+        )
+
+        let action = WakeupAction.decide(
+            state: MigrationState.inProgress(progress),
+            isManualDelivery: true,
+            window: Self.window,
+            nextTransferNumber: 3
+        )
+
+        #expect(action == WakeupAction.scheduleReadyNotification(number: 3, at: Self.window))
+    }
+
+    @Test func requiresAttentionScheduledModeSubmitsTask() {
+        let action = WakeupAction.decide(
+            state: MigrationState.requiresAttention(AttentionReason.transferStalled(transferNumber: 2)),
+            isManualDelivery: false,
+            window: Self.window,
+            nextTransferNumber: 2
+        )
+
+        #expect(action == WakeupAction.submitTask(earliestBeginDate: Self.window))
+    }
+
+    @Test func requiresAttentionManualModeSchedulesReadyNotification() {
+        let action = WakeupAction.decide(
+            state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+            isManualDelivery: true,
+            window: Self.window,
+            nextTransferNumber: 1
+        )
+
+        #expect(action == WakeupAction.scheduleReadyNotification(number: 1, at: Self.window))
+    }
+
+    // MARK: - .complete always wins, regardless of mode
+
+    @Test func completeStateCancelsAllInScheduledMode() {
+        let action = WakeupAction.decide(
+            state: MigrationState.complete,
+            isManualDelivery: false,
+            window: Self.window,
+            nextTransferNumber: 1
+        )
+
+        #expect(action == WakeupAction.cancelAll)
+    }
+
+    @Test func completeStateCancelsAllInManualMode() {
+        let action = WakeupAction.decide(
+            state: MigrationState.complete,
+            isManualDelivery: true,
+            window: Self.window,
+            nextTransferNumber: 1
+        )
+
+        #expect(action == WakeupAction.cancelAll)
+    }
+
+    // MARK: - Full table
+
+    @Test func decisionTable() {
+        struct Row {
+            let name: String
+            let state: MigrationState
+            let isManualDelivery: Bool
+            let nextTransferNumber: Int
+            let expected: WakeupAction
+        }
+
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 4,
+            remainingOrchard: Zatoshi(1_000),
+            nextTransferReadyAtHeight: 50
+        )
+
+        let rows: [Row] = [
+            Row(
+                name: "notStarted/scheduled",
+                state: MigrationState.notStarted,
+                isManualDelivery: false,
+                nextTransferNumber: 1,
+                expected: WakeupAction.submitTask(earliestBeginDate: Self.window)
+            ),
+            Row(
+                name: "notStarted/manual",
+                state: MigrationState.notStarted,
+                isManualDelivery: true,
+                nextTransferNumber: 1,
+                expected: WakeupAction.scheduleReadyNotification(number: 1, at: Self.window)
+            ),
+            Row(
+                name: "inProgress/scheduled",
+                state: MigrationState.inProgress(progress),
+                isManualDelivery: false,
+                nextTransferNumber: 2,
+                expected: WakeupAction.submitTask(earliestBeginDate: Self.window)
+            ),
+            Row(
+                name: "inProgress/manual",
+                state: MigrationState.inProgress(progress),
+                isManualDelivery: true,
+                nextTransferNumber: 2,
+                expected: WakeupAction.scheduleReadyNotification(number: 2, at: Self.window)
+            ),
+            Row(
+                name: "complete/scheduled",
+                state: MigrationState.complete,
+                isManualDelivery: false,
+                nextTransferNumber: 5,
+                expected: WakeupAction.cancelAll
+            ),
+            Row(
+                name: "complete/manual",
+                state: MigrationState.complete,
+                isManualDelivery: true,
+                nextTransferNumber: 5,
+                expected: WakeupAction.cancelAll
+            )
+        ]
+
+        for row in rows {
+            let action = WakeupAction.decide(
+                state: row.state,
+                isManualDelivery: row.isManualDelivery,
+                window: Self.window,
+                nextTransferNumber: row.nextTransferNumber
+            )
+
+            #expect(action == row.expected, "Row \(row.name) expected \(row.expected) but got \(action)")
+        }
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCadenceTests.swift
+++ b/zodlTests/MigrationTests/MigrationCadenceTests.swift
@@ -1,0 +1,176 @@
+//
+//  MigrationCadenceTests.swift
+//  zodlTests
+//
+//  Covers `MigrationCadence` (Dependencies/MigrationBGScheduler/MigrationCadence.swift) for
+//  MOB-1467: the margin constants (§8.3: 30 min / 6.5 h) and the `window(margin:
+//  preferredExecutableAt:now:)` max rule — the SDK's preferred executable time wins when it is
+//  later than the margin floor, the margin floor wins when the SDK preference is earlier (or
+//  nil, as against the current stubs). Pure math, no shared state -> no `.serialized`.
+//
+//  `preferredExecutableAt`/`window` inputs and expectations are expressed relative to a fixed
+//  `now` so every row is self-contained and doesn't depend on wall-clock time.
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct MigrationCadenceTests {
+    private static let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Margin constants
+
+    @Test func firstWindowMarginIsThirtyMinutes() {
+        #expect(MigrationCadence.firstWindowMargin == 30 * 60)
+    }
+
+    @Test func nextWindowMarginIsSixAndAHalfHours() {
+        #expect(MigrationCadence.nextWindowMargin == 6.5 * 60 * 60)
+    }
+
+    // MARK: - window(margin:preferredExecutableAt:now:) — max rule
+
+    @Test func nilPreferredFallsBackToMarginFloorForFirstWindow() {
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.firstWindowMargin,
+            preferredExecutableAt: nil,
+            now: Self.now
+        )
+
+        #expect(window == Self.now.addingTimeInterval(MigrationCadence.firstWindowMargin))
+    }
+
+    @Test func nilPreferredFallsBackToMarginFloorForNextWindow() {
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.nextWindowMargin,
+            preferredExecutableAt: nil,
+            now: Self.now
+        )
+
+        #expect(window == Self.now.addingTimeInterval(MigrationCadence.nextWindowMargin))
+    }
+
+    @Test func preferredLaterThanMarginFloorWins() {
+        // SDK preference (2 hours out) is later than the 30-minute margin floor -> SDK wins.
+        let preferred = Self.now.addingTimeInterval(2 * 60 * 60)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.firstWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == preferred)
+    }
+
+    @Test func preferredEarlierThanMarginFloorFallsBackToMargin() {
+        // SDK preference (10 minutes out) is earlier than the 30-minute margin floor -> margin wins.
+        let preferred = Self.now.addingTimeInterval(10 * 60)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.firstWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == Self.now.addingTimeInterval(MigrationCadence.firstWindowMargin))
+    }
+
+    @Test func preferredExactlyAtMarginFloorUsesThatMoment() {
+        // Boundary: preferred == margin floor exactly -> `max` picks either (they're equal).
+        let preferred = Self.now.addingTimeInterval(MigrationCadence.firstWindowMargin)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.firstWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == preferred)
+    }
+
+    @Test func preferredInThePastFallsBackToMargin() {
+        // A stale/past SDK preference must never win over the margin floor (never wake "now").
+        let preferred = Self.now.addingTimeInterval(-3600)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.nextWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == Self.now.addingTimeInterval(MigrationCadence.nextWindowMargin))
+    }
+
+    @Test func preferredLaterThanNextWindowMarginWins() {
+        // SDK preference (7 hours out) is later than the 6.5-hour next-window margin -> SDK wins.
+        let preferred = Self.now.addingTimeInterval(7 * 60 * 60)
+
+        let window = MigrationCadence.window(
+            margin: MigrationCadence.nextWindowMargin,
+            preferredExecutableAt: preferred,
+            now: Self.now
+        )
+
+        #expect(window == preferred)
+    }
+
+    // MARK: - Full table (both margins x nil/earlier/later), one assertion per row
+
+    @Test func windowTable() {
+        struct Row {
+            let name: String
+            let margin: TimeInterval
+            let preferredOffset: TimeInterval?   // relative to `now`; nil = no SDK preference
+            let expectedOffset: TimeInterval      // relative to `now`
+        }
+
+        let rows: [Row] = [
+            Row(
+                name: "first/nil",
+                margin: MigrationCadence.firstWindowMargin,
+                preferredOffset: nil,
+                expectedOffset: MigrationCadence.firstWindowMargin
+            ),
+            Row(
+                name: "first/earlier",
+                margin: MigrationCadence.firstWindowMargin,
+                preferredOffset: 60,
+                expectedOffset: MigrationCadence.firstWindowMargin
+            ),
+            Row(
+                name: "first/later",
+                margin: MigrationCadence.firstWindowMargin,
+                preferredOffset: 3600,
+                expectedOffset: 3600
+            ),
+            Row(
+                name: "next/nil",
+                margin: MigrationCadence.nextWindowMargin,
+                preferredOffset: nil,
+                expectedOffset: MigrationCadence.nextWindowMargin
+            ),
+            Row(
+                name: "next/earlier",
+                margin: MigrationCadence.nextWindowMargin,
+                preferredOffset: 3600,
+                expectedOffset: MigrationCadence.nextWindowMargin
+            ),
+            Row(
+                name: "next/later",
+                margin: MigrationCadence.nextWindowMargin,
+                preferredOffset: 8 * 60 * 60,
+                expectedOffset: 8 * 60 * 60
+            )
+        ]
+
+        for row in rows {
+            let preferred = row.preferredOffset.map { Self.now.addingTimeInterval($0) }
+            let window = MigrationCadence.window(margin: row.margin, preferredExecutableAt: preferred, now: Self.now)
+            let expected = Self.now.addingTimeInterval(row.expectedOffset)
+
+            #expect(window == expected, "Row \(row.name) expected \(expected) but got \(window)")
+        }
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
@@ -628,7 +628,7 @@ import ComposableArchitecture
 
     // MARK: - MOB-1468: Keystone signing — empty batch never submits/stores (no-partial-storage)
 
-    @MainActor @Test func foundPCZTBatchWithEmptyArrayForNoteSplitContextNeverCallsSubmitAndPresentsFailure() async {
+    @MainActor @Test func foundPCZTBatchWithEmptyArrayForNoteSplitContextAbandonsSessionWithoutSubmitting() async {
         let submitCalls = LockIsolated<Int>(0)
         var state = MigrationCoordFlow.State()
         state.pendingKeystoneSigning = .noteSplit
@@ -647,18 +647,20 @@ import ComposableArchitecture
         store.exhaustivity = .off
 
         await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch([])))))
-        await store.receive(\.keystoneSigningSubmitted)
+        await store.receive(\.keystoneScanAbandoned)
 
         #expect(submitCalls.value == 0)
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 1)
         guard case let .noteSplit(noteSplitState) = try? #require(store.state.path.last) else {
-            Issue.record("Expected .noteSplit remaining on top")
+            Issue.record("Expected pop back to .noteSplit (scan + sign removed)")
             return
         }
-        #expect(noteSplitState.isFailurePresented == true)
+        #expect(noteSplitState.phase == MigrationNoteSplit.State.Phase.explainer)
         #expect(noteSplitState.signedNoteSplitPczt == nil)
     }
 
-    @MainActor @Test func foundPCZTBatchWithEmptyArrayForPlanCommitContextNeverCallsStoreAndStaysOnScan() async {
+    @MainActor @Test func foundPCZTBatchWithEmptyArrayForPlanCommitContextAbandonsSessionWithoutStoring() async {
         let storeCalls = LockIsolated<Int>(0)
         var state = MigrationCoordFlow.State()
         state.pendingKeystoneSigning = .planCommit
@@ -674,14 +676,15 @@ import ComposableArchitecture
         store.exhaustivity = .off
 
         await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch([])))))
+        await store.receive(\.keystoneScanAbandoned)
 
         #expect(storeCalls.value == 0)
-        // No pop, no resume — the empty-batch guard is a plain no-op, leaving the user on `scan`
-        // for a re-scan (context stays pending, same as any other unresolved scan).
-        #expect(store.state.pendingKeystoneSigning == MigrationCoordFlow.KeystoneSigningContext.planCommit)
-        #expect(store.state.path.count == 3)
-        guard case .scan = try? #require(store.state.path.last) else {
-            Issue.record("Expected .scan to remain on top (no pop on an empty batch no-op)")
+        // Deferred pop of scan + sign back to the plan, context cleared — the user re-initiates
+        // signing from the confirm button (no-partial-storage invariant: nothing was stored).
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 1)
+        guard case .transferPlan = try? #require(store.state.path.last) else {
+            Issue.record("Expected pop back to .transferPlan (scan + sign removed)")
             return
         }
     }

--- a/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
@@ -6,9 +6,17 @@
 //  for MOB-1466: re-entry routing (`.onAppear`), the chaining table from Entry through Complete
 //  for all three modes (immediate/scheduled/manual), the permission-step helper's skip logic,
 //  sendNow/reschedule/recovery orchestration, and every flow-root close path's `.flowFinished`
-//  emission. `.serialized`: every `MigrationCoordFlow.State()` carries a `MigrationEntry.State`
-//  (`entryState`), which reads the process-global `@Shared(.inMemory(.selectedWalletAccount))` on
-//  init — matching the precedent in `MigrationEntryTests`, which mutates the same key directly.
+//  emission. Also covers MOB-1468's Keystone signing round-trip: each of the three signing
+//  sources' `.keystoneSignRequested` delegate sets `pendingKeystoneSigning` and pushes
+//  `keystoneSign`; `keystoneSign(.delegate(.getSignature))` pushes `scan` configured with the
+//  migration batch checker; `scan(.foundPCZTBatch)` routes to the right SDK member per context, pops
+//  `scan`+`keystoneSign`, and resumes the matching chain (noteSplit splitting phase / plan
+//  post-confirm / immediate sending) — verified with order-asserting spies; `.rejected` pops back to
+//  the signing source with its state intact and clears the context; the no-partial-storage invariant
+//  (reject, or an empty scanned batch, never calls submit/store). `.serialized`: every
+//  `MigrationCoordFlow.State()` carries a `MigrationEntry.State` (`entryState`), which reads the
+//  process-global `@Shared(.inMemory(.selectedWalletAccount))` on init — matching the precedent in
+//  `MigrationEntryTests`, which mutates the same key directly.
 //
 
 import Testing
@@ -367,6 +375,387 @@ import ComposableArchitecture
         }
         #expect(sendingState.totalCount == 1)
         #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    // MARK: - MOB-1468: Keystone signing — signRequested sets context + pushes keystoneSign
+
+    @MainActor @Test func noteSplitKeystoneSignRequestedSetsNoteSplitContextAndPushesKeystoneSign() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .explainer)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        let pczts: [Pczt] = [Data([0xAA])]
+        await store.send(.path(.element(id: 0, action: .noteSplit(.delegate(.keystoneSignRequested(pczts))))))
+
+        #expect(store.state.pendingKeystoneSigning == MigrationCoordFlow.KeystoneSigningContext.noteSplit)
+        guard case let .keystoneSign(signState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .keystoneSign pushed on top")
+            return
+        }
+        #expect(signState.pczts == pczts)
+    }
+
+    @MainActor @Test func transferPlanKeystoneSignRequestedSetsPlanCommitContextAndPushesKeystoneSign() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        let pczts: [Pczt] = [Data([0xAA]), Data([0xBB])]
+        await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.keystoneSignRequested(pczts))))))
+
+        #expect(store.state.pendingKeystoneSigning == MigrationCoordFlow.KeystoneSigningContext.planCommit)
+        guard case let .keystoneSign(signState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .keystoneSign pushed on top")
+            return
+        }
+        #expect(signState.pczts == pczts)
+    }
+
+    @MainActor @Test func reviewTransferKeystoneSignRequestedSetsImmediateReviewContextAndPushesKeystoneSign() async {
+        var state = MigrationCoordFlow.State()
+        state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        let pczts: [Pczt] = [Data([0xCC])]
+        await store.send(.path(.element(id: 0, action: .reviewTransfer(.delegate(.keystoneSignRequested(pczts))))))
+
+        #expect(store.state.pendingKeystoneSigning == MigrationCoordFlow.KeystoneSigningContext.immediateReview)
+        guard case let .keystoneSign(signState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .keystoneSign pushed on top")
+            return
+        }
+        #expect(signState.pczts == pczts)
+    }
+
+    // MARK: - MOB-1468: Keystone signing — getSignature pushes scan with the migration batch checker
+
+    @MainActor @Test func keystoneSignGetSignaturePushesScanConfiguredWithMigrationBatchChecker() async {
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .noteSplit
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .explainer)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [Pczt()])))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 1, action: .keystoneSign(.delegate(.getSignature)))))
+
+        guard case let .scan(scanState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .scan pushed on top")
+            return
+        }
+        #expect(scanState.checkers == [.keystoneMigrationBatchScanChecker])
+    }
+
+    // MARK: - MOB-1468: Keystone signing — foundPCZTBatch resumes noteSplit
+
+    @MainActor @Test func foundPCZTBatchForNoteSplitContextSubmitsSignedPcztPopsAndMutatesNoteSplitIntoSplittingPhase() async {
+        let callOrder = LockIsolated<[String]>([])
+        let signed: Pczt = Data([0xAA])
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .noteSplit
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .explainer)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [signed])))
+        state.path.append(.scan(Scan.State.initial))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.submitSignedNoteSplit = { pczt in
+                callOrder.withValue { $0.append("submitSignedNoteSplit(\(pczt))") }
+                return .success(txId: "keystone-split-tx-id")
+            }
+            $0.sdkSynchronizer.storeSignedMigrationTransactions = { _ in
+                callOrder.withValue { $0.append("storeSignedMigrationTransactions") }
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch([signed])))))
+        await store.receive(\.keystoneSigningSubmitted)
+
+        #expect(callOrder.value == ["submitSignedNoteSplit(\(signed))"])
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 1)
+        guard case let .noteSplit(noteSplitState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected scan+keystoneSign popped, .noteSplit remaining on top")
+            return
+        }
+        #expect(noteSplitState.phase == MigrationNoteSplit.State.Phase.splitting)
+        #expect(noteSplitState.txId == "keystone-split-tx-id")
+        #expect(noteSplitState.signedNoteSplitPczt == signed)
+        #expect(noteSplitState.isFailurePresented == false)
+    }
+
+    @MainActor @Test func foundPCZTBatchForNoteSplitContextWithFailureResultPresentsFailureSheetAndKeepsSignedPczt() async {
+        let signed: Pczt = Data([0xBB])
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .noteSplit
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .explainer)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [signed])))
+        state.path.append(.scan(Scan.State.initial))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.submitSignedNoteSplit = { _ in .networkError(retryable: true) }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch([signed])))))
+        await store.receive(\.keystoneSigningSubmitted)
+
+        guard case let .noteSplit(noteSplitState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .noteSplit remaining on top")
+            return
+        }
+        #expect(noteSplitState.phase == MigrationNoteSplit.State.Phase.splitting)
+        #expect(noteSplitState.isFailurePresented == true)
+        #expect(noteSplitState.signedNoteSplitPczt == signed)
+    }
+
+    // MARK: - MOB-1468: Keystone signing — foundPCZTBatch resumes planCommit (shared post-confirm chain)
+
+    @MainActor @Test func foundPCZTBatchForPlanCommitContextStoresPopsAndPushesScheduledForScheduledVariant() async {
+        let callOrder = LockIsolated<[String]>([])
+        let signed: [Pczt] = [Data([0xAA]), Data([0xBB])]
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .planCommit
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: signed)))
+        state.path.append(.scan(Scan.State.initial))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.storeSignedMigrationTransactions = { stored in
+                #expect(stored == signed)
+                callOrder.withValue { $0.append("store") }
+            }
+            $0.migrationBGScheduler.scheduleFirstWindow = { callOrder.withValue { $0.append("scheduleFirstWindow") } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch(signed)))))
+        await store.receive(\.keystoneSigningSubmitted)
+
+        #expect(callOrder.value == ["store", "scheduleFirstWindow"])
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 2)
+        guard case .scheduled = try? #require(store.state.path.last) else {
+            Issue.record("Expected .scheduled pushed on top of the retained .transferPlan element")
+            return
+        }
+        guard case .transferPlan = try? #require(store.state.path[id: 0]) else {
+            Issue.record("Expected .transferPlan retained at the bottom (never re-signs again)")
+            return
+        }
+    }
+
+    @MainActor @Test func foundPCZTBatchForPlanCommitContextPushesSendingForManualVariant() async {
+        let signed: [Pczt] = [Data([0xCC])]
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil)
+        state.pendingKeystoneSigning = .planCommit
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .manual)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: signed)))
+        state.path.append(.scan(Scan.State.initial))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.storeSignedMigrationTransactions = { _ in }
+            $0.migrationBGScheduler.scheduleFirstWindow = { }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch(signed)))))
+        await store.receive(\.keystoneSigningSubmitted)
+
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed on top for the manual variant")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
+        #expect(sendingState.networkPrivacyOptions == NetworkPrivacyOptions(useTor: true, submissionEndpoint: nil))
+    }
+
+    // MARK: - MOB-1468: Keystone signing — foundPCZTBatch resumes immediateReview
+
+    @MainActor @Test func foundPCZTBatchForImmediateReviewContextStoresPopsAndPushesSending() async {
+        let storeCalls = LockIsolated<[[Pczt]]>([])
+        let signed: [Pczt] = [Data([0xDD])]
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        state.pendingKeystoneSigning = .immediateReview
+        state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: signed)))
+        state.path.append(.scan(Scan.State.initial))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.storeSignedMigrationTransactions = { stored in storeCalls.withValue { $0.append(stored) } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch(signed)))))
+        await store.receive(\.keystoneSigningSubmitted)
+
+        #expect(storeCalls.value == [signed])
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 2)
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed on top of the retained .reviewTransfer element")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
+        guard case .reviewTransfer = try? #require(store.state.path[id: 0]) else {
+            Issue.record("Expected .reviewTransfer retained at the bottom")
+            return
+        }
+    }
+
+    // MARK: - MOB-1468: Keystone signing — empty batch never submits/stores (no-partial-storage)
+
+    @MainActor @Test func foundPCZTBatchWithEmptyArrayForNoteSplitContextNeverCallsSubmitAndPresentsFailure() async {
+        let submitCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .noteSplit
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .explainer)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [Pczt()])))
+        state.path.append(.scan(Scan.State.initial))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.submitSignedNoteSplit = { _ in
+                submitCalls.withValue { $0 += 1 }
+                return .success(txId: "should-not-be-called")
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch([])))))
+        await store.receive(\.keystoneSigningSubmitted)
+
+        #expect(submitCalls.value == 0)
+        guard case let .noteSplit(noteSplitState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .noteSplit remaining on top")
+            return
+        }
+        #expect(noteSplitState.isFailurePresented == true)
+        #expect(noteSplitState.signedNoteSplitPczt == nil)
+    }
+
+    @MainActor @Test func foundPCZTBatchWithEmptyArrayForPlanCommitContextNeverCallsStoreAndStaysOnScan() async {
+        let storeCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .planCommit
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [Pczt()])))
+        state.path.append(.scan(Scan.State.initial))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.storeSignedMigrationTransactions = { _ in storeCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 2, action: .scan(.foundPCZTBatch([])))))
+
+        #expect(storeCalls.value == 0)
+        // No pop, no resume — the empty-batch guard is a plain no-op, leaving the user on `scan`
+        // for a re-scan (context stays pending, same as any other unresolved scan).
+        #expect(store.state.pendingKeystoneSigning == MigrationCoordFlow.KeystoneSigningContext.planCommit)
+        #expect(store.state.path.count == 3)
+        guard case .scan = try? #require(store.state.path.last) else {
+            Issue.record("Expected .scan to remain on top (no pop on an empty batch no-op)")
+            return
+        }
+    }
+
+    // MARK: - MOB-1468: Keystone signing — rejected pops back with state intact, context cleared
+
+    @MainActor @Test func keystoneSignRejectedPopsBackToNoteSplitWithExplainerStateIntactAndClearsContext() async {
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .noteSplit
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .explainer)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [Pczt()])))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 1, action: .keystoneSign(.delegate(.rejected)))))
+        await store.receive(\.keystoneSignRejected)
+
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 1)
+        guard case let .noteSplit(noteSplitState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .keystoneSign popped, .noteSplit remaining on top")
+            return
+        }
+        #expect(noteSplitState.phase == MigrationNoteSplit.State.Phase.explainer)
+        #expect(noteSplitState.signedNoteSplitPczt == nil)
+    }
+
+    @MainActor @Test func keystoneSignRejectedPopsBackToUnsignedTransferPlanConfirmingScreenUntouched() async {
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .planCommit
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [Pczt(), Pczt()])))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 1, action: .keystoneSign(.delegate(.rejected)))))
+        await store.receive(\.keystoneSignRejected)
+
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 1)
+        guard case .transferPlan = try? #require(store.state.path.last) else {
+            Issue.record("Expected .keystoneSign popped, .transferPlan remaining on top, unsigned")
+            return
+        }
+    }
+
+    @MainActor @Test func keystoneSignRejectedNeverCallsSubmitOrStore() async {
+        let submitCalls = LockIsolated<Int>(0)
+        let storeCalls = LockIsolated<Int>(0)
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .noteSplit
+        state.path.append(.noteSplit(MigrationNoteSplit.State(phase: .explainer)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [Pczt()])))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.submitSignedNoteSplit = { _ in
+                submitCalls.withValue { $0 += 1 }
+                return .success(txId: "should-not-be-called")
+            }
+            $0.sdkSynchronizer.storeSignedMigrationTransactions = { _ in storeCalls.withValue { $0 += 1 } }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.path(.element(id: 1, action: .keystoneSign(.delegate(.rejected)))))
+        await store.receive(\.keystoneSignRejected)
+
+        #expect(submitCalls.value == 0)
+        #expect(storeCalls.value == 0)
     }
 
     @MainActor @Test func sendingClosedInImmediateModeAcknowledgesCompleteAndFinishesFlow() async {

--- a/zodlTests/MigrationTests/MigrationKeystoneSignTests.swift
+++ b/zodlTests/MigrationTests/MigrationKeystoneSignTests.swift
@@ -1,0 +1,70 @@
+//
+//  MigrationKeystoneSignTests.swift
+//  zodlTests
+//
+//  Covers the MigrationKeystoneSign reducer
+//  (Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignStore.swift) for MOB-1468: the
+//  default state, `getSignatureTapped`/`rejectTapped` delegate emissions, `onAppear`'s no-op
+//  contract, and the `.delegate` action itself producing no further state change or effects. The
+//  `UREncoder` is computed live in the view via `sdkSynchronizer.urEncoderForMigrationPCZTBatch`
+//  (mirroring `SignWithKeystoneView`'s `urEncoderForPCZT` approach) rather than cached in `State`,
+//  so there is no encoder-loading effect at the reducer level to assert on here. No shared/global
+//  state driven by this reducer directly -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationKeystoneSignTests {
+    @MainActor @Test func defaultStateHasNoPCZTsAndNoSelectedAccount() async {
+        let state = MigrationKeystoneSign.State()
+
+        #expect(state.pczts.isEmpty)
+        #expect(state.selectedWalletAccount == nil)
+    }
+
+    @MainActor @Test func initWithPcztsPopulatesState() async {
+        let pczts: [Pczt] = [Data([0xAA]), Data([0xBB])]
+        let state = MigrationKeystoneSign.State(pczts: pczts)
+
+        #expect(state.pczts == pczts)
+    }
+
+    @MainActor @Test func onAppearProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationKeystoneSign.State(pczts: [Pczt()])) {
+            MigrationKeystoneSign()
+        }
+
+        await store.send(.onAppear)
+    }
+
+    @MainActor @Test func getSignatureTappedEmitsDelegateGetSignature() async {
+        let store = TestStore(initialState: MigrationKeystoneSign.State(pczts: [Pczt()])) {
+            MigrationKeystoneSign()
+        }
+
+        await store.send(.getSignatureTapped)
+        await store.receive(.delegate(.getSignature))
+    }
+
+    @MainActor @Test func rejectTappedEmitsDelegateRejected() async {
+        let store = TestStore(initialState: MigrationKeystoneSign.State(pczts: [Pczt()])) {
+            MigrationKeystoneSign()
+        }
+
+        await store.send(.rejectTapped)
+        await store.receive(.delegate(.rejected))
+    }
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationKeystoneSign.State(pczts: [Pczt()])) {
+            MigrationKeystoneSign()
+        }
+
+        await store.send(.delegate(.getSignature))
+        await store.send(.delegate(.rejected))
+    }
+}

--- a/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
+++ b/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
@@ -7,18 +7,36 @@
 //  default phase/state, the txid pasteboard copy, the failure sheet dismissal (cancel/retry), the
 //  `continueTapped` delegate contract, and (MOB-1466) `onAppear` load/resume, `confirmTapped`
 //  submission, the `migrationStateStream()` subscription driving `.splitConfirmed`, and retry
-//  re-submission. The copy action writes the shared toast (`@Shared` in-memory state) ->
-//  `.serialized` per the repo rule for suites mutating process-global state.
+//  re-submission. Also covers MOB-1468's Keystone fork: a Keystone-vendor account's `confirmTapped`
+//  proposes the note-split PCZT and delegates `.keystoneSignRequested` instead of submitting locally
+//  (`.zcash` regression unaffected), and `retryTapped` re-broadcasts a coordinator-set
+//  `signedNoteSplitPczt` via `submitSignedNoteSplit` rather than re-submitting the proposal.
+//  `.serialized`: several cases drive the process-global `@Shared(.inMemory(.selectedWalletAccount))`,
+//  and the copy action writes the shared toast.
 //
 
 import Testing
 import Foundation
 @preconcurrency import Combine
 import ComposableArchitecture
-@preconcurrency import ZcashLightClientKit
+@testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite(.serialized) struct MigrationNoteSplitTests {
+    private func walletAccount(keystone: Bool, idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: keystone ? "Keystone" : "Zodl",
+                keySource: keystone ? String(localizable: .accountsKeystone).lowercased() : nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
     @MainActor @Test func defaultStateIsExplainerWithNoFailureSheet() async {
         let state = MigrationNoteSplit.State()
 
@@ -28,6 +46,8 @@ import ComposableArchitecture
         #expect(state.txId == "")
         #expect(state.isFailurePresented == false)
         #expect(state.isFlowRoot == false)
+        #expect(state.signedNoteSplitPczt == nil)
+        #expect(state.selectedWalletAccount == nil)
     }
 
     @MainActor @Test func closeTappedWhenFlowRootEmitsDelegateContinued() async {
@@ -274,5 +294,152 @@ import ComposableArchitecture
 
         stateStream.send(completion: .finished)
         await store.finish()
+    }
+
+    // MARK: - MOB-1468: Keystone confirmTapped fork
+
+    @MainActor @Test func confirmTappedWithKeystoneAccountProposesPCZTAndDelegatesKeystoneSignRequestedWithoutSubmitting() async {
+        let proposeCalls = LockIsolated<Int>(0)
+        let submitCalls = LockIsolated<Int>(0)
+        let pczt: Pczt = Data([0xAA, 0xBB])
+        var state = MigrationNoteSplit.State(phase: .explainer)
+        state.proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true, idByte: 1) }
+        let store = TestStore(initialState: state) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeNoteSplitPCZT = {
+                proposeCalls.withValue { $0 += 1 }
+                return pczt
+            }
+            $0.sdkSynchronizer.submitNoteSplit = { _ in
+                submitCalls.withValue { $0 += 1 }
+                return .success(txId: "should-not-be-called")
+            }
+        }
+
+        // Keystone confirm doesn't flip the phase locally — the coordinator does that once the QR
+        // round-trip resolves.
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.keystoneSignRequested([pczt])))
+
+        #expect(proposeCalls.value == 1)
+        #expect(submitCalls.value == 0)
+        #expect(store.state.phase == .explainer)
+    }
+
+    @MainActor @Test func confirmTappedWithZcashAccountUsesSoftwarePathUnchanged() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let proposeCalls = LockIsolated<Int>(0)
+        let proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+        var state = MigrationNoteSplit.State(phase: .explainer)
+        state.proposal = proposal
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: false, idByte: 2) }
+        let store = TestStore(initialState: state) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.proposeNoteSplitPCZT = {
+                proposeCalls.withValue { $0 += 1 }
+                return Pczt()
+            }
+            $0.sdkSynchronizer.submitNoteSplit = { _ in .success(txId: "e87f1234567890abcdef6f28b") }
+        }
+
+        await store.send(.confirmTapped) {
+            $0.phase = .splitting
+        }
+        await store.receive(\.splitResult) {
+            $0.txId = "e87f1234567890abcdef6f28b"
+        }
+
+        #expect(proposeCalls.value == 0)
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    // MARK: - MOB-1468: Keystone note-split Retry forks on signedNoteSplitPczt
+
+    @MainActor @Test func retryTappedWithSignedNoteSplitPcztRebroadcastsSamePcztInsteadOfResubmittingProposal() async {
+        let submitSignedCalls = LockIsolated<[Pczt]>([])
+        let submitProposalCalls = LockIsolated<Int>(0)
+        let signedPczt: Pczt = Data([0xCC, 0xDD])
+        var state = MigrationNoteSplit.State(phase: .splitting, isFailurePresented: true, signedNoteSplitPczt: signedPczt)
+        state.proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+        let store = TestStore(initialState: state) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.submitSignedNoteSplit = { pczt in
+                submitSignedCalls.withValue { $0.append(pczt) }
+                return .success(txId: "resubmitted-tx-id")
+            }
+            $0.sdkSynchronizer.submitNoteSplit = { _ in
+                submitProposalCalls.withValue { $0 += 1 }
+                return .success(txId: "should-not-be-called")
+            }
+        }
+
+        await store.send(.retryTapped) {
+            $0.isFailurePresented = false
+        }
+        await store.receive(\.splitResult) {
+            $0.txId = "resubmitted-tx-id"
+        }
+
+        #expect(submitSignedCalls.value == [signedPczt])
+        #expect(submitProposalCalls.value == 0)
+    }
+
+    @MainActor @Test func retryTappedWithNoSignedNoteSplitPcztUsesExistingSoftwareRetry() async {
+        let stateStream = PassthroughSubject<MigrationState, Never>()
+        let submitSignedCalls = LockIsolated<Int>(0)
+        let submitProposalCalls = LockIsolated<Int>(0)
+        let proposal = NoteSplitProposal(outputNotes: [Zatoshi(500_000_000)], fee: Zatoshi(100_000))
+        var state = MigrationNoteSplit.State(phase: .splitting, isFailurePresented: true)
+        state.proposal = proposal
+        let store = TestStore(initialState: state) {
+            MigrationNoteSplit()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.migrationStateStream = { stateStream.eraseToAnyPublisher() }
+            $0.sdkSynchronizer.submitSignedNoteSplit = { _ in
+                submitSignedCalls.withValue { $0 += 1 }
+                return .success(txId: "should-not-be-called")
+            }
+            $0.sdkSynchronizer.submitNoteSplit = { _ in
+                submitProposalCalls.withValue { $0 += 1 }
+                return .success(txId: "retried-tx-id")
+            }
+        }
+
+        await store.send(.retryTapped) {
+            $0.isFailurePresented = false
+        }
+        await store.receive(\.splitResult) {
+            $0.txId = "retried-tx-id"
+        }
+
+        #expect(submitSignedCalls.value == 0)
+        #expect(submitProposalCalls.value == 1)
+
+        stateStream.send(completion: .finished)
+        await store.finish()
+    }
+
+    @MainActor @Test func splitConfirmedClearsSignedNoteSplitPczt() async {
+        let store = TestStore(
+            initialState: MigrationNoteSplit.State(phase: .splitting, signedNoteSplitPczt: Data([0xEE]))
+        ) {
+            MigrationNoteSplit()
+        }
+
+        await store.send(.splitConfirmed) {
+            $0.phase = .confirmed
+            $0.signedNoteSplitPczt = nil
+        }
     }
 }

--- a/zodlTests/MigrationTests/MigrationNotificationTests.swift
+++ b/zodlTests/MigrationTests/MigrationNotificationTests.swift
@@ -1,0 +1,178 @@
+//
+//  MigrationNotificationTests.swift
+//  zodlTests
+//
+//  Covers `MigrationNotification` (Dependencies/UserNotifications/MigrationNotification.swift)
+//  for MOB-1467: the stable "migration."-prefixed `identifier` per case, the localized `title`/
+//  `body` (§4.4 matrix copy verbatim), and format-arg rendering (transfer numbers, hour counts,
+//  the `Zatoshi.decimalString()` remaining-amount rendering). Pure enum, no shared state ->
+//  no `.serialized`.
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationNotificationTests {
+    // MARK: - identifier
+
+    @Test func identifierTable() {
+        struct Row {
+            let name: String
+            let notification: MigrationNotification
+            let expected: String
+        }
+
+        let rows: [Row] = [
+            Row(
+                name: "transferComplete",
+                notification: MigrationNotification.transferComplete(number: 1, total: 5, nextInHours: 6, remaining: Zatoshi(100)),
+                expected: "migration.transferComplete"
+            ),
+            Row(
+                name: "transferWaiting",
+                notification: MigrationNotification.transferWaiting(number: 2),
+                expected: "migration.transferWaiting"
+            ),
+            Row(
+                name: "planNeedsUpdate",
+                notification: MigrationNotification.planNeedsUpdate,
+                expected: "migration.planNeedsUpdate"
+            ),
+            Row(
+                name: "manualTransferReady",
+                notification: MigrationNotification.manualTransferReady(number: 3),
+                expected: "migration.manualTransferReady"
+            ),
+            Row(
+                name: "migrationComplete",
+                notification: MigrationNotification.migrationComplete,
+                expected: "migration.complete"
+            )
+        ]
+
+        for row in rows {
+            #expect(row.notification.identifier == row.expected, "Row \(row.name)")
+            #expect(row.notification.identifier.hasPrefix(MigrationNotification.identifierPrefix), "Row \(row.name) prefix")
+        }
+    }
+
+    @Test func identifiersAreAllUnique() {
+        let notifications: [MigrationNotification] = [
+            MigrationNotification.transferComplete(number: 1, total: 1, nextInHours: 1, remaining: Zatoshi.zero),
+            MigrationNotification.transferWaiting(number: 1),
+            MigrationNotification.planNeedsUpdate,
+            MigrationNotification.manualTransferReady(number: 1),
+            MigrationNotification.migrationComplete
+        ]
+
+        let identifiers = Set(notifications.map { $0.identifier })
+        #expect(identifiers.count == notifications.count)
+    }
+
+    // MARK: - title
+
+    @Test func titleTable() {
+        struct Row {
+            let name: String
+            let notification: MigrationNotification
+            let expected: String
+        }
+
+        let rows: [Row] = [
+            Row(
+                name: "transferComplete",
+                notification: MigrationNotification.transferComplete(number: 1, total: 5, nextInHours: 6, remaining: Zatoshi(100)),
+                expected: "Migration update"
+            ),
+            Row(
+                name: "transferWaiting",
+                notification: MigrationNotification.transferWaiting(number: 2),
+                expected: "Action needed"
+            ),
+            Row(
+                name: "planNeedsUpdate",
+                notification: MigrationNotification.planNeedsUpdate,
+                expected: "Action needed"
+            ),
+            Row(
+                name: "manualTransferReady",
+                notification: MigrationNotification.manualTransferReady(number: 3),
+                expected: "Action needed"
+            ),
+            Row(
+                name: "migrationComplete",
+                notification: MigrationNotification.migrationComplete,
+                expected: "Migration complete"
+            )
+        ]
+
+        for row in rows {
+            #expect(row.notification.title == row.expected, "Row \(row.name)")
+        }
+    }
+
+    // MARK: - body — §4.4 matrix copy verbatim, incl. format-arg rendering
+
+    @Test func transferCompleteBodyRendersAllFourArgs() {
+        let notification = MigrationNotification.transferComplete(
+            number: 2,
+            total: 5,
+            nextInHours: 6,
+            remaining: Zatoshi(123_456_789)
+        )
+
+        let expected = "Transfer 2 of 5 complete — next send in ~6 hours. "
+            + "\(Zatoshi(123_456_789).decimalString()) ZEC remaining in Orchard."
+        #expect(notification.body == expected)
+    }
+
+    @Test func transferCompleteBodyRendersZeroRemaining() {
+        let notification = MigrationNotification.transferComplete(
+            number: 5,
+            total: 5,
+            nextInHours: 0,
+            remaining: Zatoshi.zero
+        )
+
+        let expected = "Transfer 5 of 5 complete — next send in ~0 hours. "
+            + "\(Zatoshi.zero.decimalString()) ZEC remaining in Orchard."
+        #expect(notification.body == expected)
+    }
+
+    @Test func transferWaitingBodyRendersNumber() {
+        let notification = MigrationNotification.transferWaiting(number: 3)
+
+        #expect(notification.body == "Transfer 3 waiting. Open ZODL to send or re-schedule.")
+    }
+
+    @Test func planNeedsUpdateBodyIsFixedCopy() {
+        let notification = MigrationNotification.planNeedsUpdate
+
+        #expect(notification.body == "Migration plan needs update. Open ZODL to review the details.")
+    }
+
+    @Test func manualTransferReadyBodyRendersNumber() {
+        let notification = MigrationNotification.manualTransferReady(number: 4)
+
+        #expect(notification.body == "Transfer 4 — ready to send. Open ZODL to review the details.")
+    }
+
+    @Test func migrationCompleteBodyIsFixedCopy() {
+        let notification = MigrationNotification.migrationComplete
+
+        #expect(notification.body == "Migration complete. Open ZODL to review the details.")
+    }
+
+    // MARK: - Equatable
+
+    @Test func transferCompleteIsEquatableByAllPayloadFields() {
+        let a = MigrationNotification.transferComplete(number: 1, total: 5, nextInHours: 6, remaining: Zatoshi(100))
+        let b = MigrationNotification.transferComplete(number: 1, total: 5, nextInHours: 6, remaining: Zatoshi(100))
+        let c = MigrationNotification.transferComplete(number: 2, total: 5, nextInHours: 6, remaining: Zatoshi(100))
+
+        #expect(a == b)
+        #expect(a != c)
+    }
+}

--- a/zodlTests/MigrationTests/MigrationReviewTransferTests.swift
+++ b/zodlTests/MigrationTests/MigrationReviewTransferTests.swift
@@ -10,17 +10,35 @@
 //  the coordinator (no propose) and confirm delegates directly (the transfer was already signed at
 //  plan commit). Also covers the `isFlowRoot`-gated back control for the manual-step variant: a new
 //  `Delegate.closed` case (reusing `.confirmed` for a back-tap would be a correctness bug — that
-//  case means "user confirmed the transfer", not "user backed out"). No shared/global state ->
-//  no `.serialized`.
+//  case means "user confirmed the transfer", not "user backed out"). Also covers MOB-1468's
+//  Keystone fork: a Keystone-vendor account in immediate mode proposes the schedule's PCZT via
+//  `proposeMigrationPCZTs(schedule)` and delegates `.keystoneSignRequested` instead of signing+
+//  storing locally (`.zcash` regression unaffected); the manual-step path never forks, even for a
+//  Keystone account (those transfers were already signed at plan commit). `.serialized`: several
+//  cases drive the process-global `@Shared(.inMemory(.selectedWalletAccount))`.
 //
 
 import Testing
 import Foundation
 import ComposableArchitecture
-@preconcurrency import ZcashLightClientKit
+@testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite struct MigrationReviewTransferTests {
+@Suite(.serialized) struct MigrationReviewTransferTests {
+    private func walletAccount(keystone: Bool, idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: keystone ? "Keystone" : "Zodl",
+                keySource: keystone ? String(localizable: .accountsKeystone).lowercased() : nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
     @MainActor @Test func defaultStateIsImmediateModeWithZeroAmounts() async {
         let state = MigrationReviewTransfer.State()
 
@@ -28,6 +46,7 @@ import ComposableArchitecture
         #expect(state.amount == Zatoshi.zero)
         #expect(state.fee == Zatoshi.zero)
         #expect(state.isFlowRoot == false)
+        #expect(state.selectedWalletAccount == nil)
     }
 
     @MainActor @Test func closeTappedWhenFlowRootEmitsDelegateClosed() async {
@@ -149,6 +168,91 @@ import ComposableArchitecture
         await store.send(.confirmTapped)
         await store.receive(.delegate(.confirmed))
 
+        #expect(signCalls.value == 0)
+    }
+
+    // MARK: - MOB-1468: Keystone confirmTapped fork
+
+    @MainActor @Test func confirmTappedInImmediateModeWithKeystoneAccountProposesPCZTAndDelegatesKeystoneSignRequestedWithoutSigning() async {
+        let proposeCalls = LockIsolated<[MigrationSchedule]>([])
+        let signCalls = LockIsolated<Int>(0)
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(1_245_800_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 0
+        )
+        let pczts: [Pczt] = [Data([0xAA])]
+        var state = MigrationReviewTransfer.State(mode: .immediate)
+        state.schedule = schedule
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true, idByte: 1) }
+        let store = TestStore(initialState: state) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationPCZTs = { proposed in
+                proposeCalls.withValue { $0.append(proposed) }
+                return pczts
+            }
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in signCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.keystoneSignRequested(pczts)))
+
+        #expect(proposeCalls.value == [schedule])
+        #expect(signCalls.value == 0)
+    }
+
+    @MainActor @Test func confirmTappedInImmediateModeWithZcashAccountUsesSoftwarePathUnchanged() async {
+        let proposeCalls = LockIsolated<Int>(0)
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(1_245_800_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 0
+        )
+        var state = MigrationReviewTransfer.State(mode: .immediate)
+        state.schedule = schedule
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: false, idByte: 2) }
+        let store = TestStore(initialState: state) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationPCZTs = { _ in
+                proposeCalls.withValue { $0 += 1 }
+                return []
+            }
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(proposeCalls.value == 0)
+    }
+
+    @MainActor @Test func confirmTappedInManualStepModeWithKeystoneAccountNeverForksAndDelegatesConfirmedDirectly() async {
+        let proposeCalls = LockIsolated<Int>(0)
+        let signCalls = LockIsolated<Int>(0)
+        var state = MigrationReviewTransfer.State(mode: .manualStep(number: 3, total: 5))
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true, idByte: 3) }
+        let store = TestStore(initialState: state) {
+            MigrationReviewTransfer()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationPCZTs = { _ in
+                proposeCalls.withValue { $0 += 1 }
+                return []
+            }
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in signCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(proposeCalls.value == 0)
         #expect(signCalls.value == 0)
     }
 }

--- a/zodlTests/MigrationTests/MigrationSDKStubTests.swift
+++ b/zodlTests/MigrationTests/MigrationSDKStubTests.swift
@@ -14,6 +14,7 @@
 
 import Testing
 import Foundation
+@preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite struct MigrationSDKStubTests {
@@ -41,6 +42,12 @@ import Foundation
             MigrationSchedule(transfers: [], estimatedDurationHours: 0)
         )
         #expect(pczts.isEmpty)
+
+        // MOB-1468: Keystone batch-signing stubs.
+        let noteSplitResult = await client.submitSignedNoteSplit(Pczt())
+        #expect(noteSplitResult == TransferResult.success(txId: ""))
+        #expect(client.urEncoderForMigrationPCZTBatch([Pczt()]) == nil)
+        #expect(client.parseMigrationPCZTBatch(Data()) == nil)
     }
 
     @Test func mockedMigrationEndpointsAreInert() async {
@@ -57,5 +64,11 @@ import Foundation
             NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
         )
         #expect(executedTransfer == nil)
+
+        // MOB-1468: Keystone batch-signing stubs.
+        let noteSplitResult = await client.submitSignedNoteSplit(Pczt())
+        #expect(noteSplitResult == TransferResult.success(txId: ""))
+        #expect(client.urEncoderForMigrationPCZTBatch([Pczt()]) == nil)
+        #expect(client.parseMigrationPCZTBatch(Data()) == nil)
     }
 }

--- a/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationTransferPlanTests.swift
@@ -7,18 +7,35 @@
 //  the default `variant`, the `confirmTapped` delegate contract, and (MOB-1466) `onAppear` — a
 //  fresh entry proposes transfers via `proposeMigrationTransfers()` and populates rows/duration,
 //  while an injected schedule (recovery/reschedule variants) is left untouched (no re-propose) —
-//  plus `confirmTapped` signing and storing the schedule via `signAndStoreMigrationSchedule`.
-//  State carries the shared exchange rate but only reads it — nothing here mutates process-global
-//  state -> no `.serialized`.
+//  plus `confirmTapped` signing and storing the schedule via `signAndStoreMigrationSchedule`. Also
+//  covers MOB-1468's Keystone fork: a Keystone-vendor account with `requiresSigning == true`
+//  (fresh/recreated variants) proposes the schedule's PCZTs and delegates `.keystoneSignRequested`
+//  instead of signing+storing locally (`.zcash` regression unaffected); the rescheduled
+//  (`requiresSigning == false`) variant never forks, even for a Keystone account. `.serialized`:
+//  several cases drive the process-global `@Shared(.inMemory(.selectedWalletAccount))`.
 //
 
 import Testing
 import Foundation
 import ComposableArchitecture
-@preconcurrency import ZcashLightClientKit
+@testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite struct MigrationTransferPlanTests {
+@Suite(.serialized) struct MigrationTransferPlanTests {
+    private func walletAccount(keystone: Bool, idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: keystone ? "Keystone" : "Zodl",
+                keySource: keystone ? String(localizable: .accountsKeystone).lowercased() : nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
     @MainActor @Test func defaultStateIsScheduledVariantWithNoRows() async {
         let state = MigrationTransferPlan.State()
 
@@ -26,6 +43,7 @@ import ComposableArchitecture
         #expect(state.rows.isEmpty)
         #expect(state.totalDurationHours == 0)
         #expect(state.injectedSchedule == nil)
+        #expect(state.selectedWalletAccount == nil)
     }
 
     @MainActor @Test func recreatedVariantIsPreservedInState() async {
@@ -166,5 +184,105 @@ import ComposableArchitecture
         await store.send(.confirmTapped)
         await store.receive(\.scheduleSigned)
         await store.receive(.delegate(.confirmed))
+    }
+
+    // MARK: - MOB-1468: Keystone confirmTapped fork
+
+    @MainActor @Test func confirmTappedWithKeystoneAccountAndRequiresSigningProposesPCZTsAndDelegatesKeystoneSignRequestedWithoutSigning() async {
+        let proposeCalls = LockIsolated<[MigrationSchedule]>([])
+        let signCalls = LockIsolated<Int>(0)
+        let schedule = MigrationSchedule(
+            transfers: [
+                TransferProposal(id: "t0", amount: Zatoshi(500_000_000), anchorHeight: 100, nextExecutableAfterHeight: 100, expiryHeight: 200)
+            ],
+            estimatedDurationHours: 24
+        )
+        let pczts: [Pczt] = [Data([0xAA]), Data([0xBB])]
+        var state = MigrationTransferPlan.State(variant: .scheduled)
+        state.schedule = schedule
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true, idByte: 1) }
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationPCZTs = { proposed in
+                proposeCalls.withValue { $0.append(proposed) }
+                return pczts
+            }
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in signCalls.withValue { $0 += 1 } }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.keystoneSignRequested(pczts)))
+
+        #expect(proposeCalls.value == [schedule])
+        #expect(signCalls.value == 0)
+    }
+
+    @MainActor @Test func confirmTappedWithKeystoneRecreatedVariantProposesPCZTsAndDelegatesKeystoneSignRequested() async {
+        let proposeCalls = LockIsolated<Int>(0)
+        let schedule = MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+        let pczts: [Pczt] = [Data([0xCC])]
+        var state = MigrationTransferPlan.State(variant: .recreated)
+        state.schedule = schedule
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true, idByte: 2) }
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationPCZTs = { _ in
+                proposeCalls.withValue { $0 += 1 }
+                return pczts
+            }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.keystoneSignRequested(pczts)))
+
+        #expect(proposeCalls.value == 1)
+    }
+
+    @MainActor @Test func confirmTappedWithZcashAccountUsesSoftwarePathUnchanged() async {
+        let proposeCalls = LockIsolated<Int>(0)
+        let schedule = MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+        var state = MigrationTransferPlan.State(variant: .scheduled)
+        state.schedule = schedule
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: false, idByte: 3) }
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationPCZTs = { _ in
+                proposeCalls.withValue { $0 += 1 }
+                return []
+            }
+            $0.sdkSynchronizer.signAndStoreMigrationSchedule = { _ in }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(\.scheduleSigned)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(proposeCalls.value == 0)
+    }
+
+    @MainActor @Test func confirmTappedWithKeystoneAccountAndRescheduledVariantNeverForksAndFinishesLikeSoftwarePath() async {
+        let proposeCalls = LockIsolated<Int>(0)
+        var state = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: false)
+        state.$selectedWalletAccount.withLock { $0 = walletAccount(keystone: true, idByte: 4) }
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.proposeMigrationPCZTs = { _ in
+                proposeCalls.withValue { $0 += 1 }
+                return []
+            }
+        }
+
+        await store.send(.confirmTapped)
+        await store.receive(.delegate(.confirmed))
+
+        #expect(proposeCalls.value == 0)
     }
 }

--- a/zodlTests/MigrationTests/RootMigrationBackgroundTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationBackgroundTests.swift
@@ -1,0 +1,423 @@
+//
+//  RootMigrationBackgroundTests.swift
+//  zodlTests
+//
+//  Covers MOB-1467's Root-level migration BG session decision tree
+//  (Features/Root/RootInitialization.swift, `.initialization(.migrationBackgroundSession)` and
+//  `.appDelegate(.migrationBackgroundTaskExpired)`): every branch of the spec's ordered tree —
+//  plan-broken, sync-required (deferred and not), send (success/success-to-complete/failure/nil),
+//  and session expiration — driven with spy `MigrationBGSessionHandle`s (`rawTask: nil`, since a
+//  bare `BGProcessingTask` cannot be instantiated in unit tests; see that type's doc comment).
+//
+//  `.serialized`: same precedent as `RootMigrationRoutingTests` — constructing `Root.State` builds
+//  `migrationCoordFlowState = MigrationCoordFlow.State.initial`, which reads the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` key. Uses a plain `Store` (not `TestStore`) with
+//  `withDependencies` overrides and `LockIsolated` spies + polling, mirroring
+//  `RootMigrationRoutingTests`/`FlexaSecurityTests`.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct RootMigrationBackgroundTests {
+    // MARK: - Branch 1: Plan broken
+
+    /// `hasInvalidMigrationTransfers() == true` must post `.planNeedsUpdate` immediately (nil
+    /// date), never re-arm (`scheduleNextWindow`/`scheduleFirstWindow` untouched), and complete
+    /// the session successfully — recovery's own `scheduleFirstWindow` re-arms after the user
+    /// re-creates the plan, not this session.
+    @Test func planBrokenViaInvalidTransfersNotifiesWithoutRearming() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.hasInvalidMigrationTransfers = { true }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, date in
+                    notifications.withValue { $0.append(notification) }
+                    #expect(date == nil)
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 } == [MigrationNotification.planNeedsUpdate])
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 0)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// Same branch, reached via the state shape instead: `.requiresAttention(.transferExpired)`
+    /// must also count as "plan broken", independent of `hasInvalidMigrationTransfers`.
+    @Test func planBrokenViaTransferExpiredStateNotifiesWithoutRearming() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.hasInvalidMigrationTransfers = { false }
+                $0.sdkSynchronizer.getMigrationState = { MigrationState.requiresAttention(AttentionReason.transferExpired) }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 } == [MigrationNotification.planNeedsUpdate])
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 0)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    // MARK: - Branch 2: Sync required
+
+    /// Within 10 min of a foreground broadcast (`isSyncDeferredAfterBroadcast() == true`): skip
+    /// even the sync — re-arm only, complete the session. `state.bgTask` must NOT be touched (no
+    /// sync-only session runs).
+    @Test func syncRequiredButDeferredAfterBroadcastOnlyRearms() async {
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.isSyncRequiredBeforeNextMigrationTransfer = { true }
+                $0.migrationManager.isSyncDeferredAfterBroadcast = { true }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(completeCalls.withValue { $0 } == [true])
+            #expect(store.state.bgTask == nil)
+        }
+    }
+
+    /// Not deferred: a sync-only session. Re-arms up front, stashes `state.bgTask =
+    /// handle.rawTask`, and kicks the same sync path `power_wifi_sync` uses (`.retryStart`) —
+    /// asserted here by actually observing `sdkSynchronizer.start` fire (past `.retryStart`'s
+    /// disk-space guard — overridden true, `RootMigrationRoutingTests`' `initialSetupsInvoke
+    /// MigrationReconcile` precedent — and its own `latestState().syncStatus.isPrepared` guard,
+    /// opened via a mutated `SynchronizerState.zero` with `.upToDate` status). This branch never
+    /// completes `handle` itself — that's the existing `synchronizerStateChanged` machinery's job,
+    /// exactly as for the `power_wifi_sync` task it mirrors — so `completeCalls` stays empty here.
+    @Test func syncRequiredNotDeferredRearmsAndStashesBgTaskForSyncOnlySession() async {
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let startCalls = LockIsolated<[Bool]>([])
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        let preparedState: SynchronizerState = {
+            var state = SynchronizerState.zero
+            state.syncStatus = SyncStatus.upToDate
+            return state
+        }()
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                // `latestState`/`start` are non-`@DependencyClient` `let` fields on
+                // `SDKSynchronizerClient` (no per-field override) — replace the whole client via
+                // its `.mocked(...)` builder (same defaults as `.noOp` for every other field), then
+                // layer the ordinary `var` overrides below on top.
+                $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                    latestState: { preparedState },
+                    start: { _ in startCalls.withValue { $0.append(true) } }
+                )
+                $0.sdkSynchronizer.isSyncRequiredBeforeNextMigrationTransfer = { true }
+                $0.migrationManager.isSyncDeferredAfterBroadcast = { false }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { startCalls.withValue { !$0.isEmpty } }
+
+            // Arm.
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            // Stash: `state.bgTask` takes on `handle.rawTask` (`nil` here — the spy handle shape).
+            #expect(store.state.bgTask == nil)
+            // Kick: `.retryStart` ran all the way to `sdkSynchronizer.start(true)`.
+            #expect(startCalls.withValue { $0 } == [true])
+            // This branch does not itself complete the handle.
+            #expect(completeCalls.withValue { $0 }.isEmpty)
+        }
+    }
+
+    // MARK: - Branch 3: Send
+
+    /// A successful broadcast that does NOT complete the migration: records the broadcast, posts
+    /// `.transferComplete` (never `.migrationComplete`), re-arms, and completes the session.
+    @Test func sendSuccessNotCompleteNotifiesTransferCompleteAndRearms() async {
+        let recordBroadcastCalls = LockIsolated<Int>(0)
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let cancelAllCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        let progress = MigrationProgress(
+            completedTransfers: 2,
+            totalTransfers: 5,
+            remainingOrchard: Zatoshi(12_345),
+            nextTransferReadyAtHeight: nil
+        )
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in TransferResult.success(txId: "tx-1") }
+                $0.sdkSynchronizer.getMigrationState = { MigrationState.inProgress(progress) }
+                $0.sdkSynchronizer.getMigrationProgress = { progress }
+                $0.migrationManager.recordMigrationBroadcast = { recordBroadcastCalls.withValue { $0 += 1 } }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.migrationBGScheduler.cancelAll = { cancelAllCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, date in
+                    notifications.withValue { $0.append(notification) }
+                    #expect(date == nil)
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(recordBroadcastCalls.withValue { $0 } == 1)
+            #expect(notifications.withValue { $0 }.count == 1)
+            if case let MigrationNotification.transferComplete(number, total, _, remaining)? = notifications.withValue({ $0 }).first {
+                #expect(number == 2)
+                #expect(total == 5)
+                #expect(remaining == Zatoshi(12_345))
+            } else {
+                Issue.record("Expected a .transferComplete notification, got \(notifications.withValue { $0 })")
+            }
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(cancelAllCalls.withValue { $0 } == 0)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// A successful broadcast that DOES complete the migration: posts `.migrationComplete`
+    /// (never `.transferComplete`), cancels everything instead of re-arming, and completes the
+    /// session.
+    @Test func sendSuccessToCompleteNotifiesMigrationCompleteAndCancelsAll() async {
+        let recordBroadcastCalls = LockIsolated<Int>(0)
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let cancelAllCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in TransferResult.success(txId: "tx-final") }
+                $0.sdkSynchronizer.getMigrationState = { MigrationState.complete }
+                $0.migrationManager.recordMigrationBroadcast = { recordBroadcastCalls.withValue { $0 += 1 } }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.migrationBGScheduler.cancelAll = { cancelAllCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(recordBroadcastCalls.withValue { $0 } == 1)
+            #expect(notifications.withValue { $0 } == [MigrationNotification.migrationComplete])
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 0)
+            #expect(cancelAllCalls.withValue { $0 } == 1)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// A failed send (`.networkError`) posts `.transferWaiting(number:)` — 1-based, derived from
+    /// `getMigrationProgress()?.completedTransfers ?? 0` + 1 — and re-arms.
+    @Test func sendFailureNotifiesTransferWaitingAndRearms() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        let progress = MigrationProgress(
+            completedTransfers: 3,
+            totalTransfers: 6,
+            remainingOrchard: Zatoshi(500),
+            nextTransferReadyAtHeight: nil
+        )
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in TransferResult.networkError(retryable: true) }
+                $0.sdkSynchronizer.getMigrationProgress = { progress }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 } == [MigrationNotification.transferWaiting(number: 4)])
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// Nothing pending (`nil` result): re-arm only, no notification, complete the session. (The
+    /// LiveKey's own complete-check choke point is what converts a stray re-arm into `cancelAll`
+    /// once the migration is actually done — this test only asserts the Root-level tree calls
+    /// `scheduleNextWindow`, not what that call internally decides.)
+    @Test func nilPendingTransferOnlyRearms() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in nil }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 }.isEmpty)
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    // MARK: - Expiration
+
+    /// `.migrationBackgroundTaskExpired` must re-arm — an expired session must never orphan the
+    /// wakeup chain (re-submitting with the same identifier REPLACES the pending request, so this
+    /// is safe even stacked after branch 2's own up-front re-arm).
+    @Test func expiredSessionRearms() async {
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+            }
+
+            store.send(.initialization(.appDelegate(.migrationBackgroundTaskExpired)))
+            await waitForRootStore { scheduleNextWindowCalls.withValue { $0 } == 1 }
+
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 1)
+            #expect(store.state.bgTask == nil)
+        }
+    }
+}
+
+// MARK: - Shared dependency baseline (mirrors RootMigrationRoutingTests.swift)
+
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mainQueue = .immediate
+    values.mnemonic = .mock
+    values.migrationBGScheduler.backgroundRefreshStatus = { .available }
+    values.migrationBGScheduler.scheduleFirstWindow = { }
+    values.migrationBGScheduler.scheduleNextWindow = { }
+    values.migrationBGScheduler.cancelAll = { }
+    values.migrationManager.bannerVariant = { _ in nil }
+    values.migrationManager.reentryRoute = { .entry }
+    values.migrationManager.migrationMode = { nil }
+    values.migrationManager.setMigrationMode = { _ in }
+    values.migrationManager.setManualDelivery = { _ in }
+    values.migrationManager.setNetworkPrivacyOptions = { _ in }
+    values.migrationManager.acknowledgeComplete = { }
+    values.migrationManager.recordMigrationBroadcast = { }
+    values.migrationManager.reconcile = { }
+    values.migrationManager.isSyncDeferredAfterBroadcast = { false }
+    values.migrationManager.networkPrivacyOptions = { NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil) }
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.load = { _ in }
+    values.userNotifications.authorizationStatus = { .notDetermined }
+    values.userNotifications.requestAuthorization = { false }
+    values.userNotifications.scheduleMigrationNotification = { _, _ in }
+    values.userNotifications.cancelMigrationNotifications = { }
+    values.userNotifications.clearDeliveredMigrationNotifications = { }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}
+
+@MainActor
+private func waitForRootStore(
+    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for migration-background Root store state", sourceLocation: sourceLocation)
+}

--- a/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
@@ -9,6 +9,12 @@
 //  `migrationManager.reconcile()`, and the Sending `.viewTransaction` delegate's Root-level handling
 //  (v1: treated as a flow close — see the `RootCoordinator` doc comment at that case for why).
 //
+//  Also covers MOB-1467's notification-tap deep link (`.appDelegate(.migrationNotificationTapped)`):
+//  immediate routing once Home/initialized, versus the deferred `pendingMigrationDeepLink` path that
+//  mirrors `RootDestination`'s `isAtDeeplinkWarningScreen` gating and fires from
+//  `checkBackupPhraseValidation`'s "just reached Home" checkpoint — plus the `willEnterForeground`
+//  delivered-notifications clear.
+//
 //  `.serialized`: constructing `Root.State` builds `migrationCoordFlowState = MigrationCoordFlow
 //  .State.initial`, which itself builds a `MigrationEntry.State` reading the process-global
 //  `@Shared(.inMemory(.selectedWalletAccount))` key — same precedent as `MigrationCoordFlowTests`.
@@ -173,6 +179,97 @@ import ComposableArchitecture
             await waitForRootStore { store.state.path == nil }
 
             #expect(store.state.path == nil)
+        }
+    }
+
+    // MARK: - MOB-1467: Notification-tap deep link
+
+    /// Tapping a migration notification while Home is already up/initialized must route
+    /// immediately — exactly the SmartBanner-tap routing (fresh flow state, `.migrationCoordFlow`).
+    @Test func migrationNotificationTappedOnInitializedStateRoutesImmediately() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.appInitializationState = InitializationState.initialized
+            // Poison the pre-existing flow state so a reset is actually observable, same as the
+            // banner-tap test above.
+            initialState.migrationCoordFlowState.mode = MigrationMode.immediate
+            initialState.migrationCoordFlowState.path.append(.complete(MigrationComplete.State()))
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            store.send(.initialization(.appDelegate(.migrationNotificationTapped)))
+            await waitForRootStore { store.state.path == Root.State.Path.migrationCoordFlow }
+
+            #expect(store.state.path == Root.State.Path.migrationCoordFlow)
+            #expect(store.state.migrationCoordFlowState.mode == nil)
+            #expect(store.state.migrationCoordFlowState.path.isEmpty)
+            #expect(store.state.pendingMigrationDeepLink == false)
+        }
+    }
+
+    /// Tapping a migration notification BEFORE the app has reached Home (cold start still in
+    /// flight) must stash the request rather than drop it — mirrors `RootDestination`'s
+    /// `isAtDeeplinkWarningScreen` gating. It then fires once `checkBackupPhraseValidation` (the
+    /// checkpoint that sets `appInitializationState = .initialized`) runs, exactly like a deferred
+    /// deep link is released there.
+    @Test func migrationNotificationTappedBeforeInitializedStashesThenFiresAtCheckBackupPhraseValidation() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.appInitializationState = InitializationState.uninitialized
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+            }
+
+            store.send(.initialization(.appDelegate(.migrationNotificationTapped)))
+            await waitForRootStore { store.state.pendingMigrationDeepLink == true }
+
+            #expect(store.state.pendingMigrationDeepLink == true)
+            #expect(store.state.path == nil)
+
+            store.send(.initialization(.checkBackupPhraseValidation))
+            await waitForRootStore { store.state.path == Root.State.Path.migrationCoordFlow }
+
+            #expect(store.state.path == Root.State.Path.migrationCoordFlow)
+            #expect(store.state.pendingMigrationDeepLink == false)
+        }
+    }
+
+    // MARK: - MOB-1467: Foreground-clear of delivered migration notifications
+
+    /// Every foreground entry must clear DELIVERED migration notifications (the banner/re-entry
+    /// route now carries the current state) — but must not cancel PENDING ones (a manual-mode
+    /// "ready to send" reminder must survive), so this only asserts the delivered-clear spy, never
+    /// `cancelMigrationNotifications`.
+    @Test func willEnterForegroundClearsDeliveredMigrationNotifications() async {
+        let clearDeliveredCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.userNotifications.clearDeliveredMigrationNotifications = {
+                    clearDeliveredCalls.withValue { $0 += 1 }
+                }
+            }
+
+            store.send(.initialization(.appDelegate(.willEnterForeground)))
+            await waitForRootStore { clearDeliveredCalls.withValue { $0 } == 1 }
+
+            #expect(clearDeliveredCalls.withValue { $0 } == 1)
         }
     }
 }

--- a/zodlTests/ScanTests/ScanFoundPCZTBatchTests.swift
+++ b/zodlTests/ScanTests/ScanFoundPCZTBatchTests.swift
@@ -1,0 +1,45 @@
+//
+//  ScanFoundPCZTBatchTests.swift
+//  zodlTests
+//
+//  Covers the new `.foundPCZTBatch([Pczt])` action on the shared `Scan` reducer
+//  (Features/Scan/ScanStore.swift), added for MOB-1468 migration Keystone batch signing: reaching
+//  it sets `isAnythingFound`/`progress` exactly like the sibling `.foundPCZT`/
+//  `.foundVotingDelegationPCZT` cases, additive and otherwise inert (`.none`).
+//
+//  `KeystoneMigrationBatchScanChecker.checkQRCode` (ScanChecker.swift) is NOT unit-testable here:
+//  `KeystoneSDK.DecodeResult`'s only initializer is `internal` to the `KeystoneSDK` module, so a
+//  `DecodeResult` carrying a real `UR` (the 100%-progress, parse-ready case) cannot be constructed
+//  from this test target — only `KeystoneSDK().decodeQR(_:)` driven by real animated-QR fragment
+//  strings can produce one. The checker's accumulate→parse→action path is exercised by MOB-1468
+//  phase 2's coordinator tests instead, with `sdkSynchronizer.parseMigrationPCZTBatch` stubbed.
+//  No shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct ScanFoundPCZTBatchTests {
+    @MainActor @Test func foundPCZTBatchSetsAnythingFoundAndClearsProgress() async {
+        let store = TestStore(initialState: Scan.State(info: "scanning")) {
+            Scan()
+        }
+
+        // Simulate the accumulate-with-progress phase having reported a mid-scan percentage
+        // before the completed batch UR resolved — the same sequence a real scan produces.
+        await store.send(.animatedQRProgress(42, 3, 5)) {
+            $0.reportedPart = 3
+            $0.reportedParts = 1
+            $0.expectedParts = 8
+            $0.progress = 42
+        }
+
+        await store.send(.foundPCZTBatch([Pczt(), Pczt()])) {
+            $0.isAnythingFound = true
+            $0.progress = nil
+        }
+    }
+}

--- a/zodlTests/ScanTests/ScanFoundPCZTBatchTests.swift
+++ b/zodlTests/ScanTests/ScanFoundPCZTBatchTests.swift
@@ -11,9 +11,9 @@
 //  `KeystoneSDK.DecodeResult`'s only initializer is `internal` to the `KeystoneSDK` module, so a
 //  `DecodeResult` carrying a real `UR` (the 100%-progress, parse-ready case) cannot be constructed
 //  from this test target — only `KeystoneSDK().decodeQR(_:)` driven by real animated-QR fragment
-//  strings can produce one. The checker's accumulate→parse→action path is exercised by MOB-1468
-//  phase 2's coordinator tests instead, with `sdkSynchronizer.parseMigrationPCZTBatch` stubbed.
-//  No shared/global state -> no `.serialized`.
+//  strings can produce one. The checker's accumulate→parse→action path is exercised by the
+//  MigrationCoordFlowTests Keystone-signing block instead (same PR), with
+//  `sdkSynchronizer.parseMigrationPCZTBatch` stubbed. No shared/global state -> no `.serialized`.
 //
 
 import Testing


### PR DESCRIPTION
Implements [MOB-1468](https://linear.app/zodl/issue/MOB-1468/ironwood-migration-keystone-accounts) — the full spec lives in the ticket description. Stacked on #1886 (MOB-1467). **This completes the app side of the entire Ironwood migration feature** (MOB-1458): every ticket is now built against the inert SDK stubs, dormant until MOB-1455.

## ⚠️ Joint SDK + Keystone-team asks (please route)

The user-approved **batched single-session signing** (all N transfer PCZTs in ONE animated-QR sign/scan round-trip) requires capability that does not exist today — `KeystoneZcashSDK` currently encodes/parses exactly one PCZT per UR session. Two new `[ext]` contract seams carry the ask:

1. `urEncoderForMigrationPCZTBatch([Pczt]) -> UREncoder?` — batch UR encoding for the device to sign in one session.
2. `parseMigrationPCZTBatch(Data) -> [Pczt]?` — parses the scanned signed session back into N signed PCZTs. Note: the checker feeds it the **raw accumulated UR's cbor bytes**, deliberately NOT routed through the single-PCZT `parseZcashPczt` Rust entrypoint — that pins what the future batch parser must accept.
3. `submitSignedNoteSplit(Pczt) -> TransferResult` — broadcasts the signed note split with explicit migration bookkeeping (state → `splitPendingConfirmation`); transaction-guard-wrapped like its software sibling.
4. **Proofs question**: the send flow adds proofs app-side (`addProofsToPCZT`); the migration members take signed PCZTs only, implying the SDK pairs proofs internally — confirm, or these members gain a parameter.

**Fallback**: if device validation kills the batch, the signing session takes `[Pczt]` end-to-end, so the pivot to a sequential per-PCZT loop is one screen looping sessions — no coordinator or contract reshuffle (feature-spec §14 risk stands until validated).

## What's here

- **`MigrationKeystoneSign`** screen mirroring `SignWithKeystoneView` exactly (account card + Hardware badge, animated QR, Reject / Get Signature — the Figma sign frame is that screen verbatim; zero new strings/assets).
- **Vendor forks at exactly three points** (`vendor == .keystone`): NoteSplit confirm → `proposeNoteSplitPCZT` → sign → scan → `submitSignedNoteSplit`; TransferPlan confirm (fresh + re-created, never the rescheduled variant) → `proposeMigrationPCZTs` → sign → scan → `storeSignedMigrationTransactions` → normal post-confirm chain; immediate Review → same with the single-transfer schedule. Downstream of signing, nothing is vendor-specific — manual sends, send-now, background sessions, reschedule, notifications, re-entry all unchanged (transfers pre-signed and stored).
- **Safety semantics**: no-partial-storage invariant (store/submit only fire with the complete signed set; empty scan results never store); scan-back returns to the QR for a re-scan; Reject abandons cleanly with the confirming screen intact; Keystone note-split **Retry re-broadcasts the same signed PCZT** — never a second signing round.
- New `Scan.Action.foundPCZTBatch` + `keystoneMigrationBatchScanChecker` (additive; existing checkers untouched). `MigrationPairedIcons` gains a `vendor` badge parameter (defaulted — every existing call site pixel-identical); per your no-gate decision, banner logic stays fully vendor-agnostic.

## Verification

- Full `zodlTests` target on `zodl-internal` (iPhone 17 Pro sim, `-skipMacroValidation`): **918 tests / 128 suites, all green** (+33 vs. the MOB-1467 base; 1 pre-existing unrelated known issue). New/extended: `MigrationKeystoneSignTests` (6), `ScanFoundPCZTBatchTests` (1), `MigrationCoordFlowTests` +16, store-fork suites +13.
- Implementation note: TDD surfaced a real TCA ordering constraint — popping the *acting* path element synchronously inside `coordinatorReduce()` (which composes before `.forEach`) raises "forEach received an action for a missing element"; rejection/completion pops are dispatched via follow-up actions (the existing `sendNowCompleted` pattern).
- Full build green. Added Swift lines ≤ 150 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)