### PR TITLE
[MOB-1480] Add migration SDK simulator for testnet builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] Ironwood migration screens are wired into a complete guided flow (entry, scheduling, status, recovery) driven by migration state, with a Home banner entry point — dormant until the migration SDK ships.
 - [MOB-1467] Scheduled Ironwood migration transfers can now send from background tasks, with local notifications for progress, required actions, and manual-mode send reminders — dormant until the migration SDK ships.
 - [MOB-1468] Keystone hardware-wallet accounts can complete the Ironwood migration — transfers are signed by QR in a single batched session — dormant until the migration SDK and Keystone batch support ship.
+- [MOB-1480] Testnet builds gain a migration simulator: long-press the balance on the home screen to open a debug menu that walks every Ironwood migration path — scenario presets, failure injection, simulated time, on-demand background-delivery runs with real notifications, and a simulated Keystone signing pass. Off outside testnet builds; production behavior is unchanged.
 
 ### Changed
 - [MOB-1472] The assets you can swap are now a curated set of major coins and stablecoins across the supported chains (plus swapping to ZEC), instead of the full list from the swap provider, and the address-book chain picker is limited to those chains. Existing swaps in your history (including assets no longer offered) still display normally, and existing contacts on other chains are preserved.

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
@@ -40,6 +40,10 @@ struct MigrationManagerClient: Sendable {
     var isSyncDeferredAfterBroadcast: @Sendable () -> Bool = { false }   // consumed by MOB-1467
     // Reconciliation
     var reconcile: @Sendable () -> Void
+    // Debug/testnet-only: clears every persisted migration flag this client owns (mode, manual
+    // delivery, network privacy, complete-acknowledged, last-broadcast) — consumed by the
+    // migration SDK simulator's debug panel "Reset app migration flags" control (MOB-1480).
+    var resetPersistedFlags: @Sendable () -> Void
 }
 
 enum MigrationSendGate: Equatable, Sendable {

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -35,7 +35,8 @@ extension MigrationManagerClient: DependencyKey {
             sendGate: { impl.sendGate() },
             recordMigrationBroadcast: { impl.recordMigrationBroadcast() },
             isSyncDeferredAfterBroadcast: { impl.isSyncDeferredAfterBroadcast() },
-            reconcile: { impl.reconcile() }
+            reconcile: { impl.reconcile() },
+            resetPersistedFlags: { impl.resetPersistedFlags() }
         )
     }
 }
@@ -108,6 +109,12 @@ final class MigrationManagerImpl: @unchecked Sendable {
     }
 
     func orchardBalanceToMigrate(accountUUID: AccountUUID?) async -> Zatoshi {
+        // MOB-1480: simulator active -> its own balance replaces the real per-account SDK read
+        // (the simulated migration has no real funds to look up against `accountUUID`).
+        if MigrationSimulatorFlag.isEnabled && MigrationSimulatorClient.sharedEngine.isActive {
+            return MigrationSimulatorClient.sharedEngine.orchardBalance()
+        }
+
         guard let accountUUID else { return .zero }
 
         guard let balances = try? await sdkSynchronizer.getAccountsBalances(),
@@ -146,6 +153,11 @@ final class MigrationManagerImpl: @unchecked Sendable {
         }
     }
 
+    /// MOB-1480: the migration SDK simulator's debug panel "Reset app migration flags" control.
+    func resetPersistedFlags() {
+        gateStorage.resetPersistedFlags()
+    }
+
     /// `.requiresAttention(.syncRequiredBeforeNext)` carries no progress payload of its own, but
     /// per spec it renders identically to a plain `.inProgress(p)` banner — so it's normalized to
     /// that shape here, using the SDK's own out-of-band `getMigrationProgress()` snapshot, before
@@ -163,6 +175,13 @@ final class MigrationManagerImpl: @unchecked Sendable {
 
     /// "Next due" (manual): ready height already reached (or unknown / no progress -> not due).
     private func isNextTransferDue() -> Bool {
+        // MOB-1480: `nextTransferReadyAtHeight` is a synthetic (epoch-seconds) height while the
+        // simulator is active, which can never compare true against the real chain's
+        // `latestBlockHeight` below — ask the engine directly instead.
+        if MigrationSimulatorFlag.isEnabled && MigrationSimulatorClient.sharedEngine.isActive {
+            return MigrationSimulatorClient.sharedEngine.isNextTransferDue()
+        }
+
         guard let readyAtHeight = sdkSynchronizer.getMigrationProgress()?.nextTransferReadyAtHeight else {
             return false
         }
@@ -424,5 +443,18 @@ final class MigrationGateStorage: @unchecked Sendable {
 
     func clearAcknowledgedComplete() {
         userDefaults.set(false, forKey: .migrationCompleteAcknowledged)
+    }
+
+    /// Clears every persisted migration flag this storage owns: mode, manual delivery, network
+    /// privacy, complete-acknowledged, last-broadcast. Backs the migration SDK simulator's debug
+    /// panel "Reset app migration flags" control (MOB-1480). Deliberately leaves
+    /// `migrationSyncGateUntil`/the transient sync-required flag alone: the 10-minute send gate is
+    /// a short-lived timing window, not a durable app flag, and expires on its own.
+    func resetPersistedFlags() {
+        userDefaults.removeObject(forKey: .migrationMode)
+        userDefaults.removeObject(forKey: .migrationManualDelivery)
+        userDefaults.removeObject(forKey: .migrationNetworkPrivacyOptions)
+        userDefaults.removeObject(forKey: .migrationCompleteAcknowledged)
+        userDefaults.removeObject(forKey: .migrationLastBroadcastAt)
     }
 }

--- a/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorEngine.swift
+++ b/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorEngine.swift
@@ -1,0 +1,546 @@
+//
+//  MigrationSimulatorEngine.swift
+//  zodl
+//
+//  Stateful simulated implementation of the Orchard -> Ironwood migration SDK surface (MOB-1480).
+//  `MigrationSimulatorClient.liveValue` (Phase B) wires its closures to the shared instance of
+//  this engine so the whole migration UI is walkable end-to-end before the real SDK exists
+//  (MOB-1455). Every piece of actual derivation logic is factored into
+//  `MigrationSimulatorEngineDerivations` (pure, table-testable); this type is left with locking,
+//  persistence, the state stream, and the one real timer (the note-split confirm delay).
+//
+//  Thread-safety: the snapshot is guarded by an `OSAllocatedUnfairLock` and the state subject is
+//  internally synchronized, so the type is `@unchecked Sendable`. The transient "currently
+//  broadcasting" transfer id is intentionally NOT persisted (see `SimulatorTransfer`'s doc) — it's
+//  guarded by its own lock.
+//
+
+import Foundation
+import os
+@preconcurrency import Combine
+@preconcurrency import ZcashLightClientKit
+
+final class MigrationSimulatorEngine: @unchecked Sendable {
+    private let store: MigrationSimulatorStateStore
+    private let snapshotLock: OSAllocatedUnfairLock<SimulatorSnapshot>
+    private let stateSubject: CurrentValueSubject<MigrationState, Never>
+    private let broadcastingId = OSAllocatedUnfairLock<String?>(initialState: nil)
+
+    var isActive: Bool {
+        withSnapshot { $0.isActive }
+    }
+
+    init(store: MigrationSimulatorStateStore) {
+        self.store = store
+        let initial = store.load()
+        self.snapshotLock = OSAllocatedUnfairLock(initialState: initial)
+        self.stateSubject = CurrentValueSubject<MigrationState, Never>(initial.state)
+    }
+
+    // MARK: - State reads
+
+    func currentState() -> MigrationState {
+        withSnapshot { $0.state }
+    }
+
+    func statePublisher() -> AnyPublisher<MigrationState, Never> {
+        stateSubject.eraseToAnyPublisher()
+    }
+
+    func progress() -> MigrationProgress? {
+        withSnapshot { snapshot in
+            guard case MigrationState.inProgress = snapshot.state else { return nil }
+            return MigrationSimulatorEngineDerivations.computeProgress(for: snapshot)
+        }
+    }
+
+    func setActive(_ isActive: Bool) {
+        withSnapshot { $0.isActive = isActive }
+    }
+
+    func orchardBalance() -> Zatoshi {
+        withSnapshot { $0.orchardBalance }
+    }
+
+    func hasOverdue() -> Bool {
+        withSnapshot { snapshot in
+            MigrationSimulatorEngineDerivations.hasOverdue(snapshot: snapshot, now: self.simNow(snapshot))
+        }
+    }
+
+    func hasInvalid() -> Bool {
+        withSnapshot { snapshot in
+            MigrationSimulatorEngineDerivations.hasInvalid(snapshot: snapshot)
+        }
+    }
+
+    /// Simulator-side substitute for the real SDK-facing `isNextTransferDue()` derivation
+    /// (`MigrationManagerLiveKey.swift`), which compares `progress().nextTransferReadyAtHeight`
+    /// against the real chain's `latestBlockHeight` — a comparison that can never fire against our
+    /// synthetic (epoch-seconds) heights. `MigrationManagerLiveKey`'s simulated hook calls this
+    /// instead whenever the engine is active (MOB-1480).
+    func isNextTransferDue() -> Bool {
+        withSnapshot { snapshot in
+            MigrationSimulatorEngineDerivations.isNextTransferDue(snapshot: snapshot, now: self.simNow(snapshot))
+        }
+    }
+
+    func summary() -> MigrationSummary {
+        withSnapshot { MigrationSimulatorEngineDerivations.computeSummary(for: $0) }
+    }
+
+    func transferRows() -> [MigrationTransferRow] {
+        withSnapshot { snapshot in
+            MigrationSimulatorEngineDerivations.rows(
+                for: snapshot,
+                now: self.simNow(snapshot),
+                broadcastingId: self.broadcastingId.withLock { $0 }
+            )
+        }
+    }
+
+    // MARK: - Note splitting
+
+    func isNoteSplitNeeded() -> Bool {
+        withSnapshot { snapshot in
+            snapshot.mode == MigrationMode.privateScheduled
+                && snapshot.state == MigrationState.notStarted
+                && snapshot.notes.count == 1
+        }
+    }
+
+    func prepareSplit() async -> NoteSplitProposal {
+        let (net, seed) = withSnapshot { snapshot in
+            (MigrationSimulatorEngineDerivations.netOfFee(snapshot.orchardBalance), snapshot.rngSeed)
+        }
+        let notes = MigrationSimulatorEngineDerivations.splitNotes(net: net, seed: seed)
+        return NoteSplitProposal(outputNotes: notes, fee: MigrationSimulatorEngineDerivations.Constants.fee)
+    }
+
+    func submitSplit(_ proposal: NoteSplitProposal) async -> TransferResult {
+        await submitSplitCore(outputNotes: proposal.outputNotes)
+    }
+
+    func submitSignedSplit(_ pczt: Pczt) async -> TransferResult {
+        let proposal = await prepareSplit()
+        return await submitSplitCore(outputNotes: proposal.outputNotes)
+    }
+
+    func confirmSplitNow() {
+        withSnapshot { snapshot in
+            guard snapshot.state == MigrationState.splitPendingConfirmation else { return }
+            snapshot.state = MigrationState.readyToPropose
+        }
+    }
+
+    // MARK: - Proposal / commit
+
+    func selectMode(_ mode: MigrationMode) {
+        withSnapshot { $0.mode = mode }
+    }
+
+    /// Stamps each `TransferProposal`'s height fields with a synthetic height derived from its
+    /// `dueAt` (MOB-1480, supersedes spec §9.1 as an improvement): `nextExecutableAfterHeight` and
+    /// `anchorHeight` both carry `dueAt`'s synthetic height, `expiryHeight` is one synthetic day
+    /// past it. `dueAt` uses the exact same formula `signAndStore()` will seed
+    /// `SimulatorTransfer.dueAt` with (`MigrationSimulatorEngineDerivations.dueAt`), so a
+    /// transfer's proposed height and its later-stored due time never drift apart.
+    func propose() async -> MigrationSchedule {
+        withSnapshot { snapshot in
+            let now = self.simNow(snapshot)
+
+            if snapshot.mode == MigrationMode.immediate {
+                let dueAt = MigrationSimulatorEngineDerivations.dueAt(forTransferAt: 0, isImmediate: true, now: now)
+                let height = MigrationSimulatorEngineDerivations.syntheticHeight(for: dueAt)
+                let proposal = TransferProposal(
+                    id: MigrationSimulatorEngineDerivations.makeTransferId(index: 0),
+                    amount: snapshot.orchardBalance,
+                    anchorHeight: height,
+                    nextExecutableAfterHeight: height,
+                    expiryHeight: height + MigrationSimulatorEngineDerivations.Constants.syntheticExpiryOffset
+                )
+                return MigrationSchedule(transfers: [proposal], estimatedDurationHours: 0)
+            }
+
+            let notes = snapshot.notes.isEmpty ? [snapshot.orchardBalance] : snapshot.notes
+            let transfers = notes.enumerated().map { index, note -> TransferProposal in
+                let dueAt = MigrationSimulatorEngineDerivations.dueAt(forTransferAt: index, isImmediate: false, now: now)
+                let height = MigrationSimulatorEngineDerivations.syntheticHeight(for: dueAt)
+                return TransferProposal(
+                    id: MigrationSimulatorEngineDerivations.makeTransferId(index: index),
+                    amount: note,
+                    anchorHeight: height,
+                    nextExecutableAfterHeight: height,
+                    expiryHeight: height + MigrationSimulatorEngineDerivations.Constants.syntheticExpiryOffset
+                )
+            }
+            return MigrationSchedule(transfers: transfers, estimatedDurationHours: notes.count * 6)
+        }
+    }
+
+    func signAndStore(_ schedule: MigrationSchedule) async {
+        withSnapshot { snapshot in
+            let now = self.simNow(snapshot)
+            let isImmediate = snapshot.mode == MigrationMode.immediate
+            snapshot.transfers = schedule.transfers.enumerated().map { index, proposal in
+                let dueAt = MigrationSimulatorEngineDerivations.dueAt(forTransferAt: index, isImmediate: isImmediate, now: now)
+                return SimulatorTransfer(id: proposal.id, index: index, amount: proposal.amount, dueAt: dueAt)
+            }
+            // Legitimately arrives while `.splitPendingConfirmation` (the UI's silent split commits
+            // optimistically) — accept unconditionally; the pending 15s confirm task then no-ops
+            // since it only acts while state is still `.splitPendingConfirmation`.
+            snapshot.state = MigrationState.inProgress(MigrationSimulatorEngineDerivations.computeProgress(for: snapshot))
+        }
+    }
+
+    // MARK: - Background execution
+
+    func isSyncRequired() -> Bool {
+        withSnapshot { $0.syncRequired }
+    }
+
+    func setSyncRequired(_ required: Bool) {
+        withSnapshot { $0.syncRequired = required }
+    }
+
+    func executeNext(_ options: NetworkPrivacyOptions) async -> TransferResult? {
+        let pendingIndex = withSnapshot { snapshot in
+            snapshot.transfers.filter { $0.sentAt == nil }.min(by: { $0.index < $1.index })?.index
+        }
+        guard let targetIndex = pendingIndex else { return nil }
+
+        let armed = withSnapshot { snapshot -> TransferResult? in
+            guard let armed = snapshot.armedTransferResult else { return nil }
+            snapshot.armedTransferResult = nil
+            return armed
+        }
+        if let armed {
+            return await apply(armed, toPendingIndex: targetIndex)
+        }
+
+        let isDue = withSnapshot { snapshot -> Bool in
+            guard let transfer = snapshot.transfers.first(where: { $0.index == targetIndex }) else { return false }
+            return self.simNow(snapshot) >= transfer.dueAt
+        }
+        guard isDue else { return nil }
+        return await performSend(targetIndex: targetIndex)
+    }
+
+    // MARK: - Recovery
+
+    func restart() async -> MigrationSchedule {
+        withSnapshot { snapshot in
+            snapshot.transfers.removeAll { $0.sentAt == nil }
+            snapshot.armedTransferResult = nil
+            snapshot.armedSplitFailure = false
+            snapshot.syncRequired = false
+            if snapshot.mode == MigrationMode.privateScheduled {
+                let net = MigrationSimulatorEngineDerivations.netOfFee(snapshot.orchardBalance)
+                snapshot.notes = MigrationSimulatorEngineDerivations.splitNotes(net: net, seed: snapshot.rngSeed)
+            } else {
+                snapshot.notes = snapshot.orchardBalance.amount > 0 ? [snapshot.orchardBalance] : []
+            }
+            snapshot.state = MigrationState.readyToPropose
+            snapshot.lastBackgroundRunSummary = "restarted"
+        }
+        return await propose()
+    }
+
+    func rescheduleStalled() async {
+        withSnapshot { snapshot in
+            guard case MigrationState.requiresAttention(let reason) = snapshot.state,
+                  case AttentionReason.transferStalled = reason else { return }
+
+            let now = self.simNow(snapshot)
+            let unsentInOrder = snapshot.transfers.filter { $0.sentAt == nil }.sorted { $0.index < $1.index }
+            for (offset, transfer) in unsentInOrder.enumerated() {
+                guard let index = snapshot.transfers.firstIndex(where: { $0.id == transfer.id }) else { continue }
+                let step = MigrationSimulatorEngineDerivations.Constants.transferSpacing * Double(offset + 1)
+                snapshot.transfers[index].dueAt = now.addingTimeInterval(step)
+            }
+            snapshot.state = MigrationState.inProgress(MigrationSimulatorEngineDerivations.computeProgress(for: snapshot))
+            snapshot.lastBackgroundRunSummary = "rescheduled stalled transfer"
+        }
+    }
+
+    func recreateInvalid() async {
+        withSnapshot { snapshot in
+            let now = self.simNow(snapshot)
+            if case MigrationState.requiresAttention(let reason) = snapshot.state {
+                if case AttentionReason.invalidTransfer(let transferId) = reason,
+                   let index = snapshot.transfers.firstIndex(where: { $0.id == transferId }) {
+                    let step = MigrationSimulatorEngineDerivations.Constants.transferSpacing
+                    snapshot.transfers[index].dueAt = now.addingTimeInterval(step)
+                } else if case AttentionReason.transferExpired = reason {
+                    for index in snapshot.transfers.indices {
+                        let transfer = snapshot.transfers[index]
+                        let expiryWindow = MigrationSimulatorEngineDerivations.Constants.expiryWindow
+                        guard transfer.sentAt == nil, now > transfer.dueAt.addingTimeInterval(expiryWindow) else { continue }
+                        snapshot.transfers[index].dueAt = now.addingTimeInterval(
+                            MigrationSimulatorEngineDerivations.Constants.transferSpacing
+                        )
+                    }
+                }
+            }
+            snapshot.state = MigrationState.inProgress(MigrationSimulatorEngineDerivations.computeProgress(for: snapshot))
+            snapshot.lastBackgroundRunSummary = "recreated invalid/expired transfer(s)"
+        }
+    }
+
+    // MARK: - Keystone (PCZT)
+
+    func fabricateNoteSplitPCZT() -> Pczt {
+        let balance = orchardBalance()
+        return MigrationSimulatorEngineDerivations.fabricatePczt(index: -1, amount: balance)
+    }
+
+    func fabricateMigrationPCZTs(_ schedule: MigrationSchedule) -> [Pczt] {
+        schedule.transfers.enumerated().map { index, transfer in
+            MigrationSimulatorEngineDerivations.fabricatePczt(index: index, amount: transfer.amount)
+        }
+    }
+
+    func storeSignedBatch(_ pczts: [Pczt]) {
+        withSnapshot { $0.signedBatchCount = pczts.count }
+    }
+
+    // MARK: - Lifecycle
+
+    func initializePostUpgrade() {
+        withSnapshot { _ in }
+    }
+
+    // MARK: - Debug controls
+
+    func reset() {
+        replaceSnapshot(SimulatorSnapshot.seeded())
+    }
+
+    func seed(orchard: Zatoshi, noteCount: Int) {
+        withSnapshot { snapshot in
+            snapshot.orchardBalance = orchard
+            let count = max(1, noteCount)
+            if count <= 1 {
+                snapshot.notes = orchard.amount > 0 ? [orchard] : []
+            } else {
+                let net = MigrationSimulatorEngineDerivations.netOfFee(orchard)
+                snapshot.notes = MigrationSimulatorEngineDerivations.splitNotes(net: net, seed: snapshot.rngSeed, countOverride: count)
+            }
+            snapshot.transfers = []
+            snapshot.armedTransferResult = nil
+            snapshot.armedSplitFailure = false
+            snapshot.syncRequired = false
+            snapshot.dustRemainder = Zatoshi.zero
+            snapshot.signedBatchCount = 0
+            snapshot.state = MigrationState.notStarted
+            snapshot.lastBackgroundRunSummary = "seeded \(orchard.amount) zats, \(count) note(s)"
+        }
+    }
+
+    func applyPreset(_ preset: SimulatorPreset) {
+        withSnapshot { snapshot in
+            MigrationSimulatorEngineDerivations.applyPreset(preset, to: &snapshot, now: self.simNow(snapshot))
+        }
+    }
+
+    func advanceTime(by interval: TimeInterval) {
+        withSnapshot { $0.timeOffset += interval }
+    }
+
+    func makeNextTransferDueNow() {
+        withSnapshot { snapshot in
+            let now = self.simNow(snapshot)
+            guard let earliest = snapshot.transfers.filter({ $0.sentAt == nil }).min(by: { $0.index < $1.index }),
+                  let index = snapshot.transfers.firstIndex(where: { $0.id == earliest.id }) else { return }
+            snapshot.transfers[index].dueAt = now
+        }
+    }
+
+    func armTransferResult(_ result: TransferResult) {
+        withSnapshot { $0.armedTransferResult = result }
+    }
+
+    func armSplitFailure() {
+        withSnapshot { $0.armedSplitFailure = true }
+    }
+
+    func readout() -> SimulatorReadout {
+        withSnapshot { snapshot in
+            let now = self.simNow(snapshot)
+            return SimulatorReadout(
+                isActive: snapshot.isActive,
+                state: snapshot.state,
+                mode: snapshot.mode,
+                orchardBalance: snapshot.orchardBalance,
+                timeOffset: snapshot.timeOffset,
+                rows: MigrationSimulatorEngineDerivations.rows(
+                    for: snapshot,
+                    now: now,
+                    broadcastingId: self.broadcastingId.withLock { $0 }
+                ),
+                signedBatchCount: snapshot.signedBatchCount,
+                armedResultDescription: MigrationSimulatorEngineDerivations.describeArmedResult(
+                    snapshot.armedTransferResult,
+                    splitFailureArmed: snapshot.armedSplitFailure
+                ),
+                isSplitPending: snapshot.state == MigrationState.splitPendingConfirmation,
+                lastBackgroundRunSummary: snapshot.lastBackgroundRunSummary
+            )
+        }
+    }
+}
+
+// MARK: - Private helpers
+
+private extension MigrationSimulatorEngine {
+    func simNow(_ snapshot: SimulatorSnapshot) -> Date {
+        Date().addingTimeInterval(snapshot.timeOffset)
+    }
+
+    /// Every public accessor/mutator funnels through here: recomputes time-driven derived state
+    /// first (so reads/mutations see fresh truth), runs `body`, then persists and — only if the
+    /// resulting `MigrationState` actually changed — emits to the state stream.
+    @discardableResult
+    func withSnapshot<T: Sendable>(_ body: @Sendable (inout SimulatorSnapshot) -> T) -> T {
+        let (result, updated) = snapshotLock.withLock { snapshot -> (T, SimulatorSnapshot) in
+            MigrationSimulatorEngineDerivations.recompute(&snapshot, now: Date().addingTimeInterval(snapshot.timeOffset))
+            let result = body(&snapshot)
+            return (result, snapshot)
+        }
+        store.save(updated)
+        if stateSubject.value != updated.state {
+            stateSubject.send(updated.state)
+        }
+        return result
+    }
+
+    func replaceSnapshot(_ fresh: SimulatorSnapshot) {
+        snapshotLock.withLock { $0 = fresh }
+        store.save(fresh)
+        if stateSubject.value != fresh.state {
+            stateSubject.send(fresh.state)
+        }
+    }
+
+    /// Applies a (just-consumed) armed result to `targetIndex`, bypassing due-gating entirely —
+    /// arming a result is a deliberate debug action meant to force the NEXT `executeNext` call's
+    /// outcome regardless of timing.
+    func apply(_ armed: TransferResult, toPendingIndex targetIndex: Int) async -> TransferResult {
+        switch armed {
+        case TransferResult.invalidNote:
+            return withSnapshot { snapshot in
+                guard let transfer = snapshot.transfers.first(where: { $0.index == targetIndex }) else {
+                    return TransferResult.invalidNote
+                }
+                snapshot.state = MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: transfer.id))
+                snapshot.lastBackgroundRunSummary = "armed invalidNote -> transfer \(targetIndex + 1) invalid"
+                return TransferResult.invalidNote
+            }
+
+        case TransferResult.expired:
+            return withSnapshot { snapshot in
+                let now = self.simNow(snapshot)
+                if let index = snapshot.transfers.firstIndex(where: { $0.index == targetIndex }) {
+                    let pastExpiry = -(MigrationSimulatorEngineDerivations.Constants.expiryWindow + 1)
+                    snapshot.transfers[index].dueAt = now.addingTimeInterval(pastExpiry)
+                }
+                snapshot.state = MigrationState.requiresAttention(AttentionReason.transferExpired)
+                snapshot.lastBackgroundRunSummary = "armed expired -> transfer \(targetIndex + 1) expired"
+                return TransferResult.expired
+            }
+
+        case TransferResult.networkError(let retryable):
+            return withSnapshot { snapshot in
+                let now = self.simNow(snapshot)
+                if let index = snapshot.transfers.firstIndex(where: { $0.index == targetIndex }) {
+                    snapshot.transfers[index].dueAt = now.addingTimeInterval(-MigrationSimulatorEngineDerivations.Constants.overdueGrace)
+                }
+                snapshot.state = MigrationState.requiresAttention(
+                    AttentionReason.transferStalled(transferNumber: targetIndex + 1)
+                )
+                snapshot.lastBackgroundRunSummary = "armed networkError -> stalled"
+                return TransferResult.networkError(retryable: retryable)
+            }
+
+        case TransferResult.success:
+            return await performSend(targetIndex: targetIndex)
+        }
+    }
+
+    /// Simulates ~1.5s of broadcast latency (`isBroadcasting` set on the target row throughout),
+    /// then marks it sent, decrements the balance, and rolls the whole migration to `.complete`
+    /// once every transfer has been sent.
+    func performSend(targetIndex: Int) async -> TransferResult {
+        guard let transferId = withSnapshot({ snapshot in
+            snapshot.transfers.first(where: { $0.index == targetIndex })?.id
+        }) else {
+            return TransferResult.success(txId: MigrationSimulatorEngineDerivations.makeTxId(prefix: "xfer", discriminator: "missing"))
+        }
+
+        broadcastingId.withLock { $0 = transferId }
+        try? await Task.sleep(for: .seconds(MigrationSimulatorEngineDerivations.Constants.broadcastLatency))
+        broadcastingId.withLock { $0 = nil }
+
+        return withSnapshot { snapshot in
+            guard let index = snapshot.transfers.firstIndex(where: { $0.id == transferId }),
+                  snapshot.transfers[index].sentAt == nil else {
+                return TransferResult.success(txId: MigrationSimulatorEngineDerivations.makeTxId(prefix: "xfer", discriminator: transferId))
+            }
+
+            let now = self.simNow(snapshot)
+            snapshot.transfers[index].sentAt = now
+            let amount = snapshot.transfers[index].amount
+            let total = snapshot.transfers.count
+            let allSent = snapshot.transfers.allSatisfy { $0.sentAt != nil }
+
+            if allSent {
+                snapshot.orchardBalance = snapshot.dustRemainder
+                snapshot.state = MigrationState.complete
+                snapshot.lastBackgroundRunSummary = "sent #\(index + 1) of \(total) -> complete"
+            } else {
+                snapshot.orchardBalance = Zatoshi(max(0, snapshot.orchardBalance.amount - amount.amount))
+                snapshot.state = MigrationState.inProgress(MigrationSimulatorEngineDerivations.computeProgress(for: snapshot))
+                snapshot.lastBackgroundRunSummary = "sent #\(index + 1) of \(total)"
+            }
+            return TransferResult.success(txId: MigrationSimulatorEngineDerivations.makeTxId(prefix: "xfer", discriminator: transferId))
+        }
+    }
+
+    /// Shared core for `submitSplit`/`submitSignedSplit`: consumes `armedSplitFailure` if set
+    /// (returning a network error with NO state change), otherwise commits `outputNotes` and arms
+    /// the 15s confirm task.
+    func submitSplitCore(outputNotes: [Zatoshi]) async -> TransferResult {
+        let shouldFail = withSnapshot { snapshot -> Bool in
+            guard snapshot.armedSplitFailure else { return false }
+            snapshot.armedSplitFailure = false
+            return true
+        }
+        if shouldFail {
+            return TransferResult.networkError(retryable: true)
+        }
+
+        withSnapshot { snapshot in
+            snapshot.notes = outputNotes
+            snapshot.state = MigrationState.splitPendingConfirmation
+            snapshot.splitSubmittedAt = self.simNow(snapshot)
+        }
+        armSplitConfirmTask()
+        return TransferResult.success(
+            txId: MigrationSimulatorEngineDerivations.makeTxId(prefix: "split", discriminator: "\(outputNotes.count)")
+        )
+    }
+
+    /// The one real timer in the engine: after `splitConfirmDelay`, flips
+    /// `.splitPendingConfirmation -> .readyToPropose` — but only if state is STILL
+    /// `.splitPendingConfirmation` by then (a `signAndStore` arriving first moves state to
+    /// `.inProgress`, and this task correctly no-ops).
+    func armSplitConfirmTask() {
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(MigrationSimulatorEngineDerivations.Constants.splitConfirmDelay))
+            self?.withSnapshot { snapshot in
+                guard snapshot.state == MigrationState.splitPendingConfirmation else { return }
+                snapshot.state = MigrationState.readyToPropose
+            }
+        }
+    }
+}

