### PR TITLE
[PRO-325] Surface FAILED and PROCESSING statuses for swaps out of ZEC and CrossPays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Fixed
+- [PRO-325] Swaps out of ZEC and CrossPays that fail on the swap provider's side now show "Swap Failed" / "Payment Failed" (with the contact-support option) instead of appearing to stay in progress forever. Long-running swaps in this direction also correctly show their processing state.
+
 ## 3.7.3 build 1 (20026-07-12)
 
 ### Changed

--- a/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
+++ b/secant/Sources/Dependencies/SwapAndPay/sources/Near1Click.swift
@@ -216,6 +216,32 @@ struct Near1Click {
         assets.filter { Constants.supportedAssetIds.contains($0.assetId) }
     }
 
+    /// Maps a 1Click `status` string to `SwapDetails.Status`. Pure so it can be
+    /// unit-tested independently of the networking in the `status` closure.
+    static func swapStatus(from statusStr: String, isSwapToZec: Bool) -> SwapDetails.Status {
+        if isSwapToZec {
+            switch statusStr {
+            case SwapConstants.pendingDeposit: .pendingDeposit
+            case SwapConstants.refunded: .refunded
+            case SwapConstants.success: .success
+            case SwapConstants.failed: .failed
+            case SwapConstants.incompleteDeposit: .incompleteDeposit
+            case SwapConstants.processing: .processing
+            default: .pending
+            }
+        } else {
+            switch statusStr {
+            case SwapConstants.incompleteDeposit: .incompleteDeposit
+            case SwapConstants.pendingDeposit: .pending
+            case SwapConstants.refunded: .refunded
+            case SwapConstants.success: .success
+            case SwapConstants.failed: .failed
+            case SwapConstants.processing: .processing
+            default: .pending
+            }
+        }
+    }
+
     /// Fetches and parses the provider's full token list — every asset, deduped,
     /// before curation. `swapAssets` returns `curated(...)` of this (the offering);
     /// `swapAssetsCatalog` returns this full list (for resolving historical assets).
@@ -388,27 +414,7 @@ extension Near1Click {
                 throw SwapAndPayClient.EndpointError.message("Check status: Missing `status` parameter.")
             }
             
-            var status: SwapDetails.Status
-            
-            if isSwapToZec {
-                status = switch statusStr {
-                case SwapConstants.pendingDeposit: .pendingDeposit
-                case SwapConstants.refunded: .refunded
-                case SwapConstants.success: .success
-                case SwapConstants.failed: .failed
-                case SwapConstants.incompleteDeposit: .incompleteDeposit
-                case SwapConstants.processing: .processing
-                default: .pending
-                }
-            } else {
-                status = switch statusStr {
-                case SwapConstants.incompleteDeposit: .incompleteDeposit
-                case SwapConstants.pendingDeposit: .pending
-                case SwapConstants.refunded: .refunded
-                case SwapConstants.success: .success
-                default: .pending
-                }
-            }
+            var status = Near1Click.swapStatus(from: statusStr, isSwapToZec: isSwapToZec)
             
             guard let quoteResponseDict = jsonObject[Constants.quoteResponse] as? [String: Any],
                   let quoteRequestDict = quoteResponseDict[Constants.quoteRequest] as? [String: Any] else {

--- a/zodlTests/SwapTests/Near1ClickTests.swift
+++ b/zodlTests/SwapTests/Near1ClickTests.swift
@@ -65,6 +65,36 @@ import Foundation
         }
     }
 
