### PR TITLE
Fixes for Fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "open3"
-require "tmpdir"
 require "fileutils"
 require "shellwords"
 
@@ -11,6 +10,7 @@ require "shellwords"
 $LOAD_PATH.unshift(File.expand_path("lib", __dir__))
 require_relative "lib/zodl/preflight"
 require_relative "lib/zodl/build_paths"
+require_relative "lib/zodl/local_packages"
 require_relative "lib/zodl/notify"
 
 # Refuse to run outside bundler so the pinned gem versions in Gemfile.lock are
@@ -66,6 +66,7 @@ lane :release do |options|
   sha = resolve_sha(repo_root, ref)
   branch_version = Zodl::Version.from_branch(ref)
   project_version = marketing_version_at(repo_root, sha)
+  local_packages = local_packages_at(repo_root, sha)
   api_key = asc_api_key
   # Resolve+verify the signing key path now (cwd is still the real repo), so it's
   # an absolute path into the real fastlane dir before we chdir into the worktree.
@@ -85,7 +86,8 @@ lane :release do |options|
       dirty_tree: dirty_tree?(repo_root),
       partner_keys_error: partner_keys_error(repo_root),
       xcode_ok: xcode_ok?(repo_root),
-      signing_identity_ok: signing_identity_ok?
+      signing_identity_ok: signing_identity_ok?,
+      local_packages: local_packages
     )
     report = Zodl::Preflight.check(ctx)
     print_summary(variant, cfg, ref, sha, ctx, report)
@@ -104,7 +106,11 @@ lane :release do |options|
   # API-permission problem fails now instead of after the ~15-minute build.
   ensure_appstore_profiles(variants, api_key)
 
-  worktree = File.join(Dir.tmpdir, "zodl-release-#{sha[0, 8]}")
+  # The worktree is a sibling of the repo, NOT under $TMPDIR: the project may
+  # reference local Swift packages by relative path (XCLocalSwiftPackageReference,
+  # e.g. ../ZcashLightClientKit), and only a sibling worktree resolves those to
+  # the same directories the primary checkout uses in Xcode.
+  worktree = File.join(File.dirname(repo_root), "zodl-release-#{sha[0, 8]}")
   begin
     UI.message("Creating a clean build worktree at #{sha[0, 8]}…")
     run("git -C #{repo_root.shellescape} worktree add --detach #{worktree.shellescape} #{sha}", must_succeed: true)
@@ -244,6 +250,27 @@ def marketing_version_at(repo_root, sha)
   line[/MARKETING_VERSION = ([^;]+);/, 1]&.strip
 end
 
+# Local Swift package references (XCLocalSwiftPackageReference) in the project
+# as committed at `sha`, with the live state of each referenced directory. The
+# relativePath is relative to the .xcodeproj's directory — the repo root here —
+# and the build worktree is the repo's sibling, so the reference resolves to the
+# same directory for both. The referenced checkout is consumed as-is (HEAD plus
+# any uncommitted changes), so capture its git state for the preflight report.
+def local_packages_at(repo_root, sha)
+  pbxproj = run("git -C #{repo_root.shellescape} show #{sha}:secant.xcodeproj/project.pbxproj", must_succeed: true)
+  Zodl::LocalPackages.parse(pbxproj).map do |rel|
+    resolved = File.expand_path(rel, repo_root)
+    unless File.directory?(resolved)
+      next { path: rel, resolved: resolved, exists: false, git: nil, dirty: nil }
+    end
+
+    head = run("git -C #{resolved.shellescape} rev-parse --short HEAD 2>/dev/null").strip
+    git = head.empty? ? nil : head
+    dirty = git && !run("git -C #{resolved.shellescape} status --porcelain 2>/dev/null").strip.empty?
+    { path: rel, resolved: resolved, exists: true, git: git, dirty: dirty }
+  end
+end
+
 # Sets MARKETING_VERSION on all targets directly in the pbxproj. agvtool's
 # new-marketing-version does not update the build-setting form this project uses.
 def set_marketing_version(version)
@@ -340,7 +367,11 @@ end
 # flips it to INVALID), unexpired, and backed by a certificate in the local
 # keychain — exactly what exportArchive needs, and -allowProvisioningUpdates
 # does not mint such a profile. Only when reuse is impossible is the profile
