### PR TITLE
[MOB-1483] Gate the migration offering on Ironwood network activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] Ironwood migration screens are wired into a complete guided flow (entry, scheduling, status, recovery) driven by migration state, with a Home banner entry point — dormant until the migration SDK ships.
 - [MOB-1467] Scheduled Ironwood migration transfers can now send from background tasks, with local notifications for progress, required actions, and manual-mode send reminders — dormant until the migration SDK ships.
 - [MOB-1468] Keystone hardware-wallet accounts can complete the Ironwood migration — transfers are signed by QR in a single batched session — dormant until the migration SDK and Keystone batch support ship.
+- [MOB-1483] The Ironwood migration is only offered once the network has actually activated Ironwood — before the chain tip reaches the activation height there is no migration banner, no way into the flow, and no migration background work or notifications. The offer appears automatically once the activated network is detected, without restarting the app.
 
 ### Changed
 - [MOB-1472] The assets you can swap are now a curated set of major coins and stablecoins across the supported chains (plus swapping to ZEC), instead of the full list from the swap provider, and the address-book chain picker is limited to those chains. Existing swaps in your history (including assets no longer offered) still display normally, and existing contacts on other chains are preserved.

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
@@ -24,6 +24,10 @@ struct MigrationManagerClient: Sendable {
     // Derivations (pure given SDK members + persistence; unit-tested as tables)
     var bannerVariant: @Sendable (_ accountUUID: AccountUUID?) async -> MigrationBannerVariant? = { _ in nil }
     var reentryRoute: @Sendable () -> MigrationReentryRoute = { .entry }
+    // MOB-1483: "Ironwood (NU6.3) activated on the current network" — gates `bannerVariant`,
+    // `reentryRoute`, and `reconcile()`. Defaults closed so a test that doesn't override it stays
+    // fail-safe instead of trapping via the macro's `unimplemented`.
+    var isIronwoodActivated: @Sendable () -> Bool = { false }
     var orchardBalanceToMigrate: @Sendable (_ accountUUID: AccountUUID?) async -> Zatoshi = { _ in .zero }
     // Persistence (UserDefaults-backed; keys in SharedStateKeys.swift)
     var migrationMode: @Sendable () -> MigrationMode?

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -5,7 +5,8 @@
 //  Live implementation of `MigrationManagerClient`. Every piece of actual logic is factored
 //  into pure, table-testable types below (`MigrationDerivations`, `MigrationGateStorage`) so
 //  `MigrationManagerTests` can exercise them without touching the SDK; this file is left with
-//  only the wiring between those types and `@Dependency(\.sdkSynchronizer)`.
+//  only the wiring between those types and `@Dependency(\.sdkSynchronizer)` /
+//  `@Dependency(\.zcashSDKEnvironment)`.
 //
 
 import Foundation
@@ -23,6 +24,7 @@ extension MigrationManagerClient: DependencyKey {
         return MigrationManagerClient(
             bannerVariant: { accountUUID in await impl.bannerVariant(accountUUID: accountUUID) },
             reentryRoute: { impl.reentryRoute() },
+            isIronwoodActivated: { impl.isIronwoodActivated() },
             orchardBalanceToMigrate: { accountUUID in await impl.orchardBalanceToMigrate(accountUUID: accountUUID) },
             migrationMode: { impl.gateStorage.migrationMode() },
             setMigrationMode: { impl.gateStorage.setMigrationMode($0) },
@@ -46,6 +48,7 @@ extension MigrationManagerClient: DependencyKey {
 /// subscription handle below, both of which are safe to share across isolation domains.
 final class MigrationManagerImpl: @unchecked Sendable {
     @Dependency(\.sdkSynchronizer) var sdkSynchronizer
+    @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
 
     let gateStorage: MigrationGateStorage
 
@@ -80,6 +83,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
         let balance = await orchardBalanceToMigrate(accountUUID: accountUUID)
 
         return MigrationDerivations.bannerVariant(
+            isIronwoodActivated: isIronwoodActivated(),
             state: state,
             hasInvalid: sdkSynchronizer.hasInvalidMigrationTransfers(),
             hasOverdue: sdkSynchronizer.hasOverdueMigrationTransfers(),
@@ -97,6 +101,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
         let progress = sdkSynchronizer.getMigrationProgress()
 
         return MigrationDerivations.reentryRoute(
+            isIronwoodActivated: isIronwoodActivated(),
             state: normalizedState(),
             hasInvalid: sdkSynchronizer.hasInvalidMigrationTransfers(),
             hasOverdue: sdkSynchronizer.hasOverdueMigrationTransfers(),
@@ -137,6 +142,11 @@ final class MigrationManagerImpl: @unchecked Sendable {
     }
 
     func reconcile() {
+        // MOB-1483: pre-activation there is nothing to reconcile — the SDK has no migration state
+        // to initialize or acknowledge yet, so skip both entirely rather than touch the SDK/storage
+        // on every launch before Ironwood activates.
+        guard isIronwoodActivated() else { return }
+
         sdkSynchronizer.initializeMigrationPostUpgrade()
 
         // Stale-acknowledge reset: the acknowledged flag must never suppress a *new* migration's
@@ -169,6 +179,17 @@ final class MigrationManagerImpl: @unchecked Sendable {
 
         return readyAtHeight <= sdkSynchronizer.latestState().latestBlockHeight
     }
+
+    /// MOB-1483: "Ironwood (NU6.3) activated on the current network." `tip > 0` is the fail-safe
+    /// sentinel — a cached tip of `0` (before the first server round-trip) is an *unknown* tip, not
+    /// a low one, so it must read as "not activated" rather than happening to satisfy `tip >=
+    /// activationHeight` by coincidence (mirrors the sentinel idiom in
+    /// `SDKSynchronizerClient.transactionStatesFromZcashTransactions`). Not `private`: wired
+    /// directly to `MigrationManagerClient.isIronwoodActivated` in `live()`.
+    func isIronwoodActivated() -> Bool {
+        let tip = sdkSynchronizer.latestState().latestBlockHeight
+        return tip > 0 && tip >= zcashSDKEnvironment.ironwoodActivationHeight()
+    }
 }
 
 // MARK: - Pure derivations (table-testable, no SDK dependency)
@@ -179,8 +200,10 @@ final class MigrationManagerImpl: @unchecked Sendable {
 /// `AttentionReason`, `MigrationTransferRow`) — so `MigrationManagerTests` can exercise every row
 /// directly.
 enum MigrationDerivations {
-    /// See MOB-1466 spec, "bannerVariant derivation" table.
+    /// See MOB-1466 spec, "bannerVariant derivation" table. `isIronwoodActivated` (MOB-1483) is
+    /// checked first and gates the whole derivation — pre-activation there is no banner.
     static func bannerVariant(
+        isIronwoodActivated: Bool,
         state: MigrationState,
         hasInvalid: Bool,
         hasOverdue: Bool,
@@ -190,6 +213,8 @@ enum MigrationDerivations {
         isCompleteAcknowledged: Bool,
         transferRows: [MigrationTransferRow]
     ) -> MigrationBannerVariant? {
+        guard isIronwoodActivated else { return nil }
+
         switch state {
         case MigrationState.notStarted, MigrationState.readyToPropose:
             return orchardBalance > Zatoshi.zero ? MigrationBannerVariant.required : nil
@@ -227,7 +252,10 @@ enum MigrationDerivations {
     }
 
     /// See MOB-1466 spec, "reentryRoute" — §4.3 table, checked in this exact order.
+    /// `isIronwoodActivated` (MOB-1483) is checked first, ahead of row 1 — pre-activation every
+    /// input falls through to `.entry`.
     static func reentryRoute(
+        isIronwoodActivated: Bool,
         state: MigrationState,
         hasInvalid: Bool,
         hasOverdue: Bool,
@@ -236,6 +264,8 @@ enum MigrationDerivations {
         isCompleteAcknowledged: Bool,
         progress: MigrationProgress?
     ) -> MigrationReentryRoute {
+        guard isIronwoodActivated else { return MigrationReentryRoute.entry }
+
         if hasInvalid {
             let isExpired = isTransferExpired(state)
             return MigrationReentryRoute.recovery(isExpired: isExpired)

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
@@ -115,6 +115,9 @@ extension ZcashSDKEnvironment {
 @DependencyClient
 struct ZcashSDKEnvironment {
     var latestCheckpoint: @Sendable () -> BlockHeight = { 0 }
+    // Fail-closed default: an unconfigured environment must never report Ironwood as activated
+    // (`{ 0 }` would open the activation gate for any synced tip).
+    var ironwoodActivationHeight: @Sendable () -> BlockHeight = { BlockHeight.max }
     var endpoint: @Sendable () -> LightWalletEndpoint = {
         LightWalletEndpoint(address: "", port: 0, secure: false, singleCallTimeoutInMillis: 0, streamingCallTimeoutInMillis: 0)
     }

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
@@ -15,6 +15,19 @@ extension ZcashSDKEnvironment: DependencyKey {
     static func live(network: ZcashNetwork) -> Self {
         Self(
             latestCheckpoint: { BlockHeight.ofLatestCheckpoint(network: network) },
+            ironwoodActivationHeight: {
+                switch network.networkType {
+                case .mainnet:
+                    // zcash_protocol 0.10.0: NU6.3 (Ironwood) mainnet activation height, set 2026-07-09.
+                    return BlockHeight(3_428_143)
+                case .testnet:
+                    // zcash_protocol 0.10.0: NU6.3 (Ironwood) testnet activation height, set 2026-06-30.
+                    return BlockHeight(4_134_000)
+                case .regtest:
+                    // Custom/regtest network: read the configured NU6.3 height, or "never activated" if absent.
+                    return network.customActivationHeights?.nu6_3 ?? BlockHeight.max
+                }
+            },
             endpoint: {
                 ZcashSDKEnvironment.serverConfig(
                     for: network.networkType

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
@@ -16,6 +16,7 @@ extension ZcashSDKEnvironment: TestDependencyKey {
     static func test() -> Self {
         Self(
             latestCheckpoint: { 0 },
+            ironwoodActivationHeight: { BlockHeight(4_134_000) },
             endpoint: { defaultEndpoint(for: .testnet) },
             exchangeRateIPRateLimit: { 120 },
             exchangeRateStaleLimit: { 15 * 60 },

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -167,11 +167,17 @@ extension Root {
                 // `power_wifi_sync` task: stop the synchronizer and release `state.bgTask` (a
                 // sync-only session may have set it), then re-arm — an expired session must never
                 // orphan the wakeup chain. Re-submitting with the same identifier REPLACES the
-                // pending request, so this is safe even if branch 2's up-front re-arm already ran
+                // pending request, so this is safe even if branch 3's up-front re-arm already ran
                 // in this same session.
                 sdkSynchronizer.stop()
                 state.bgTask?.setTaskCompleted(success: false)
                 state.bgTask = nil
+                // MOB-1483: pre-activation, branch 1 of the decision tree below never arms in the
+                // first place — skip the re-arm here too, for the same reason: there's nothing to
+                // keep alive, so let the wakeup chain lapse rather than resurrect a stale one.
+                if !migrationManager.isIronwoodActivated() {
+                    return .none
+                }
                 return .run { [migrationBGScheduler] _ in await migrationBGScheduler.scheduleNextWindow() }
 
             case .initialization(.appDelegate(.migrationNotificationTapped)):
@@ -852,12 +858,17 @@ extension Root {
 
     /// The migration BG session's decision tree (spec "Root: BG session decision tree"), checked
     /// in this exact order:
-    /// 1. Plan broken (invalid transfer, or expired-attention state) — notify, do NOT re-arm.
-    /// 2. Sync required before the next transfer — either skip (deferred-after-broadcast) or run a
+    /// 1. Ironwood not yet activated (MOB-1483) — there is no migration work to do
+    ///    pre-activation. Complete the session immediately: no notification, no executor call,
+    ///    and deliberately no re-arm — a task chain armed before activation (or before this gate
+    ///    landed) is left to lapse here rather than kept alive; the next arm happens once
+    ///    `isIronwoodActivated()` flips true (self-healing).
+    /// 2. Plan broken (invalid transfer, or expired-attention state) — notify, do NOT re-arm.
+    /// 3. Sync required before the next transfer — either skip (deferred-after-broadcast) or run a
     ///    sync-only session that never broadcasts, reusing the existing `power_wifi_sync` sync-kick
     ///    machinery verbatim (`state.bgTask` + `.retryStart`; `synchronizerStateChanged` completes
     ///    the task on `.upToDate`/`.stopped`/`.error`).
-    /// 3. Otherwise, send: `executeNextPendingMigrationTransfer` and notify/re-arm per outcome.
+    /// 4. Otherwise, send: `executeNextPendingMigrationTransfer` and notify/re-arm per outcome.
     /// Every branch except the sync-only session completes `handle` itself (that session's
     /// completion is the existing `synchronizerStateChanged` machinery, exactly like the
     /// `power_wifi_sync` task it mirrors).
@@ -865,6 +876,10 @@ extension Root {
         state: inout Root.State,
         handle: MigrationBGSessionHandle
     ) -> Effect<Root.Action> {
+        if !migrationManager.isIronwoodActivated() {
+            return .run { _ in handle.complete(true) }
+        }
+
         let migrationState = sdkSynchronizer.getMigrationState()
         let isPlanBroken = sdkSynchronizer.hasInvalidMigrationTransfers()
             || migrationState == MigrationState.requiresAttention(AttentionReason.transferExpired)

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -68,6 +68,9 @@ struct SmartBanner {
         var lastKnownBlocksRemaining: BlockHeight = -1
         var lastKnownErrorMessage = ""
         var lastKnownSyncPercentage = -1.0
+        // MOB-1483: latch for the Ironwood-activation flip check in `.synchronizerStateChanged` —
+        // nil until the first observation, then tracks the last-seen `isIronwoodActivated()`.
+        var lastObservedIronwoodActivation: Bool?
         var messageToBeShared: String?
         var migrationBannerVariant = MigrationBannerVariant.required
         var priorityContent: PriorityContent? = nil
@@ -136,6 +139,7 @@ struct SmartBanner {
         case migrationStateChanged(MigrationState)
         case migrationVariantLoaded(MigrationBannerVariant?)
         case migrationVariantUpdated(MigrationBannerVariant?)
+        case reevaluateMigrationOnActivationFlip
         case networkMonitorChanged(Bool)
         case openBanner
         case openBannerRequest
@@ -368,86 +372,16 @@ struct SmartBanner {
                 }
                 
             case .synchronizerStateChanged(let latestState):
-                let snapshot = SyncStatusSnapshot.snapshotFor(state: latestState.data.syncStatus)
-                
-                if let account = state.selectedWalletAccount, let accountBalance = latestState.data.accountsBalances[account.id] {
-                    state.spendableBalance = accountBalance.shieldedSpendableValue
-                }
-
-                if snapshot.syncStatus != state.synchronizerStatusSnapshot.syncStatus {
-                    state.synchronizerStatusSnapshot = snapshot
-                    
-                    var isSyncing = false
-                    if case let .syncing(syncProgress, isScanProgressComplete) = snapshot.syncStatus {
-                        state.lastKnownSyncPercentage = Double(syncProgress)
-                        state.lastKnownBlocksRemaining = max(
-                            0,
-                            latestState.data.latestBlockHeight - latestState.data.fullyScannedHeight
-                        )
-                        state.isScanProgressComplete = isScanProgressComplete
-                        isSyncing = true
-
-                        if state.priorityContent == .priority2 {
-                            return .send(.closeAndCleanupBanner)
-                        }
-                    }
-
-                    // error syncing check
-                    switch snapshot.syncStatus {
-                    case .upToDate:
-                        state.isSyncTimedOutAutoAppeareDisabled = false
-                        // Reset the syncing block-count so a re-eval of priority 4 after sync
-                        // completes (account change, reconnect) doesn't see the last `.syncing`
-                        // sample (which can still be >= the show threshold if the SDK skipped
-                        // a final low-remainder update) and spuriously re-show the banner.
-                        state.lastKnownBlocksRemaining = -1
-                        if state.priorityContent == .priority3 || state.priorityContent == .priority45 || state.priorityContent == .priority4 {
-                            return .send(.closeAndCleanupBanner)
-                        }
-                    case .error, .unprepared:
-                        if state.lastKnownErrorMessage != snapshot.message {
-                            state.lastKnownErrorMessage = snapshot.message
-                            return .send(.triggerPriority(.priority2))
-                        }
-                    default: break
-                    }
-                    
-                    if let account = state.selectedWalletAccount, let accountBalance = latestState.data.accountsBalances[account.id] {
-                        if state.priorityContent == .priority7 {
-                            if accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold() {
-                                return .send(.transparentBalanceUpdated(accountBalance.unshielded))
-                            } else {
-                                return .merge(
-                                    .send(.closeAndCleanupBanner),
-                                    .send(.closeSheetTapped)
-                                )
-                            }
-                        } else if state.transparentBalance < zcashSDKEnvironment.shieldingThreshold() && accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold() {
-                            return .merge(
-                                .send(.transparentBalanceUpdated(accountBalance.unshielded)),
-                                .send(.triggerPriority(.priority7))
-                            )
-                        }
-                    }
-                    
-                    // return of restoring/syncing
-                    // `rank` (not `rawValue`) so `priorityMigration`'s rank (1.5, between priority2
-                    // and priority3) correctly keeps this branch from replacing a showing migration
-                    // banner with priority3/priority4 — `rawValue` (-1) would give the same numeric
-                    // answer here today only by coincidence.
-                    let isSyncingHigherPriority = (state.priorityContent?.rank ?? 0) > State.PriorityContent.priority4.rank
-                    if isSyncing && (state.priorityContent == nil || isSyncingHigherPriority) {
-                        if state.walletStatus == .resyncing {
-                            //return .send(.triggerPriority(.priority45))
-                        } else if state.walletStatus == .restoring {
-                            return .send(.triggerPriority(.priority3))
-                        } else if state.lastKnownBlocksRemaining >= Constants.smartBannerSyncingBlocksThreshold {
-                            return .send(.triggerPriority(.priority4))
-                        }
-                    }
-                }
-
-                return .none
+                // MOB-1483 (W4): computed as two independent effects and merged, rather than
+                // folded into one flow — `syncStatusChangedEffect` below has many early-return
+                // branches (sync status change handling), and any one of those firing on the same
+                // tick as an activation flip must not silently swallow the flip's re-evaluation
+                // (a cold-launch tick is exactly where both are likely to coincide: the priority
+                // walk racing the first chain-tip fetch is the scenario `ironwoodActivationFlipEffect`
+                // exists to correct).
+                let activationFlipEffect = ironwoodActivationFlipEffect(state: &state)
+                let syncStatusEffect = syncStatusChangedEffect(state: &state, latestState: latestState)
+                return .merge(activationFlipEffect, syncStatusEffect)
 
             case .migrationStateChanged:
                 // The stream only tells us migration state changed, not what it resolved to — the
@@ -480,6 +414,15 @@ struct SmartBanner {
                     }
                 }
                 return .none
+
+            case .reevaluateMigrationOnActivationFlip:
+                // MOB-1483 (W4): identical fetch-and-route to `.migrationStateChanged` above —
+                // reused rather than duplicated, so an activation-day crossing (or a reorg back
+                // below the activation height) raises/lowers the banner through the same
+                // variant-fetch + `.migrationVariantUpdated` path.
+                return .run { [accountUUID = state.selectedWalletAccount?.id] send in
+                    await send(.migrationVariantUpdated(migrationManager.bannerVariant(accountUUID)))
+                }
 
                 // disconnected
             case .evaluatePriority1:
@@ -695,6 +638,123 @@ struct SmartBanner {
                 return .none
             }
         }
+    }
+
+    // MARK: - MOB-1483: Ironwood-activation flip (W4)
+
+    /// Detects an Ironwood-activation flip on every synchronizer tick and, when one occurs,
+    /// triggers a migration-variant re-evaluation through the existing raise/lower machinery
+    /// (`.reevaluateMigrationOnActivationFlip` mirrors `.migrationStateChanged`). Returned as a
+    /// separate effect from `syncStatusChangedEffect` and merged with it by the caller, so
+    /// neither can silently drop the other regardless of which of that function's several
+    /// early-return branches fires on the same tick.
+    ///
+    /// - First observation (`lastObservedIronwoodActivation == nil`): latches the current value.
+    ///   If already activated, the priority walk earlier in this same cold launch may have
+    ///   evaluated while the chain tip was still unknown (0) — re-evaluate once to close that race.
+    /// - Latched flip (`activated != lastObservedIronwoodActivation`): activation-day crossing
+    ///   raises the banner; a reorg back below the activation height lowers it again.
+    /// Unchanged latch: `.none`, no further state write — the steady-state cost of this check is
+    /// one cached-state read plus a comparison, every tick.
+    private func ironwoodActivationFlipEffect(state: inout State) -> Effect<Action> {
+        let activated = migrationManager.isIronwoodActivated()
+
+        guard let latch = state.lastObservedIronwoodActivation else {
+            state.lastObservedIronwoodActivation = activated
+            return activated ? .send(.reevaluateMigrationOnActivationFlip) : .none
+        }
+
+        guard activated != latch else {
+            return .none
+        }
+        state.lastObservedIronwoodActivation = activated
+        return .send(.reevaluateMigrationOnActivationFlip)
+    }
+
+    /// The pre-MOB-1483 body of `.synchronizerStateChanged`, unchanged — extracted verbatim so it
+    /// can be merged with `ironwoodActivationFlipEffect` above instead of racing it for the
+    /// case's single return value.
+    private func syncStatusChangedEffect(state: inout State, latestState: RedactableSynchronizerState) -> Effect<Action> {
+        let snapshot = SyncStatusSnapshot.snapshotFor(state: latestState.data.syncStatus)
+
+        if let account = state.selectedWalletAccount, let accountBalance = latestState.data.accountsBalances[account.id] {
+            state.spendableBalance = accountBalance.shieldedSpendableValue
+        }
+
+        if snapshot.syncStatus != state.synchronizerStatusSnapshot.syncStatus {
+            state.synchronizerStatusSnapshot = snapshot
+
+            var isSyncing = false
+            if case let .syncing(syncProgress, isScanProgressComplete) = snapshot.syncStatus {
+                state.lastKnownSyncPercentage = Double(syncProgress)
+                state.lastKnownBlocksRemaining = max(
+                    0,
+                    latestState.data.latestBlockHeight - latestState.data.fullyScannedHeight
+                )
+                state.isScanProgressComplete = isScanProgressComplete
+                isSyncing = true
+
+                if state.priorityContent == .priority2 {
+                    return .send(.closeAndCleanupBanner)
+                }
+            }
+
+            // error syncing check
+            switch snapshot.syncStatus {
+            case .upToDate:
+                state.isSyncTimedOutAutoAppeareDisabled = false
+                // Reset the syncing block-count so a re-eval of priority 4 after sync
+                // completes (account change, reconnect) doesn't see the last `.syncing`
+                // sample (which can still be >= the show threshold if the SDK skipped
+                // a final low-remainder update) and spuriously re-show the banner.
+                state.lastKnownBlocksRemaining = -1
+                if state.priorityContent == .priority3 || state.priorityContent == .priority45 || state.priorityContent == .priority4 {
+                    return .send(.closeAndCleanupBanner)
+                }
+            case .error, .unprepared:
+                if state.lastKnownErrorMessage != snapshot.message {
+                    state.lastKnownErrorMessage = snapshot.message
+                    return .send(.triggerPriority(.priority2))
+                }
+            default: break
+            }
+
+            if let account = state.selectedWalletAccount, let accountBalance = latestState.data.accountsBalances[account.id] {
+                if state.priorityContent == .priority7 {
+                    if accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold() {
+                        return .send(.transparentBalanceUpdated(accountBalance.unshielded))
+                    } else {
+                        return .merge(
+                            .send(.closeAndCleanupBanner),
+                            .send(.closeSheetTapped)
+                        )
+                    }
+                } else if state.transparentBalance < zcashSDKEnvironment.shieldingThreshold() && accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold() {
+                    return .merge(
+                        .send(.transparentBalanceUpdated(accountBalance.unshielded)),
+                        .send(.triggerPriority(.priority7))
+                    )
+                }
+            }
+
+            // return of restoring/syncing
+            // `rank` (not `rawValue`) so `priorityMigration`'s rank (1.5, between priority2
+            // and priority3) correctly keeps this branch from replacing a showing migration
+            // banner with priority3/priority4 — `rawValue` (-1) would give the same numeric
+            // answer here today only by coincidence.
+            let isSyncingHigherPriority = (state.priorityContent?.rank ?? 0) > State.PriorityContent.priority4.rank
+            if isSyncing && (state.priorityContent == nil || isSyncingHigherPriority) {
+                if state.walletStatus == .resyncing {
+                    //return .send(.triggerPriority(.priority45))
+                } else if state.walletStatus == .restoring {
+                    return .send(.triggerPriority(.priority3))
+                } else if state.lastKnownBlocksRemaining >= Constants.smartBannerSyncingBlocksThreshold {
+                    return .send(.triggerPriority(.priority4))
+                }
+            }
+        }
+
+        return .none
     }
 }
 

--- a/zodlTests/MigrationTests/MigrationManagerTests.swift
+++ b/zodlTests/MigrationTests/MigrationManagerTests.swift
@@ -20,6 +20,7 @@ struct MigrationManagerTests {
 
     @Test func notStartedWithPositiveBalanceIsRequired() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.notStarted,
             hasInvalid: false,
             hasOverdue: false,
@@ -35,6 +36,7 @@ struct MigrationManagerTests {
 
     @Test func notStartedWithZeroBalanceIsNil() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.notStarted,
             hasInvalid: false,
             hasOverdue: false,
@@ -50,6 +52,7 @@ struct MigrationManagerTests {
 
     @Test func readyToProposeWithPositiveBalanceIsRequired() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.readyToPropose,
             hasInvalid: false,
             hasOverdue: false,
@@ -65,6 +68,7 @@ struct MigrationManagerTests {
 
     @Test func readyToProposeWithZeroBalanceIsNil() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.readyToPropose,
             hasInvalid: false,
             hasOverdue: false,
@@ -80,6 +84,7 @@ struct MigrationManagerTests {
 
     @Test func splitPendingConfirmationIsSplitting() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.splitPendingConfirmation,
             hasInvalid: false,
             hasOverdue: false,
@@ -102,6 +107,7 @@ struct MigrationManagerTests {
         )
 
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.inProgress(progress),
             hasInvalid: false,
             hasOverdue: false,
@@ -124,6 +130,7 @@ struct MigrationManagerTests {
         )
 
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.inProgress(progress),
             hasInvalid: false,
             hasOverdue: false,
@@ -146,6 +153,7 @@ struct MigrationManagerTests {
         )
 
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.inProgress(progress),
             hasInvalid: false,
             hasOverdue: false,
@@ -172,6 +180,7 @@ struct MigrationManagerTests {
         )
 
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.inProgress(progress),
             hasInvalid: false,
             hasOverdue: false,
@@ -187,6 +196,7 @@ struct MigrationManagerTests {
 
     @Test func requiresAttentionTransferStalledIsTransferWaiting() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.requiresAttention(AttentionReason.transferStalled(transferNumber: 3)),
             hasInvalid: false,
             hasOverdue: false,
@@ -202,6 +212,7 @@ struct MigrationManagerTests {
 
     @Test func requiresAttentionInvalidTransferIsUpdatePlan() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
             hasInvalid: true,
             hasOverdue: false,
@@ -225,6 +236,7 @@ struct MigrationManagerTests {
         ]
 
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.requiresAttention(AttentionReason.transferExpired),
             hasInvalid: false,
             hasOverdue: false,
@@ -245,6 +257,7 @@ struct MigrationManagerTests {
         ]
 
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.requiresAttention(AttentionReason.transferExpired),
             hasInvalid: false,
             hasOverdue: false,
@@ -260,6 +273,7 @@ struct MigrationManagerTests {
 
     @Test func requiresAttentionTransferExpiredFallsBackToOneAndZeroWithNoRowsAtAll() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.requiresAttention(AttentionReason.transferExpired),
             hasInvalid: false,
             hasOverdue: false,
@@ -275,6 +289,7 @@ struct MigrationManagerTests {
 
     @Test func completeUnacknowledgedIsComplete() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.complete,
             hasInvalid: false,
             hasOverdue: false,
@@ -290,6 +305,7 @@ struct MigrationManagerTests {
 
     @Test func completeAcknowledgedIsNil() {
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.complete,
             hasInvalid: false,
             hasOverdue: false,
@@ -310,6 +326,7 @@ struct MigrationManagerTests {
         // `reconcileClearsAcknowledgedFlagWhenStateIsNotComplete` /
         // `reconcileKeepsAcknowledgedFlagWhenStateIsComplete` below, not this pure table).
         let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: true,
             state: MigrationState.notStarted,
             hasInvalid: false,
             hasOverdue: false,
@@ -323,6 +340,24 @@ struct MigrationManagerTests {
         #expect(variant == MigrationBannerVariant.required)
     }
 
+    @Test func gateClosedBeatsMaximallyOfferingBannerInput() {
+        // MOB-1483: `isIronwoodActivated: false` must win over even the input that otherwise
+        // produces the strongest banner (`notStarted` + a positive balance -> `.required`).
+        let variant = MigrationDerivations.bannerVariant(
+            isIronwoodActivated: false,
+            state: MigrationState.notStarted,
+            hasInvalid: false,
+            hasOverdue: false,
+            isManualDelivery: false,
+            isNextTransferDue: false,
+            orchardBalance: Zatoshi(1),
+            isCompleteAcknowledged: false,
+            transferRows: []
+        )
+
+        #expect(variant == nil)
+    }
+
     // MARK: - reentryRoute
 
     @Test func hasInvalidTransfersWinsOverEverythingElse() {
@@ -334,6 +369,7 @@ struct MigrationManagerTests {
         )
 
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.complete,
             hasInvalid: true,
             hasOverdue: true,
@@ -346,8 +382,36 @@ struct MigrationManagerTests {
         #expect(route == MigrationReentryRoute.recovery(isExpired: false))
     }
 
+    @Test func gateClosedBeatsMaximallyOfferingReentryInput() {
+        // MOB-1483: `isIronwoodActivated: false` must win over even the top of the priority
+        // chain — this is the same maximally-offering input as
+        // `hasInvalidTransfersWinsOverEverythingElse` (which would-be produce `.recovery`, and
+        // with `hasInvalid` false would-be produce `.statusResume`), but with the gate closed it
+        // must still be `.entry`.
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 2,
+            remainingOrchard: Zatoshi.zero,
+            nextTransferReadyAtHeight: nil
+        )
+
+        let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: false,
+            state: MigrationState.complete,
+            hasInvalid: true,
+            hasOverdue: true,
+            isManualDelivery: true,
+            isNextTransferDue: true,
+            isCompleteAcknowledged: false,
+            progress: progress
+        )
+
+        #expect(route == MigrationReentryRoute.entry)
+    }
+
     @Test func invalidTransferWithTransferExpiredAttentionReasonIsExpiredRecovery() {
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.requiresAttention(AttentionReason.transferExpired),
             hasInvalid: true,
             hasOverdue: false,
@@ -362,6 +426,7 @@ struct MigrationManagerTests {
 
     @Test func invalidTransferWithOtherAttentionReasonIsNonExpiredRecovery() {
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
             hasInvalid: true,
             hasOverdue: false,
@@ -376,6 +441,7 @@ struct MigrationManagerTests {
 
     @Test func hasOverdueWinsOverInProgressAndComplete() {
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.complete,
             hasInvalid: false,
             hasOverdue: true,
@@ -397,6 +463,7 @@ struct MigrationManagerTests {
         )
 
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.inProgress(progress),
             hasInvalid: false,
             hasOverdue: false,
@@ -418,6 +485,7 @@ struct MigrationManagerTests {
         )
 
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.inProgress(progress),
             hasInvalid: false,
             hasOverdue: false,
@@ -439,6 +507,7 @@ struct MigrationManagerTests {
         )
 
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.inProgress(progress),
             hasInvalid: false,
             hasOverdue: false,
@@ -460,6 +529,7 @@ struct MigrationManagerTests {
         )
 
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.inProgress(progress),
             hasInvalid: false,
             hasOverdue: false,
@@ -474,6 +544,7 @@ struct MigrationManagerTests {
 
     @Test func completeUnacknowledgedIsCompleteRoute() {
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.complete,
             hasInvalid: false,
             hasOverdue: false,
@@ -488,6 +559,7 @@ struct MigrationManagerTests {
 
     @Test func completeAcknowledgedFallsThroughToEntry() {
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.complete,
             hasInvalid: false,
             hasOverdue: false,
@@ -502,6 +574,7 @@ struct MigrationManagerTests {
 
     @Test func splitPendingConfirmationIsNoteSplitProgress() {
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.splitPendingConfirmation,
             hasInvalid: false,
             hasOverdue: false,
@@ -516,6 +589,7 @@ struct MigrationManagerTests {
 
     @Test func notStartedIsEntry() {
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.notStarted,
             hasInvalid: false,
             hasOverdue: false,
@@ -530,6 +604,7 @@ struct MigrationManagerTests {
 
     @Test func readyToProposeIsEntry() {
         let route = MigrationDerivations.reentryRoute(
+            isIronwoodActivated: true,
             state: MigrationState.readyToPropose,
             hasInvalid: false,
             hasOverdue: false,
@@ -546,6 +621,7 @@ struct MigrationManagerTests {
         // §4.3 priority order, verified as one table so a future reordering trips a single test.
         struct Row {
             let name: String
+            let isIronwoodActivated: Bool
             let hasInvalid: Bool
             let hasOverdue: Bool
             let isManualDelivery: Bool
@@ -563,8 +639,22 @@ struct MigrationManagerTests {
         )
 
         let rows: [Row] = [
+            // MOB-1483: the activation gate outranks every other row — a closed gate beats even
+            // the highest-priority pre-gate input (`hasInvalid`, which would otherwise win row 1).
+            Row(
+                name: "0: gate closed",
+                isIronwoodActivated: false,
+                hasInvalid: true,
+                hasOverdue: false,
+                isManualDelivery: false,
+                isNextTransferDue: false,
+                isCompleteAcknowledged: false,
+                state: MigrationState.requiresAttention(AttentionReason.invalidTransfer(transferId: "t1")),
+                expected: MigrationReentryRoute.entry
+            ),
             Row(
                 name: "1: recovery",
+                isIronwoodActivated: true,
                 hasInvalid: true,
                 hasOverdue: false,
                 isManualDelivery: false,
@@ -575,6 +665,7 @@ struct MigrationManagerTests {
             ),
             Row(
                 name: "2: statusResume",
+                isIronwoodActivated: true,
                 hasInvalid: false,
                 hasOverdue: true,
                 isManualDelivery: false,
@@ -585,6 +676,7 @@ struct MigrationManagerTests {
             ),
             Row(
                 name: "3: reviewManual",
+                isIronwoodActivated: true,
                 hasInvalid: false,
                 hasOverdue: false,
                 isManualDelivery: true,
@@ -595,6 +687,7 @@ struct MigrationManagerTests {
             ),
             Row(
                 name: "4: statusProgress",
+                isIronwoodActivated: true,
                 hasInvalid: false,
                 hasOverdue: false,
                 isManualDelivery: false,
@@ -605,6 +698,7 @@ struct MigrationManagerTests {
             ),
             Row(
                 name: "5: complete",
+                isIronwoodActivated: true,
                 hasInvalid: false,
                 hasOverdue: false,
                 isManualDelivery: false,
@@ -615,6 +709,7 @@ struct MigrationManagerTests {
             ),
             Row(
                 name: "6: noteSplitProgress",
+                isIronwoodActivated: true,
                 hasInvalid: false,
                 hasOverdue: false,
                 isManualDelivery: false,
@@ -625,6 +720,7 @@ struct MigrationManagerTests {
             ),
             Row(
                 name: "7: entry",
+                isIronwoodActivated: true,
                 hasInvalid: false,
                 hasOverdue: false,
                 isManualDelivery: false,
@@ -637,6 +733,7 @@ struct MigrationManagerTests {
 
         for row in rows {
             let route = MigrationDerivations.reentryRoute(
+                isIronwoodActivated: row.isIronwoodActivated,
                 state: row.state,
                 hasInvalid: row.hasInvalid,
                 hasOverdue: row.hasOverdue,
@@ -910,7 +1007,17 @@ struct MigrationManagerTests {
         #expect(storage.isCompleteAcknowledged() == true)
 
         withDependencies {
-            $0.sdkSynchronizer = SDKSynchronizerClient.noOp
+            // MOB-1483: `reconcile()` now gates on `isIronwoodActivated()` first — open the gate
+            // (tip past the ambient `ZcashSDKEnvironment.testValue` activation height) so this
+            // test still exercises the stale-acknowledge reset it's actually about. `latestState`
+            // is a `let` on the client, so it must be set through the `mocked(latestState:)` base.
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                latestState: {
+                    var state = SynchronizerState.zero
+                    state.latestBlockHeight = 5_000_000
+                    return state
+                }
+            )
             $0.sdkSynchronizer.getMigrationState = {
                 MigrationState.inProgress(
                     MigrationProgress(completedTransfers: 1, totalTransfers: 5, remainingOrchard: Zatoshi(1), nextTransferReadyAtHeight: nil)
@@ -936,13 +1043,178 @@ struct MigrationManagerTests {
         #expect(storage.isCompleteAcknowledged() == true)
 
         withDependencies {
-            $0.sdkSynchronizer = SDKSynchronizerClient.noOp
+            // MOB-1483: open the gate — see the comment in
+            // `reconcileClearsAcknowledgedFlagWhenStateIsNotComplete` above.
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                latestState: {
+                    var state = SynchronizerState.zero
+                    state.latestBlockHeight = 5_000_000
+                    return state
+                }
+            )
             $0.sdkSynchronizer.getMigrationState = { MigrationState.complete }
         } operation: {
             let impl = MigrationManagerImpl(gateStorage: storage)
             impl.reconcile()
         }
 
+        #expect(storage.isCompleteAcknowledged() == true)
+    }
+
+    // MARK: - isIronwoodActivated(): MOB-1483 activation gate
+    //
+    // `MigrationManagerImpl.isIronwoodActivated() == tip > 0 && tip >= ironwoodActivationHeight`.
+    // `tip > 0` is the fail-safe sentinel: an unsynced cached tip (0, before the first server
+    // round-trip) must read as "not activated," independent of whatever height is configured.
+
+    @Test func isIronwoodActivatedFalseWhenTipIsUnknown() {
+        let result = withDependencies {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked() // `mocked()` keeps `latestState` at `.zero` — tip == 0: unsynced
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { 0 } // even a trivially-met height must not matter
+        } operation: {
+            MigrationManagerImpl().isIronwoodActivated()
+        }
+
+        #expect(result == false)
+    }
+
+    @Test func isIronwoodActivatedFalseWhenTipIsBelowActivationHeight() {
+        let result = withDependencies {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                latestState: {
+                    var state = SynchronizerState.zero
+                    state.latestBlockHeight = 99
+                    return state
+                }
+            )
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { 100 }
+        } operation: {
+            MigrationManagerImpl().isIronwoodActivated()
+        }
+
+        #expect(result == false)
+    }
+
+    @Test func isIronwoodActivatedTrueAtExactActivationHeight() {
+        let result = withDependencies {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                latestState: {
+                    var state = SynchronizerState.zero
+                    state.latestBlockHeight = 100
+                    return state
+                }
+            )
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { 100 }
+        } operation: {
+            MigrationManagerImpl().isIronwoodActivated()
+        }
+
+        #expect(result == true)
+    }
+
+    @Test func isIronwoodActivatedTrueWhenTipIsPastActivationHeight() {
+        let result = withDependencies {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                latestState: {
+                    var state = SynchronizerState.zero
+                    state.latestBlockHeight = 500
+                    return state
+                }
+            )
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { 100 }
+        } operation: {
+            MigrationManagerImpl().isIronwoodActivated()
+        }
+
+        #expect(result == true)
+    }
+
+    // MARK: - reconcile(): Ironwood activation gate (MOB-1483)
+    //
+    // `reconcile()` must skip `initializeMigrationPostUpgrade()` and the acknowledged-flag
+    // maintenance entirely while Ironwood is not activated on the current network — there is
+    // nothing to reconcile pre-activation. `initializeMigrationPostUpgrade` / `getMigrationState`
+    // are wrapped in `LockIsolated<Int>` call counters (the `RootMigrationBackgroundTests` spy
+    // precedent) asserted `== 0`; `gateStorage`'s persisted flag is asserted unchanged as evidence
+    // `clearAcknowledgedComplete()` was never reached either. (`sdkSynchronizer.latestState()`
+    // itself *is* called — that's the gate check.)
+
+    @Test func reconcileSkipsSDKAndStorageCallsWhenIronwoodIsNotActivated() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testReconcileSkipsSDKAndStorageCallsWhenIronwoodIsNotActivated"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: "testReconcileSkipsSDKAndStorageCallsWhenIronwoodIsNotActivated")
+        }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        storage.acknowledgeComplete()
+        #expect(storage.isCompleteAcknowledged() == true)
+
+        let initializeCalls = LockIsolated<Int>(0)
+        let getMigrationStateCalls = LockIsolated<Int>(0)
+
+        withDependencies {
+            // Tip 0 == "no server round-trip yet": the gate's own fail-safe sentinel, independent
+            // of whatever height `zcashSDKEnvironment.ironwoodActivationHeight()` reports.
+            // `mocked()` keeps `latestState` at `.zero` (it's a `let` on the client).
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked()
+            $0.sdkSynchronizer.initializeMigrationPostUpgrade = { initializeCalls.withValue { $0 += 1 } }
+            $0.sdkSynchronizer.getMigrationState = {
+                getMigrationStateCalls.withValue { $0 += 1 }
+                return MigrationState.notStarted
+            }
+        } operation: {
+            let impl = MigrationManagerImpl(gateStorage: storage)
+            impl.reconcile()
+        }
+
+        #expect(initializeCalls.withValue { $0 } == 0)
+        #expect(getMigrationStateCalls.withValue { $0 } == 0)
+        // Unchanged (still true): `clearAcknowledgedComplete()` was never reached either.
+        #expect(storage.isCompleteAcknowledged() == true)
+    }
+
+    @Test func reconcileSkipsSDKAndStorageCallsWhenTipIsBelowActivationHeight() throws {
+        let userDefaults = try #require(
+            UserDefaults(suiteName: "testReconcileSkipsSDKAndStorageCallsWhenTipIsBelowActivationHeight"),
+            "MigrationGateStorage: UserDefaults failed to initialize"
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: "testReconcileSkipsSDKAndStorageCallsWhenTipIsBelowActivationHeight")
+        }
+
+        let storage = MigrationGateStorage(userDefaults: userDefaults)
+        storage.acknowledgeComplete()
+        #expect(storage.isCompleteAcknowledged() == true)
+
+        let initializeCalls = LockIsolated<Int>(0)
+        let getMigrationStateCalls = LockIsolated<Int>(0)
+
+        withDependencies {
+            // A known, synced tip that simply hasn't reached activation yet — distinct from the
+            // tip == 0 sentinel case above, exercising the actual height comparison.
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                latestState: {
+                    var state = SynchronizerState.zero
+                    state.latestBlockHeight = 99
+                    return state
+                }
+            )
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { 100 }
+            $0.sdkSynchronizer.initializeMigrationPostUpgrade = { initializeCalls.withValue { $0 += 1 } }
+            $0.sdkSynchronizer.getMigrationState = {
+                getMigrationStateCalls.withValue { $0 += 1 }
+                return MigrationState.notStarted
+            }
+        } operation: {
+            let impl = MigrationManagerImpl(gateStorage: storage)
+            impl.reconcile()
+        }
+
+        #expect(initializeCalls.withValue { $0 } == 0)
+        #expect(getMigrationStateCalls.withValue { $0 } == 0)
         #expect(storage.isCompleteAcknowledged() == true)
     }
 }

--- a/zodlTests/MigrationTests/RootMigrationBackgroundTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationBackgroundTests.swift
@@ -5,15 +5,20 @@
 //  Covers MOB-1467's Root-level migration BG session decision tree
 //  (Features/Root/RootInitialization.swift, `.initialization(.migrationBackgroundSession)` and
 //  `.appDelegate(.migrationBackgroundTaskExpired)`): every branch of the spec's ordered tree —
-//  plan-broken, sync-required (deferred and not), send (success/success-to-complete/failure/nil),
-//  and session expiration — driven with spy `MigrationBGSessionHandle`s (`rawTask: nil`, since a
-//  bare `BGProcessingTask` cannot be instantiated in unit tests; see that type's doc comment).
+//  the Ironwood-activation gate (MOB-1483), plan-broken, sync-required (deferred and not), send
+//  (success/success-to-complete/failure/nil), and session expiration — driven with spy
+//  `MigrationBGSessionHandle`s (`rawTask: nil`, since a bare `BGProcessingTask` cannot be
+//  instantiated in unit tests; see that type's doc comment).
 //
 //  `.serialized`: same precedent as `RootMigrationRoutingTests` — constructing `Root.State` builds
 //  `migrationCoordFlowState = MigrationCoordFlow.State.initial`, which reads the process-global
 //  `@Shared(.inMemory(.selectedWalletAccount))` key. Uses a plain `Store` (not `TestStore`) with
 //  `withDependencies` overrides and `LockIsolated` spies + polling, mirroring
 //  `RootMigrationRoutingTests`/`FlexaSecurityTests`.
+//
+//  `baseNoOpDependencies` defaults `migrationManager.isIronwoodActivated` to `true` — every branch
+//  below except the two Branch 1 (gated) tests exists to exercise post-activation behavior, so
+//  that's the natural shared baseline; the gated tests override it back to `false` locally.
 //
 
 import Foundation
@@ -23,7 +28,81 @@ import ComposableArchitecture
 @testable import zodl_internal
 
 @Suite(.serialized) @MainActor struct RootMigrationBackgroundTests {
-    // MARK: - Branch 1: Plan broken
+    // MARK: - Branch 1 (MOB-1483): Ironwood not yet activated
+
+    /// Pre-activation, the whole decision tree is a no-op: complete the handle immediately, with
+    /// zero notification/scheduler/executor calls — none of the later branches (plan-broken,
+    /// sync-required, send) are even consulted. `sdkSynchronizer`'s other migration-facing
+    /// dependencies are deliberately left at their `baseNoOpDependencies` defaults (which would
+    /// otherwise route into "plan broken") to prove the gate short-circuits before any of them
+    /// are read.
+    @Test func ironwoodNotActivatedCompletesSessionWithoutAnyWork() async {
+        let notifications = LockIsolated<[MigrationNotification]>([])
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let executeNextPendingMigrationTransferCalls = LockIsolated<Int>(0)
+        let completeCalls = LockIsolated<[Bool]>([])
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.migrationManager.isIronwoodActivated = { false }
+                $0.sdkSynchronizer.executeNextPendingMigrationTransfer = { _ in
+                    executeNextPendingMigrationTransferCalls.withValue { $0 += 1 }
+                    return nil
+                }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+                $0.userNotifications.scheduleMigrationNotification = { notification, _ in
+                    notifications.withValue { $0.append(notification) }
+                }
+            }
+
+            let handle = MigrationBGSessionHandle(rawTask: nil) { success in completeCalls.withValue { $0.append(success) } }
+            store.send(.initialization(.migrationBackgroundSession(handle)))
+            await waitForRootStore { completeCalls.withValue { !$0.isEmpty } }
+
+            #expect(notifications.withValue { $0 }.isEmpty)
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 0)
+            #expect(executeNextPendingMigrationTransferCalls.withValue { $0 } == 0)
+            #expect(completeCalls.withValue { $0 } == [true])
+        }
+    }
+
+    /// Mirrors `expiredSessionRearms` below, gated: the synchronizer still stops and the task
+    /// still completes/releases exactly as before (expiration handling is unconditional), but the
+    /// wakeup chain must NOT be kept alive — no `scheduleNextWindow` call, since branch 1 of the
+    /// session tree never arms it in the first place pre-activation.
+    @Test func ironwoodNotActivatedExpiredSessionDoesNotRearm() async {
+        let scheduleNextWindowCalls = LockIsolated<Int>(0)
+        let stopCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Store(initialState: Root.State.initial) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                    stop: { stopCalls.withValue { $0 += 1 } }
+                )
+                $0.migrationManager.isIronwoodActivated = { false }
+                $0.migrationBGScheduler.scheduleNextWindow = { scheduleNextWindowCalls.withValue { $0 += 1 } }
+            }
+
+            store.send(.initialization(.appDelegate(.migrationBackgroundTaskExpired)))
+            await waitForRootStore { stopCalls.withValue { $0 } == 1 }
+
+            #expect(stopCalls.withValue { $0 } == 1)
+            #expect(scheduleNextWindowCalls.withValue { $0 } == 0)
+            #expect(store.state.bgTask == nil)
+        }
+    }
+
+    // MARK: - Branch 2: Plan broken
 
     /// `hasInvalidMigrationTransfers() == true` must post `.planNeedsUpdate` immediately (nil
     /// date), never re-arm (`scheduleNextWindow`/`scheduleFirstWindow` untouched), and complete
@@ -91,7 +170,7 @@ import ComposableArchitecture
         }
     }
 
-    // MARK: - Branch 2: Sync required
+    // MARK: - Branch 3: Sync required
 
     /// Within 10 min of a foreground broadcast (`isSyncDeferredAfterBroadcast() == true`): skip
     /// even the sync — re-arm only, complete the session. `state.bgTask` must NOT be touched (no
@@ -177,7 +256,7 @@ import ComposableArchitecture
         }
     }
 
-    // MARK: - Branch 3: Send
+    // MARK: - Branch 4: Send
 
     /// A successful broadcast that does NOT complete the migration: records the broadcast, posts
     /// `.transferComplete` (never `.migrationComplete`), re-arms, and completes the session.
@@ -348,7 +427,9 @@ import ComposableArchitecture
 
     /// `.migrationBackgroundTaskExpired` must re-arm — an expired session must never orphan the
     /// wakeup chain (re-submitting with the same identifier REPLACES the pending request, so this
-    /// is safe even stacked after branch 2's own up-front re-arm).
+    /// is safe even stacked after branch 3's own up-front re-arm). Post-activation (the
+    /// `baseNoOpDependencies` default) — see `ironwoodNotActivatedExpiredSessionDoesNotRearm`
+    /// above for the pre-activation counterpart, which must NOT re-arm.
     @Test func expiredSessionRearms() async {
         let scheduleNextWindowCalls = LockIsolated<Int>(0)
 
@@ -387,6 +468,7 @@ private func baseNoOpDependencies(_ values: inout DependencyValues) {
     values.migrationBGScheduler.scheduleNextWindow = { }
     values.migrationBGScheduler.cancelAll = { }
     values.migrationManager.bannerVariant = { _ in nil }
+    values.migrationManager.isIronwoodActivated = { true }
     values.migrationManager.reentryRoute = { .entry }
     values.migrationManager.migrationMode = { nil }
     values.migrationManager.setMigrationMode = { _ in }

--- a/zodlTests/SmartBannerTests/SmartBannerMigrationTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerMigrationTests.swift
@@ -342,6 +342,154 @@ import ComposableArchitecture
         #expect(store.state.isOpen)
     }
 
+    // MARK: - Reactive trigger: Ironwood-activation flip (MOB-1483)
+
+    /// First-ever observation, gate closed: latches `false` and triggers nothing — no
+    /// `.reevaluateMigrationOnActivationFlip`, no further receives. (Exhaustive `TestStore` mode
+    /// is itself the proof: an unasserted action here would fail the test.)
+    @MainActor @Test func synchronizerStateChangedFirstObservationGateClosedLatchesWithoutTriggering() async {
+        let store = TestStore(initialState: SmartBanner.State()) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.isIronwoodActivated = { false }
+        }
+
+        await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted)) {
+            $0.lastObservedIronwoodActivation = false
+        }
+    }
+
+    /// First-ever observation, gate already open: latches `true` and ALSO triggers a
+    /// re-evaluation — the cold-launch race this latch exists to close (the priority walk may
+    /// have run while the chain tip was still unknown, i.e. before `isIronwoodActivated()` could
+    /// answer `true`).
+    @MainActor @Test func synchronizerStateChangedFirstObservationGateOpenAlsoTriggersReevaluation() async {
+        let account = walletAccount(idByte: 9)
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.isIronwoodActivated = { true }
+            $0.migrationManager.bannerVariant = { accountUUID in
+                #expect(accountUUID == account.id)
+                // `.complete`, not the `State()` default (`.required`), so the assignment is an
+                // observable change — proves the loaded variant actually lands in state.
+                return MigrationBannerVariant.complete
+            }
+        }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted)) {
+            $0.lastObservedIronwoodActivation = true
+        }
+        await store.receive(\.reevaluateMigrationOnActivationFlip)
+        await store.receive(\.migrationVariantUpdated) {
+            $0.migrationBannerVariant = MigrationBannerVariant.complete
+        }
+        await store.receive(\.triggerPriority) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    /// Latched flip false -> true (activation-day crossing): updates the latch and triggers
+    /// exactly one re-evaluation, which raises the banner through the ordinary
+    /// `.migrationVariantUpdated` route — exhaustive `TestStore` mode proves "exactly one" (a
+    /// second, spurious trigger would surface as an unasserted action).
+    @MainActor @Test func synchronizerStateChangedActivationFlipToTrueRaisesMigrationBanner() async {
+        let account = walletAccount(idByte: 11)
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+        state.lastObservedIronwoodActivation = false
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.isIronwoodActivated = { true }
+            $0.migrationManager.bannerVariant = { accountUUID in
+                #expect(accountUUID == account.id)
+                return MigrationBannerVariant.complete
+            }
+        }
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted)) {
+            $0.lastObservedIronwoodActivation = true
+        }
+        await store.receive(\.reevaluateMigrationOnActivationFlip)
+        await store.receive(\.migrationVariantUpdated) {
+            $0.migrationBannerVariant = MigrationBannerVariant.complete
+        }
+        await store.receive(\.triggerPriority) {
+            $0.priorityContentRequested = .priorityMigration
+        }
+        await store.receive(\.openBannerRequest) {
+            $0.priorityContent = .priorityMigration
+        }
+        await store.receive(\.openBanner) {
+            $0.delay = 1.0
+            $0.isOpen = true
+        }
+    }
+
+    /// Latched flip true -> false (a reorg back below the activation height): updates the latch
+    /// and triggers a re-evaluation, which lowers an already-showing migration banner through the
+    /// same close-and-rewalk path `.migrationStateChanged`'s nil-variant case uses. `.off`
+    /// exhaustivity mirrors `migrationStateChangedWithNilVariantWhileMigrationShowingClosesAndRewalks`
+    /// above — only the hop into the rewalk is asserted in detail, not every step of it.
+    @MainActor @Test func synchronizerStateChangedActivationFlipToFalseLowersMigrationBanner() async {
+        var state = SmartBanner.State()
+        state.lastObservedIronwoodActivation = true
+        state.priorityContent = .priorityMigration
+        state.priorityContentRequested = .priorityMigration
+        state.isOpen = true
+        state.migrationBannerVariant = MigrationBannerVariant.complete
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.isIronwoodActivated = { false }
+            $0.migrationManager.bannerVariant = { _ in nil }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted)) {
+            $0.lastObservedIronwoodActivation = false
+        }
+        await store.receive(\.reevaluateMigrationOnActivationFlip)
+        await store.receive(\.migrationVariantUpdated)
+        await store.receive(\.closeBanner) {
+            $0.isOpen = false
+            $0.priorityContentRequested = nil
+            $0.priorityContent = nil
+        }
+        await store.receive(\.openBannerRequest)
+        await store.receive(\.evaluatePriority1)
+        // The re-walk continues (evaluatePriority2 -> evaluatePriorityMigration -> ...); with the
+        // same `nil`-returning override it walks all the way down without re-triggering migration.
+        #expect(store.state.priorityContent == nil)
+    }
+
+    /// Second identical tick (latch already `false`, gate still closed): no spam — zero further
+    /// triggers. Exhaustive `TestStore` mode is the proof (a stray `.reevaluateMigrationOnActivationFlip`
+    /// would fail the test as an unasserted action).
+    @MainActor @Test func synchronizerStateChangedUnchangedActivationTriggersNothing() async {
+        var state = SmartBanner.State()
+        state.lastObservedIronwoodActivation = false
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.migrationManager.isIronwoodActivated = { false }
+        }
+
+        await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted))
+    }
+
     // MARK: - Tap
 
     @MainActor @Test func smartBannerContentTappedWithMigrationShowingRequestsMigrationScreen() async {

--- a/zodlTests/UtilTests/IronwoodActivationHeightTests.swift
+++ b/zodlTests/UtilTests/IronwoodActivationHeightTests.swift
@@ -1,0 +1,36 @@
+//
+//  IronwoodActivationHeightTests.swift
+//  zodlTests
+//
+//  Covers `ZcashSDKEnvironment.live(network:).ironwoodActivationHeight()` (MOB-1483): the
+//  app-side NU6.3 ("Ironwood") activation heights mirrored from librustzcash zcash_protocol
+//  0.10.0, keyed off `network.networkType` (Dependencies/ZcashSDKEnvironment/).
+//
+
+import Testing
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct IronwoodActivationHeightTests {
+    @Test func mainnetReturnsTheZcashProtocolActivationHeight() {
+        let environment = ZcashSDKEnvironment.live(network: ZcashNetworkBuilder.network(for: .mainnet))
+        #expect(environment.ironwoodActivationHeight() == 3_428_143)
+    }
+
+    @Test func testnetReturnsTheZcashProtocolActivationHeight() {
+        let environment = ZcashSDKEnvironment.live(network: ZcashNetworkBuilder.network(for: .testnet))
+        #expect(environment.ironwoodActivationHeight() == 4_134_000)
+    }
+
+    @Test func customNetworkWithConfiguredNU6_3HeightReturnsThatHeight() {
+        let network = ZcashNetworkBuilder.regtest(activationHeights: NetworkActivationHeights(nu6_3: 12_345))
+        let environment = ZcashSDKEnvironment.live(network: network)
+        #expect(environment.ironwoodActivationHeight() == 12_345)
+    }
+
+    @Test func customNetworkWithoutConfiguredNU6_3HeightNeverActivates() {
+        let network = ZcashNetworkBuilder.regtest(activationHeights: NetworkActivationHeights())
+        let environment = ZcashSDKEnvironment.live(network: network)
+        #expect(environment.ironwoodActivationHeight() == BlockHeight.max)
+    }
+}


### PR DESCRIPTION
> Supersedes #1898 (same commit, `25818b99`) — the head branch was renamed to the Linear-ticket schema (`michal/MOB-1458/MOB-1483-…`) and GitHub closes rather than retargets open PRs on a rename. No review activity existed on #1898.

## Summary

Gates the Orchard → Ironwood migration offering on **"Ironwood (NU6.3) is actually activated on the current network"**: known chain tip ≥ the network's activation height. Before that — no migration banner, no way into the flow, no reconcile side effects, and background migration sessions complete immediately without notifying or re-arming. Today that means mainnet builds are gate-closed (tip < 3,428,143) while testnet is open — which is the point: the rust migration crate has no activation guard of its own, so this app-layer gate is currently the only thing preventing a pre-activation migration attempt.

- **The check**: `tip > 0 && tip >= ironwoodActivationHeight` — tip from the synchronizer's cached network chain tip; unknown tip (fresh install, offline) fails closed. Heights live on `ZcashSDKEnvironment` (new `ironwoodActivationHeight()`): mainnet **3_428_143**, testnet **4_134_000** — mirrored from `zcash_protocol` 0.10.0 (consensus-frozen; the Rust-sourced getter naturally replaces this at MOB-1455 real-SDK wiring). Custom/regtest networks read `customActivationHeights.nu6_3`, defaulting to never-activated.
- **Derivation tables**: `MigrationDerivations.bannerVariant` / `.reentryRoute` gain a leading `isIronwoodActivated` input — `false` short-circuits to no banner / plain entry before any other branch. `reconcile()` early-returns when gated. The client member defaults to `{ false }` (fail-closed everywhere, including macro-generated test values).
- **Background sessions**: `migrationBackgroundSessionEffect` gets a first branch — not activated → complete the task, **no notification, no re-arm** (a stale-armed task chain self-heals by dying out); the expiration handler likewise skips its re-arm.
- **Reactivity (the subtle part)**: nothing re-evaluated the banner on chain-tip movement, and the cold-launch priority walk runs while the tip is still 0 — so even an activated network would have shown no migration banner for the entire first session. `SmartBannerStore` now merges a flip-latch effect into the existing `synchronizerStateChanged` subscription: when the activation state flips (first tip fetch, activation-day crossing, or a reorg back below), the migration variant re-evaluates through the existing in-place raise/lower path. The old ~80-line sync-status body was extracted verbatim into a helper so the flip check can't be swallowed by that case's early returns (which fire on nearly every tick during a restore — exactly the cold-launch scenario).

Approved spec: in the [MOB-1483 ticket description](https://linear.app/zodl/issue/MOB-1483/dont-offer-ironwood-migration-before-the-network-activates-ironwood).

## Integration notes for PR #1900 (migration simulator — unmerged)

Whichever of the two lands second needs two mechanical follow-ups on the combined tree (both compiler-enforced or one-liners):
1. **Simulator gate bypass**: prepend `MigrationSimulatorFlag.isEnabled && MigrationSimulatorClient.sharedEngine.isActive → true` to `MigrationManagerImpl.isIronwoodActivated()` (same idiom as #1900's two existing hooks) — otherwise a fresh-install/offline testnet run (tip 0) hides the simulator's banner.
2. #1900's preset derivation-table tests call `MigrationDerivations.bannerVariant/reentryRoute` directly and need the new leading `isIronwoodActivated: true` argument.

Also a trivial one-line CHANGELOG conflict, as between any two of the open PRs.

## Test plan

- Full `zodlTests` on `zodl-internal`: **964 tests in 130 suites passed** (1 pre-existing known issue: MOB-1364), `-skipMacroValidation`. Net **+19 tests** vs the base branch: activation-formula boundaries (tip 0 / below / exact / above), gate-beats-everything cases for both derivation tables (+ a new leading row in the all-routes precedence table), reconcile-guard call-count spies, gated background session and gated expiry (no re-arm), and 5 SmartBanner flip-latch tests (first-observation both ways, raise, lower, no-spam).
- `zodl-testnet` build green.
- Every pre-existing test that the fail-closed default would have silently flipped was updated deliberately (a shared `isIronwoodActivated = { true }` baseline in the BG tests; explicit tip overrides in the two reconcile tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