+    // MARK: - swapStatus(from:isSwapToZec:) 1Click status mapping (PRO-325)
+
+    @Test func failedMapsToFailedInBothDirections() {
+        #expect(Near1Click.swapStatus(from: SwapConstants.failed, isSwapToZec: false) == .failed)
+        #expect(Near1Click.swapStatus(from: SwapConstants.failed, isSwapToZec: true) == .failed)
+    }
+
+    @Test func processingMapsToProcessingInBothDirections() {
+        #expect(Near1Click.swapStatus(from: SwapConstants.processing, isSwapToZec: false) == .processing)
+        #expect(Near1Click.swapStatus(from: SwapConstants.processing, isSwapToZec: true) == .processing)
+    }
+
+    @Test func pendingDepositKeepsDirectionSpecificMapping() {
+        #expect(Near1Click.swapStatus(from: SwapConstants.pendingDeposit, isSwapToZec: false) == .pending)
+        #expect(Near1Click.swapStatus(from: SwapConstants.pendingDeposit, isSwapToZec: true) == .pendingDeposit)
+    }
+
+    @Test func sharedTerminalAndPartialStatusesMap() {
+        for isSwapToZec in [false, true] {
+            #expect(Near1Click.swapStatus(from: SwapConstants.refunded, isSwapToZec: isSwapToZec) == .refunded)
+            #expect(Near1Click.swapStatus(from: SwapConstants.success, isSwapToZec: isSwapToZec) == .success)
+            #expect(Near1Click.swapStatus(from: SwapConstants.incompleteDeposit, isSwapToZec: isSwapToZec) == .incompleteDeposit)
+        }
+    }
+
+    @Test func unknownStatusFallsBackToPending() {
+        #expect(Near1Click.swapStatus(from: "KNOWN_DEPOSIT_TX", isSwapToZec: false) == .pending)
+        #expect(Near1Click.swapStatus(from: "KNOWN_DEPOSIT_TX", isSwapToZec: true) == .pending)
+    }
+
     // MARK: - curated(_:) source-level allow-list (MOB-1472)
 
     @Test func curatedKeepsSupportedAndDropsRest() {

--- a/zodlTests/SwapTests/Near1ClickTests.swift
+++ b/zodlTests/SwapTests/Near1ClickTests.swift
@@ -71,13 +71,14 @@ import Foundation
         let kept = Near1Click.curated([
             swapAsset(assetId: "nep141:btc.omft.near"),                                     // supported
             swapAsset(assetId: "nep141:eth.omft.near"),                                     // supported
-            swapAsset(assetId: "nep245:v2_1.omni.hot.tg:137_qiStmoQJDQPTebaPjgx5VBxZv6L"),  // pol.usdc — dropped
+            swapAsset(assetId: "nep245:v2_1.omni.hot.tg:137_qiStmoQJDQPTebaPjgx5VBxZv6L"),  // pol.usdc — supported
             swapAsset(assetId: "nep141:doge.omft.near")                                     // dropped
         ])
         let ids = kept.map(\.assetId)
-        #expect(kept.count == 2)
+        #expect(kept.count == 3)
         #expect(ids.contains("nep141:btc.omft.near"))
         #expect(ids.contains("nep141:eth.omft.near"))
+        #expect(ids.contains("nep245:v2_1.omni.hot.tg:137_qiStmoQJDQPTebaPjgx5VBxZv6L"))
         #expect(!ids.contains("nep141:doge.omft.near"))
     }
 


### PR DESCRIPTION
## Why

The 1Click status parser in `Near1Click.swift` only mapped `INCOMPLETE_DEPOSIT` / `PENDING_DEPOSIT` / `REFUNDED` / `SUCCESS` for the out-of-ZEC direction — `FAILED` and `PROCESSING` fell through to `.pending`. A swap out of ZEC or CrossPay that failed on NEAR's side after the deposit landed therefore showed "Paying…" / "Swapping…" indefinitely, kept polling forever, and never surfaced the failed state or the contact-support footer. (The swap-to-ZEC branch already mapped both correctly.)

Context: [PRO-325](https://linear.app/zodl/issue/PRO-325/suppress-the-amount-for-failed-transactions-in-the-activity-list#comment-28337a0b) — we can't safely message "funds are still in your wallet" while a NEAR-side failure is indistinguishable from a pending swap.

## What

- Extracted the status-string mapping into `Near1Click.swapStatus(from:isSwapToZec:)` (pure, unit-testable — same pattern as `curated(_:)` / `amountMessageResolution`) and added `FAILED` → `.failed`, `PROCESSING` → `.processing` to the out-of-ZEC branch.
- The direction-specific `PENDING_DEPOSIT` mapping is preserved (`.pendingDeposit` for swap-to-ZEC, `.pending` otherwise) — the transaction-detail deposit-info footer keys off `.pendingDeposit`.
- Android already stores `FAILED` / `PROCESSING` in shared user metadata, so cross-platform metadata is unaffected (verified against `SwapStatusSerializer.kt`).
- Drive-by (separate commit): updated `curatedKeepsSupportedAndDropsRest`, which has been failing on `main` since USDC@pol was added to the curated list in 196249a0.

## Testing

- New Swift Testing cases in `Near1ClickTests` cover the full mapping in both directions, including the `KNOWN_DEPOSIT_TX` → `.pending` fallback.
- `xcodebuild test -only-testing:zodlTests/Near1ClickTests` — 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)