### PR TITLE
[MOB-1482] Per-target versioning: preflight reads the built target; bump requires --target scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Added
 - [MOB-1482] The macOS ZODL app can now be built and shipped through the release tooling on two channels: TestFlight (`mac-internal`) and a notarized drag-to-Applications DMG for distribution outside the App Store (`mac-dmg`; combined variant `mac` builds both).
 
+### Fixed
+- [MOB-1482] The release preflight now validates `--version` against the `MARKETING_VERSION` of the variant's own target, so the macOS app can be versioned independently of the iOS app.
+
 ## 3.7.2 build 1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Added
 - [MOB-1482] The macOS ZODL app can now be built and shipped through the release tooling on two channels: TestFlight (`mac-internal`) and a notarized drag-to-Applications DMG for distribution outside the App Store (`mac-dmg`; combined variant `mac` builds both).
 
+### Changed
+- [MOB-1482] `Scripts/bump.sh` now requires `--target` (an Xcode target name, `ios`, or `all`), so version bumps are explicitly scoped — bumping iOS no longer silently rewrites the independently-versioned macOS app.
+
 ### Fixed
 - [MOB-1482] The release preflight now validates `--version` against the `MARKETING_VERSION` of the variant's own target, so the macOS app can be versioned independently of the iOS app.
 

--- a/Scripts/bump.sh
+++ b/Scripts/bump.sh
@@ -5,20 +5,24 @@ export LC_ALL="${LC_ALL:-en_US.UTF-8}"
 
 usage() {
   cat <<'EOF'
-Usage: Scripts/bump.sh --version <X.Y.Z> --build <n>
+Usage: Scripts/bump.sh --version <X.Y.Z> --build <n> --target <t>
 
   --version   marketing version to set (X.Y.Z)
   --build     build number to set
+  --target    scope of the bump: an Xcode target name (e.g. zodlmac-internal),
+              'ios' (all iOS app targets), or 'all' (every app target).
+              Targets are versioned independently — macOS does not track iOS.
   -h, --help  show this help
 EOF
 }
 
-VERSION="" ; BUILD=""
+VERSION="" ; BUILD="" ; TARGET=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --version) VERSION="$2" ; shift 2 ;;
     --build) BUILD="$2" ; shift 2 ;;
+    --target) TARGET="$2" ; shift 2 ;;
     -h|--help) usage ; exit 0 ;;
     *) echo "error: unknown argument: $1" >&2 ; usage >&2 ; exit 2 ;;
   esac
@@ -26,6 +30,7 @@ done
 
 [[ -z "$VERSION" ]] && { echo "error: --version is required" >&2 ; usage >&2 ; exit 2 ; }
 [[ -z "$BUILD" ]] && { echo "error: --build is required" >&2 ; usage >&2 ; exit 2 ; }
+[[ -z "$TARGET" ]] && { echo "error: --target is required" >&2 ; usage >&2 ; exit 2 ; }
 
 FASTLANE="${FASTLANE_CMD:-bundle exec fastlane}"
-exec $FASTLANE bump version:"$VERSION" build:"$BUILD"
+exec $FASTLANE bump version:"$VERSION" build:"$BUILD" target:"$TARGET"

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -117,8 +117,8 @@ worktree`. Your current checkout and working changes are left untouched.
 then cut the release branch:
 
 ```bash
-./Scripts/bump.sh --version 3.8.0 --build 1     # edits the project + commits
-git push                                         # push the bump commit on main
+./Scripts/bump.sh --version 3.8.0 --build 1 --target ios   # edits the project + commits
+git push                                                    # push the bump commit on main
 git checkout -b release/3.8.0
 git push -u origin release/3.8.0
 ```
@@ -177,14 +177,17 @@ Scripts/release.sh --variant <v> --ref <ref> --version <X.Y.Z> --build <n> [opti
   --skip-tests  skip the unit-test step
   -h, --help
 
-Scripts/bump.sh --version <X.Y.Z> --build <n>
+Scripts/bump.sh --version <X.Y.Z> --build <n> --target <target|ios|all>
+  --target      scope of the bump: an Xcode target name (e.g. zodlmac-internal),
+                'ios' (all iOS app targets), or 'all' (every app target) —
+                targets are versioned independently (macOS does not track iOS)
 ```
 
 ## Troubleshooting (preflight messages)
 
 | Message | Fix |
 |---|---|