-# renewed, keeping its canonical name.
+# renewed, keeping its canonical name. Name matching must be exact
+# (ignore_profiles_with_different_name): sigh's default fuzzy match happily
+# adopts one of the "<name> <timestamp>" duplicates the old force renewal left
+# behind, and the export step would then fail to find a profile under the
+# canonical name it asks for.
 def ensure_appstore_profiles(variants, api_key)
   variants.each do |variant|
     cfg = Zodl::Variants.config(variant)
@@ -350,7 +381,8 @@ def ensure_appstore_profiles(variants, api_key)
         api_key: api_key,
         app_identifier: cfg[:app_identifier],
         provisioning_name: name,
-        readonly: true
+        readonly: true,
+        ignore_profiles_with_different_name: true
       )
     rescue FastlaneCore::Interface::FastlaneError => e
       UI.important("Cannot reuse profile '#{name}' (#{e.message.strip}) — renewing it.")
@@ -380,7 +412,8 @@ def renew_appstore_profile(name, app_identifier, api_key)
     api_key: api_key,
     app_identifier: app_identifier,
     provisioning_name: name,
-    fail_on_name_taken: true
+    fail_on_name_taken: true,
+    ignore_profiles_with_different_name: true
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -332,21 +332,56 @@ def appstore_profile_name(variant)
   "ZODL #{variant} App Store"
 end
 
-# Create or refresh an App Store distribution profile for each variant via the ASC
-# API key. force: true regenerates it so it always carries the App ID's current
-# capabilities (Associated Domains, iCloud) — exportArchive requires a profile with
-# those, and -allowProvisioningUpdates does not mint one. Installed into
-# ~/Library/MobileDevice/Provisioning Profiles for the export step to pick up.
+# Reuse or renew the App Store distribution profile for each variant via the ASC
+# API key, and install it into ~/Library/MobileDevice/Provisioning Profiles for
+# the export step to pick up. The readonly pass reuses the existing profile
+# without touching App Store Connect; it succeeds only when the profile is
+# ACTIVE (a capability change on the App ID — Associated Domains, iCloud —
+# flips it to INVALID), unexpired, and backed by a certificate in the local
+# keychain — exactly what exportArchive needs, and -allowProvisioningUpdates
+# does not mint such a profile. Only when reuse is impossible is the profile
+# renewed, keeping its canonical name.
 def ensure_appstore_profiles(variants, api_key)
   variants.each do |variant|
     cfg = Zodl::Variants.config(variant)
-    get_provisioning_profile(
-      api_key: api_key,
-      app_identifier: cfg[:app_identifier],
-      provisioning_name: appstore_profile_name(variant),
-      force: true
-    )
+    name = appstore_profile_name(variant)
+    begin
+      get_provisioning_profile(
+        api_key: api_key,
+        app_identifier: cfg[:app_identifier],
+        provisioning_name: name,
+        readonly: true
+      )
+    rescue FastlaneCore::Interface::FastlaneError => e
+      UI.important("Cannot reuse profile '#{name}' (#{e.message.strip}) — renewing it.")
+      renew_appstore_profile(name, cfg[:app_identifier], api_key)
+    end
   end