--- a/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorEngineDerivations.swift
+++ b/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorEngineDerivations.swift
@@ -1,0 +1,441 @@
+//
+//  MigrationSimulatorEngineDerivations.swift
+//  zodl
+//
+//  Pure, table-testable derivation logic for `MigrationSimulatorEngine` (MOB-1480) — no locking,
+//  no I/O, no `Date()` (the caller always supplies `now`/`simNow`). Factored out so
+//  `MigrationSimulatorEngine` itself is left with only locking/orchestration, matching the
+//  established house pattern (see `MigrationDerivations` in `MigrationManagerLiveKey.swift`).
+//
+
+import Foundation
+@preconcurrency import ZcashLightClientKit
+
+enum MigrationSimulatorEngineDerivations {
+    enum Constants {
+        static let fee = Zatoshi(10_000)
+        /// Spacing between successive scheduled transfers.
+        static let transferSpacing: TimeInterval = 6 * 3600
+        /// A pending transfer more than this far past its `dueAt` reads as `.overdue`.
+        static let overdueGrace: TimeInterval = 3600
+        /// A pending transfer more than this far past its `dueAt` reads as `.expired` and escalates
+        /// the whole migration into `.requiresAttention(.transferExpired)`.
+        static let expiryWindow: TimeInterval = 24 * 3600
+        static let splitConfirmDelay: TimeInterval = 15
+        /// Simulated network latency while a transfer is "broadcasting".
+        static let broadcastLatency: TimeInterval = 1.5
+        /// ≈ 12.458 ZEC, matching the Figma frames.
+        static let defaultOrchardBalance = Zatoshi(1_245_800_000)
+        static let defaultRNGSeed: UInt64 = 12_458
+        static let presetTransferCount = 5
+        /// ASCII header every fabricated PCZT blob starts with (`fabricatePczt`) — also the
+        /// recognition marker `SDKSynchronizerClient+Simulated`'s `parseMigrationPCZTBatch`
+        /// override checks for (MOB-1480).
+        static let fabricatedPCZTHeader = "ZODL-SIM-PCZT"
+        /// Real Zcash chain heights are ~3,000,000 (as of 2026); epoch-second timestamps are
+        /// ~1.77e9 — any `BlockHeight` at or above this threshold is unambiguously synthetic, never
+        /// a real chain height (MOB-1480, supersedes spec §9 flag #1 — see `isSyntheticHeight`).
+        static let syntheticHeightThreshold: BlockHeight = 1_000_000_000
+        /// One synthetic day, added to a transfer's synthetic `nextExecutableAfterHeight` to derive
+        /// its `expiryHeight`. Synthetic heights ARE epoch-second timestamps, so this is literally
+        /// `expiryWindow` expressed in the same "height" units (MOB-1480).
+        static let syntheticExpiryOffset: BlockHeight = 86_400
+    }
+
+    // MARK: - Time-driven escalation
+
+    /// Escalates `.inProgress`/`.requiresAttention(.transferStalled)` into
+    /// `.requiresAttention(.transferExpired)` once any unsent transfer's own window has been past
+    /// due for more than `expiryWindow`. Never demotes/resurrects any other state (`.complete`,
+    /// `.notStarted`, `.invalidTransfer`, etc. are left untouched).
+    static func recompute(_ snapshot: inout SimulatorSnapshot, now: Date) {
+        guard !snapshot.transfers.isEmpty else { return }
+
+        let hasNewlyExpired = snapshot.transfers.contains { transfer in
+            transfer.sentAt == nil && now > transfer.dueAt.addingTimeInterval(Constants.expiryWindow)
+        }
+        guard hasNewlyExpired else { return }
+
+        switch snapshot.state {
+        case MigrationState.inProgress:
+            snapshot.state = MigrationState.requiresAttention(AttentionReason.transferExpired)
+        case MigrationState.requiresAttention(let reason):
+            if case AttentionReason.transferStalled = reason {
+                snapshot.state = MigrationState.requiresAttention(AttentionReason.transferExpired)
+            }
+        default:
+            break
+        }
+    }
+
+    // MARK: - Synthetic heights (MOB-1480, supersedes spec §9 flag #1)
+
+    /// True for a `BlockHeight` fabricated from a wall-clock timestamp (`syntheticHeight(for:)`)
+    /// rather than a real chain height — see `Constants.syntheticHeightThreshold`.
+    static func isSyntheticHeight(_ height: BlockHeight) -> Bool {
+        height >= Constants.syntheticHeightThreshold
+    }
+
+    /// Encodes `date` as a synthetic `BlockHeight` (its epoch-second timestamp, truncated).
+    static func syntheticHeight(for date: Date) -> BlockHeight {
+        BlockHeight(date.timeIntervalSince1970)
+    }
+
+    /// Inverse of `syntheticHeight(for:)` — recovers the original timestamp from a synthetic
+    /// height. Only meaningful when `isSyntheticHeight(height)` is true; callers (the simulated
+    /// `estimateTimestamp` override) always check that first.
+    static func timestamp(forSyntheticHeight height: BlockHeight) -> TimeInterval {
+        TimeInterval(height)
+    }
+
+    /// Shared due-time formula for both `propose()` (stamping synthetic heights on each
+    /// `TransferProposal`) and `signAndStore()` (seeding each `SimulatorTransfer.dueAt`) — kept in
+    /// one place so the two can never drift apart, which would desync a proposed transfer's
+    /// stamped height from the `dueAt` it's actually signed/stored with. Immediate mode is always
+    /// due `now`; scheduled mode spaces transfers `transferSpacing` apart starting one spacing
+    /// unit out.
+    static func dueAt(forTransferAt index: Int, isImmediate: Bool, now: Date) -> Date {
+        isImmediate ? now : now.addingTimeInterval(Constants.transferSpacing * Double(index + 1))
+    }
+
+    // MARK: - Row derivation (transferRows / readout)
+
+    /// Derives the full row list for display, in schedule order. Row `status` is always derived
+    /// here (never stored) from `(sentAt, dueAt, now, state, broadcastingId)` — see spec §5.2.
+    static func rows(for snapshot: SimulatorSnapshot, now: Date, broadcastingId: String?) -> [MigrationTransferRow] {
+        var firstPendingSeen = false
+        var result: [MigrationTransferRow] = []
+        for transfer in snapshot.transfers.sorted(by: { $0.index < $1.index }) {
+            let status = derivedStatus(for: transfer, state: snapshot.state, now: now, firstPendingSeen: &firstPendingSeen)
+            let isBroadcasting = status == MigrationTransferRow.Status.active && transfer.id == broadcastingId
+            let (hoursFromNow, sentMinutesAgo) = captionFields(transfer: transfer, status: status, now: now)
+            result.append(
+                MigrationTransferRow(
+                    id: transfer.id,
+                    index: transfer.index,
+                    amount: transfer.amount,
+                    status: status,
+                    hoursFromNow: hoursFromNow,
+                    sentMinutesAgo: sentMinutesAgo,
+                    isBroadcasting: isBroadcasting
+                )
+            )
+        }
+        return result
+    }
+
+    /// Only the earliest not-yet-sent transfer can ever read `.active`/`.overdue` — everything
+    /// behind it is blocked in the queue and always reads `.pending` regardless of its own window
+    /// (matches the MOB-1451 prototype's round-4 semantics).
+    private static func derivedStatus(
+        for transfer: SimulatorTransfer,
+        state: MigrationState,
+        now: Date,
+        firstPendingSeen: inout Bool
+    ) -> MigrationTransferRow.Status {
+        if transfer.sentAt != nil {
+            return MigrationTransferRow.Status.sent
+        }
+
+        if case MigrationState.requiresAttention(let reason) = state {
+            if case AttentionReason.invalidTransfer(let transferId) = reason, transferId == transfer.id {
+                return MigrationTransferRow.Status.invalid
+            }
+            if case AttentionReason.transferExpired = reason, now > transfer.dueAt.addingTimeInterval(Constants.expiryWindow) {
+                return MigrationTransferRow.Status.expired
+            }
+        }
+
+        guard !firstPendingSeen else { return MigrationTransferRow.Status.pending }
+        firstPendingSeen = true
+        let isOverdue = now > transfer.dueAt.addingTimeInterval(Constants.overdueGrace)
+        return isOverdue ? MigrationTransferRow.Status.overdue : MigrationTransferRow.Status.active
+    }
+
+    /// `hoursFromNow`/`sentMinutesAgo` are contextually overloaded per `MigrationStatusView`'s
+    /// caption function: for `.sent` / `.overdue` rows they mean "hours ago"; for `.active`/
+    /// `.pending` they mean "hours until due"; `.invalid`/`.expired` don't render an ETA caption
+    /// today, so they default to `0`. ETA/overdue round to the nearest hour (matching the
+    /// MOB-1451 prototype's convention) rather than flooring, so a row scheduled exactly "6h out"
+    /// still reads as `6` a moment later instead of immediately dropping to `5`; `.sent` stays
+    /// floor-based since sub-hour precision is already covered by `sentMinutesAgo`.
+    private static func captionFields(
+        transfer: SimulatorTransfer,
+        status: MigrationTransferRow.Status,
+        now: Date
+    ) -> (hoursFromNow: Int, sentMinutesAgo: Int?) {
+        switch status {
+        case MigrationTransferRow.Status.sent:
+            guard let sentAt = transfer.sentAt else { return (0, nil) }
+            let elapsedMinutes = max(0, Int(now.timeIntervalSince(sentAt) / 60))
+            let sentMinutesAgo = elapsedMinutes < 60 ? elapsedMinutes : nil
+            return (elapsedMinutes / 60, sentMinutesAgo)
+
+        case MigrationTransferRow.Status.overdue:
+            let elapsedHours = max(0, Int((now.timeIntervalSince(transfer.dueAt) / 3600).rounded()))
+            return (elapsedHours, nil)
+
+        case MigrationTransferRow.Status.invalid, MigrationTransferRow.Status.expired:
+            return (0, nil)
+
+        case MigrationTransferRow.Status.active, MigrationTransferRow.Status.pending:
+            let remainingHours = max(0, Int((transfer.dueAt.timeIntervalSince(now) / 3600).rounded()))
+            return (remainingHours, nil)
+        }
+    }
+
+    // MARK: - hasOverdue / hasInvalid
+
+    /// Only the earliest not-yet-sent transfer can make the migration read as overdue — later
+    /// transfers are simply blocked behind it (mirrors `derivedStatus`'s "first pending" rule).
+    static func hasOverdue(snapshot: SimulatorSnapshot, now: Date) -> Bool {
+        if case MigrationState.requiresAttention(let reason) = snapshot.state, case AttentionReason.transferStalled = reason {
+            return true
+        }
+        guard let earliestPending = snapshot.transfers.filter({ $0.sentAt == nil }).min(by: { $0.index < $1.index }) else {
+            return false
+        }
+        return now > earliestPending.dueAt.addingTimeInterval(Constants.overdueGrace)
+    }
+
+    /// A row only ever reads `.invalid`/`.expired` while `state` carries the matching attention
+    /// reason (see `derivedStatus`), so checking `state` alone is equivalent to scanning rows.
+    static func hasInvalid(snapshot: SimulatorSnapshot) -> Bool {
+        guard case MigrationState.requiresAttention(let reason) = snapshot.state else { return false }
+        switch reason {
+        case AttentionReason.invalidTransfer, AttentionReason.transferExpired:
+            return true
+        case AttentionReason.transferStalled, AttentionReason.syncRequiredBeforeNext:
+            return false
+        }
+    }
+
+    // MARK: - isNextTransferDue
+
+    /// True when the earliest unsent transfer is already due AND the migration is in the one
+    /// state where "next transfer due" is a meaningful signal: `.inProgress` is the only state
+    /// `computeProgress`/`progress()` ever return non-`nil` for, which is what
+    /// `MigrationDerivations.bannerVariant`/`reentryRoute` pair this signal with (manual-delivery
+    /// "transfer ready"/"review manual" rows). Supersedes the real SDK-facing derivation
+    /// (`MigrationManagerLiveKey.isNextTransferDue()`), which compares a `BlockHeight` against the
+    /// real chain's `latestBlockHeight` — a comparison that can never fire against our synthetic
+    /// (epoch-seconds) heights (MOB-1480).
+    static func isNextTransferDue(snapshot: SimulatorSnapshot, now: Date) -> Bool {
+        guard case MigrationState.inProgress = snapshot.state else { return false }
+        guard let earliestPending = snapshot.transfers.filter({ $0.sentAt == nil }).min(by: { $0.index < $1.index }) else {
+            return false
+        }
+        return earliestPending.dueAt <= now
+    }
+
+    // MARK: - Progress / summary
+
+    static func computeProgress(for snapshot: SimulatorSnapshot) -> MigrationProgress {
+        let nextUnsent = snapshot.transfers.filter { $0.sentAt == nil }.min(by: { $0.index < $1.index })
+        return MigrationProgress(
+            completedTransfers: snapshot.transfers.filter { $0.sentAt != nil }.count,
+            totalTransfers: snapshot.transfers.count,
+            remainingOrchard: snapshot.orchardBalance,
+            // Synthetic height of the next unsent transfer's `dueAt` (supersedes spec §9 flag #1,
+            // as an improvement — see `syntheticHeight(for:)`); `nil` once every transfer is sent.
+            nextTransferReadyAtHeight: nextUnsent.map { syntheticHeight(for: $0.dueAt) }
+        )
+    }
+
+    static func computeSummary(for snapshot: SimulatorSnapshot) -> MigrationSummary {
+        let sent = snapshot.transfers.filter { $0.sentAt != nil }
+        let transferred = sent.reduce(Zatoshi.zero) { $0 + $1.amount }
+        let isComplete = snapshot.state == MigrationState.complete
+        let estimatedDurationHours = snapshot.mode == MigrationMode.immediate
+            ? 0
+            : snapshot.transfers.count * Int(Constants.transferSpacing / 3600)
+
+        return MigrationSummary(
+            transferred: transferred,
+            dust: isComplete ? snapshot.dustRemainder : Zatoshi.zero,
+            transfersSent: sent.count,
+            transfersTotal: snapshot.transfers.count,
+            estimatedDurationHours: estimatedDurationHours
+        )
+    }
+
+    // MARK: - Note splitting
+
+    /// Splits `net` into 3–5 (or `countOverride`) random-weighted notes summing EXACTLY to `net`,
+    /// reproducible for a fixed `seed`. Weights are drawn from a fresh `SplitMix64(seed:)` every
+    /// call (not evolved/persisted), so the same `(seed, net, countOverride)` always yields the
+    /// same split — see spec §9 flag #3.
+    static func splitNotes(net: Zatoshi, seed: UInt64, countOverride: Int? = nil) -> [Zatoshi] {
+        guard net.amount > 0 else { return [] }
+
+        var rng = SplitMix64(seed: seed)
+        let count = countOverride ?? Int.random(in: 3...5, using: &rng)
+        guard count > 1, net.amount >= Int64(count) else { return [net] }
+
+        let weights = (0..<count).map { _ in Double.random(in: 0.5...1.5, using: &rng) }
+        let totalWeight = weights.reduce(0, +)
+        var amounts = weights.map { weight in Int64((Double(net.amount) * weight / totalWeight).rounded(.down)) }
+        let allocated = amounts.reduce(0, +)
+        amounts[amounts.count - 1] += net.amount - allocated
+        return amounts.map { Zatoshi($0) }
+    }
+
+    // MARK: - Deterministic IDs / fabricated PCZTs
+
+    static func makeTransferId(index: Int) -> String {
+        "xfer-\(index)"
+    }
+
+    static func makeTxId(prefix: String, discriminator: String) -> String {
+        "tx-\(prefix)-\(discriminator)"
+    }
+
+    /// Non-empty, deterministic fabricated PCZT blob: an ASCII header, then the index and amount
+    /// as fixed-width little-endian bytes.
+    static func fabricatePczt(index: Int, amount: Zatoshi) -> Pczt {
+        var data = Data(Constants.fabricatedPCZTHeader.utf8)
+        withUnsafeBytes(of: Int32(index).littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: amount.amount.littleEndian) { data.append(contentsOf: $0) }
+        return data
+    }
+
+    static func describeArmedResult(_ result: TransferResult?, splitFailureArmed: Bool) -> String? {
+        if splitFailureArmed { return "splitFailure" }
+        guard let result else { return nil }
+        switch result {
+        case TransferResult.success(let txId): return "success(txId: \(txId))"
+        case TransferResult.networkError(let retryable): return "networkError(retryable: \(retryable))"
+        case TransferResult.invalidNote: return "invalidNote"
+        case TransferResult.expired: return "expired"
+        }
+    }
+
+    // MARK: - Presets (spec §5.3)
+
+    /// Seeds a whole, internally-consistent snapshot for `preset`. Always clears any armed
+    /// result/split-failure first so presets are reliably reproducible regardless of prior state.
+    static func applyPreset(_ preset: SimulatorPreset, to snapshot: inout SimulatorSnapshot, now: Date) {
+        snapshot.armedTransferResult = nil
+        snapshot.armedSplitFailure = false
+        snapshot.lastBackgroundRunSummary = "applied preset \(preset.rawValue)"
+
+        switch preset {
+        case SimulatorPreset.freshRequired:
+            snapshot.orchardBalance = Constants.defaultOrchardBalance
+            snapshot.notes = [Constants.defaultOrchardBalance]
+            snapshot.mode = MigrationMode.privateScheduled
+            snapshot.transfers = []
+            snapshot.syncRequired = false
+            snapshot.dustRemainder = Zatoshi.zero
+            snapshot.state = MigrationState.notStarted
+
+        case SimulatorPreset.splitting:
+            snapshot.orchardBalance = Constants.defaultOrchardBalance
+            snapshot.mode = MigrationMode.privateScheduled
+            snapshot.notes = splitNotes(net: netOfFee(Constants.defaultOrchardBalance), seed: snapshot.rngSeed)
+            snapshot.transfers = []
+            snapshot.splitSubmittedAt = now
+            snapshot.state = MigrationState.splitPendingConfirmation
+
+        case SimulatorPreset.readyToPropose:
+            snapshot.orchardBalance = Constants.defaultOrchardBalance
+            snapshot.mode = MigrationMode.privateScheduled
+            snapshot.notes = splitNotes(net: netOfFee(Constants.defaultOrchardBalance), seed: snapshot.rngSeed)
+            snapshot.transfers = []
+            snapshot.state = MigrationState.readyToPropose
+
+        case SimulatorPreset.inProgress:
+            seedPresetSchedule(&snapshot, now: now, sentCount: 2)
+            snapshot.state = MigrationState.inProgress(computeProgress(for: snapshot))
+
+        case SimulatorPreset.transferReadyManual:
+            seedPresetSchedule(&snapshot, now: now, sentCount: 2)
+            if let index = firstPendingIndex(in: snapshot) {
+                snapshot.transfers[index].dueAt = now
+            }
+            snapshot.state = MigrationState.inProgress(computeProgress(for: snapshot))
+
+        case SimulatorPreset.transferStalled:
+            seedPresetSchedule(&snapshot, now: now, sentCount: 2)
+            if let index = firstPendingIndex(in: snapshot) {
+                snapshot.transfers[index].dueAt = now.addingTimeInterval(-Constants.overdueGrace)
+                snapshot.state = MigrationState.requiresAttention(
+                    AttentionReason.transferStalled(transferNumber: snapshot.transfers[index].index + 1)
+                )
+            }
+
+        case SimulatorPreset.updatePlanInvalid:
+            seedPresetSchedule(&snapshot, now: now, sentCount: 2)
+            if let index = firstPendingIndex(in: snapshot) {
+                snapshot.state = MigrationState.requiresAttention(
+                    AttentionReason.invalidTransfer(transferId: snapshot.transfers[index].id)
+                )
+            }
+
+        case SimulatorPreset.transfersExpired:
+            seedPresetSchedule(&snapshot, now: now, sentCount: 2)
+            if let index = firstPendingIndex(in: snapshot) {
+                snapshot.transfers[index].dueAt = now.addingTimeInterval(-(Constants.expiryWindow + 1))
+            }
+            snapshot.state = MigrationState.requiresAttention(AttentionReason.transferExpired)
+
+        case SimulatorPreset.syncRequired:
+            seedPresetSchedule(&snapshot, now: now, sentCount: 2)
+            snapshot.state = MigrationState.inProgress(computeProgress(for: snapshot))
+            snapshot.syncRequired = true
+
+        case SimulatorPreset.complete:
+            seedPresetSchedule(&snapshot, now: now, sentCount: Constants.presetTransferCount)
+            snapshot.dustRemainder = Zatoshi.zero
+            snapshot.orchardBalance = snapshot.dustRemainder
+            snapshot.state = MigrationState.complete
+
+        case SimulatorPreset.completeWithDust:
+            seedPresetSchedule(&snapshot, now: now, sentCount: Constants.presetTransferCount)
+            snapshot.dustRemainder = Zatoshi(5_000)
+            snapshot.orchardBalance = snapshot.dustRemainder
+            snapshot.state = MigrationState.complete
+        }
+    }
+
+    static func netOfFee(_ balance: Zatoshi) -> Zatoshi {
+        Zatoshi(max(0, balance.amount - Constants.fee.amount))
+    }
+
+    /// Common base for every multi-transfer preset: a fresh `presetTransferCount`-note scheduled
+    /// migration, with the first `sentCount` transfers already sent (and the balance decremented
+    /// to match) and the rest pending, 6h apart, starting from `now`.
+    private static func seedPresetSchedule(_ snapshot: inout SimulatorSnapshot, now: Date, sentCount: Int) {
+        snapshot.mode = MigrationMode.privateScheduled
+        snapshot.orchardBalance = Constants.defaultOrchardBalance
+        let notes = splitNotes(
+            net: netOfFee(Constants.defaultOrchardBalance),
+            seed: snapshot.rngSeed,
+            countOverride: Constants.presetTransferCount
+        )
+        snapshot.notes = notes
+
+        var remaining = Constants.defaultOrchardBalance
+        var transfers: [SimulatorTransfer] = []
+        for (index, note) in notes.enumerated() {
+            let dueAt = now.addingTimeInterval(Constants.transferSpacing * Double(index + 1))
+            let isSent = index < sentCount
+            let sentAt = isSent ? now.addingTimeInterval(-Constants.transferSpacing * Double(notes.count - index)) : nil
+            transfers.append(
+                SimulatorTransfer(id: makeTransferId(index: index), index: index, amount: note, dueAt: dueAt, sentAt: sentAt)
+            )
+            if isSent {
+                remaining = Zatoshi(max(0, remaining.amount - note.amount))
+            }
+        }
+        snapshot.transfers = transfers
+        snapshot.orchardBalance = remaining
+    }
+
+    private static func firstPendingIndex(in snapshot: SimulatorSnapshot) -> Int? {
+        snapshot.transfers.enumerated()
+            .filter { $0.element.sentAt == nil }
+            .min(by: { $0.element.index < $1.element.index })
+            .map { $0.offset }
+    }
+}