-| `version … does not match project MARKETING_VERSION …` | Run `bump` first, or pass the version the project is actually at. |
+| `version … does not match project MARKETING_VERSION …` | Run `bump` scoped to the variant's target first (e.g. `--target zodlmac-internal` for mac variants), or pass the version that target is actually at. |
 | `build N already exists` / `is lower than the latest build` | Pick a higher number — check that variant's app in App Store Connect / TestFlight. |
 | `ref is not on origin` | `git push` the branch or commit first. |
 | `Could not resolve ref …` | The branch/tag/commit isn't on `origin` or locally — push or fetch it. |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,6 +13,7 @@ require_relative "lib/zodl/build_paths"
 require_relative "lib/zodl/notify"
 require_relative "lib/zodl/signing"
 require_relative "lib/zodl/dmg"
+require_relative "lib/zodl/pbxproj"
 
 # Refuse to run outside bundler so the pinned gem versions in Gemfile.lock are
 # always used. The Scripts/*.sh wrappers invoke `bundle exec fastlane`.
@@ -66,7 +67,7 @@ lane :release do |options|
   run("git -C #{repo_root.shellescape} fetch --quiet --tags origin", must_succeed: true)
   sha = resolve_sha(repo_root, ref)
   branch_version = Zodl::Version.from_branch(ref)
-  project_version = marketing_version_at(repo_root, sha)
+  pbxproj = pbxproj_at(repo_root, sha)
 
   installed_identities = run("security find-identity -v -p codesigning")
   sdk = sdk_facts(repo_root)
@@ -78,7 +79,7 @@ lane :release do |options|
       variant: variant,
       requested_version: version,
       requested_build: build,
-      project_version: project_version,
+      project_version: marketing_version_for(pbxproj, cfg[:target]),
       branch_version: branch_version,
       latest_build: cfg[:channel] == :dmg ? nil : latest_build_number(cfg[:app_identifier], version, cfg[:platform]),
       ref_on_origin: ref_on_origin?(repo_root, sha),
@@ -283,11 +284,22 @@ rescue StandardError => e
   UI.user_error!("Could not fetch the latest build number for #{app_identifier} #{version} from App Store Connect (#{e.message}). Re-run once App Store Connect is reachable.")
 end
 
-# MARKETING_VERSION as committed at `sha`. All app targets share one value, so
-# the first MARKETING_VERSION line in the project at that commit is correct.
-def marketing_version_at(repo_root, sha)
-  line = run("git -C #{repo_root.shellescape} show #{sha}:secant.xcodeproj/project.pbxproj | grep -m1 'MARKETING_VERSION ='")
-  line[/MARKETING_VERSION = ([^;]+);/, 1]&.strip
+# The project file as committed at `sha` — the version source of truth for the
+# ref being built (NOT the current checkout).
+def pbxproj_at(repo_root, sha)
+  run("git -C #{repo_root.shellescape} show #{sha}:#{Zodl::BuildPaths::PROJECT}/project.pbxproj", must_succeed: true)
+end
+
+# MARKETING_VERSION of the variant's own target. Targets are versioned
+# independently (the macOS app does not track the iOS version), so the check
+# must read the target this variant actually builds — never a whole-file first
+# match. nil (target/setting not found) skips the preflight version check.
+def marketing_version_for(pbxproj, target)
+  versions = Zodl::Pbxproj.marketing_versions(pbxproj, target: target)
+  if versions.size > 1
+    UI.user_error!("target '#{target}' configurations disagree on MARKETING_VERSION (#{versions.join(', ')}) — align them in the project")
+  end
+  versions.first
 end
 
 # Sets MARKETING_VERSION on all targets directly in the pbxproj. agvtool's

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -157,24 +157,29 @@ lane :release do |options|
   UI.success("Done: #{outcomes.join('; ')} — #{version} (#{build}) from #{ref} @ #{sha[0, 8]}")
 end
 
-desc "Set MARKETING_VERSION and CURRENT_PROJECT_VERSION and commit. Driven by Scripts/bump.sh."
+desc "Set MARKETING_VERSION and CURRENT_PROJECT_VERSION for a target scope and commit. Driven by Scripts/bump.sh."
 lane :bump do |options|
   version = options.fetch(:version)
   build   = Integer(options.fetch(:build))