+end
+
+# Replaces the profile on App Store Connect under its canonical name. The stale
+# profile must be deleted through the API first: sigh's force renewal only
+# deletes profiles it could fetch, and it never fetches a profile whose
+# certificate is missing from the local keychain — for exactly that profile it
+# would fall back to creating "<name> <timestamp>" duplicates on every run,
+# leaving the stale one in place. Deleting by exact name frees it, then sigh
+# recreates the profile with the App ID's current capabilities and a locally
+# installed certificate; fail_on_name_taken turns any leftover name collision
+# into a loud failure instead of another duplicate. Spaceship is already loaded
+# here: the failed readonly get_provisioning_profile above required sigh, which
+# requires spaceship.
+def renew_appstore_profile(name, app_identifier, api_key)
+  Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from(hash: api_key)
+  Spaceship::ConnectAPI::Profile.all(filter: { name: name })
+    .select { |profile| profile.name == name }
+    .each(&:delete!)
+
+  get_provisioning_profile(
+    api_key: api_key,
+    app_identifier: app_identifier,
+    provisioning_name: name,
+    fail_on_name_taken: true
+  )
 end
 
 # Run a block with Apple's /usr/bin ahead of everything else in PATH, then restore

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,6 +45,14 @@ own App Store Connect app), an unpushed ref, a missing/invalid `PartnerKeys.plis
 the wrong Xcode, or no distribution signing identity. Run with `--dry-run` to see
 it without building.
 
+If the project at the built ref references local Swift packages (e.g. a local
+`../ZcashLightClientKit` checkout), preflight fails when that directory is
+missing and otherwise warns with the package's git state — the build consumes
+that checkout as-is (HEAD plus any uncommitted changes), so it is not
+reproducible from this repo alone. The throwaway build worktree is created
+beside the repo precisely so those relative references resolve to the same
+directories Xcode uses.
+
 ## Notifications
 
 A finished `release` posts a native macOS notification with a sound, so you can

--- a/fastlane/lib/zodl/build_paths.rb
+++ b/fastlane/lib/zodl/build_paths.rb
@@ -6,8 +6,8 @@ module Zodl
   # fastlane runs every top-level action wrapped in `Dir.chdir("..")` — it assumes
   # it was invoked from the `fastlane/` folder and steps up to the project root
   # (see fastlane runner.rb: "go up from the fastlane folder, to the project
-  # folder"). The release lane instead `Dir.chdir`es into a worktree under
-  # $TMPDIR, so that per-action `..` lands in the worktree's PARENT. Any RELATIVE
+  # folder"). The release lane instead `Dir.chdir`es into a throwaway worktree
+  # beside the repo, so that per-action `..` lands in the worktree's PARENT. Any RELATIVE
   # path handed to an action (project, derived-data, output dir) then resolves
   # there — outside the worktree — and fails (e.g. "Project file not found at
   # '.../T/secant.xcodeproj'"). Anchoring every action path to the absolute
@@ -17,8 +17,8 @@ module Zodl
 
     module_function
 
-    # worktree must be an absolute path (the release lane builds it from
-    # Dir.tmpdir, which is absolute).
+    # worktree must be an absolute path (the release lane derives it from the
+    # absolute repo root).
     def resolve(worktree)
       build = File.join(worktree, "build")
       {

--- a/fastlane/lib/zodl/local_packages.rb
+++ b/fastlane/lib/zodl/local_packages.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Zodl
+  # Extracts local Swift package references (XCLocalSwiftPackageReference) from
+  # pbxproj text. Xcode stores each reference's relativePath relative to the
+  # .xcodeproj's directory — the repo root for this project — and writes the
+  # value quoted or bare depending on the characters in it.
+  module LocalPackages
+    module_function
+
+    def parse(pbxproj)
+      pbxproj.scan(/isa = XCLocalSwiftPackageReference;\s*relativePath = "?([^";\n]+?)"?;/).flatten.uniq
+    end
+  end
+end

--- a/fastlane/lib/zodl/preflight.rb
+++ b/fastlane/lib/zodl/preflight.rb
@@ -14,7 +14,7 @@ module Zodl
     Context = Struct.new(
       :variant, :requested_version, :requested_build, :project_version,
       :branch_version, :latest_build, :ref_on_origin, :dirty_tree,
-      :partner_keys_error, :xcode_ok, :signing_identity_ok,
+      :partner_keys_error, :xcode_ok, :signing_identity_ok, :local_packages,
       keyword_init: true
     )
 
@@ -50,6 +50,27 @@ module Zodl
       errors << "no distribution signing identity found in the keychain" unless ctx.signing_identity_ok
 
       warnings << "working tree has uncommitted changes — they are NOT included in this build" if ctx.dirty_tree
+
+      # Local Swift packages (XCLocalSwiftPackageReference) are consumed live from
+      # their on-disk checkout — HEAD plus any uncommitted changes — so a build
+      # using them cannot be reproduced from this repo alone. A missing directory
+      # is a certain build failure; a present one is shipped knowingly.
+      (ctx.local_packages || []).each do |pkg|
+        unless pkg[:exists]
+          errors << "local Swift package #{pkg[:path]} not found at #{pkg[:resolved]}"
+          next
+        end
+
+        state =
+          if pkg[:git].nil?
+            "not a git repository"
+          elsif pkg[:dirty]
+            "#{pkg[:git]} + UNCOMMITTED changes"
+          else
+            "#{pkg[:git]}, clean"
+          end
+        warnings << "build uses local Swift package #{pkg[:path]} (#{state}) — not reproducible from this repo alone"
+      end
 
       Report.new(errors, warnings)
     end

--- a/fastlane/spec/local_packages_test.rb
+++ b/fastlane/spec/local_packages_test.rb
@@ -1,0 +1,44 @@
+require "minitest/autorun"
+require "zodl/local_packages"
+
+class ZodlLocalPackagesTest < Minitest::Test
+  def test_parses_bare_relative_path
+    pbxproj = <<~PBX
+      /* Begin XCLocalSwiftPackageReference section */
+      \t\t34FC670D2FFD1644004175E0 /* XCLocalSwiftPackageReference "../ZcashLightClientKit" */ = {
+      \t\t\tisa = XCLocalSwiftPackageReference;
+      \t\t\trelativePath = ../ZcashLightClientKit;
+      \t\t};
+      /* End XCLocalSwiftPackageReference section */
+    PBX
+    assert_equal ["../ZcashLightClientKit"], Zodl::LocalPackages.parse(pbxproj)
+  end
+
+  def test_parses_quoted_relative_path_and_dedupes
+    pbxproj = <<~PBX
+      \t\tAAA /* XCLocalSwiftPackageReference "../Some Package" */ = {
+      \t\t\tisa = XCLocalSwiftPackageReference;
+      \t\t\trelativePath = "../Some Package";
+      \t\t};
+      \t\tBBB /* XCLocalSwiftPackageReference "../Some Package" */ = {
+      \t\t\tisa = XCLocalSwiftPackageReference;
+      \t\t\trelativePath = "../Some Package";
+      \t\t};
+    PBX
+    assert_equal ["../Some Package"], Zodl::LocalPackages.parse(pbxproj)
+  end
+
+  def test_remote_references_do_not_match
+    pbxproj = <<~PBX
+      \t\tCCC /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
+      \t\t\tisa = XCRemoteSwiftPackageReference;
+      \t\t\trepositoryURL = "https://github.com/apple/swift-atomics.git";
+      \t\t};
+    PBX
+    assert_equal [], Zodl::LocalPackages.parse(pbxproj)
+  end
+
+  def test_no_references_in_empty_project
+    assert_equal [], Zodl::LocalPackages.parse("/* pbxproj without packages */")
+  end
+end

--- a/fastlane/spec/preflight_test.rb
+++ b/fastlane/spec/preflight_test.rb
@@ -59,4 +59,41 @@ class ZodlPreflightTest < Minitest::Test
     refute report.ok?
     assert_equal 1, report.errors.length
   end
+
+  def local_pkg(**overrides)
+    {
+      path: "../ZcashLightClientKit", resolved: "/Users/dev/ZcashLightClientKit",
+      exists: true, git: "6bfe97fc", dirty: false
+    }.merge(overrides)
+  end
+
+  def test_missing_local_package_blocks
+    report = Zodl::Preflight.check(facts(local_packages: [local_pkg(exists: false, git: nil, dirty: nil)]))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("../ZcashLightClientKit") && e.include?("not found") })
+  end
+
+  def test_local_package_warns_with_git_state
+    report = Zodl::Preflight.check(facts(local_packages: [local_pkg]))
+    assert report.ok?
+    assert(report.warnings.any? { |w| w.include?("6bfe97fc") && w.include?("clean") })
+  end
+
+  def test_dirty_local_package_warning_mentions_uncommitted_changes
+    report = Zodl::Preflight.check(facts(local_packages: [local_pkg(dirty: true)]))
+    assert report.ok?
+    assert(report.warnings.any? { |w| w.include?("UNCOMMITTED") })
+  end
+
+  def test_non_git_local_package_warns
+    report = Zodl::Preflight.check(facts(local_packages: [local_pkg(git: nil, dirty: nil)]))
+    assert report.ok?
+    assert(report.warnings.any? { |w| w.include?("not a git repository") })
+  end
+
+  def test_no_local_packages_is_silent
+    report = Zodl::Preflight.check(facts(local_packages: []))
+    assert report.ok?
+    assert_empty report.warnings
+  end
 end


### PR DESCRIPTION
- Fix handling of provision profiles. Previously script tried to create provision profile for each build run no matter what. Now it reuses existing profiles.
- Add support for builds with local SDKs.