--- a/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorFlag.swift
+++ b/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorFlag.swift
@@ -1,0 +1,20 @@
+//
+//  MigrationSimulatorFlag.swift
+//  zodl
+//
+//  Compile-time master switch for the migration SDK simulator (MOB-1480). This is the ONLY `#if`
+//  in the whole feature — everything else checks `MigrationSimulatorFlag.isEnabled` at runtime, so
+//  all simulator code compiles in every target (required: `zodlTests` builds `zodl-internal` /
+//  `SECANT_MAINNET` and must still be able to unit-test the engine directly). In non-testnet
+//  builds the flag is constant `false` and every hook fed by it is inert.
+//
+enum MigrationSimulatorFlag {
+    /// Hardcoded master switch. Flip to `false` to disable the simulator in testnet builds too.
+    static let isEnabled: Bool = {
+        #if SECANT_TESTNET
+        return true
+        #else
+        return false
+        #endif
+    }()
+}

--- a/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorInterface.swift
+++ b/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorInterface.swift
@@ -1,0 +1,49 @@
+//
+//  MigrationSimulatorInterface.swift
+//  zodl
+//
+//  Panel-facing dependency surface over the shared `MigrationSimulatorEngine` (MOB-1480). Phase B's
+//  debug panel drives the engine exclusively through this client; the simulated
+//  `SDKSynchronizerClient`/`MigrationManagerClient` hooks (also Phase B) talk to
+//  `MigrationSimulatorClient.sharedEngine` directly instead, since their surface is the much larger
+//  SDK-shaped member list already pinned on the engine itself.
+//
+
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+extension DependencyValues {
+    var migrationSimulator: MigrationSimulatorClient {
+        get { self[MigrationSimulatorClient.self] }
+        set { self[MigrationSimulatorClient.self] = newValue }
+    }
+}
+
+@DependencyClient
+struct MigrationSimulatorClient: Sendable {
+    var readout: @Sendable () -> SimulatorReadout = {
+        SimulatorReadout(
+            isActive: false,
+            state: MigrationState.notStarted,
+            mode: MigrationMode.privateScheduled,
+            orchardBalance: Zatoshi.zero,
+            timeOffset: 0,
+            rows: [],
+            signedBatchCount: 0,
+            armedResultDescription: nil,
+            isSplitPending: false,
+            lastBackgroundRunSummary: nil
+        )
+    }
+    var setActive: @Sendable (Bool) -> Void
+    var reset: @Sendable () -> Void
+    var seed: @Sendable (Zatoshi, Int) -> Void
+    var applyPreset: @Sendable (SimulatorPreset) -> Void
+    var advanceTime: @Sendable (TimeInterval) -> Void
+    var makeNextTransferDueNow: @Sendable () -> Void
+    var confirmSplitNow: @Sendable () -> Void
+    var armTransferResult: @Sendable (TransferResult) -> Void
+    var armSplitFailure: @Sendable () -> Void
+    var setSyncRequired: @Sendable (Bool) -> Void
+}

--- a/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorLiveKey.swift
@@ -1,0 +1,42 @@
+//
+//  MigrationSimulatorLiveKey.swift
+//  zodl
+//
+//  Live implementation of `MigrationSimulatorClient`. `sharedEngine` is the single engine
+//  instance (backed by the on-disk live store) that Phase B's `SDKSynchronizerLive` migration
+//  member block and `MigrationManagerLiveKey`'s balance hook also read from directly, so the
+//  debug panel and the simulated SDK surface always observe the same state.
+//
+
+import Foundation
+import ComposableArchitecture
+
+extension MigrationSimulatorClient: DependencyKey {
+    /// Backs every simulated migration hook across the app (panel + `SDKSynchronizerLive` +
+    /// `MigrationManagerLiveKey`) — a single shared instance, backed by the on-disk live store.
+    static let sharedEngine = MigrationSimulatorEngine(store: MigrationSimulatorStateStore.live())
+
+    static let liveValue: MigrationSimulatorClient = Self.live(engine: Self.sharedEngine)
+
+    static func live(engine: MigrationSimulatorEngine) -> Self {
+        Self(
+            readout: { engine.readout() },
+            setActive: { engine.setActive($0) },
+            reset: { engine.reset() },
+            seed: { orchard, noteCount in engine.seed(orchard: orchard, noteCount: noteCount) },
+            applyPreset: { engine.applyPreset($0) },
+            advanceTime: { engine.advanceTime(by: $0) },
+            makeNextTransferDueNow: { engine.makeNextTransferDueNow() },
+            confirmSplitNow: { engine.confirmSplitNow() },
+            armTransferResult: { engine.armTransferResult($0) },
+            armSplitFailure: { engine.armSplitFailure() },
+            setSyncRequired: { engine.setSyncRequired($0) }
+        )
+    }
+
+    /// A fresh client over a fresh in-memory engine — for tests/previews that need panel-level
+    /// behavior without touching `sharedEngine`'s on-disk state.
+    static func ephemeral() -> Self {
+        Self.live(engine: MigrationSimulatorEngine(store: MigrationSimulatorStateStore.ephemeral()))
+    }
+}

--- a/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorModels.swift
+++ b/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorModels.swift
@@ -1,0 +1,199 @@
+//
+//  MigrationSimulatorModels.swift
+//  zodl
+//
+//  Value types for the migration SDK simulator (MOB-1480, testnet-only debug tooling). These
+//  model the *persisted* simulated state (`SimulatorSnapshot`/`SimulatorTransfer`), the debug
+//  panel's preset menu (`SimulatorPreset`), the panel's read-only status display
+//  (`SimulatorReadout`), and a seeded RNG (`SplitMix64`) so note splits are reproducible per
+//  `rngSeed`. See docs/superpowers/specs/2026-07-13-mob1480-migration-sdk-simulator-design.md §5.1.
+//
+
+import Foundation
+@preconcurrency import ZcashLightClientKit
+
+/// A splittable, reproducible 64-bit RNG (public-domain SplitMix64 algorithm). Used to derive
+/// note splits deterministically from a persisted `rngSeed`, so re-deriving the same seed against
+/// the same balance always yields the same split (spec §9 flag: "reproducible per reset").
+struct SplitMix64: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+}
+
+/// One scheduled/sent migration transfer as tracked by the simulator. Deliberately minimal:
+/// `derivedStatus`/caption fields (`hoursFromNow`, `sentMinutesAgo`, `isBroadcasting`) are NEVER
+/// stored here — they're recomputed at read time from `dueAt`/`sentAt` plus the engine's current
+/// `MigrationState` (see `MigrationSimulatorEngineDerivations`).
+struct SimulatorTransfer: Equatable, Sendable, Codable, Identifiable {
+    var id: String
+    /// 0-based position in the schedule (stable even as earlier transfers are sent).
+    var index: Int
+    var amount: Zatoshi
+    var dueAt: Date
+    var sentAt: Date?
+
+    init(id: String, index: Int, amount: Zatoshi, dueAt: Date, sentAt: Date? = nil) {
+        self.id = id
+        self.index = index
+        self.amount = amount
+        self.dueAt = dueAt
+        self.sentAt = sentAt
+    }
+}
+
+/// The complete persisted simulator state. Envelope-versioned via `schemaVersion` — the store
+/// reseeds on any decode failure or version mismatch rather than attempting migration.
+struct SimulatorSnapshot: Equatable, Sendable, Codable {
+    /// Bump whenever this shape changes; the store treats a mismatch like a decode failure.
+    static let currentSchemaVersion = 1
+
+    static func seeded(rngSeed: UInt64 = MigrationSimulatorEngineDerivations.Constants.defaultRNGSeed) -> SimulatorSnapshot {
+        SimulatorSnapshot(
+            schemaVersion: SimulatorSnapshot.currentSchemaVersion,
+            isActive: true,
+            orchardBalance: MigrationSimulatorEngineDerivations.Constants.defaultOrchardBalance,
+            notes: [MigrationSimulatorEngineDerivations.Constants.defaultOrchardBalance],
+            mode: MigrationMode.privateScheduled,
+            state: MigrationState.notStarted,
+            transfers: [],
+            timeOffset: 0,
+            syncRequired: false,
+            armedTransferResult: nil,
+            armedSplitFailure: false,
+            splitSubmittedAt: nil,
+            signedBatchCount: 0,
+            rngSeed: rngSeed,
+            lastBackgroundRunSummary: nil,
+            dustRemainder: Zatoshi.zero
+        )
+    }
+
+    var schemaVersion: Int
+    var isActive: Bool
+    var orchardBalance: Zatoshi
+    var notes: [Zatoshi]
+    var mode: MigrationMode
+    var state: MigrationState
+    var transfers: [SimulatorTransfer]
+    /// Simulated-clock offset from the wall clock: `simNow = Date() + timeOffset`.
+    var timeOffset: TimeInterval
+    var syncRequired: Bool
+    var armedTransferResult: TransferResult?
+    var armedSplitFailure: Bool
+    var splitSubmittedAt: Date?
+    /// Keystone: count of PCZTs most recently stored via `storeSignedBatch`.
+    var signedBatchCount: Int
+    var rngSeed: UInt64
+    /// One-line summary of the most recent `executeNext` outcome, for the debug panel.
+    var lastBackgroundRunSummary: String?
+    /// Balance left over once every transfer has been sent (usually `.zero`).
+    var dustRemainder: Zatoshi
+
+    init(
+        schemaVersion: Int,
+        isActive: Bool = true,
+        orchardBalance: Zatoshi,
+        notes: [Zatoshi],
+        mode: MigrationMode,
+        state: MigrationState,
+        transfers: [SimulatorTransfer],
+        timeOffset: TimeInterval,
+        syncRequired: Bool,
+        armedTransferResult: TransferResult?,
+        armedSplitFailure: Bool,
+        splitSubmittedAt: Date?,
+        signedBatchCount: Int,
+        rngSeed: UInt64,
+        lastBackgroundRunSummary: String?,
+        dustRemainder: Zatoshi
+    ) {
+        self.schemaVersion = schemaVersion
+        self.isActive = isActive
+        self.orchardBalance = orchardBalance
+        self.notes = notes
+        self.mode = mode
+        self.state = state
+        self.transfers = transfers
+        self.timeOffset = timeOffset
+        self.syncRequired = syncRequired
+        self.armedTransferResult = armedTransferResult
+        self.armedSplitFailure = armedSplitFailure
+        self.splitSubmittedAt = splitSubmittedAt
+        self.signedBatchCount = signedBatchCount
+        self.rngSeed = rngSeed
+        self.lastBackgroundRunSummary = lastBackgroundRunSummary
+        self.dustRemainder = dustRemainder
+    }
+}
+
+/// The debug panel's preset menu (spec §5.3). Each preset seeds a whole, internally-consistent
+/// snapshot targeting a specific banner variant / re-entry route for manual QA.
+enum SimulatorPreset: String, Equatable, Sendable, Codable, CaseIterable {
+    case freshRequired
+    case splitting
+    case readyToPropose
+    case inProgress
+    case transferReadyManual
+    case transferStalled
+    case updatePlanInvalid
+    case transfersExpired
+    case syncRequired
+    case complete
+    case completeWithDust
+
+    /// True for the one preset that needs the app-side `isManualDelivery` flag flipped on too —
+    /// the panel reads this to know which `MigrationManagerClient` flag to align (the engine
+    /// itself has no notion of "manual delivery").
+    var requiresManualDelivery: Bool {
+        self == .transferReadyManual
+    }
+}
+
+/// Read-only snapshot of engine state for the debug panel's status display.
+struct SimulatorReadout: Equatable, Sendable {
+    var isActive: Bool
+    var state: MigrationState
+    var mode: MigrationMode
+    var orchardBalance: Zatoshi
+    var timeOffset: TimeInterval
+    var rows: [MigrationTransferRow]
+    var signedBatchCount: Int
+    var armedResultDescription: String?
+    var isSplitPending: Bool
+    var lastBackgroundRunSummary: String?
+
+    init(
+        isActive: Bool,
+        state: MigrationState,
+        mode: MigrationMode,
+        orchardBalance: Zatoshi,
+        timeOffset: TimeInterval,
+        rows: [MigrationTransferRow],
+        signedBatchCount: Int,
+        armedResultDescription: String?,
+        isSplitPending: Bool,
+        lastBackgroundRunSummary: String?
+    ) {
+        self.isActive = isActive
+        self.state = state
+        self.mode = mode
+        self.orchardBalance = orchardBalance
+        self.timeOffset = timeOffset
+        self.rows = rows
+        self.signedBatchCount = signedBatchCount
+        self.armedResultDescription = armedResultDescription
+        self.isSplitPending = isSplitPending
+        self.lastBackgroundRunSummary = lastBackgroundRunSummary
+    }
+}