+  selector = options[:target].to_s
+  UI.user_error!("target is required — an Xcode target name, 'ios' (all iOS app targets), or 'all'") if selector.empty?
   UI.user_error!("version '#{version}' is not in X.Y.Z form") unless Zodl::Version.valid?(version)
+  targets = begin
+    Zodl::Variants.bump_targets(selector)
+  rescue ArgumentError => e
+    UI.user_error!(e.message)
+  end
   repo_root = run("git rev-parse --show-toplevel", must_succeed: true).strip
 
   Dir.chdir(repo_root) do
-    UI.message("Setting marketing version to #{version}…")
-    set_marketing_version(version)
-    UI.message("Setting build number to #{build}…")
-    run("agvtool new-version -all #{build}", must_succeed: true)
+    UI.message("Setting #{targets.join(', ')} to #{version} (#{build})…")
+    set_versions(targets, version, build)
     UI.message("Committing the version bump…")
     run("git add secant.xcodeproj/project.pbxproj", must_succeed: true)
-    run("git commit -m #{"Bump to #{version} (#{build})".shellescape}", must_succeed: true)
+    run("git commit -m #{"Bump #{selector} to #{version} (#{build})".shellescape}", must_succeed: true)
   end
 
-  UI.success("Bumped to #{version} (#{build}) and committed.")
+  UI.success("Bumped #{selector} to #{version} (#{build}) and committed.")
 end
 
 # Notify on a failed release. The success and dry-run paths post inline (where
@@ -302,13 +307,19 @@ def marketing_version_for(pbxproj, target)
   versions.first
 end
 
-# Sets MARKETING_VERSION on all targets directly in the pbxproj. agvtool's
-# new-marketing-version does not update the build-setting form this project uses.
-def set_marketing_version(version)
-  path = "secant.xcodeproj/project.pbxproj"
-  content = File.read(path)
-  content.gsub!(/MARKETING_VERSION = [^;]+;/, "MARKETING_VERSION = #{version};")
-  File.write(path, content)
+# Rewrites MARKETING_VERSION and CURRENT_PROJECT_VERSION inside each named
+# target's own configuration blocks. agvtool has no per-target mode, and every
+# Info.plist references these build settings, so pbxproj surgery is the whole
+# job. Targets not named keep their versions — macOS is versioned independently
+# of iOS.
+def set_versions(targets, version, build)
+  path = "#{Zodl::BuildPaths::PROJECT}/project.pbxproj"
+  text = File.read(path)
+  targets.each do |target|
+    text = Zodl::Pbxproj.set_setting(text, target: target, key: "MARKETING_VERSION", value: version)
+    text = Zodl::Pbxproj.set_setting(text, target: target, key: "CURRENT_PROJECT_VERSION", value: build.to_s)
+  end
+  File.write(path, text)
 end
 
 # Resolves a branch/tag/commit to a commit SHA. Prefers origin/<ref> so a release

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -37,7 +37,8 @@ Other flags: `--yes` (skip confirmation), `--skip-tests`, `--help`.
 
 Preflight reconciles your declared `--version` / `--build` / `--variant` / `--ref`
 against git, the project, and App Store Connect, and refuses to build on any
-mismatch: wrong version (vs the project `MARKETING_VERSION` and the release
+mismatch: wrong version (vs the built target's `MARKETING_VERSION` — targets are
+versioned independently, e.g. macOS vs iOS — and the release
 branch), a duplicate or regressing build number (checked against the variant's
 own App Store Connect app), an unpushed ref, a missing/invalid `PartnerKeys.plist`,
 the wrong Xcode, no distribution signing identity, or a local ../ZcashLightClientKit

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -29,7 +29,11 @@ Dry run (all checks, no build):
 
 Bump the marketing version + build (the deliberate version-change step, run in `main`):
 
-    ./Scripts/bump.sh --version 3.8.0 --build 1
+    ./Scripts/bump.sh --version 3.8.0 --build 1 --target ios
+
+`--target` scopes the bump and is required: an Xcode target name (e.g.
+`zodlmac-internal`), `ios` (all iOS app targets), or `all`. Targets are
+versioned independently — bumping iOS never rewrites the macOS app.
 
 Other flags: `--yes` (skip confirmation), `--skip-tests`, `--help`.
 

--- a/fastlane/lib/zodl/pbxproj.rb
+++ b/fastlane/lib/zodl/pbxproj.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Zodl
+  # Reads per-target build settings out of a pbxproj's TEXT, so the preflight
+  # can check the version of the target a variant actually builds without a
+  # checkout (the Fastfile feeds it `git show <sha>:...project.pbxproj`).
+  # Targets may carry different MARKETING_VERSIONs — the macOS app is versioned
+  # independently of iOS — so a whole-file "first match" is not meaningful.
+  module Pbxproj
+    module_function
+
+    # The unique MARKETING_VERSION values across `target`'s build
+    # configurations, sorted. One element means the target is consistent;
+    # several mean its own configs disagree (caller decides how loud to be);
+    # empty means the target or setting was not found.
+    def marketing_versions(pbxproj, target:)
+      list = pbxproj[
+        /\/\* Build configuration list for PBXNativeTarget "#{Regexp.escape(target)}" \*\/ = \{.*?buildConfigurations = \((.*?)\);/m, 1
+      ]
+      return [] unless list
+
+      list.scan(/[A-F0-9]{24}/).filter_map { |config_id|
+        # A configuration block runs from its id header to its trailing
+        # `name = <configuration>;` line — build settings are UPPER_CASE, so a
+        # lowercase `name = ` cannot occur earlier inside buildSettings.
+        block = pbxproj[/#{config_id} \/\* [^*]* \*\/ = \{\s*isa = XCBuildConfiguration;.*?name = [^;]+;/m]
+        block && block[/MARKETING_VERSION = ([^;]+);/, 1]&.strip
+      }.uniq.sort
+    end
+  end
+end

--- a/fastlane/lib/zodl/pbxproj.rb
+++ b/fastlane/lib/zodl/pbxproj.rb
@@ -14,18 +14,44 @@ module Zodl
     # several mean its own configs disagree (caller decides how loud to be);
     # empty means the target or setting was not found.
     def marketing_versions(pbxproj, target:)
+      ids = config_ids(pbxproj, target: target)
+      return [] unless ids
+
+      ids.filter_map { |config_id|
+        block = config_block(pbxproj, config_id)
+        block && block[/MARKETING_VERSION = ([^;]+);/, 1]&.strip
+      }.uniq.sort
+    end
+
+    # Returns a copy of `pbxproj` with `key = value;` rewritten in each of
+    # `target`'s configuration blocks. Blocks that don't carry the key are left
+    # untouched (nothing is inserted). Raises on an unknown target.
+    def set_setting(pbxproj, target:, key:, value:)
+      ids = config_ids(pbxproj, target: target)
+      raise ArgumentError, "unknown target: #{target.inspect}" unless ids
+
+      ids.reduce(pbxproj) do |text, config_id|
+        block = config_block(text, config_id)
+        next text unless block
+
+        text.sub(block, block.gsub(/#{Regexp.escape(key)} = [^;]+;/, "#{key} = #{value};"))
+      end
+    end
+
+    # The configuration ids listed by the target's XCConfigurationList, or nil
+    # when the target does not exist in this project.
+    def config_ids(pbxproj, target:)
       list = pbxproj[
         /\/\* Build configuration list for PBXNativeTarget "#{Regexp.escape(target)}" \*\/ = \{.*?buildConfigurations = \((.*?)\);/m, 1
       ]
-      return [] unless list
+      list&.scan(/[A-F0-9]{24}/)
+    end
 
-      list.scan(/[A-F0-9]{24}/).filter_map { |config_id|
-        # A configuration block runs from its id header to its trailing
-        # `name = <configuration>;` line — build settings are UPPER_CASE, so a
-        # lowercase `name = ` cannot occur earlier inside buildSettings.
-        block = pbxproj[/#{config_id} \/\* [^*]* \*\/ = \{\s*isa = XCBuildConfiguration;.*?name = [^;]+;/m]
-        block && block[/MARKETING_VERSION = ([^;]+);/, 1]&.strip
-      }.uniq.sort
+    # A configuration block runs from its id header to its trailing
+    # `name = <configuration>;` line — build settings are UPPER_CASE, so a
+    # lowercase `name = ` cannot occur earlier inside buildSettings.
+    def config_block(pbxproj, config_id)
+      pbxproj[/#{config_id} \/\* [^*]* \*\/ = \{\s*isa = XCBuildConfiguration;.*?name = [^;]+;/m]
     end
   end
 end

--- a/fastlane/lib/zodl/variants.rb
+++ b/fastlane/lib/zodl/variants.rb
@@ -63,5 +63,23 @@ module Zodl
     def config(atomic_name)
       ATOMIC.fetch(atomic_name) { raise ArgumentError, "not an atomic variant: #{atomic_name.inspect}" }
     end
+
+    # Resolves a bump --target selector to Xcode target names: an exact target
+    # name bumps just that target, "ios" every iOS app target, "all" every app
+    # target. Targets are versioned independently (macOS does not track iOS),
+    # so the caller must always say which scope it means.
+    def bump_targets(selector)
+      targets = ATOMIC.values
+      case selector
+      when "all" then targets.map { |cfg| cfg[:target] }.uniq
+      when "ios" then targets.select { |cfg| cfg[:platform] == :ios }.map { |cfg| cfg[:target] }.uniq
+      else
+        known = targets.map { |cfg| cfg[:target] }.uniq
+        return [selector] if known.include?(selector)
+
+        raise ArgumentError,
+              "unknown bump target #{selector.inspect} — use one of: #{known.join(', ')}, or 'ios' / 'all'"
+      end
+    end
   end
 end

--- a/fastlane/spec/pbxproj_test.rb
+++ b/fastlane/spec/pbxproj_test.rb
@@ -1,0 +1,96 @@
+require "minitest/autorun"
+require "zodl/pbxproj"
+
+class ZodlPbxprojTest < Minitest::Test
+  # Two targets whose versions deliberately differ (the mac app is versioned
+  # independently of iOS), plus one target whose own configs disagree.
+  FIXTURE = <<~PBX
+    		AAAAAAAAAAAAAAAAAAAAAAA1 /* Debug */ = {
+    			isa = XCBuildConfiguration;
+    			buildSettings = {
+    				MARKETING_VERSION = 3.7.2;
+    				PRODUCT_BUNDLE_IDENTIFIER = "co.example.ios";
+    			};
+    			name = Debug;
+    		};
+    		AAAAAAAAAAAAAAAAAAAAAAA2 /* Release-Testflight */ = {
+    			isa = XCBuildConfiguration;
+    			buildSettings = {
+    				MARKETING_VERSION = 3.7.2;
+    			};
+    			name = "Release-Testflight";
+    		};
+    		BBBBBBBBBBBBBBBBBBBBBBB1 /* Debug */ = {
+    			isa = XCBuildConfiguration;
+    			buildSettings = {
+    				MARKETING_VERSION = 3.7.1;
+    				SDKROOT = macosx;
+    			};
+    			name = Debug;
+    		};
+    		BBBBBBBBBBBBBBBBBBBBBBB2 /* Release-AppStore */ = {
+    			isa = XCBuildConfiguration;
+    			buildSettings = {
+    				MARKETING_VERSION = 3.7.1;
+    			};
+    			name = "Release-AppStore";
+    		};
+    		CCCCCCCCCCCCCCCCCCCCCCC1 /* Debug */ = {
+    			isa = XCBuildConfiguration;
+    			buildSettings = {
+    				MARKETING_VERSION = 1.0.0;
+    			};
+    			name = Debug;
+    		};
+    		CCCCCCCCCCCCCCCCCCCCCCC2 /* Release */ = {
+    			isa = XCBuildConfiguration;
+    			buildSettings = {
+    				MARKETING_VERSION = 2.0.0;
+    			};
+    			name = Release;
+    		};
+    		DDDDDDDDDDDDDDDDDDDDDDD1 /* Build configuration list for PBXNativeTarget "zodl-internal" */ = {
+    			isa = XCConfigurationList;
+    			buildConfigurations = (
+    				AAAAAAAAAAAAAAAAAAAAAAA1 /* Debug */,
+    				AAAAAAAAAAAAAAAAAAAAAAA2 /* Release-Testflight */,
+    			);
+    		};
+    		DDDDDDDDDDDDDDDDDDDDDDD2 /* Build configuration list for PBXNativeTarget "zodlmac-internal" */ = {
+    			isa = XCConfigurationList;
+    			buildConfigurations = (
+    				BBBBBBBBBBBBBBBBBBBBBBB1 /* Debug */,
+    				BBBBBBBBBBBBBBBBBBBBBBB2 /* Release-AppStore */,
+    			);
+    		};
+    		DDDDDDDDDDDDDDDDDDDDDDD3 /* Build configuration list for PBXNativeTarget "disagreeing" */ = {
+    			isa = XCConfigurationList;
+    			buildConfigurations = (
+    				CCCCCCCCCCCCCCCCCCCCCCC1 /* Debug */,
+    				CCCCCCCCCCCCCCCCCCCCCCC2 /* Release */,
+    			);
+    		};
+  PBX
+
+  def versions(target)
+    Zodl::Pbxproj.marketing_versions(FIXTURE, target: target)
+  end
+
+  def test_reads_the_named_targets_version
+    assert_equal ["3.7.2"], versions("zodl-internal")
+  end
+
+  def test_mac_target_version_is_independent_of_ios
+    # The regression that motivated this parser: the mac target carries a
+    # different version than iOS, and the check must see the mac value.
+    assert_equal ["3.7.1"], versions("zodlmac-internal")
+  end
+
+  def test_disagreeing_configs_return_all_values_sorted
+    assert_equal ["1.0.0", "2.0.0"], versions("disagreeing")
+  end
+
+  def test_unknown_target_returns_empty
+    assert_equal [], versions("nope")
+  end
+end

--- a/fastlane/spec/pbxproj_test.rb
+++ b/fastlane/spec/pbxproj_test.rb
@@ -23,6 +23,7 @@ class ZodlPbxprojTest < Minitest::Test
     		BBBBBBBBBBBBBBBBBBBBBBB1 /* Debug */ = {
     			isa = XCBuildConfiguration;
     			buildSettings = {
+    				CURRENT_PROJECT_VERSION = 6;
     				MARKETING_VERSION = 3.7.1;
     				SDKROOT = macosx;
     			};
@@ -31,6 +32,7 @@ class ZodlPbxprojTest < Minitest::Test
     		BBBBBBBBBBBBBBBBBBBBBBB2 /* Release-AppStore */ = {
     			isa = XCBuildConfiguration;
     			buildSettings = {
+    				CURRENT_PROJECT_VERSION = 6;
     				MARKETING_VERSION = 3.7.1;
     			};
     			name = "Release-AppStore";
@@ -92,5 +94,32 @@ class ZodlPbxprojTest < Minitest::Test
 
   def test_unknown_target_returns_empty
     assert_equal [], versions("nope")
+  end
+
+  def test_set_setting_rewrites_only_the_named_targets_configs
+    updated = Zodl::Pbxproj.set_setting(FIXTURE, target: "zodlmac-internal", key: "MARKETING_VERSION", value: "3.8.0")
+    assert_equal ["3.8.0"], Zodl::Pbxproj.marketing_versions(updated, target: "zodlmac-internal")
+    # The other targets keep their values.
+    assert_equal ["3.7.2"], Zodl::Pbxproj.marketing_versions(updated, target: "zodl-internal")
+    assert_equal ["1.0.0", "2.0.0"], Zodl::Pbxproj.marketing_versions(updated, target: "disagreeing")
+  end
+
+  def test_set_setting_handles_other_keys
+    updated = Zodl::Pbxproj.set_setting(FIXTURE, target: "zodlmac-internal", key: "CURRENT_PROJECT_VERSION", value: "7")
+    assert_equal 2, updated.scan("CURRENT_PROJECT_VERSION = 7;").length
+    refute_includes updated, "CURRENT_PROJECT_VERSION = 6;"
+  end
+
+  def test_set_setting_leaves_configs_without_the_key_untouched
+    # The iOS fixture configs carry no CURRENT_PROJECT_VERSION — nothing is
+    # added or changed for them.
+    updated = Zodl::Pbxproj.set_setting(FIXTURE, target: "zodl-internal", key: "CURRENT_PROJECT_VERSION", value: "9")
+    assert_equal FIXTURE, updated
+  end
+
+  def test_set_setting_rejects_unknown_target
+    assert_raises(ArgumentError) do
+      Zodl::Pbxproj.set_setting(FIXTURE, target: "nope", key: "MARKETING_VERSION", value: "1.0.0")
+    end
   end
 end

--- a/fastlane/spec/variants_test.rb
+++ b/fastlane/spec/variants_test.rb
@@ -71,4 +71,25 @@ class ZodlVariantsTest < Minitest::Test
   def test_valid_accepts_mac_variants
     %w[mac-internal mac-dmg mac].each { |v| assert Zodl::Variants.valid?(v), v }
   end
+
+  def test_bump_targets_all_covers_every_app_target_once
+    assert_equal %w[zodl-internal zodl-testnet zodl-production zodlmac-internal],
+                 Zodl::Variants.bump_targets("all")
+  end
+
+  def test_bump_targets_ios_covers_only_ios_targets
+    assert_equal %w[zodl-internal zodl-testnet zodl-production],
+                 Zodl::Variants.bump_targets("ios")
+  end
+
+  def test_bump_targets_accepts_an_exact_target_name
+    assert_equal ["zodlmac-internal"], Zodl::Variants.bump_targets("zodlmac-internal")
+  end
+
+  def test_bump_targets_rejects_unknown_selector_naming_the_options
+    error = assert_raises(ArgumentError) { Zodl::Variants.bump_targets("zodl-mac") }
+    assert_match(/zodlmac-internal/, error.message)
+    assert_match(/ios/, error.message)
+    assert_match(/all/, error.message)
+  end
 end


### PR DESCRIPTION
## Problem

The demo branch now deliberately versions the mac app (3.7.1, commit 6a2e45c4) apart from iOS (3.7.2), and two tools still assumed "all targets share one version":

1. `./Scripts/release.sh --variant mac-dmg --ref ironwood-testnet-demo --version 3.7.1 …` failed with `version 3.7.1 does not match project MARKETING_VERSION 3.7.2` — the preflight read the version with a whole-file first-match (an iOS line).
2. `Scripts/bump.sh` set **every** target's version (global gsub + `agvtool -all`), so the next iOS bump would have silently clobbered the mac target's 3.7.1 — and the docs' troubleshooting advice ("run bump first") would have walked someone straight into that.

## Fix (commit 1 — preflight)

- New pure, minitest-covered `Zodl::Pbxproj.marketing_versions(text, target:)` parses the built ref's pbxproj (`git show <sha>:…`) per target.
- Preflight checks `--version` against the **variant's own target**, and errors clearly if a target's configs disagree among themselves.

## Fix (commit 2 — bump)

- `bump.sh`/the bump lane now **require `--target`**: an exact Xcode target name (e.g. `zodlmac-internal`), `ios` (all iOS app targets), or `all` — resolved from the variant table (`Zodl::Variants.bump_targets`) so the mapping can't drift.
- `MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` are rewritten only inside the named targets' configuration blocks (`Zodl::Pbxproj.set_setting`); `agvtool -all` is gone (every Info.plist references these build settings, so pbxproj surgery is the whole job).
- Docs updated: bump invocations in `fastlane/README.md` + `docs/release-automation.md` (bump-scoped edits only), CHANGELOG entries.

## Verification

- `bundle exec rake test`: 80 runs, 185 assertions, 0 failures (12 new tests: per-target reader incl. the exact mac/iOS regression, per-target writer incl. untouched-sibling and missing-key cases, selector resolution incl. unknown-selector error).
- Parser/writer rehearsed against the real pbxproj: reader → `zodlmac-internal 3.7.1`, iOS targets `3.7.2`; writer (in memory) → mac-only bump rewrites exactly 3+3 lines, all 9 iOS lines untouched; `ios` selector → the three iOS app targets.
- Live: the exact previously-failing command passes as `--dry-run` (`version 3.7.1 (project 3.7.1)`, exit 0); iOS `internal` dry-run vs ASC passes (`project 3.7.2`).
- `ruby -c` + `bundle exec fastlane lanes` clean; `bump.sh` arg translation verified (`FASTLANE_CMD=echo`), missing `--target` exits 2 with usage.

Linear: MOB-1482 (sub-issue of MOB-1458).

🤖 Generated with [Claude Code](https://claude.com/claude-code)