--- a/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorStateStore.swift
+++ b/secant/Sources/Dependencies/MigrationSimulator/MigrationSimulatorStateStore.swift
@@ -1,0 +1,73 @@
+//
+//  MigrationSimulatorStateStore.swift
+//  zodl
+//
+//  Persistence for `MigrationSimulatorEngine` (MOB-1480). The simulated state must survive app
+//  restarts and the background-task lifecycle, so the live store snapshots itself to a JSON file
+//  under Application Support. Envelope-versioned: any decode failure OR a `schemaVersion`
+//  mismatch reseeds (and persists the reseed) rather than attempting a migration.
+//
+
+import Foundation
+import os
+
+/// Load/save/clear the snapshot. Two factories: `.live` (JSON file, for the shared engine) and
+/// `.ephemeral` (in-memory, for tests/previews).
+struct MigrationSimulatorStateStore: Sendable {
+    var load: @Sendable () -> SimulatorSnapshot
+    var save: @Sendable (SimulatorSnapshot) -> Void
+    var clear: @Sendable () -> Void
+
+    /// Default on-disk location in Application Support.
+    static var defaultFileURL: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent("migration_simulator_state.json")
+    }
+
+    /// JSON-file-backed store. File access is serialized by a lock so the foreground app and a
+    /// background-task relaunch never corrupt the file.
+    static func live(fileURL: URL = MigrationSimulatorStateStore.defaultFileURL) -> MigrationSimulatorStateStore {
+        let lock = OSAllocatedUnfairLock(initialState: ())
+
+        @Sendable func reseed() -> SimulatorSnapshot {
+            let fresh = SimulatorSnapshot.seeded()
+            if let data = try? JSONEncoder().encode(fresh) {
+                try? data.write(to: fileURL, options: .atomic)
+            }
+            return fresh
+        }
+
+        @Sendable func read() -> SimulatorSnapshot {
+            guard
+                let data = try? Data(contentsOf: fileURL),
+                let snapshot = try? JSONDecoder().decode(SimulatorSnapshot.self, from: data),
+                snapshot.schemaVersion == SimulatorSnapshot.currentSchemaVersion
+            else {
+                return reseed()
+            }
+            return snapshot
+        }
+
+        return MigrationSimulatorStateStore(
+            load: { lock.withLockUnchecked { _ in read() } },
+            save: { snapshot in
+                lock.withLockUnchecked { _ in
+                    guard let data = try? JSONEncoder().encode(snapshot) else { return }
+                    try? data.write(to: fileURL, options: .atomic)
+                }
+            },
+            clear: { lock.withLockUnchecked { _ in try? FileManager.default.removeItem(at: fileURL) } }
+        )
+    }
+
+    /// In-memory store for tests and previews.
+    static func ephemeral() -> MigrationSimulatorStateStore {
+        let state = OSAllocatedUnfairLock(initialState: SimulatorSnapshot.seeded())
+        return MigrationSimulatorStateStore(
+            load: { state.withLock { $0 } },
+            save: { snapshot in state.withLock { $0 = snapshot } },
+            clear: { state.withLock { $0 = SimulatorSnapshot.seeded() } }
+        )
+    }
+}

--- a/secant/Sources/Dependencies/MigrationSimulator/SDKSynchronizerClient+Simulated.swift
+++ b/secant/Sources/Dependencies/MigrationSimulator/SDKSynchronizerClient+Simulated.swift
@@ -1,0 +1,306 @@
+//
+//  SDKSynchronizerClient+Simulated.swift
+//  zodl
+//
+//  Wires every migration-surface member of `SDKSynchronizerClient` (plus `estimateTimestamp`)
+//  through `MigrationSimulatorEngine` (MOB-1480). `SDKSynchronizerLive.live()` calls
+//  `applySimulatedMigration(engine:)` on the client it already built, immediately before
+//  returning, whenever `MigrationSimulatorFlag.isEnabled` — the stub/live construction itself
+//  never changes.
+//
+//  CAPTURE-ORIGINAL pattern, applied to every member: read the existing closure into a local
+//  `original...` constant BEFORE overwriting `self`'s property, then have the override close over
+//  that local constant (never over `self`, which would recurse). When `engine.isActive` is
+//  `false`, every override calls straight through to `original...`, so flipping the debug panel's
+//  toggle off — or never applying this at all, in `zodl-internal`/`zodl-production` where
+//  `MigrationSimulatorFlag.isEnabled` is a compile-time `false` — reproduces today's behavior
+//  byte-for-byte, including the existing 5-row `migrationTransfers` demo fixture (spec §3 flag-off
+//  guarantee).
+//
+//  Member mapping follows spec §5.2 exactly; grouped into one `private mutating func` per table
+//  row-group so no single function threatens the 150-line SwiftLint warning.
+//
+
+import Foundation
+@preconcurrency import Combine
+@preconcurrency import ZcashLightClientKit
+@preconcurrency import KeystoneSDK
+import URKit
+
+extension SDKSynchronizerClient {
+    mutating func applySimulatedMigration(engine: MigrationSimulatorEngine) {
+        applySimulatedState(engine: engine)
+        applySimulatedNoteSplit(engine: engine)
+        applySimulatedProposalAndSchedule(engine: engine)
+        applySimulatedBackgroundExecution(engine: engine)
+        applySimulatedRecovery(engine: engine)
+        applySimulatedProgressUI(engine: engine)
+        applySimulatedKeystone(engine: engine)
+        applySimulatedLifecycleAndTimestamp(engine: engine)
+    }
+
+    // MARK: - State (spec §5.2 "State" row)
+
+    private mutating func applySimulatedState(engine: MigrationSimulatorEngine) {
+        let originalGetMigrationState = self.getMigrationState
+        self.getMigrationState = {
+            engine.isActive ? engine.currentState() : originalGetMigrationState()
+        }
+
+        let originalMigrationStateStream = self.migrationStateStream
+        self.migrationStateStream = {
+            engine.isActive ? engine.statePublisher() : originalMigrationStateStream()
+        }
+
+        let originalGetMigrationProgress = self.getMigrationProgress
+        self.getMigrationProgress = {
+            engine.isActive ? engine.progress() : originalGetMigrationProgress()
+        }
+    }
+
+    // MARK: - Note splitting (spec §5.2 "Note splitting" row)
+
+    private mutating func applySimulatedNoteSplit(engine: MigrationSimulatorEngine) {
+        let originalIsNoteSplitNeeded = self.isNoteSplitNeeded
+        self.isNoteSplitNeeded = {
+            engine.isActive ? engine.isNoteSplitNeeded() : originalIsNoteSplitNeeded()
+        }
+
+        let originalPrepareNoteSplit = self.prepareNoteSplit
+        self.prepareNoteSplit = {
+            if engine.isActive {
+                return await engine.prepareSplit()
+            } else {
+                return await originalPrepareNoteSplit()
+            }
+        }
+
+        let originalSubmitNoteSplit = self.submitNoteSplit
+        self.submitNoteSplit = { proposal in
+            if engine.isActive {
+                return await engine.submitSplit(proposal)
+            } else {
+                return await originalSubmitNoteSplit(proposal)
+            }
+        }
+
+        let originalSubmitSignedNoteSplit = self.submitSignedNoteSplit
+        self.submitSignedNoteSplit = { pczt in
+            if engine.isActive {
+                return await engine.submitSignedSplit(pczt)
+            } else {
+                return await originalSubmitSignedNoteSplit(pczt)
+            }
+        }
+    }
+
+    // MARK: - Proposal / commit (spec §5.2 "Proposal" rows)
+
+    private mutating func applySimulatedProposalAndSchedule(engine: MigrationSimulatorEngine) {
+        let originalSelectMigrationMode = self.selectMigrationMode
+        self.selectMigrationMode = { mode in
+            if engine.isActive {
+                engine.selectMode(mode)
+            } else {
+                originalSelectMigrationMode(mode)
+            }
+        }
+
+        let originalProposeMigrationTransfers = self.proposeMigrationTransfers
+        self.proposeMigrationTransfers = {
+            if engine.isActive {
+                return await engine.propose()
+            } else {
+                return await originalProposeMigrationTransfers()
+            }
+        }
+
+        let originalSignAndStoreMigrationSchedule = self.signAndStoreMigrationSchedule
+        self.signAndStoreMigrationSchedule = { schedule in
+            if engine.isActive {
+                await engine.signAndStore(schedule)
+            } else {
+                await originalSignAndStoreMigrationSchedule(schedule)
+            }
+        }
+    }
+
+    // MARK: - Background execution (spec §5.2 "Background execution" + "On-launch" rows)
+
+    private mutating func applySimulatedBackgroundExecution(engine: MigrationSimulatorEngine) {
+        let originalIsSyncRequired = self.isSyncRequiredBeforeNextMigrationTransfer
+        self.isSyncRequiredBeforeNextMigrationTransfer = {
+            engine.isActive ? engine.isSyncRequired() : originalIsSyncRequired()
+        }
+
+        let originalExecuteNext = self.executeNextPendingMigrationTransfer
+        self.executeNextPendingMigrationTransfer = { options in
+            if engine.isActive {
+                return await engine.executeNext(options)
+            } else {
+                return await originalExecuteNext(options)
+            }
+        }
+
+        let originalHasOverdue = self.hasOverdueMigrationTransfers
+        self.hasOverdueMigrationTransfers = {
+            engine.isActive ? engine.hasOverdue() : originalHasOverdue()
+        }
+
+        let originalHasInvalid = self.hasInvalidMigrationTransfers
+        self.hasInvalidMigrationTransfers = {
+            engine.isActive ? engine.hasInvalid() : originalHasInvalid()
+        }
+    }
+
+    // MARK: - Recovery (spec §5.2 "Recovery" rows)
+
+    private mutating func applySimulatedRecovery(engine: MigrationSimulatorEngine) {
+        let originalRestart = self.restartCurrentMigrationStep
+        self.restartCurrentMigrationStep = {
+            if engine.isActive {
+                return await engine.restart()
+            } else {
+                return await originalRestart()
+            }
+        }
+
+        let originalRescheduleStalled = self.rescheduleStalledMigrationTransfer
+        self.rescheduleStalledMigrationTransfer = {
+            if engine.isActive {
+                await engine.rescheduleStalled()
+            } else {
+                await originalRescheduleStalled()
+            }
+        }
+
+        let originalRecreateInvalid = self.recreateInvalidMigrationTransfer
+        self.recreateInvalidMigrationTransfer = {
+            if engine.isActive {
+                await engine.recreateInvalid()
+            } else {
+                await originalRecreateInvalid()
+            }
+        }
+    }
+
+    // MARK: - Progress UI (spec §5.2 "Progress UI" row)
+
+    /// Inactive engine falls back to `original()`, preserving today's 5-row `migrationTransfers`
+    /// demo fixture byte-for-byte (spec §3 flag-off guarantee).
+    private mutating func applySimulatedProgressUI(engine: MigrationSimulatorEngine) {
+        let originalMigrationSummary = self.migrationSummary
+        self.migrationSummary = {
+            engine.isActive ? engine.summary() : originalMigrationSummary()
+        }
+
+        let originalMigrationTransfers = self.migrationTransfers
+        self.migrationTransfers = {
+            engine.isActive ? engine.transferRows() : originalMigrationTransfers()
+        }
+    }
+
+    // MARK: - Keystone / PCZT (spec §5.2 "Keystone" rows + §7)
+
+    private mutating func applySimulatedKeystone(engine: MigrationSimulatorEngine) {
+        let originalProposeNoteSplitPCZT = self.proposeNoteSplitPCZT
+        self.proposeNoteSplitPCZT = {
+            if engine.isActive {
+                return engine.fabricateNoteSplitPCZT()
+            } else {
+                return await originalProposeNoteSplitPCZT()
+            }
+        }
+
+        let originalProposeMigrationPCZTs = self.proposeMigrationPCZTs
+        self.proposeMigrationPCZTs = { schedule in
+            if engine.isActive {
+                return engine.fabricateMigrationPCZTs(schedule)
+            } else {
+                return await originalProposeMigrationPCZTs(schedule)
+            }
+        }
+
+        let originalStoreSignedMigrationTransactions = self.storeSignedMigrationTransactions
+        self.storeSignedMigrationTransactions = { pczts in
+            if engine.isActive {
+                engine.storeSignedBatch(pczts)
+            } else {
+                await originalStoreSignedMigrationTransactions(pczts)
+            }
+        }
+
+        let originalUrEncoderForMigrationPCZTBatch = self.urEncoderForMigrationPCZTBatch
+        self.urEncoderForMigrationPCZTBatch = { pczts in
+            guard engine.isActive else { return originalUrEncoderForMigrationPCZTBatch(pczts) }
+            return SDKSynchronizerClient.simulatedBatchUREncoder(for: pczts)
+        }
+
+        let originalParseMigrationPCZTBatch = self.parseMigrationPCZTBatch
+        self.parseMigrationPCZTBatch = { data in
+            let header = Data(MigrationSimulatorEngineDerivations.Constants.fabricatedPCZTHeader.utf8)
+            guard engine.isActive, data.starts(with: header) else {
+                return originalParseMigrationPCZTBatch(data)
+            }
+            return [data]
+        }
+    }
+
+    // MARK: - Lifecycle (spec §5.2 "Lifecycle" row) + estimateTimestamp
+
+    /// `initializeMigrationPostUpgrade` isn't part of the migration member block's spec table by
+    /// name overlap alone — it IS the "Lifecycle" row. `estimateTimestamp` sits outside the
+    /// migration block entirely (it's a general SDK member), but the Transfer Plan screen's
+    /// per-row ETAs and the transfer-complete notification's "next in ~N h"
+    /// (`MigrationBGSchedulerLiveKey.arm(margin:)`) both resolve a `BlockHeight` through it —
+    /// translating our synthetic (epoch-seconds) heights back into real timestamps is what makes
+    /// those readings truthful against the simulated schedule instead of falling back to the
+    /// cadence-margin default (spec §9 flag #1, superseded).
+    private mutating func applySimulatedLifecycleAndTimestamp(engine: MigrationSimulatorEngine) {
+        let originalInitializeMigrationPostUpgrade = self.initializeMigrationPostUpgrade
+        self.initializeMigrationPostUpgrade = {
+            if engine.isActive {
+                engine.initializePostUpgrade()
+            } else {
+                originalInitializeMigrationPostUpgrade()
+            }
+        }
+
+        let originalEstimateTimestamp = self.estimateTimestamp
+        self.estimateTimestamp = { height in
+            if engine.isActive && MigrationSimulatorEngineDerivations.isSyntheticHeight(height) {
+                return MigrationSimulatorEngineDerivations.timestamp(forSyntheticHeight: height)
+            } else {
+                return originalEstimateTimestamp(height)
+            }
+        }
+    }
+
+    // MARK: - Keystone batch UR encoding helper
+
+    /// Real rendering `UREncoder` over the fabricated batch (spec §7 — the sign screen must look
+    /// real, including an actually-animating QR). Joins every fabricated PCZT blob into ONE `Data`
+    /// payload — the whole batch, not just the first blob, for a more realistic multi-part payload
+    /// size — then feeds it through the exact `KeystoneZcashSDK` mechanism `urEncoderForPCZT` uses
+    /// for the single-PCZT path (`SDKSynchronizerLive.swift`). The fabricated bytes aren't a
+    /// spec-valid PCZT (spec §9 flag #2), so `generateZcashPczt` rejecting them is the
+    /// expected/common case; the fallback constructs a `UR` directly via URKit, under a distinct,
+    /// self-describing type so nothing could mistake it for a real Zcash PCZT UR, so the screen
+    /// still has something to render. `nil` (both paths failing, or an empty batch) is tolerable —
+    /// the Keystone bypass button is the real lane — but worth flagging during QA.
+    private static func simulatedBatchUREncoder(for pczts: [Pczt]) -> UREncoder? {
+        let joined = pczts.reduce(into: Data()) { $0.append($1) }
+        // FountainEncoder traps (fragment-count range 1...0) for messages shorter than its
+        // 10-byte minFragmentLen, and UREncoder.init cannot throw — refuse tiny payloads instead.
+        // Fabricated PCZTs are always larger (the 13-byte header alone), so this only guards
+        // impossible/foreign inputs.
+        guard joined.count >= 10 else { return nil }
+
+        if let encoder = try? KeystoneZcashSDK().generateZcashPczt(pczt_hex: joined) {
+            return encoder
+        }
+
+        guard let fallbackUR = try? UR(type: "zodl-sim-pczt-batch", cbor: CBOR.bytes(joined)) else { return nil }
+        return UREncoder(fallbackUR, maxFragmentLen: 200)
+    }
+}

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -69,7 +69,7 @@ extension SDKSynchronizerClient: DependencyKey {
             synchronizer = SDKSynchronizer(initializer: initializer)
         }
 
-        return SDKSynchronizerClient(
+        var client = SDKSynchronizerClient(
             stateStream: { synchronizer.stateStream },
             eventStream: { synchronizer.eventStream },
             exchangeRateUSDStream: { synchronizer.exchangeRateUSDStream },
@@ -406,6 +406,15 @@ extension SDKSynchronizerClient: DependencyKey {
             parseMigrationPCZTBatch: { _ in nil },
             initializeMigrationPostUpgrade: { }
         )
+
+        // MOB-1480: routes the migration member block above (plus `estimateTimestamp`) through
+        // the shared simulator engine on testnet builds — see `SDKSynchronizerClient+Simulated`.
+        // The stub construction above stays byte-identical either way.
+        if MigrationSimulatorFlag.isEnabled {
+            client.applySimulatedMigration(engine: MigrationSimulatorClient.sharedEngine)
+        }
+
+        return client
     }
 }
 

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -32,6 +32,13 @@
 //  - W8: `nextPermissionStepResult()` picks the Notifications variant off `isManualDelivery()`.
 //  - W10: the Keystone scan push sets `instructions`/`forceLibraryToHide`.
 //
+//  MOB-1480 adds a simulator-only Keystone bypass (no physical device required): `MigrationKeystoneSign
+//  Store`'s "Simulate signed result" button delegates `.simulateSignature`, handled here by reading
+//  the batch straight off the already-pushed `keystoneSign` element (the bypass never pushes `scan`,
+//  so there is no scanned result to read instead) and running the identical store/resume chain the
+//  real round-trip uses. `resumeAfterKeystoneSigning` pops 1 or 2 path elements depending on whether
+//  `scan` is actually on top, so that one shared resume path stays correct for both callers.
+//
 
 import Foundation
 import ComposableArchitecture
@@ -201,6 +208,26 @@ extension MigrationCoordFlow {
                     await send(.keystoneSigningSubmitted(context: context))
                 }
 
+                // MARK: - Keystone signing (MOB-1480): simulator-only bypass
+
+            case .path(.element(id: let id, action: .keystoneSign(.delegate(.simulateSignature)))):
+                guard let context = state.pendingKeystoneSigning else { return .none }
+                guard case let .keystoneSign(signState) = state.path[id: id] else { return .none }
+
+                // Simulator-only bypass: no physical device exists to scan a QR back, so the batch
+                // is read straight off the already-pushed `keystoneSign` element's own state instead
+                // of arriving via `.scan(.foundPCZTBatch)`. Unlike that real path (which abandons an
+                // empty batch as a no-partial-storage safeguard against a failed scan), this button
+                // exists purely to exercise the resume chain for manual QA, so an empty batch falls
+                // back to a single fabricated placeholder rather than abandoning — the coordinator
+                // never inspects PCZT contents either way.
+                let signed: [Pczt] = signState.pczts.isEmpty ? [Pczt()] : signState.pczts
+
+                return .run { [sdkSynchronizer] send in
+                    await sdkSynchronizer.storeSignedMigrationTransactions(signed)
+                    await send(.keystoneSigningSubmitted(context: context))
+                }
+
             case .keystoneSigningSubmitted(let context):
                 return resumeAfterKeystoneSigning(context: context, state: &state)
 
@@ -350,13 +377,20 @@ extension MigrationCoordFlow {
 
     // MARK: - Keystone signing (MOB-1468): resume after store
 
-    /// Pops `scan`+`keystoneSign` (the two elements the QR round-trip pushed) and resumes whichever
-    /// chain `context` represents, mirroring how the equivalent software `.confirmed` row would
-    /// proceed from the now-topmost signing-source element:
+    /// Pops back to the signing-source element and resumes whichever chain `context` represents,
+    /// mirroring how the equivalent software `.confirmed` row would proceed from the now-topmost
+    /// signing-source element:
     /// - `.planCommit`: the `transferPlan` element now on top never re-signs again — resumes via
     ///   `transferPlanPostConfirmChain(variant:state:)`, identical to the software `.confirmed` row.
     /// - `.immediateReview`: pushes `.sending`, identical to the software `reviewTransfer.confirmed`
     ///   row.
+    ///
+    /// MOB-1480: how much to pop depends on which caller reached here. The real QR round-trip
+    /// pushes `scan` on top of `keystoneSign` (2 elements to unwind back to the signing source); the
+    /// simulator-only bypass (`keystoneSign(.delegate(.simulateSignature))`) never pushes `scan` at
+    /// all (1 element to unwind). Rather than trust the caller, this reads the actual top of the
+    /// path — `.scan` on top means the real round-trip ran (unchanged behavior, still always finds
+    /// `.scan` there), anything else means the bypass ran.
     ///
     /// Clears `pendingKeystoneSigning` in every case.
     private func resumeAfterKeystoneSigning(
@@ -364,7 +398,8 @@ extension MigrationCoordFlow {
         state: inout MigrationCoordFlow.State
     ) -> Effect<MigrationCoordFlow.Action> {
         state.pendingKeystoneSigning = nil
-        state.path.removeLast(2)
+        let topElementIsScan = state.path.last?.is(\.scan) == true
+        state.path.removeLast(topElementIsScan ? 2 : 1)
 
         switch context {
         case .planCommit:

--- a/secant/Sources/Features/Home/HomeStore.swift
+++ b/secant/Sources/Features/Home/HomeStore.swift
@@ -18,6 +18,10 @@ struct Home {
         var isRateEducationEnabled = false
         var isRateTooltipEnabled = false
         var migratingDatabase = true
+        /// Debug-only migration SDK simulator panel (MOB-1480), presented as a sheet when
+        /// non-`nil`. Entered via a long-press on the balance amount, gated on
+        /// `MigrationSimulatorFlag.isEnabled` at the point `state.migrationSimulator` is set.
+        @Presents var migrationSimulator: MigrationSimulatorPanel.State?
         var moreRequest = false
         var payRequest = false
         var smartBannerState = SmartBanner.State.initial
@@ -74,6 +78,7 @@ struct Home {
         case currencyConversionSetupTapped
         case foundTransactions
         case keystoneBannerTapped
+        case migrationSimulator(PresentationAction<MigrationSimulatorPanel.Action>)
         case moreTapped
         case moreInMoreTapped
         case onAppear
@@ -289,6 +294,12 @@ struct Home {
                 state.isRateTooltipEnabled = state.walletBalancesState.isExchangeRateStale
                 return .none
 
+            case .walletBalances(.migrationSimulatorLongPressed):
+                if MigrationSimulatorFlag.isEnabled {
+                    state.migrationSimulator = MigrationSimulatorPanel.State()
+                }
+                return .none
+
             case .alert(.presented(let action)):
                 return .send(action)
 
@@ -355,10 +366,16 @@ struct Home {
 
             case .walletBalances:
                 return .none
-                
+
             case .smartBanner:
                 return .none
+
+            case .migrationSimulator:
+                return .none
             }
+        }
+        .ifLet(\.$migrationSimulator, action: \.migrationSimulator) {
+            MigrationSimulatorPanel()
         }
     }
 }

--- a/secant/Sources/Features/Home/HomeView.swift
+++ b/secant/Sources/Features/Home/HomeView.swift
@@ -106,6 +106,14 @@ struct HomeView: View {
                     InAppBrowserView(url: url)
                 }
             }
+            .sheet(item: $store.scope(state: \.migrationSimulator, action: \.migrationSimulator)) { panelStore in
+                // The sheet content closure is escaping — needs its own `WithPerceptionTracking`
+                // so reads inside the presented store register with TCA's observation system
+                // (same precedent as `SettingsView`'s `votingCoordFlow` `fullScreenCover(item:)`).
+                WithPerceptionTracking {
+                    MigrationSimulatorPanelView(store: panelStore)
+                }
+            }
             .zashiSheet(isPresented: $store.accountSwitchRequest, horizontalPadding: Design.Spacing.edgeToEdgeSpacing) {
                 accountSwitchContent()
             }

--- a/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignStore.swift
+++ b/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignStore.swift
@@ -15,6 +15,11 @@
 //  design, until the SDK + Keystone batch support land (MOB-1455). The coordinator consumes both
 //  delegates (`.getSignature` -> scan -> submit/store, `.rejected` -> deferred pop) — MOB-1468.
 //
+//  MOB-1480 adds a simulator-only bypass: a "Simulate signed result" button, visible iff
+//  `MigrationSimulatorFlag.isEnabled && migrationSimulator.readout().isActive` (computed once in
+//  `onAppear`), delegates `.simulateSignature` so the coordinator can feed the exact post-scan path
+//  with the batch already carried in `State.pczts` — no physical Keystone device required.
+//
 
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
@@ -24,6 +29,9 @@ struct MigrationKeystoneSign {
     @ObservableState
     struct State: Equatable {
         var pczts: [Pczt] = []
+        /// MOB-1480: drives the simulator-only "Simulate signed result" button's visibility — set
+        /// once in `onAppear`, never touched anywhere else.
+        var isSimulatorBypassVisible = false
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
 
         init(pczts: [Pczt] = []) {
@@ -36,17 +44,24 @@ struct MigrationKeystoneSign {
         case getSignatureTapped
         case onAppear
         case rejectTapped
+        /// MOB-1480: the simulator-only "Simulate signed result" button tap (visible iff
+        /// `State.isSimulatorBypassVisible`). The coordinator handles the delegate by mirroring the
+        /// real scanned-batch path, minus the scan step itself.
+        case simulateSignatureTapped
 
         enum Delegate: Equatable {
             case getSignature
             case rejected
+            case simulateSignature
         }
     }
+
+    @Dependency(\.migrationSimulator) var migrationSimulator
 
     init() { }
 
     var body: some Reducer<State, Action> {
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
             case .delegate:
                 return .none
@@ -55,10 +70,14 @@ struct MigrationKeystoneSign {
                 return .send(.delegate(.getSignature))
 
             case .onAppear:
+                state.isSimulatorBypassVisible = MigrationSimulatorFlag.isEnabled && migrationSimulator.readout().isActive
                 return .none
 
             case .rejectTapped:
                 return .send(.delegate(.rejected))
+
+            case .simulateSignatureTapped:
+                return .send(.delegate(.simulateSignature))
             }
         }
     }

--- a/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignView.swift
+++ b/secant/Sources/Features/Migration/MigrationKeystoneSign/MigrationKeystoneSignView.swift
@@ -7,7 +7,12 @@
 //  truncated ZIP-316 address + "Hardware" badge, `AnimatedQRCode` (or the same empty/loading
 //  treatment while the batch encoder is nil), "Scan with your Keystone wallet" copy, Reject
 //  (secondary/destructive) / Get Signature (primary). Reuses `SignWithKeystoneView`'s existing
-//  localized keys — zero new strings.
+//  localized keys — zero new *localized* strings.
+//
+//  MOB-1480 adds one tertiary "Simulate signed result (simulator)" button (iff `store
+//  .isSimulatorBypassVisible`), between the QR/copy content and Reject/Get Signature — a
+//  deliberate inline English literal (dev-only control, not added to `Localizable.xcstrings`;
+//  approved spec §6/§7 deviation from the localization rule).
 //
 
 import SwiftUI
@@ -48,6 +53,19 @@ struct MigrationKeystoneSignView: View {
                             .fixedSize(horizontal: false, vertical: true)
                             .padding(.top, 4)
                     }
+                }
+
+                if store.isSimulatorBypassVisible {
+                    // MOB-1480: deliberate inline English literal — dev-only simulator control,
+                    // approved spec §6/§7 deviation from the Localizable.xcstrings rule (not added
+                    // there; do not localize).
+                    ZashiButton(
+                        "Simulate signed result (simulator)",
+                        type: .tertiary
+                    ) {
+                        store.send(.simulateSignatureTapped)
+                    }
+                    .padding(.top, 16)
                 }
 
                 Spacer()

--- a/secant/Sources/Features/MigrationSimulatorPanel/MigrationSimulatorPanelStore.swift
+++ b/secant/Sources/Features/MigrationSimulatorPanel/MigrationSimulatorPanelStore.swift
@@ -1,0 +1,170 @@
+//
+//  MigrationSimulatorPanelStore.swift
+//  zodl
+//
+//  Debug-only panel driving the migration SDK simulator engine (MOB-1480, testnet builds only —
+//  gated end-to-end by `MigrationSimulatorFlag.isEnabled` at the entry gesture). Every control
+//  action calls the matching `MigrationSimulatorClient`/`MigrationManagerClient`/`WalletStorageClient`
+//  closure and then re-sends `.refresh` to reload the status readout. Presets additionally clear the
+//  app-side persisted flags first for the two "finished flow" presets (`.complete`/
+//  `.completeWithDust` — the acknowledged flag must be cleared for the complete banner/route to
+//  show) and always align the manual-delivery flag afterward via `preset.requiresManualDelivery`.
+//  See docs/superpowers/specs/2026-07-13-mob1480-migration-sdk-simulator-design.md §5.3 and §6.
+//
+
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+@Reducer
+struct MigrationSimulatorPanel {
+    @ObservableState
+    struct State: Equatable {
+        var noteCount = 1
+        var orchardZec = "12.458"
+        var readout: SimulatorReadout?
+
+        var isActive: Bool {
+            readout?.isActive ?? false
+        }
+
+        init(
+            noteCount: Int = 1,
+            orchardZec: String = "12.458",
+            readout: SimulatorReadout? = nil
+        ) {
+            self.noteCount = noteCount
+            self.orchardZec = orchardZec
+            self.readout = readout
+        }
+    }
+
+    enum Action: BindableAction, Equatable {
+        case activeToggled(Bool)
+        case advanceTimeTapped(hours: Int)
+        case applySeedTapped
+        case armResultTapped(TransferResult)
+        case armSplitFailureTapped
+        case binding(BindingAction<State>)
+        case confirmSplitNowTapped
+        case delegate(Delegate)
+        case makeNextDueNowTapped
+        case onAppear
+        case openMigrationFlowTapped
+        case presetTapped(SimulatorPreset)
+        case readoutLoaded(SimulatorReadout)
+        case refresh
+        case resetAppFlagsTapped
+        case resetSimulationTapped
+        case resetTorFlagTapped
+        case runBackgroundSessionTapped
+
+        enum Delegate: Equatable {
+            case openMigrationFlow
+            case runBackgroundSession
+        }
+    }
+
+    @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.migrationSimulator) var migrationSimulator
+    @Dependency(\.walletStorage) var walletStorage
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .activeToggled(let isActive):
+                // Synchronous, non-throwing dependency closure — no effect needed.
+                migrationSimulator.setActive(isActive)
+                return .send(.refresh)
+
+            case .advanceTimeTapped(let hours):
+                migrationSimulator.advanceTime(TimeInterval(hours * 3600))
+                return .send(.refresh)
+
+            case .applySeedTapped:
+                migrationSimulator.seed(Self.parsedOrchardBalance(state.orchardZec), state.noteCount)
+                return .send(.refresh)
+
+            case .armResultTapped(let result):
+                migrationSimulator.armTransferResult(result)
+                return .send(.refresh)
+
+            case .armSplitFailureTapped:
+                migrationSimulator.armSplitFailure()
+                return .send(.refresh)
+
+            case .binding:
+                return .none
+
+            case .confirmSplitNowTapped:
+                migrationSimulator.confirmSplitNow()
+                return .send(.refresh)
+
+            case .delegate:
+                return .none
+
+            case .makeNextDueNowTapped:
+                migrationSimulator.makeNextTransferDueNow()
+                return .send(.refresh)
+
+            case .onAppear:
+                return .send(.refresh)
+
+            case .openMigrationFlowTapped:
+                return .send(.delegate(.openMigrationFlow))
+
+            case .presetTapped(let preset):
+                // The complete presets represent an already-finished flow — the app-side
+                // acknowledged/mode/manual/network-privacy flags must be cleared BEFORE the preset
+                // is applied, or the complete banner/re-entry route derivation would still see the
+                // previous run's stale flags.
+                if preset == .complete || preset == .completeWithDust {
+                    migrationManager.resetPersistedFlags()
+                }
+                migrationSimulator.applyPreset(preset)
+                // Every preset (not just the complete ones) aligns the manual-delivery flag — the
+                // engine itself has no notion of "manual delivery", only the panel knows which
+                // presets need it.
+                migrationManager.setManualDelivery(preset.requiresManualDelivery)
+                return .send(.refresh)
+
+            case .readoutLoaded(let readout):
+                state.readout = readout
+                return .none
+
+            case .refresh:
+                return .send(.readoutLoaded(migrationSimulator.readout()))
+
+            case .resetAppFlagsTapped:
+                migrationManager.resetPersistedFlags()
+                return .send(.refresh)
+
+            case .resetSimulationTapped:
+                migrationSimulator.reset()
+                return .send(.refresh)
+
+            case .resetTorFlagTapped:
+                try? walletStorage.importTorSetupFlag(false)
+                return .send(.refresh)
+
+            case .runBackgroundSessionTapped:
+                return .send(.delegate(.runBackgroundSession))
+            }
+        }
+    }
+
+    /// Parses the panel's "orchard ZEC" seed field (a plain decimal string, e.g. `"12.458"`) into
+    /// `Zatoshi` for `MigrationSimulatorClient.seed`. Unparseable input seeds a zero balance rather
+    /// than crashing — this is a debug tool, not a validated user-facing amount field.
+    private static func parsedOrchardBalance(_ text: String) -> Zatoshi {
+        guard let decimalZec = Decimal(string: text) else {
+            return Zatoshi.zero
+        }
+        let zatoshiDecimal = decimalZec * Decimal(Zatoshi.Constants.oneZecInZatoshi)
+        return Zatoshi(NSDecimalNumber(decimal: zatoshiDecimal).int64Value)
+    }
+}

--- a/secant/Sources/Features/MigrationSimulatorPanel/MigrationSimulatorPanelView.swift
+++ b/secant/Sources/Features/MigrationSimulatorPanel/MigrationSimulatorPanelView.swift
@@ -1,0 +1,245 @@
+// NOTE: Every string literal in this file is deliberately inline English, not routed through
+// `String(localizable:)` / `Localizable.xcstrings` — an approved deviation (spec §6) for this
+// debug-only panel, which never ships outside testnet builds (`MigrationSimulatorFlag.isEnabled`
+// is a constant `false` everywhere else).
+//
+//  MigrationSimulatorPanelView.swift
+//  zodl
+//
+//  Debug panel for the migration SDK simulator (MOB-1480): a plain `Form` in a `NavigationStack`
+//  presenting the engine's status readout plus every control from
+//  `MigrationSimulatorPanelStore.swift`. Reached via a long-press on the Home balance amount
+//  (`WalletBalancesView.balanceContent()`), gated by `MigrationSimulatorFlag.isEnabled`.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct MigrationSimulatorPanelView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Perception.Bindable var store: StoreOf<MigrationSimulatorPanel>
+
+    var body: some View {
+        WithPerceptionTracking {
+            NavigationStack {
+                Form {
+                    statusSection()
+                    simulationSection()
+                    seedSection()
+                    presetsSection()
+                    driveSection()
+                    armResultSection()
+                    flowSection()
+                    notesSection()
+                }
+                .navigationTitle("Migration Simulator")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") {
+                            dismiss()
+                        }
+                    }
+                }
+            }
+            .onAppear {
+                store.send(.onAppear)
+            }
+        }
+    }
+
+    @ViewBuilder private func statusSection() -> some View {
+        Section("Status") {
+            if let readout = store.readout {
+                Text(summary(for: readout))
+                    .font(.system(.footnote, design: .monospaced))
+
+                Toggle(
+                    "Simulation active",
+                    isOn: Binding(
+                        get: { readout.isActive },
+                        set: { store.send(.activeToggled($0)) }
+                    )
+                )
+
+                if readout.rows.isEmpty {
+                    Text("No transfers scheduled yet.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(readout.rows) { row in
+                        Text(summary(for: row))
+                            .font(.system(.footnote, design: .monospaced))
+                    }
+                }
+            } else {
+                Text("Loading…")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder private func simulationSection() -> some View {
+        Section("Simulation") {
+            Button("Reset simulation", role: .destructive) {
+                store.send(.resetSimulationTapped)
+            }
+
+            Button("Reset app migration flags", role: .destructive) {
+                store.send(.resetAppFlagsTapped)
+            }
+
+            Button("Reset Tor setup flag", role: .destructive) {
+                store.send(.resetTorFlagTapped)
+            }
+        }
+    }
+
+    @ViewBuilder private func seedSection() -> some View {
+        Section("Seed") {
+            HStack {
+                Text("Orchard ZEC")
+
+                Spacer()
+
+                TextField("12.458", text: $store.orchardZec)
+                    .keyboardType(.decimalPad)
+                    .multilineTextAlignment(.trailing)
+            }
+
+            Stepper("Notes: \(store.noteCount)", value: $store.noteCount, in: 1...5)
+
+            Button("Apply & restart") {
+                store.send(.applySeedTapped)
+            }
+        }
+    }
+
+    @ViewBuilder private func presetsSection() -> some View {
+        Section("Presets") {
+            ForEach(SimulatorPreset.allCases, id: \.rawValue) { preset in
+                Button(Self.label(for: preset)) {
+                    store.send(.presetTapped(preset))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private func driveSection() -> some View {
+        Section("Drive") {
+            Button("Advance +1h") {
+                store.send(.advanceTimeTapped(hours: 1))
+            }
+
+            Button("Advance +6h") {
+                store.send(.advanceTimeTapped(hours: 6))
+            }
+
+            Button("Make next transfer due now") {
+                store.send(.makeNextDueNowTapped)
+            }
+
+            Button("Confirm note split now") {
+                store.send(.confirmSplitNowTapped)
+            }
+
+            Button("Run background session now") {
+                store.send(.runBackgroundSessionTapped)
+            }
+        }
+    }
+
+    @ViewBuilder private func armResultSection() -> some View {
+        Section("Arm next result") {
+            Button("Success") {
+                store.send(.armResultTapped(TransferResult.success(txId: "")))
+            }
+
+            Button("Network error") {
+                store.send(.armResultTapped(TransferResult.networkError(retryable: true)))
+            }
+
+            Button("Invalid note") {
+                store.send(.armResultTapped(TransferResult.invalidNote))
+            }
+
+            Button("Expired") {
+                store.send(.armResultTapped(TransferResult.expired))
+            }
+
+            Button("Arm note-split failure") {
+                store.send(.armSplitFailureTapped)
+            }
+        }
+    }
+
+    @ViewBuilder private func flowSection() -> some View {
+        Section("Flow") {
+            Button("Open migration flow") {
+                store.send(.openMigrationFlowTapped)
+            }
+        }
+    }
+
+    @ViewBuilder private func notesSection() -> some View {
+        Section("Notes") {
+            Text(
+                """
+                Strings on this screen are intentionally left in English — it's a debug-only tool, \
+                never shown outside testnet builds, and isn't part of the localized catalogue.
+                """
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+
+            Text(
+                """
+                LLDB, to fire the real background task: e -l objc -- (void)[[BGTaskScheduler \
+                sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"co.electriccoin.migration_transfer"]
+                """
+            )
+            .font(.system(.footnote, design: .monospaced))
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private func summary(for readout: SimulatorReadout) -> String {
+        """
+        active: \(readout.isActive)
+        state: \(String(describing: readout.state))
+        mode: \(String(describing: readout.mode))
+        balance: \(readout.orchardBalance.decimalZashiFullFormatted()) ZEC
+        time offset: \(Int(readout.timeOffset))s
+        split pending: \(readout.isSplitPending)
+        signed batches: \(readout.signedBatchCount)
+        armed result: \(readout.armedResultDescription ?? "none")
+        last bg run: \(readout.lastBackgroundRunSummary ?? "none")
+        """
+    }
+
+    private func summary(for row: MigrationTransferRow) -> String {
+        let statusText = String(describing: row.status)
+        let broadcasting = row.isBroadcasting ? " · sending now" : ""
+        let sentRecently = row.sentMinutesAgo.map { " · sent \($0)m ago" } ?? ""
+        let amountText = row.amount.decimalZashiFullFormatted()
+        return "#\(row.index) \(amountText) ZEC — \(statusText)\(broadcasting) · due in \(row.hoursFromNow)h\(sentRecently)"
+    }
+
+    private static func label(for preset: SimulatorPreset) -> String {
+        switch preset {
+        case .freshRequired: return "Fresh — migration required"
+        case .splitting: return "Splitting"
+        case .readyToPropose: return "Ready to propose"
+        case .inProgress: return "In progress (2 of 5 sent)"
+        case .transferReadyManual: return "Transfer ready (manual)"
+        case .transferStalled: return "Transfer stalled"
+        case .updatePlanInvalid: return "Update plan (invalid)"
+        case .transfersExpired: return "Transfers expired"
+        case .syncRequired: return "Sync required"
+        case .complete: return "Complete"
+        case .completeWithDust: return "Complete with dust"
+        }
+    }
+}

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -259,6 +259,20 @@ extension Root {
                 state.path = .migrationCoordFlow
                 return .none
 
+                // MARK: - Migration Simulator Panel (MOB-1480, debug-only)
+
+            case .home(.migrationSimulator(.presented(.delegate(.openMigrationFlow)))):
+                state.migrationCoordFlowState = MigrationCoordFlow.State.initial
+                state.path = .migrationCoordFlow
+                return .none
+
+            case .home(.migrationSimulator(.presented(.delegate(.runBackgroundSession)))):
+                return .send(
+                    .initialization(
+                        .migrationBackgroundSession(MigrationBGSessionHandle(rawTask: nil, complete: { _ in }))
+                    )
+                )
+
             case .migrationCoordFlow(.flowFinished):
                 state.path = nil
                 return .none

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -77,6 +77,7 @@ struct WalletBalances {
         case balanceUpdated(AccountBalance?)
         case exchangeRateRefreshTapped
         case exchangeRateEvent(ExchangeRateClient.EchangeRateEvent)
+        case migrationSimulatorLongPressed
         case onAppear
         case onDisappear
         case synchronizerStateChanged(RedactableSynchronizerState)
@@ -128,6 +129,12 @@ struct WalletBalances {
                 )
                 
             case .availableBalanceTapped:
+                return .none
+
+            case .migrationSimulatorLongPressed:
+                // Debug-only entry gesture (MOB-1480); the parent (`Home`) intercepts this to
+                // present the migration simulator panel when `MigrationSimulatorFlag.isEnabled`,
+                // mirroring the `.exchangeRateRefreshTapped` interception below.
                 return .none
 
             case .exchangeRateRefreshTapped:

--- a/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
@@ -71,11 +71,25 @@ struct WalletBalancesView: View {
     }
     
     @ViewBuilder private func balanceContent() -> some View {
+        // Debug-only entry gesture for the migration SDK simulator (MOB-1480): long-press the
+        // balance amount. Gated on `shortened` (unique to Home, so SendForm/CrossPay never get
+        // it) and `MigrationSimulatorFlag.isEnabled` (compiles everywhere, inert outside testnet).
+        if shortened && MigrationSimulatorFlag.isEnabled {
+            balanceRow()
+                .onLongPressGesture {
+                    store.send(.migrationSimulatorLongPressed)
+                }
+        } else {
+            balanceRow()
+        }
+    }
+
+    @ViewBuilder private func balanceRow() -> some View {
         HStack(spacing: 0) {
             ZcashSymbol()
                 .frame(width: 32, height: 32)
                 .zForegroundColor(Design.Text.primary)
-            
+
             if shortened {
                 ZatoshiText(store.totalBalance, .abbreviated)
                     .zFont(.semiBold, size: 48, style: Design.Text.primary)

--- a/zodlTests/MigrationSimulatorTests/MigrationSimulatorEngineTests.swift
+++ b/zodlTests/MigrationSimulatorTests/MigrationSimulatorEngineTests.swift
@@ -1,0 +1,687 @@
+//
+//  MigrationSimulatorEngineTests.swift
+//  zodlTests
+//
+//  Covers `MigrationSimulatorEngine` (MOB-1480): fresh defaults, the full scheduled/immediate
+//  lifecycles, due-gating, armed results (invalidNote/expired/networkError incl. stalled slip +
+//  reschedule recovery), restart after invalid, passive overdue/expiry time derivation, split
+//  sum-exactness/reproducibility, transferRows caption fields, summary/progress math, Keystone
+//  PCZT fabrication, the silent-split ordering edge case, the real split-confirm timer, and every
+//  preset's `MigrationDerivations` table assertion (spec §5.3). Each test builds its own engine
+//  over `.ephemeral()` — no shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+@preconcurrency import Combine
+@preconcurrency import ZcashLightClientKit
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite struct MigrationSimulatorEngineTests {
+    private static let networkPrivacy = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+    private static let defaultBalance = Zatoshi(1_245_800_000)
+    private static let fee = Zatoshi(10_000)
+    private static let spacing: TimeInterval = 6 * 3600
+    private static let overdueGrace: TimeInterval = 3600
+    private static let expiryWindow: TimeInterval = 24 * 3600
+
+    private func makeEngine() -> MigrationSimulatorEngine {
+        MigrationSimulatorEngine(store: MigrationSimulatorStateStore.ephemeral())
+    }
+
+    // MARK: - Fresh defaults
+
+    @Test func freshEngineSeedsExpectedDefaults() {
+        let engine = makeEngine()
+
+        #expect(engine.currentState() == MigrationState.notStarted)
+        #expect(engine.orchardBalance() == Self.defaultBalance)
+        #expect(engine.isActive == true)
+        #expect(engine.isNoteSplitNeeded() == true)
+        #expect(engine.hasOverdue() == false)
+        #expect(engine.hasInvalid() == false)
+        #expect(engine.progress() == nil)
+    }
+
+    @Test func setActiveTogglesAndReflectsInReadout() {
+        let engine = makeEngine()
+
+        engine.setActive(false)
+
+        #expect(engine.isActive == false)
+        #expect(engine.readout().isActive == false)
+    }
+
+    @Test func resetReturnsToSeededDefault() {
+        let engine = makeEngine()
+        engine.seed(orchard: Zatoshi(1), noteCount: 1)
+
+        engine.reset()
+
+        #expect(engine.currentState() == MigrationState.notStarted)
+        #expect(engine.orchardBalance() == Self.defaultBalance)
+    }
+
+    // MARK: - Full scheduled lifecycle
+
+    @Test func fullScheduledLifecycleReachesCompleteWithZeroBalance() async {
+        let engine = makeEngine()
+
+        #expect(engine.isNoteSplitNeeded() == true)
+        let proposal = await engine.prepareSplit()
+        #expect((3...5).contains(proposal.outputNotes.count))
+        #expect(proposal.outputNotes.reduce(Zatoshi.zero, +) == Zatoshi(Self.defaultBalance.amount - Self.fee.amount))
+
+        let submitResult = await engine.submitSplit(proposal)
+        guard case TransferResult.success = submitResult else {
+            Issue.record("Expected submitSplit to succeed")
+            return
+        }
+        #expect(engine.currentState() == MigrationState.splitPendingConfirmation)
+
+        engine.confirmSplitNow()
+        #expect(engine.currentState() == MigrationState.readyToPropose)
+
+        let schedule = await engine.propose()
+        #expect(schedule.transfers.count == proposal.outputNotes.count)
+
+        await engine.signAndStore(schedule)
+        guard case MigrationState.inProgress(let progressAfterSign) = engine.currentState() else {
+            Issue.record("Expected .inProgress after signAndStore")
+            return
+        }
+        #expect(progressAfterSign.totalTransfers == schedule.transfers.count)
+        #expect(progressAfterSign.completedTransfers == 0)
+
+        for _ in 0..<schedule.transfers.count {
+            engine.makeNextTransferDueNow()
+            let result = await engine.executeNext(Self.networkPrivacy)
+            guard case TransferResult.success? = result else {
+                Issue.record("Expected executeNext to succeed once due")
+                return
+            }
+        }
+
+        #expect(engine.currentState() == MigrationState.complete)
+        #expect(engine.orchardBalance() == Zatoshi.zero)
+        #expect(engine.transferRows().allSatisfy { $0.status == .sent })
+    }
+
+    // MARK: - Immediate lifecycle
+
+    @Test func immediateLifecycleSingleTransferDueImmediately() async {
+        let engine = makeEngine()
+        engine.selectMode(MigrationMode.immediate)
+
+        let schedule = await engine.propose()
+        #expect(schedule.transfers.count == 1)
+        #expect(schedule.transfers[0].amount == Self.defaultBalance)
+
+        await engine.signAndStore(schedule)
+        let result = await engine.executeNext(Self.networkPrivacy)
+        guard case TransferResult.success? = result else {
+            Issue.record("Expected the single immediate transfer to be due right away")
+            return
+        }
+
+        #expect(engine.currentState() == MigrationState.complete)
+        #expect(engine.orchardBalance() == Zatoshi.zero)
+    }
+
+    // MARK: - Due-gating
+
+    @Test func executeNextReturnsNilBeforeDueAndSucceedsAfterAdvancingTime() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+
+        let before = await engine.executeNext(Self.networkPrivacy)
+        #expect(before == nil)
+        guard case MigrationState.inProgress(let progressStillPending) = engine.currentState() else {
+            Issue.record("Expected state to remain .inProgress when nothing is due")
+            return
+        }
+        #expect(progressStillPending.completedTransfers == 0)
+
+        engine.advanceTime(by: Self.spacing + 1)
+        let after = await engine.executeNext(Self.networkPrivacy)
+        guard case TransferResult.success? = after else {
+            Issue.record("Expected executeNext to succeed once the first transfer is due")
+            return
+        }
+    }
+
+    @Test func makeNextTransferDueNowForcesImmediateSend() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+        #expect(await engine.executeNext(Self.networkPrivacy) == nil)
+
+        engine.makeNextTransferDueNow()
+        let result = await engine.executeNext(Self.networkPrivacy)
+
+        guard case TransferResult.success? = result else {
+            Issue.record("Expected success after makeNextTransferDueNow")
+            return
+        }
+    }
+
+    // MARK: - Armed results
+
+    @Test func armedInvalidNoteMarksRowInvalidAndSetsAttentionState() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+
+        engine.armTransferResult(TransferResult.invalidNote)
+        let result = await engine.executeNext(Self.networkPrivacy)
+
+        #expect(result == TransferResult.invalidNote)
+        guard case MigrationState.requiresAttention(let reason) = engine.currentState(),
+              case AttentionReason.invalidTransfer = reason else {
+            Issue.record("Expected .requiresAttention(.invalidTransfer)")
+            return
+        }
+        #expect(engine.hasInvalid() == true)
+        #expect(engine.transferRows().contains { $0.status == .invalid })
+    }
+
+    @Test func armedExpiredMarksRowExpiredAndSetsAttentionState() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+
+        engine.armTransferResult(TransferResult.expired)
+        let result = await engine.executeNext(Self.networkPrivacy)
+
+        #expect(result == TransferResult.expired)
+        #expect(engine.currentState() == MigrationState.requiresAttention(AttentionReason.transferExpired))
+        #expect(engine.hasInvalid() == true)
+        #expect(engine.transferRows().contains { $0.status == .expired })
+    }
+
+    @Test func armedNetworkErrorStallsTransferAndRescheduleRecovers() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+
+        engine.armTransferResult(TransferResult.networkError(retryable: true))
+        let result = await engine.executeNext(Self.networkPrivacy)
+
+        #expect(result == TransferResult.networkError(retryable: true))
+        guard case MigrationState.requiresAttention(let reason) = engine.currentState(),
+              case AttentionReason.transferStalled(let number) = reason else {
+            Issue.record("Expected .requiresAttention(.transferStalled)")
+            return
+        }
+        #expect(number == 1)
+        #expect(engine.hasOverdue() == true)
+
+        await engine.rescheduleStalled()
+
+        guard case MigrationState.inProgress = engine.currentState() else {
+            Issue.record("Expected .inProgress after rescheduleStalled")
+            return
+        }
+        #expect(engine.hasOverdue() == false)
+    }
+
+    @Test func armSplitFailureCausesNetworkErrorWithNoStateChange() async {
+        let engine = makeEngine()
+        let stateBefore = engine.currentState()
+        engine.armSplitFailure()
+
+        let proposal = await engine.prepareSplit()
+        let result = await engine.submitSplit(proposal)
+
+        #expect(result == TransferResult.networkError(retryable: true))
+        #expect(engine.currentState() == stateBefore)
+        #expect(engine.readout().armedResultDescription == nil)
+    }
+
+    // MARK: - Restart
+
+    @Test func restartAfterInvalidDropsBrokenRowsAndRebuildsSchedule() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.updatePlanInvalid)
+        #expect(engine.hasInvalid() == true)
+
+        let schedule = await engine.restart()
+
+        #expect(engine.currentState() == MigrationState.readyToPropose)
+        #expect(engine.hasInvalid() == false)
+        #expect(!schedule.transfers.isEmpty)
+        // The 2 already-sent transfers are kept (only invalid/expired/pending rows are dropped).
+        #expect(engine.transferRows().count == 2)
+        #expect(engine.transferRows().allSatisfy { $0.status == .sent })
+    }
+
+    // MARK: - Overdue / expiry time derivation
+
+    @Test func overdueDerivesAfterGraceAndExpiryEscalatesAttentionState() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+
+        #expect(engine.hasOverdue() == false)
+
+        engine.advanceTime(by: Self.spacing + Self.overdueGrace + 1)
+        #expect(engine.hasOverdue() == true)
+        #expect(engine.transferRows().first?.status == .overdue)
+
+        engine.advanceTime(by: Self.expiryWindow)
+        guard case MigrationState.requiresAttention(let reason) = engine.currentState(),
+              case AttentionReason.transferExpired = reason else {
+            Issue.record("Expected passive time-based expiry to escalate to .requiresAttention(.transferExpired)")
+            return
+        }
+        #expect(engine.hasInvalid() == true)
+    }
+
+    // MARK: - Split sum-exactness and reproducibility
+
+    @Test func splitSumsExactlyToNetAndIsReproducibleForTheDefaultSeed() async {
+        let engineA = makeEngine()
+        let proposalA = await engineA.prepareSplit()
+        let engineB = makeEngine()
+        let proposalB = await engineB.prepareSplit()
+
+        #expect(proposalA.outputNotes.reduce(Zatoshi.zero, +) == Zatoshi(Self.defaultBalance.amount - Self.fee.amount))
+        #expect(proposalA.outputNotes == proposalB.outputNotes)
+    }
+
+    @Test func seedWithExplicitNoteCountIsReproducibleAndSumsExactly() async {
+        let engineA = makeEngine()
+        engineA.seed(orchard: Zatoshi(500_000_000), noteCount: 4)
+        let scheduleA = await engineA.propose()
+
+        let engineB = makeEngine()
+        engineB.seed(orchard: Zatoshi(500_000_000), noteCount: 4)
+        let scheduleB = await engineB.propose()
+
+        #expect(scheduleA.transfers.count == 4)
+        #expect(scheduleA.transfers.map { $0.amount } == scheduleB.transfers.map { $0.amount })
+        #expect(scheduleA.transfers.reduce(Zatoshi.zero) { $0 + $1.amount } == Zatoshi(500_000_000 - 10_000))
+    }
+
+    // MARK: - transferRows caption fields
+
+    @Test func transferRowsCaptionFieldsMatchActivePendingAndSentSemantics() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+
+        let initialRows = engine.transferRows()
+        #expect(initialRows[0].status == .active)
+        #expect(initialRows[0].hoursFromNow == 6)
+        #expect(initialRows[0].sentMinutesAgo == nil)
+        #expect(initialRows[0].isBroadcasting == false)
+        #expect(initialRows[1].status == .pending)
+
+        engine.makeNextTransferDueNow()
+        _ = await engine.executeNext(Self.networkPrivacy)
+
+        let afterSendRows = engine.transferRows()
+        #expect(afterSendRows[0].status == .sent)
+        #expect(afterSendRows[0].sentMinutesAgo == 0)
+        #expect(afterSendRows[0].hoursFromNow == 0)
+    }
+
+    // MARK: - Summary / progress math
+
+    @Test func summaryAndProgressMathTracksSentAndRemaining() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.inProgress)
+
+        let summary = engine.summary()
+        #expect(summary.transfersTotal == 5)
+        #expect(summary.transfersSent == 2)
+        #expect(summary.dust == Zatoshi.zero)
+
+        let progress = engine.progress()
+        #expect(progress?.completedTransfers == 2)
+        #expect(progress?.totalTransfers == 5)
+
+        // MOB-1480: supersedes spec §9 flag #1 as an improvement — `nextTransferReadyAtHeight` now
+        // carries the synthetic height of the next unsent transfer (index 2 of 5) instead of nil.
+        guard let nextReadyAtHeight = progress?.nextTransferReadyAtHeight else {
+            Issue.record("Expected nextTransferReadyAtHeight to carry the next unsent transfer's synthetic height")
+            return
+        }
+        #expect(MigrationSimulatorEngineDerivations.isSyntheticHeight(nextReadyAtHeight) == true)
+        let expectedDueAt = Date().addingTimeInterval(Self.spacing * 3)
+        let actualTimestamp = MigrationSimulatorEngineDerivations.timestamp(forSyntheticHeight: nextReadyAtHeight)
+        #expect(abs(actualTimestamp - expectedDueAt.timeIntervalSince1970) < 5)
+    }
+
+    // MARK: - isNextTransferDue
+
+    @Test func isNextTransferDueFalseUntilEarliestUnsentTransferMatures() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+
+        #expect(engine.isNextTransferDue() == false)
+
+        engine.advanceTime(by: Self.spacing + 1)
+        #expect(engine.isNextTransferDue() == true)
+    }
+
+    @Test func isNextTransferDueFalseOutsideInProgressState() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.freshRequired)
+
+        #expect(engine.isNextTransferDue() == false)
+
+        engine.applyPreset(SimulatorPreset.complete)
+        #expect(engine.isNextTransferDue() == false)
+    }
+
+    // MARK: - propose() synthetic heights (MOB-1480, supersedes spec §9.1 as an improvement)
+
+    @Test func proposeStampsSyntheticHeightsMatchingSignAndStoreDueAt() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+
+        let schedule = await engine.propose()
+        guard let first = schedule.transfers.first else {
+            Issue.record("Expected at least one proposed transfer")
+            return
+        }
+
+        #expect(MigrationSimulatorEngineDerivations.isSyntheticHeight(first.anchorHeight) == true)
+        #expect(first.anchorHeight == first.nextExecutableAfterHeight)
+        #expect(first.expiryHeight == first.nextExecutableAfterHeight + 86_400)
+
+        // The height propose() stamped must agree (within a 1s truncation tolerance — each call
+        // reads its own `Date()`) with the dueAt signAndStore() actually seeds: the whole point of
+        // sharing `MigrationSimulatorEngineDerivations.dueAt`.
+        await engine.signAndStore(schedule)
+        guard let nextReadyAtHeight = engine.progress()?.nextTransferReadyAtHeight else {
+            Issue.record("Expected .inProgress after signAndStore, with a non-nil nextTransferReadyAtHeight")
+            return
+        }
+        #expect(abs(nextReadyAtHeight - first.nextExecutableAfterHeight) <= 1)
+    }
+
+    @Test func proposeImmediateStampsHeightDueNow() async {
+        let engine = makeEngine()
+        engine.selectMode(MigrationMode.immediate)
+
+        let schedule = await engine.propose()
+        guard let only = schedule.transfers.first else {
+            Issue.record("Expected exactly one proposed transfer for immediate mode")
+            return
+        }
+
+        let nowHeight = MigrationSimulatorEngineDerivations.syntheticHeight(for: Date())
+        #expect(abs(only.nextExecutableAfterHeight - nowHeight) <= 2)
+    }
+
+    // MARK: - Keystone (PCZT)
+
+    @Test func fabricatedPCZTsAreDeterministicAndNonEmpty() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+
+        let batchA = engine.fabricateMigrationPCZTs(schedule)
+        let batchB = engine.fabricateMigrationPCZTs(schedule)
+
+        #expect(batchA == batchB)
+        #expect(batchA.allSatisfy { !$0.isEmpty })
+        #expect(!engine.fabricateNoteSplitPCZT().isEmpty)
+    }
+
+    @Test func storeSignedBatchRecordsCount() async {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+        let schedule = await engine.propose()
+        let pczts = engine.fabricateMigrationPCZTs(schedule)
+
+        engine.storeSignedBatch(pczts)
+
+        #expect(engine.readout().signedBatchCount == pczts.count)
+    }
+
+    @Test func submitSignedSplitAppliesSameDeterministicSplitAsPrepareSplit() async {
+        let engine = makeEngine()
+        let expectedProposal = await engine.prepareSplit()
+
+        let pczt = engine.fabricateNoteSplitPCZT()
+        let result = await engine.submitSignedSplit(pczt)
+
+        guard case TransferResult.success = result else {
+            Issue.record("Expected success from submitSignedSplit")
+            return
+        }
+        #expect(engine.currentState() == MigrationState.splitPendingConfirmation)
+
+        engine.confirmSplitNow()
+        let schedule = await engine.propose()
+        #expect(schedule.transfers.map { $0.amount } == expectedProposal.outputNotes)
+    }
+
+    // MARK: - Silent-split ordering + real split-confirm timer
+
+    @Test func signAndStoreDuringSplitPendingConfirmationMovesToInProgress() async {
+        let engine = makeEngine()
+        let proposal = await engine.prepareSplit()
+        _ = await engine.submitSplit(proposal)
+        #expect(engine.currentState() == MigrationState.splitPendingConfirmation)
+
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+
+        guard case MigrationState.inProgress = engine.currentState() else {
+            Issue.record("Expected .inProgress immediately after signAndStore, even without an explicit confirm")
+            return
+        }
+    }
+
+    @Test func staleSplitConfirmTaskNoOpsAfterSignAndStoreAlreadyMovedPastIt() async throws {
+        let engine = makeEngine()
+        let proposal = await engine.prepareSplit()
+        _ = await engine.submitSplit(proposal)
+        let schedule = await engine.propose()
+        await engine.signAndStore(schedule)
+        guard case MigrationState.inProgress = engine.currentState() else {
+            Issue.record("Expected .inProgress after signAndStore")
+            return
+        }
+
+        try await Task.sleep(for: .seconds(15.5))
+
+        guard case MigrationState.inProgress = engine.currentState() else {
+            Issue.record("Stale split-confirm task must not revert .inProgress back to .readyToPropose")
+            return
+        }
+    }
+
+    @Test func splitConfirmTaskFlipsToReadyToProposeAfterRealDelay() async throws {
+        let engine = makeEngine()
+        let proposal = await engine.prepareSplit()
+        _ = await engine.submitSplit(proposal)
+        #expect(engine.currentState() == MigrationState.splitPendingConfirmation)
+
+        // Poll rather than sleep-once-then-check: under a fully parallel test-suite run the
+        // Swift concurrency thread pool can be saturated enough to delay the confirm task's
+        // firing well past the nominal 15s delay. Polling for up to 45s tolerates that
+        // scheduling jitter while still failing if the timer is genuinely broken.
+        var reachedReadyToPropose = false
+        for _ in 0..<90 {
+            try await Task.sleep(for: .milliseconds(500))
+            if engine.currentState() == MigrationState.readyToPropose {
+                reachedReadyToPropose = true
+                break
+            }
+        }
+
+        #expect(reachedReadyToPropose == true)
+    }
+
+    // MARK: - State stream
+
+    @Test func statePublisherEmitsOnStateChange() {
+        let engine = makeEngine()
+        let collected = LockIsolated<[MigrationState]>([])
+        let cancellable = engine.statePublisher().sink { state in
+            collected.withValue { $0.append(state) }
+        }
+
+        engine.applyPreset(SimulatorPreset.splitting)
+        engine.confirmSplitNow()
+
+        #expect(collected.value.contains(MigrationState.splitPendingConfirmation))
+        #expect(collected.value.contains(MigrationState.readyToPropose))
+        cancellable.cancel()
+    }
+
+    // MARK: - Presets vs. MigrationDerivations (spec §5.3 table)
+
+    @Test func freshRequiredPresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.freshRequired)
+
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.required)
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.entry)
+    }
+
+    @Test func splittingPresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.splitting)
+
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.splitting)
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.noteSplitProgress)
+    }
+
+    @Test func readyToProposePresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.readyToPropose)
+
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.required)
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.entry)
+    }
+
+    @Test func inProgressPresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.inProgress)
+
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.inProgress(done: 2, total: 5))
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.statusProgress)
+    }
+
+    @Test func transferReadyManualPresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.transferReadyManual)
+        #expect(SimulatorPreset.transferReadyManual.requiresManualDelivery == true)
+
+        let isNextTransferDue = engine.transferRows().first { $0.status != .sent }?.hoursFromNow == 0
+        #expect(isNextTransferDue == true)
+
+        #expect(
+            bannerVariant(for: engine, isManualDelivery: true, isNextTransferDue: isNextTransferDue)
+                == MigrationBannerVariant.transferReady(number: 3)
+        )
+        #expect(
+            reentryRoute(for: engine, isManualDelivery: true, isNextTransferDue: isNextTransferDue)
+                == MigrationReentryRoute.reviewManual(step: 3, total: 5)
+        )
+    }
+
+    @Test func transferStalledPresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.transferStalled)
+
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.transferWaiting(number: 3))
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.statusResume)
+    }
+
+    @Test func updatePlanInvalidPresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.updatePlanInvalid)
+
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.updatePlan)
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.recovery(isExpired: false))
+    }
+
+    @Test func transfersExpiredPresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.transfersExpired)
+
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.transfersExpired(first: 3, last: 3))
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.recovery(isExpired: true))
+    }
+
+    @Test func syncRequiredPresetMatchesDerivationTableAndSetsEngineFlag() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.syncRequired)
+
+        #expect(engine.isSyncRequired() == true)
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.inProgress(done: 2, total: 5))
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.statusProgress)
+    }
+
+    @Test func completePresetMatchesDerivationTable() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.complete)
+
+        #expect(engine.orchardBalance() == Zatoshi.zero)
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.complete)
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.complete)
+    }
+
+    @Test func completeWithDustPresetMatchesDerivationTableAndLeavesDust() {
+        let engine = makeEngine()
+        engine.applyPreset(SimulatorPreset.completeWithDust)
+
+        #expect(engine.orchardBalance() == Zatoshi(5_000))
+        #expect(engine.summary().dust == Zatoshi(5_000))
+        #expect(bannerVariant(for: engine) == MigrationBannerVariant.complete)
+        #expect(reentryRoute(for: engine) == MigrationReentryRoute.complete)
+    }
+
+    // MARK: - Derivation-table helpers
+
+    private func bannerVariant(
+        for engine: MigrationSimulatorEngine,
+        isManualDelivery: Bool = false,
+        isNextTransferDue: Bool = false
+    ) -> MigrationBannerVariant? {
+        MigrationDerivations.bannerVariant(
+            state: engine.currentState(),
+            hasInvalid: engine.hasInvalid(),
+            hasOverdue: engine.hasOverdue(),
+            isManualDelivery: isManualDelivery,
+            isNextTransferDue: isNextTransferDue,
+            orchardBalance: engine.orchardBalance(),
+            isCompleteAcknowledged: false,
+            transferRows: engine.transferRows()
+        )
+    }
+
+    private func reentryRoute(
+        for engine: MigrationSimulatorEngine,
+        isManualDelivery: Bool = false,
+        isNextTransferDue: Bool = false
+    ) -> MigrationReentryRoute {
+        MigrationDerivations.reentryRoute(
+            state: engine.currentState(),
+            hasInvalid: engine.hasInvalid(),
+            hasOverdue: engine.hasOverdue(),
+            isManualDelivery: isManualDelivery,
+            isNextTransferDue: isNextTransferDue,
+            isCompleteAcknowledged: false,
+            progress: engine.progress()
+        )
+    }
+}

--- a/zodlTests/MigrationSimulatorTests/MigrationSimulatorPanelTests.swift
+++ b/zodlTests/MigrationSimulatorTests/MigrationSimulatorPanelTests.swift
@@ -1,0 +1,424 @@
+//
+//  MigrationSimulatorPanelTests.swift
+//  zodlTests
+//
+//  Covers the MigrationSimulatorPanel reducer
+//  (Features/MigrationSimulatorPanel/MigrationSimulatorPanelStore.swift, MOB-1480): the default
+//  seed values, every control action calling its matching `MigrationSimulatorClient`/
+//  `MigrationManagerClient`/`WalletStorageClient` closure and then re-sending `.refresh`, the
+//  preset-specific `resetPersistedFlags` -> `applyPreset` ordering for `.complete`/
+//  `.completeWithDust` (asserted via a shared call-log spy), the always-on
+//  `setManualDelivery(preset.requiresManualDelivery)` call for every preset, and the
+//  `runBackgroundSession`/`openMigrationFlow` delegate emissions. Spy closures only -> no
+//  shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationSimulatorPanelTests {
+    private static func makeReadout(isActive: Bool = true) -> SimulatorReadout {
+        SimulatorReadout(
+            isActive: isActive,
+            state: MigrationState.notStarted,
+            mode: MigrationMode.privateScheduled,
+            orchardBalance: Zatoshi(1_245_800_000),
+            timeOffset: 0,
+            rows: [],
+            signedBatchCount: 0,
+            armedResultDescription: nil,
+            isSplitPending: false,
+            lastBackgroundRunSummary: nil
+        )
+    }
+
+    // MARK: - Default state
+
+    @MainActor @Test func defaultStateHasExpectedSeedValues() async {
+        let state = MigrationSimulatorPanel.State()
+
+        #expect(state.orchardZec == "12.458")
+        #expect(state.noteCount == 1)
+        #expect(state.readout == nil)
+        #expect(state.isActive == false)
+    }
+
+    // MARK: - onAppear / refresh
+
+    @MainActor @Test func onAppearLoadsReadout() async {
+        let readout = Self.makeReadout(isActive: false)
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+    }
+
+    @MainActor @Test func refreshLoadsReadout() async {
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+    }
+
+    // MARK: - activeToggled
+
+    @MainActor @Test func activeToggledCallsSetActiveThenRefreshes() async {
+        let setActiveCalls = LockIsolated<[Bool]>([])
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.setActive = { value in setActiveCalls.withValue { $0.append(value) } }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.activeToggled(true))
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(setActiveCalls.value == [true])
+    }
+
+    // MARK: - Simulation section
+
+    @MainActor @Test func resetSimulationTappedCallsResetThenRefreshes() async {
+        let resetCalls = LockIsolated<Int>(0)
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.reset = { resetCalls.withValue { $0 += 1 } }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.resetSimulationTapped)
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(resetCalls.value == 1)
+    }
+
+    @MainActor @Test func resetAppFlagsTappedCallsResetPersistedFlagsThenRefreshes() async {
+        let resetFlagsCalls = LockIsolated<Int>(0)
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationManager.resetPersistedFlags = { resetFlagsCalls.withValue { $0 += 1 } }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.resetAppFlagsTapped)
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(resetFlagsCalls.value == 1)
+    }
+
+    @MainActor @Test func resetTorFlagTappedCallsImportTorSetupFlagFalse() async {
+        let torFlagCalls = LockIsolated<[Bool]>([])
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.walletStorage = .noOp
+            $0.walletStorage.importTorSetupFlag = { value in torFlagCalls.withValue { $0.append(value) } }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.resetTorFlagTapped)
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(torFlagCalls.value == [false])
+    }
+
+    // MARK: - Seed section
+
+    @MainActor @Test func applySeedTappedParsesOrchardZecAndCallsSeedThenRefreshes() async {
+        let capturedOrchard = LockIsolated<Zatoshi?>(nil)
+        let capturedNoteCount = LockIsolated<Int?>(nil)
+        let readout = Self.makeReadout()
+        var state = MigrationSimulatorPanel.State()
+        state.orchardZec = "1.5"
+        state.noteCount = 3
+        let store = TestStore(initialState: state) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.seed = { orchard, noteCount in
+                capturedOrchard.setValue(orchard)
+                capturedNoteCount.setValue(noteCount)
+            }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.applySeedTapped)
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(capturedOrchard.value == Zatoshi(150_000_000))
+        #expect(capturedNoteCount.value == 3)
+    }
+
+    // MARK: - Presets
+
+    @MainActor @Test func presetTappedManualDeliveryCallsApplyPresetThenSetManualDeliveryTrue() async {
+        let callLog = LockIsolated<[String]>([])
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.applyPreset = { preset in
+                callLog.withValue { $0.append("applyPreset(\(preset.rawValue))") }
+            }
+            $0.migrationManager.setManualDelivery = { isManual in
+                callLog.withValue { $0.append("setManualDelivery(\(isManual))") }
+            }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.presetTapped(.transferReadyManual))
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(callLog.value == ["applyPreset(transferReadyManual)", "setManualDelivery(true)"])
+    }
+
+    @MainActor @Test func presetTappedCompleteResetsFlagsBeforeApplyPresetAndSetsManualDeliveryFalse() async {
+        let callLog = LockIsolated<[String]>([])
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationManager.resetPersistedFlags = { callLog.withValue { $0.append("resetPersistedFlags") } }
+            $0.migrationSimulator.applyPreset = { _ in callLog.withValue { $0.append("applyPreset") } }
+            $0.migrationManager.setManualDelivery = { isManual in
+                callLog.withValue { $0.append("setManualDelivery(\(isManual))") }
+            }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.presetTapped(.complete))
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(callLog.value == ["resetPersistedFlags", "applyPreset", "setManualDelivery(false)"])
+    }
+
+    @MainActor @Test func presetTappedCompleteWithDustAlsoResetsFlagsBeforeApplyPreset() async {
+        let callLog = LockIsolated<[String]>([])
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationManager.resetPersistedFlags = { callLog.withValue { $0.append("resetPersistedFlags") } }
+            $0.migrationSimulator.applyPreset = { _ in callLog.withValue { $0.append("applyPreset") } }
+            $0.migrationManager.setManualDelivery = { isManual in
+                callLog.withValue { $0.append("setManualDelivery(\(isManual))") }
+            }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.presetTapped(.completeWithDust))
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(callLog.value == ["resetPersistedFlags", "applyPreset", "setManualDelivery(false)"])
+    }
+
+    @MainActor @Test func presetTappedNonSpecialPresetSkipsResetPersistedFlags() async {
+        let resetFlagsCalls = LockIsolated<Int>(0)
+        let callLog = LockIsolated<[String]>([])
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationManager.resetPersistedFlags = { resetFlagsCalls.withValue { $0 += 1 } }
+            $0.migrationSimulator.applyPreset = { _ in callLog.withValue { $0.append("applyPreset") } }
+            $0.migrationManager.setManualDelivery = { isManual in
+                callLog.withValue { $0.append("setManualDelivery(\(isManual))") }
+            }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.presetTapped(.splitting))
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(resetFlagsCalls.value == 0)
+        #expect(callLog.value == ["applyPreset", "setManualDelivery(false)"])
+    }
+
+    // MARK: - Drive section
+
+    @MainActor @Test(arguments: [1, 6])
+    func advanceTimeTappedConvertsHoursToSecondsAndCallsAdvanceTime(_ hours: Int) async {
+        let capturedInterval = LockIsolated<TimeInterval?>(nil)
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.advanceTime = { capturedInterval.setValue($0) }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.advanceTimeTapped(hours: hours))
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(capturedInterval.value == TimeInterval(hours * 3600))
+    }
+
+    @MainActor @Test func makeNextDueNowTappedCallsClientThenRefreshes() async {
+        let calls = LockIsolated<Int>(0)
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.makeNextTransferDueNow = { calls.withValue { $0 += 1 } }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.makeNextDueNowTapped)
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(calls.value == 1)
+    }
+
+    @MainActor @Test func confirmSplitNowTappedCallsClientThenRefreshes() async {
+        let calls = LockIsolated<Int>(0)
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.confirmSplitNow = { calls.withValue { $0 += 1 } }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.confirmSplitNowTapped)
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(calls.value == 1)
+    }
+
+    @MainActor @Test func runBackgroundSessionTappedEmitsDelegate() async {
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        }
+
+        await store.send(.runBackgroundSessionTapped)
+        await store.receive(.delegate(.runBackgroundSession))
+    }
+
+    // MARK: - Arm next result
+
+    @MainActor @Test(
+        arguments: [
+            TransferResult.success(txId: ""),
+            TransferResult.networkError(retryable: true),
+            TransferResult.invalidNote,
+            TransferResult.expired
+        ]
+    )
+    func armResultTappedPassesResultThrough(_ result: TransferResult) async {
+        let capturedResult = LockIsolated<TransferResult?>(nil)
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.armTransferResult = { capturedResult.setValue($0) }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.armResultTapped(result))
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(capturedResult.value == result)
+    }
+
+    @MainActor @Test func armSplitFailureTappedCallsClientThenRefreshes() async {
+        let calls = LockIsolated<Int>(0)
+        let readout = Self.makeReadout()
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        } withDependencies: {
+            $0.migrationSimulator.armSplitFailure = { calls.withValue { $0 += 1 } }
+            $0.migrationSimulator.readout = { readout }
+        }
+
+        await store.send(.armSplitFailureTapped)
+        await store.receive(\.refresh)
+        await store.receive(\.readoutLoaded) {
+            $0.readout = readout
+        }
+
+        #expect(calls.value == 1)
+    }
+
+    // MARK: - Flow section
+
+    @MainActor @Test func openMigrationFlowTappedEmitsDelegate() async {
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        }
+
+        await store.send(.openMigrationFlowTapped)
+        await store.receive(.delegate(.openMigrationFlow))
+    }
+
+    // MARK: - Delegate
+
+    @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
+        let store = TestStore(initialState: MigrationSimulatorPanel.State()) {
+            MigrationSimulatorPanel()
+        }
+
+        await store.send(.delegate(.openMigrationFlow))
+    }
+}

--- a/zodlTests/MigrationSimulatorTests/MigrationSimulatorStateStoreTests.swift
+++ b/zodlTests/MigrationSimulatorTests/MigrationSimulatorStateStoreTests.swift
@@ -1,0 +1,120 @@
+//
+//  MigrationSimulatorStateStoreTests.swift
+//  zodlTests
+//
+//  Covers `MigrationSimulatorStateStore` (MOB-1480): the ephemeral (in-memory) store used by
+//  engine tests, and the live (file-backed) store's round-trip + reseed-on-corruption/version-
+//  mismatch behavior. No shared/global state (each test uses its own temp file or an isolated
+//  in-memory store) -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct MigrationSimulatorStateStoreTests {
+    // MARK: - Ephemeral
+
+    @Test func ephemeralStoreStartsWithSeededDefault() {
+        let store = MigrationSimulatorStateStore.ephemeral()
+
+        #expect(store.load() == SimulatorSnapshot.seeded())
+    }
+
+    @Test func ephemeralStoreRoundTripsSaveAndLoad() {
+        let store = MigrationSimulatorStateStore.ephemeral()
+        var snapshot = SimulatorSnapshot.seeded()
+        snapshot.orchardBalance = Zatoshi(42)
+        snapshot.state = MigrationState.readyToPropose
+
+        store.save(snapshot)
+
+        #expect(store.load() == snapshot)
+    }
+
+    @Test func ephemeralStoreClearResetsToSeededDefault() {
+        let store = MigrationSimulatorStateStore.ephemeral()
+        var snapshot = SimulatorSnapshot.seeded()
+        snapshot.orchardBalance = Zatoshi(999)
+        store.save(snapshot)
+
+        store.clear()
+
+        #expect(store.load() == SimulatorSnapshot.seeded())
+    }
+
+    // MARK: - Live (file-backed)
+
+    private func makeTempFileURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("migration_simulator_test_\(UUID().uuidString).json")
+    }
+
+    @Test func liveStoreReturnsSeededDefaultWhenFileMissing() {
+        let url = makeTempFileURL()
+        let store = MigrationSimulatorStateStore.live(fileURL: url)
+
+        #expect(store.load() == SimulatorSnapshot.seeded())
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func liveStoreRoundTripsSaveAndLoad() {
+        let url = makeTempFileURL()
+        let store = MigrationSimulatorStateStore.live(fileURL: url)
+        var snapshot = SimulatorSnapshot.seeded()
+        snapshot.orchardBalance = Zatoshi(123_456)
+        snapshot.signedBatchCount = 3
+
+        store.save(snapshot)
+
+        #expect(store.load() == snapshot)
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func liveStoreReseedsAndPersistsOnDecodeFailure() {
+        let url = makeTempFileURL()
+        try? Data("not valid json".utf8).write(to: url)
+
+        let store = MigrationSimulatorStateStore.live(fileURL: url)
+        let loaded = store.load()
+
+        #expect(loaded == SimulatorSnapshot.seeded())
+
+        // The reseed must have been persisted: a fresh store instance over the same file also
+        // reads the seeded default (not a fresh "missing file" seed that happens to look the
+        // same) — verified via the file now containing valid, decodable JSON.
+        let data = try? Data(contentsOf: url)
+        let decoded = data.flatMap { try? JSONDecoder().decode(SimulatorSnapshot.self, from: $0) }
+        #expect(decoded == SimulatorSnapshot.seeded())
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func liveStoreReseedsOnSchemaVersionMismatch() throws {
+        let url = makeTempFileURL()
+        var stale = SimulatorSnapshot.seeded()
+        stale.schemaVersion = SimulatorSnapshot.currentSchemaVersion + 1
+        stale.orchardBalance = Zatoshi(777)
+        let data = try JSONEncoder().encode(stale)
+        try data.write(to: url)
+
+        let store = MigrationSimulatorStateStore.live(fileURL: url)
+
+        #expect(store.load() == SimulatorSnapshot.seeded())
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func liveStoreClearRemovesFile() {
+        let url = makeTempFileURL()
+        let store = MigrationSimulatorStateStore.live(fileURL: url)
+        store.save(SimulatorSnapshot.seeded())
+        #expect(FileManager.default.fileExists(atPath: url.path))
+
+        store.clear()
+
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+}

--- a/zodlTests/MigrationSimulatorTests/SimulatedSDKSynchronizerTests.swift
+++ b/zodlTests/MigrationSimulatorTests/SimulatedSDKSynchronizerTests.swift
@@ -1,0 +1,396 @@
+//
+//  SimulatedSDKSynchronizerTests.swift
+//  zodlTests
+//
+//  Covers `SDKSynchronizerClient.applySimulatedMigration` (MOB-1480,
+//  `SDKSynchronizerClient+Simulated.swift`): builds a base client whose migration members (plus
+//  `estimateTimestamp`) are SENTINEL closures — never `.noOp`'s bare inert values, so a fallback
+//  to "original" is unambiguously distinguishable both by a fixed, obviously-fake return value AND
+//  by a call counter (the primary signal — some sentinel values legitimately collide with what a
+//  freshly-seeded engine would also answer, e.g. both can plausibly answer `false` for
+//  `isNoteSplitNeeded`). Applies the simulated migration against a fresh engine over
+//  `MigrationSimulatorStateStore.ephemeral()` and asserts, for a representative spread of members:
+//  active-engine behavior, and that `setActive(false)` restores every one of them to the sentinel.
+//  Constructs `SDKSynchronizerClient`/`MigrationSimulatorEngine` directly — never touches
+//  `MigrationSimulatorClient.sharedEngine` or `liveValue` — mirroring `MigrationSDKStubTests`'
+//  precedent, so those pinned `.noOp`/`.mocked()` contract tests stay untouched and green.
+//
+//  `MigrationManagerResetPersistedFlagsTests` below is `.serialized` because it's the one part of
+//  this file that touches `UserDefaults` (even via isolated named suites — same reasoning as
+//  `MigrationManagerTests.swift`'s class-level doc comment); the rest of the file has no
+//  shared/global state and runs unserialized.
+//
+
+import Testing
+import Foundation
+@preconcurrency import Combine
+@preconcurrency import ZcashLightClientKit
+import ComposableArchitecture
+import URKit
+@testable import zodl_internal
+
+@Suite struct SimulatedSDKSynchronizerTests {
+    /// Fixed, obviously-fake sentinel values — never a value the engine itself would plausibly
+    /// produce for the scenarios below — so a return-value check alone would already catch a
+    /// wiring mistake, independent of the call counters.
+    private enum SentinelValues {
+        static let migrationState = MigrationState.complete
+        static let migrationSchedule = MigrationSchedule(transfers: [], estimatedDurationHours: -1)
+        static let transferResult = TransferResult.invalidNote
+        static let transferRow = MigrationTransferRow(
+            id: "sentinel-row", index: 0, amount: Zatoshi(1), status: MigrationTransferRow.Status.sent, hoursFromNow: 0
+        )
+        static let pczt: Pczt = Data([0xFF])
+        static let parsedBatch: [Pczt] = [Data([0xAB, 0xCD])]
+        static let estimatedTimestamp: TimeInterval = 999_999
+    }
+
+    /// One call counter per sentinel closure — see the file header for why this is the primary
+    /// "did the override call through to `original`" signal.
+    private struct CallCounters: Sendable {
+        let getMigrationState = LockIsolated<Int>(0)
+        let migrationStateStream = LockIsolated<Int>(0)
+        let isNoteSplitNeeded = LockIsolated<Int>(0)
+        let proposeMigrationTransfers = LockIsolated<Int>(0)
+        let signAndStoreMigrationSchedule = LockIsolated<Int>(0)
+        let executeNextPendingMigrationTransfer = LockIsolated<Int>(0)
+        let migrationTransfers = LockIsolated<Int>(0)
+        let proposeMigrationPCZTs = LockIsolated<Int>(0)
+        let parseMigrationPCZTBatch = LockIsolated<Int>(0)
+        let urEncoderForMigrationPCZTBatch = LockIsolated<Int>(0)
+        let estimateTimestamp = LockIsolated<Int>(0)
+    }
+
+    private static let networkPrivacy = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+
+    private func makeBaseClient(_ counters: CallCounters) -> SDKSynchronizerClient {
+        var client = SDKSynchronizerClient.noOp
+
+        client.getMigrationState = {
+            counters.getMigrationState.withValue { $0 += 1 }
+            return SentinelValues.migrationState
+        }
+        client.migrationStateStream = {
+            counters.migrationStateStream.withValue { $0 += 1 }
+            return Just(SentinelValues.migrationState).eraseToAnyPublisher()
+        }
+        client.isNoteSplitNeeded = {
+            counters.isNoteSplitNeeded.withValue { $0 += 1 }
+            return false
+        }
+        client.proposeMigrationTransfers = {
+            counters.proposeMigrationTransfers.withValue { $0 += 1 }
+            return SentinelValues.migrationSchedule
+        }
+        client.signAndStoreMigrationSchedule = { _ in
+            counters.signAndStoreMigrationSchedule.withValue { $0 += 1 }
+        }
+        client.executeNextPendingMigrationTransfer = { _ in
+            counters.executeNextPendingMigrationTransfer.withValue { $0 += 1 }
+            return SentinelValues.transferResult
+        }
+        client.migrationTransfers = {
+            counters.migrationTransfers.withValue { $0 += 1 }
+            return [SentinelValues.transferRow]
+        }
+        client.proposeNoteSplitPCZT = { SentinelValues.pczt }
+        client.proposeMigrationPCZTs = { _ in
+            counters.proposeMigrationPCZTs.withValue { $0 += 1 }
+            return [SentinelValues.pczt]
+        }
+        client.parseMigrationPCZTBatch = { _ in
+            counters.parseMigrationPCZTBatch.withValue { $0 += 1 }
+            return SentinelValues.parsedBatch
+        }
+        client.urEncoderForMigrationPCZTBatch = { _ in
+            counters.urEncoderForMigrationPCZTBatch.withValue { $0 += 1 }
+            // The payload must beat FountainEncoder's minFragmentLen (10 bytes) — a shorter
+            // message makes UREncoder's fragment-count range 1...0, which traps at runtime.
+            guard let ur = try? UR(type: "sentinel-ur", cbor: CBOR.bytes(Data(repeating: 0x5A, count: 64))) else { return nil }
+            return UREncoder(ur, maxFragmentLen: 200)
+        }
+        client.estimateTimestamp = { _ in
+            counters.estimateTimestamp.withValue { $0 += 1 }
+            return SentinelValues.estimatedTimestamp
+        }
+
+        return client
+    }
+
+    // MARK: - State (getMigrationState / migrationStateStream)
+
+    @Test func stateMembersRouteThroughTheEngineWhenActiveAndFallBackWhenInactive() {
+        let counters = CallCounters()
+        var client = makeBaseClient(counters)
+        let engine = MigrationSimulatorEngine(store: MigrationSimulatorStateStore.ephemeral())
+        client.applySimulatedMigration(engine: engine)
+
+        // Active: reads the engine's real (fresh-seeded) state, never the sentinel.
+        #expect(client.getMigrationState() == MigrationState.notStarted)
+        #expect(counters.getMigrationState.value == 0)
+
+        // Active: a live CurrentValueSubject that re-ticks on state changes (the improvement over
+        // HEAD's one-shot `Just`), not the sentinel stream.
+        let collected = LockIsolated<[MigrationState]>([])
+        let cancellable = client.migrationStateStream().sink { state in
+            collected.withValue { $0.append(state) }
+        }
+        engine.applyPreset(SimulatorPreset.splitting)
+        engine.confirmSplitNow()
+        #expect(collected.value.contains(MigrationState.splitPendingConfirmation))
+        #expect(collected.value.contains(MigrationState.readyToPropose))
+        #expect(counters.migrationStateStream.value == 0)
+        cancellable.cancel()
+
+        // Inactive: both fall back to the sentinel originals.
+        engine.setActive(false)
+        #expect(client.getMigrationState() == SentinelValues.migrationState)
+        #expect(counters.getMigrationState.value == 1)
+
+        _ = client.migrationStateStream()
+        #expect(counters.migrationStateStream.value == 1)
+    }
+
+    // MARK: - Note splitting (isNoteSplitNeeded)
+
+    @Test func isNoteSplitNeededRoutesThroughEngineWhenActiveAndFallsBackWhenInactive() {
+        let counters = CallCounters()
+        var client = makeBaseClient(counters)
+        let engine = MigrationSimulatorEngine(store: MigrationSimulatorStateStore.ephemeral())
+        client.applySimulatedMigration(engine: engine)
+
+        // Fresh engine default (privateScheduled / notStarted / 1 note) answers true; the sentinel
+        // always answers false, so a true here proves the engine (not the sentinel) answered.
+        #expect(client.isNoteSplitNeeded() == true)
+        #expect(counters.isNoteSplitNeeded.value == 0)
+
+        engine.setActive(false)
+        #expect(client.isNoteSplitNeeded() == false)
+        #expect(counters.isNoteSplitNeeded.value == 1)
+    }
+
+    // MARK: - propose -> signAndStore -> executeNext round trip + transferRows
+
+    @Test func proposeSignAndStoreExecuteNextRoundTripAndTransferRows() async {
+        let counters = CallCounters()
+        var client = makeBaseClient(counters)
+        let engine = MigrationSimulatorEngine(store: MigrationSimulatorStateStore.ephemeral())
+        engine.selectMode(MigrationMode.immediate)
+        client.applySimulatedMigration(engine: engine)
+
+        let schedule = await client.proposeMigrationTransfers()
+        #expect(schedule != SentinelValues.migrationSchedule)
+        #expect(schedule.transfers.count == 1)
+        #expect(counters.proposeMigrationTransfers.value == 0)
+
+        await client.signAndStoreMigrationSchedule(schedule)
+        #expect(counters.signAndStoreMigrationSchedule.value == 0)
+
+        let result = await client.executeNextPendingMigrationTransfer(Self.networkPrivacy)
+        #expect(counters.executeNextPendingMigrationTransfer.value == 0)
+        guard case .some(TransferResult.success) = result else {
+            Issue.record("Expected the immediate-mode transfer to be due right away and succeed")
+            return
+        }
+
+        let rows = client.migrationTransfers()
+        #expect(counters.migrationTransfers.value == 0)
+        #expect(rows.count == 1)
+        #expect(rows.first?.status == MigrationTransferRow.Status.sent)
+
+        // Inactive: every member above falls back to the sentinel.
+        engine.setActive(false)
+
+        let inactiveSchedule = await client.proposeMigrationTransfers()
+        #expect(inactiveSchedule == SentinelValues.migrationSchedule)
+        #expect(counters.proposeMigrationTransfers.value == 1)
+
+        await client.signAndStoreMigrationSchedule(inactiveSchedule)
+        #expect(counters.signAndStoreMigrationSchedule.value == 1)
+
+        let inactiveResult = await client.executeNextPendingMigrationTransfer(Self.networkPrivacy)
+        #expect(inactiveResult == SentinelValues.transferResult)
+        #expect(counters.executeNextPendingMigrationTransfer.value == 1)
+
+        let inactiveRows = client.migrationTransfers()
+        #expect(inactiveRows == [SentinelValues.transferRow])
+        #expect(counters.migrationTransfers.value == 1)
+    }
+
+    // MARK: - Keystone (PCZT fabrication + batch parse round trip)
+
+    @Test func keystonePCZTsFabricatedWhenActiveAndParseRoundTripsRecognizedHeader() async {
+        let counters = CallCounters()
+        var client = makeBaseClient(counters)
+        let engine = MigrationSimulatorEngine(store: MigrationSimulatorStateStore.ephemeral())
+        client.applySimulatedMigration(engine: engine)
+
+        let noteSplitPCZT = await client.proposeNoteSplitPCZT()
+        #expect(!noteSplitPCZT.isEmpty)
+        #expect(noteSplitPCZT != SentinelValues.pczt)
+
+        let schedule = await client.proposeMigrationTransfers()
+        let batch = await client.proposeMigrationPCZTs(schedule)
+        #expect(!batch.isEmpty)
+        #expect(batch.allSatisfy { !$0.isEmpty })
+        #expect(counters.proposeMigrationPCZTs.value == 0)
+
+        // Active + recognized fabricated-format header -> returns the whole batch as one element.
+        let fabricated = engine.fabricateNoteSplitPCZT()
+        #expect(client.parseMigrationPCZTBatch(fabricated) == [fabricated])
+        #expect(counters.parseMigrationPCZTBatch.value == 0)
+
+        // Active but NOT the fabricated format -> falls through to original, same as inactive.
+        let unrecognized = Data([0x00, 0x01])
+        #expect(client.parseMigrationPCZTBatch(unrecognized) == SentinelValues.parsedBatch)
+        #expect(counters.parseMigrationPCZTBatch.value == 1)
+
+        // Inactive: every member above falls back to the sentinel.
+        engine.setActive(false)
+
+        let inactiveNoteSplitPCZT = await client.proposeNoteSplitPCZT()
+        #expect(inactiveNoteSplitPCZT == SentinelValues.pczt)
+
+        let inactiveBatch = await client.proposeMigrationPCZTs(schedule)
+        #expect(inactiveBatch == [SentinelValues.pczt])
+        #expect(counters.proposeMigrationPCZTs.value == 1)
+
+        #expect(client.parseMigrationPCZTBatch(fabricated) == SentinelValues.parsedBatch)
+        #expect(counters.parseMigrationPCZTBatch.value == 2)
+    }
+
+    /// Deliberately does NOT exercise the active path with a non-empty batch: that path calls the
+    /// real `KeystoneZcashSDK().generateZcashPczt` with fabricated (not spec-valid) bytes, and
+    /// while the Swift-visible contract is "throws on rejection" (caught via `try?`), this is a
+    /// native FFI boundary whose crash-safety on malformed input isn't something this unit test
+    /// can verify without risking the whole run. Covered instead by Phase C's planned manual smoke
+    /// of the panel/Keystone sign screen in the testnet simulator (spec §11) — flagged in the
+    /// final report for that verification.
+    @Test func urEncoderForMigrationPCZTBatchEmptyBatchIsNilActiveAndFallsBackWhenInactive() {
+        let counters = CallCounters()
+        var client = makeBaseClient(counters)
+        let engine = MigrationSimulatorEngine(store: MigrationSimulatorStateStore.ephemeral())
+        client.applySimulatedMigration(engine: engine)
+
+        // Active + empty batch -> nil without reaching KeystoneSDK/URKit or the sentinel.
+        #expect(client.urEncoderForMigrationPCZTBatch([]) == nil)
+        #expect(counters.urEncoderForMigrationPCZTBatch.value == 0)
+
+        // Inactive -> always the sentinel's (always-constructible) encoder, regardless of input.
+        engine.setActive(false)
+        #expect(client.urEncoderForMigrationPCZTBatch([]) != nil)
+        #expect(counters.urEncoderForMigrationPCZTBatch.value == 1)
+    }
+
+    // MARK: - estimateTimestamp (synthetic-height translation + real-height passthrough)
+
+    @Test func estimateTimestampTranslatesSyntheticHeightsAndPassesThroughRealLookingOnes() {
+        let counters = CallCounters()
+        var client = makeBaseClient(counters)
+        let engine = MigrationSimulatorEngine(store: MigrationSimulatorStateStore.ephemeral())
+        client.applySimulatedMigration(engine: engine)
+
+        let syntheticHeight = MigrationSimulatorEngineDerivations.syntheticHeight(for: Date())
+        let realLookingHeight = BlockHeight(3_000_000)
+
+        // Active + synthetic height -> translated back to (approximately) the original timestamp.
+        guard let syntheticResult = client.estimateTimestamp(syntheticHeight) else {
+            Issue.record("Expected a non-nil timestamp for a synthetic height while the engine is active")
+            return
+        }
+        #expect(abs(syntheticResult - Date().timeIntervalSince1970) < 5)
+        #expect(counters.estimateTimestamp.value == 0)
+
+        // Active + real-looking (non-synthetic) height -> passes straight through to the sentinel.
+        #expect(client.estimateTimestamp(realLookingHeight) == SentinelValues.estimatedTimestamp)
+        #expect(counters.estimateTimestamp.value == 1)
+
+        // Inactive -> always the sentinel, even for a synthetic-looking height.
+        engine.setActive(false)
+        #expect(client.estimateTimestamp(syntheticHeight) == SentinelValues.estimatedTimestamp)
+        #expect(counters.estimateTimestamp.value == 2)
+    }
+
+    // MARK: - isNextTransferDue hook (MigrationManagerLiveKey's simulated hook)
+    //
+    // `MigrationManagerLiveKey.isNextTransferDue()`'s simulated branch reads the process-wide
+    // `MigrationSimulatorClient.sharedEngine` singleton and is `private`, so it isn't independently
+    // unit-testable from this file without touching global state. `MigrationSimulatorEngineTests`
+    // already covers the engine-level `isNextTransferDue()` API that hook delegates to
+    // (`isNextTransferDueFalseUntilEarliestUnsentTransferMatures`,
+    // `isNextTransferDueFalseOutsideInProgressState`). The seam directly testable from here — and
+    // the one actually chosen — is the pure derivation underneath both:
+    // `MigrationSimulatorEngineDerivations.isNextTransferDue(snapshot:now:)`.
+
+    @Test func isNextTransferDueDerivationMatchesTheSimulatedHookContract() {
+        var snapshot = SimulatorSnapshot.seeded()
+        snapshot.transfers = [
+            SimulatorTransfer(id: "xfer-0", index: 0, amount: Zatoshi(1), dueAt: Date().addingTimeInterval(-1))
+        ]
+        snapshot.state = MigrationState.inProgress(
+            MigrationProgress(completedTransfers: 0, totalTransfers: 1, remainingOrchard: Zatoshi(1), nextTransferReadyAtHeight: nil)
+        )
+        #expect(MigrationSimulatorEngineDerivations.isNextTransferDue(snapshot: snapshot, now: Date()) == true)
+
+        snapshot.transfers = [
+            SimulatorTransfer(id: "xfer-0", index: 0, amount: Zatoshi(1), dueAt: Date().addingTimeInterval(3600))
+        ]
+        #expect(MigrationSimulatorEngineDerivations.isNextTransferDue(snapshot: snapshot, now: Date()) == false)
+    }
+}
+
+// MARK: - resetPersistedFlags (UserDefaults-backed; dedicated serialized suite)
+
+@Suite(.serialized)
+struct MigrationManagerResetPersistedFlagsTests {
+    @Test func gateStorageResetPersistedFlagsClearsEveryNamedFlagButLeavesTheSyncGateWindow() throws {
+        let suiteName = "testGateStorageResetPersistedFlagsClearsEveryNamedFlagButLeavesTheSyncGateWindow"
+        let userDefaults = try #require(
+            UserDefaults(suiteName: suiteName),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        storage.setMigrationMode(MigrationMode.immediate)
+        storage.setManualDelivery(true)
+        storage.setNetworkPrivacyOptions(NetworkPrivacyOptions(useTor: true, submissionEndpoint: "https://example.com:9067"))
+        storage.acknowledgeComplete()
+        storage.recordMigrationBroadcast(at: Date())
+        storage.recordSyncCompletion(at: Date())
+
+        storage.resetPersistedFlags()
+
+        #expect(storage.migrationMode() == nil)
+        #expect(storage.isManualDelivery() == false)
+        #expect(storage.networkPrivacyOptions() == NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil))
+        #expect(storage.isCompleteAcknowledged() == false)
+        #expect(storage.isSyncDeferredAfterBroadcast(now: Date()) == false)
+
+        // Deliberately untouched: the 10-minute sync<->send gate window is a short-lived timing
+        // value, not a durable app flag (see `resetPersistedFlags`'s doc comment).
+        guard case MigrationSendGate.waitUntil = storage.sendGate(now: Date()) else {
+            Issue.record("Expected the sync<->send gate window to survive resetPersistedFlags")
+            return
+        }
+    }
+
+    @Test func migrationManagerImplResetPersistedFlagsDelegatesToGateStorage() throws {
+        let suiteName = "testMigrationManagerImplResetPersistedFlagsDelegatesToGateStorage"
+        let userDefaults = try #require(
+            UserDefaults(suiteName: suiteName),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        storage.setMigrationMode(MigrationMode.privateScheduled)
+        storage.setManualDelivery(true)
+
+        let impl = MigrationManagerImpl(gateStorage: storage)
+        impl.resetPersistedFlags()
+
+        #expect(storage.migrationMode() == nil)
+        #expect(storage.isManualDelivery() == false)
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
@@ -1295,4 +1295,82 @@ import ComposableArchitecture
 
         #expect(acknowledgeCalls.value == 1)
     }
+
+    // MARK: - MOB-1480: Keystone signing — simulator-only bypass (no `.scan` ever pushed)
+
+    @MainActor @Test func keystoneSignSimulateSignatureForImmediateReviewContextStoresPopsAndPushesSendingWithoutScan() async {
+        let storeCalls = LockIsolated<[[Pczt]]>([])
+        let signed: [Pczt] = [Data([0xEE])]
+        var state = MigrationCoordFlow.State()
+        state.networkPrivacyOptions = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+        state.pendingKeystoneSigning = .immediateReview
+        state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: signed)))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.storeSignedMigrationTransactions = { stored in storeCalls.withValue { $0.append(stored) } }
+        }
+        store.exhaustivity = .off
+
+        // No `.scan` element on the path at all — the bypass button lives on `keystoneSign` itself
+        // and the coordinator reads the batch straight off that element instead of a scanned
+        // result. Deliberately NOT asserting `isSimulatorBypassVisible` here: this test target
+        // (zodl-internal) always has `MigrationSimulatorFlag.isEnabled == false`, so the button
+        // would never actually be visible in this build — the coordinator's handler is
+        // intentionally not flag-gated (only the button's visibility is), so driving the delegate
+        // directly is the correct boundary to test.
+        await store.send(.path(.element(id: 1, action: .keystoneSign(.delegate(.simulateSignature)))))
+        await store.receive(\.keystoneSigningSubmitted)
+
+        #expect(storeCalls.value == [signed])
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 2)
+        guard case let .sending(sendingState) = try? #require(store.state.path.last) else {
+            Issue.record("Expected .sending pushed on top of the retained .reviewTransfer element")
+            return
+        }
+        #expect(sendingState.totalCount == 1)
+        guard case .reviewTransfer = try? #require(store.state.path[id: 0]) else {
+            Issue.record("Expected .reviewTransfer retained at the bottom (only keystoneSign popped)")
+            return
+        }
+    }
+
+    @MainActor @Test func keystoneSignSimulateSignatureWithEmptyBatchFallsBackToPlaceholderAndResumesPlanCommit() async {
+        let storeCalls = LockIsolated<[[Pczt]]>([])
+        var state = MigrationCoordFlow.State()
+        state.pendingKeystoneSigning = .planCommit
+        state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
+        state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: [])))
+        let store = TestStore(initialState: state) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.sdkSynchronizer = .noOp
+            $0.sdkSynchronizer.storeSignedMigrationTransactions = { stored in storeCalls.withValue { $0.append(stored) } }
+            $0.migrationBGScheduler.scheduleFirstWindow = { }
+        }
+        store.exhaustivity = .off
+
+        // Unlike the real `.scan(.foundPCZTBatch([]))` path (which abandons the session — see
+        // `foundPCZTBatchWithEmptyArrayForPlanCommitContextAbandonsSessionWithoutStoring` above),
+        // the simulator bypass falls back to a single fabricated placeholder `Pczt` instead: this
+        // button exists purely to exercise the resume chain for manual QA, never a real signing
+        // session that could legitimately fail to decode.
+        await store.send(.path(.element(id: 1, action: .keystoneSign(.delegate(.simulateSignature)))))
+        await store.receive(\.keystoneSigningSubmitted)
+
+        #expect(storeCalls.value == [[Pczt()]])
+        #expect(store.state.pendingKeystoneSigning == nil)
+        #expect(store.state.path.count == 2)
+        guard case .scheduled = try? #require(store.state.path.last) else {
+            Issue.record("Expected .scheduled pushed on top of the retained .transferPlan element")
+            return
+        }
+        guard case .transferPlan = try? #require(store.state.path[id: 0]) else {
+            Issue.record("Expected .transferPlan retained at the bottom (only keystoneSign popped)")
+            return
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds a **migration SDK simulator** so every Orchard → Ironwood migration path can be walked end-to-end in testnet builds today, while the real SDK (MOB-1455) is blocked on librustzcash #2572.

- **Engine** (`Dependencies/MigrationSimulator/`): a persisted, lock-guarded state machine implementing the entire `SDKSynchronizerClient` migration stub surface — note split (with a real 15 s confirmation window), schedule proposal (seeded random 3–5 splits summing exactly), due-time-gated sends with ~1.5 s broadcast latency, stalled/invalid/expired semantics, reschedule/restart recovery, dust remainder, and a live `migrationStateStream` (the stub's one-shot `Just` never re-ticked). State survives restarts (versioned JSON in Application Support).
- **Wiring**: one capture-original overlay applied inside `SDKSynchronizerLive` (the `useSlipstreamSynchronizer` precedent) — every member falls back to today's inert stub when the simulator is inactive. Synthetic schedule "heights" encode due timestamps, so `estimateTimestamp` (and with it the Transfer Plan ETAs and the transfer-complete notification's "next in ~N h") stays truthful. Two one-line hooks in `MigrationManagerLiveKey` make the balance and the manual transfer-ready signal simulator-aware — the whole flow works with **zero real testnet funds**.
- **Debug panel**: long-press the balance on Home (testnet only) → snapshot readout, active toggle, seed controls, 11 scenario presets (each labels the banner/re-entry state it produces), armed failure results, simulated-time advance, note-split controls, resets (simulation / app migration flags / Tor flag), "Open migration flow", and **"Run background session now"** — which drives the real `RootInitialization` background decision tree via a no-op `MigrationBGSessionHandle`, so background delivery, real local notifications, and notification-tap re-entry are the production code path.
- **Keystone**: fabricated PCZT batches, a genuinely rendering animated UR QR on the sign screen, and a simulator-only "Simulate signed result" button that feeds the exact post-scan coordinator path (`resumeAfterKeystoneSigning` now pops based on what's actually on the stack — provably equivalent for the real scan path).
- **Gating**: one hardcoded flag, `true` only under `SECANT_TESTNET`; that's the single `#if` in the feature. Everything compiles in all targets (so `zodlTests`, built as zodl-internal, covers it) but is unreachable outside testnet — production behavior is byte-identical, including the existing 5-row demo fixture.

Approved spec: in the [MOB-1480 ticket description](https://linear.app/zodl/issue/MOB-1480/migration-sdk-simulator-for-testnet-builds-debug-menu-background) — specs live on the ticket, not in the repo. Inspired by the MOB-1451 prototype simulator (5f4bccef) and its follow-ups; re-derived against the post-MOB-1478 UI rather than ported.

Linear: [MOB-1480](https://linear.app/zodl/issue/MOB-1480/migration-sdk-simulator-for-testnet-builds-debug-menu-background)

## Test plan

- Full `zodlTests` on `zodl-internal`: **1023 tests in 134 suites passed** (1 pre-existing known issue: `CurrencyConversionSetupTests`, MOB-1364), `-skipMacroValidation`. Net **+78 tests** vs the base branch: engine lifecycle/timing/failure semantics, state-store versioning, simulated-client overlay (active + inactive fallback), panel store, reset-flags, and the Keystone bypass coordinator round-trips.
- `zodl-testnet` build green (device + simulator).
- Manual QA (suggested): run `zodl-testnet` in a simulator, long-press the balance, walk the presets against the flows; fire a real background wakeup via LLDB `_simulateLaunchForTaskWithIdentifier` (hint shown in the panel footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
