### PR TITLE
[MOB-1485] macOS: move wallet keychain items to the Data Protection keychain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Added
+- [MOB-1485] macOS: the keychain-error screen now offers a confirmed "Reset Zodl" action, so a wallet stuck on a failed keychain migration can be wiped and set up fresh without hunting for workarounds (recovery-phrase restore still applies).
 - [MOB-1484] The macOS ZODL app now ships in two side-by-side flavors — Zodl Internal (mainnet) and Zodl Testnet — each buildable for TestFlight (`mac-internal`, `mac-testnet`) and as a notarized DMG (`mac-internal-dmg`, `mac-testnet-dmg`; `mac` builds all four). The testnet flavor has its own app icon.
 - [MOB-1482] The macOS ZODL app can now be built and shipped through the release tooling on two channels: TestFlight (`mac-internal`) and a notarized drag-to-Applications DMG for distribution outside the App Store (`mac-dmg`; combined variant `mac` builds both).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1482] `Scripts/bump.sh` now requires `--target` (an Xcode target name, `ios`, or `all`), so version bumps are explicitly scoped — bumping iOS no longer silently rewrites the independently-versioned macOS app.
 
 ### Fixed
+- [MOB-1485] macOS: launching a differently-signed build (Xcode vs DMG vs TestFlight) no longer triggers repeated "wants to use your confidential information" keychain password dialogs — wallet data now lives in the Data Protection keychain and existing items migrate over automatically on first launch.
 - [MOB-1482] The release preflight now validates `--version` against the `MARKETING_VERSION` of the variant's own target, so the macOS app can be versioned independently of the iOS app.
 
 ## 3.7.2 build 1

--- a/docs/macos/KEYCHAIN_SE_HARDENING.md
+++ b/docs/macos/KEYCHAIN_SE_HARDENING.md
@@ -285,14 +285,28 @@ token-backed keys always lived in the DP domain (which is why it never password-
 
 Mechanics (`WalletStorage+KeychainRelocation.swift`):
 
+- **THE platform rule (learned from a wallet-destroying regression, verified via `secd`'s log on
+  a real Mac):** on macOS, SecItem calls **without** `kSecUseDataProtectionKeychain` are *not*
+  scoped to the file keychain — `SecItemCopyMatching` sees, and `SecItemDelete` deletes, Data
+  Protection items too. The first cut of this engine scanned and deleted unscoped: every launch
+  re-discovered the app's own DP items as "legacy leftovers" and the delete-the-original step
+  destroyed the freshly relocated DP copy — the wallet vanished on every relaunch. All
+  file-keychain operations therefore go through the `SecItemClient.fileKeychain*` primitives,
+  which scope by `SecKeychainItemRef`: only file items are backed by one (the macOS 26 SDK
+  removed `SecKeychainCopySearchList`/`SecKeychainCopyDefault`, so `kSecMatchSearchList` scoping
+  is no longer constructible), making the ref both the file/DP discriminator for the scan and the
+  precision handle for the per-item read (`kSecMatchItemList`) and delete
+  (`SecKeychainItemDelete`).
 - **Lazy once-per-process gate:** every public accessor calls it first, so any first keychain
   touch (including Splash's `areKeysPresent`) relocates before reading. Trigger is "the file
-  keychain still contains our items" — self-healing, no storage-version bump
-  (`zcashStorageVersion` keeps meaning the SE-split format, and the v2 migration composes on top:
-  a v1 plaintext blob relocates as-is, then splits inside the DP keychain).
-- **Crash-safe per item:** read file bytes (the one step an ACL can still gate — cross-signature
-  installs see one final prompt round) → write into DP (file bytes win over a crashed run's
-  duplicate) → read back and verify → only then delete the file original.
+  keychain still contains our items" (ref-discriminated, so DP items can never re-trigger it) —
+  self-healing, no storage-version bump (`zcashStorageVersion` keeps meaning the SE-split format,
+  and the v2 migration composes on top: a v1 plaintext blob relocates as-is, then splits inside
+  the DP keychain).
+- **Crash-safe per item:** read file bytes by ref (the one step an ACL can still gate —
+  cross-signature installs see one final prompt round) → write into DP (file bytes win over a
+  crashed run's duplicate) → read back and verify → only then delete the file original, by its
+  `SecKeychainItemRef`, never by a service-name query.
 - **Failure is sticky and loud:** any failure (including a denied prompt, `errSecAuthFailed`)
   makes every throwing accessor throw `KeychainError.unknown(status)`, which
   `walletInitializationState` routes to the OSStatusError screen. A denied relocation can never

--- a/docs/macos/KEYCHAIN_SE_HARDENING.md
+++ b/docs/macos/KEYCHAIN_SE_HARDENING.md
@@ -270,3 +270,40 @@ safe to launch as-is** (no Mac users yet; the gate is the friendly fallback).
 `seedFingerprint`), `RootInitialization.swift` (:460 eager derive, :495 fingerprint compare, migration
 trigger), `SmartBannerStore.swift` / `ResyncWalletStore.swift` (use metadata accessor), `Root/`
 (migration action). iOS paths untouched.
+
+## Data Protection keychain relocation (MOB-1485)
+
+The items this document describes originally lived in the **file-based login keychain**, whose
+per-item ACLs are bound to the creating app's code signature — so a differently-signed build
+(Xcode dev vs Developer ID DMG vs TestFlight) threw a password-only "wants to use your
+confidential information" dialog per item at launch. Since MOB-1485, the macOS live storage sets
+`WalletStorage.useDataProtectionKeychain`, which adds `kSecUseDataProtectionKeychain` to every
+keychain query: items live in the iOS-style Data Protection keychain, authorized silently from
+the code signature (Team ID + bundle ID, default access group — `kSecAttrAccessGroup` is
+deliberately never set, keeping internal/testnet isolated). The SE wrapping key needed no change:
+token-backed keys always lived in the DP domain (which is why it never password-prompted).
+
+Mechanics (`WalletStorage+KeychainRelocation.swift`):
+
+- **Lazy once-per-process gate:** every public accessor calls it first, so any first keychain
+  touch (including Splash's `areKeysPresent`) relocates before reading. Trigger is "the file
+  keychain still contains our items" — self-healing, no storage-version bump
+  (`zcashStorageVersion` keeps meaning the SE-split format, and the v2 migration composes on top:
+  a v1 plaintext blob relocates as-is, then splits inside the DP keychain).
+- **Crash-safe per item:** read file bytes (the one step an ACL can still gate — cross-signature
+  installs see one final prompt round) → write into DP (file bytes win over a crashed run's
+  duplicate) → read back and verify → only then delete the file original.
+- **Failure is sticky and loud:** any failure (including a denied prompt, `errSecAuthFailed`)
+  makes every throwing accessor throw `KeychainError.unknown(status)`, which
+  `walletInitializationState` routes to the OSStatusError screen. A denied relocation can never
+  read as "no wallet" — nobody gets sent to onboarding over a still-recoverable wallet.
+  Relaunching retries. Dev note: `errSecMissingEntitlement` (−34018) on the DP write means an
+  improperly signed/provisioned build.
+- **`resetZashi` is the escape hatch:** deliberately ungated (deletes are never ACL-gated) and it
+  additionally sweeps ZODL leftovers out of the file keychain.
+
+Ship notes: once relocated, older (file-keychain era) builds cannot see the wallet — downgrading
+means restoring from the mnemonic. `ThisDeviceOnly` is now genuinely enforced (no Migration
+Assistant / Time Machine carry-over; the mnemonic is the portable secret). Keychain Access and
+the `security` CLI no longer see the items — the `security delete-generic-password` rescue trick
+above only applies to pre-relocation installs.

--- a/docs/macos/KEYCHAIN_SE_HARDENING.md
+++ b/docs/macos/KEYCHAIN_SE_HARDENING.md
@@ -299,8 +299,13 @@ Mechanics (`WalletStorage+KeychainRelocation.swift`):
   read as "no wallet" — nobody gets sent to onboarding over a still-recoverable wallet.
   Relaunching retries. Dev note: `errSecMissingEntitlement` (−34018) on the DP write means an
   improperly signed/provisioned build.
-- **`resetZashi` is the escape hatch:** deliberately ungated (deletes are never ACL-gated) and it
-  additionally sweeps ZODL leftovers out of the file keychain.
+- **`resetZashi` is the escape hatch:** deliberately ungated (deletes are never ACL-gated), it
+  additionally sweeps ZODL leftovers out of the file keychain, and it clears the sticky gate so
+  the next access re-derives from reality (without that, Root's post-reset verification read
+  would rethrow the stale failure and mis-report a successful wipe). The macOS OSStatusError
+  screen exposes it as a confirmed "Reset Zodl" action (`OSStatusError.Action.startOverTapped` →
+  Root's `wipeRequest` alert → the standard reset flow), so the hatch is reachable from exactly
+  the failed-relocation state it exists for.
 
 Ship notes: once relocated, older (file-keychain era) builds cannot see the wallet — downgrading
 means restoring from the mnemonic. `ThisDeviceOnly` is now genuinely enforced (no Migration

--- a/secant/Sources/Dependencies/SecItem/SecItemInterface.swift
+++ b/secant/Sources/Dependencies/SecItem/SecItemInterface.swift
@@ -13,4 +13,22 @@ struct SecItemClient {
     var add: @Sendable (CFDictionary, inout CFTypeRef?) -> OSStatus = { _, _ in 0 }
     var update: @Sendable (CFDictionary, CFDictionary) -> OSStatus = { _, _ in 0 }
     var delete: @Sendable (CFDictionary) -> OSStatus = { _ in 0 }
+
+    // File-keychain-ONLY primitives (MOB-1485). On macOS, SecItem calls WITHOUT
+    // `kSecUseDataProtectionKeychain` are NOT scoped to the legacy file keychain — copy/delete
+    // operate on BOTH keychain implementations. Anything that must touch only the file (login)
+    // keychain — the relocation scan, its ACL-gated read, and the delete of relocated originals —
+    // goes through these, which the live client scopes via SecKeychainItemRef. Never called on
+    // iOS (there is no file keychain).
+
+    /// Attribute scan of ONLY the file keychain's generic passwords. On success, the result is an
+    /// array of dictionaries carrying `kSecAttrService`, `kSecAttrAccount`, and `kSecValueRef`
+    /// (the item's `SecKeychainItemRef`). `errSecItemNotFound` when the file keychain has none.
+    var fileKeychainItems: @Sendable (inout CFTypeRef?) -> OSStatus = { _ in 0 }
+    /// Data of exactly one file-keychain item, identified by the `kSecValueRef` handle the scan
+    /// returned. The one relocation step a login-keychain ACL can gate (may prompt).
+    var fileKeychainReadData: @Sendable (CFTypeRef, inout CFTypeRef?) -> OSStatus = { _, _ in 0 }
+    /// Deletes exactly one file-keychain item by its `kSecValueRef` handle. Succeeds if the item
+    /// is already gone.
+    var fileKeychainDeleteItem: @Sendable (CFTypeRef) -> OSStatus = { _ in 0 }
 }

--- a/secant/Sources/Dependencies/SecItem/SecItemLive.swift
+++ b/secant/Sources/Dependencies/SecItem/SecItemLive.swift
@@ -21,6 +21,75 @@ extension SecItemClient {
         },
         delete: { query in
             SecItemDelete(query)
+        },
+        fileKeychainItems: { result in
+            #if os(macOS)
+            // An UNFLAGGED SecItemCopyMatching consults BOTH keychain implementations on macOS.
+            // Only file-keychain items are backed by a SecKeychainItemRef, so the ref is the
+            // discriminator: keep exactly the results that carry one.
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecMatchLimit as String: kSecMatchLimitAll,
+                kSecReturnAttributes as String: kCFBooleanTrue as Any,
+                kSecReturnRef as String: kCFBooleanTrue as Any
+            ]
+            var raw: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &raw)
+            guard status == errSecSuccess else { return status }
+            guard let items = raw as? [[String: Any]] else { return errSecDecode }
+            let fileItems = items.filter { attributes in
+                guard let ref = attributes[kSecValueRef as String] else { return false }
+                return LegacyFileKeychain.isKeychainItemRef(ref as CFTypeRef)
+            }
+            guard !fileItems.isEmpty else { return errSecItemNotFound }
+            result = fileItems as CFTypeRef
+            return errSecSuccess
+            #else
+            return errSecUnimplemented
+            #endif
+        },
+        fileKeychainReadData: { ref, result in
+            #if os(macOS)
+            // kSecMatchItemList (an array of SecKeychainItemRef) pins the read to exactly this
+            // file-keychain item — the one relocation step a login-keychain ACL can gate.
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecMatchItemList as String: [ref] as CFArray,
+                kSecMatchLimit as String: kSecMatchLimitOne,
+                kSecReturnData as String: kCFBooleanTrue as Any
+            ]
+            return SecItemCopyMatching(query as CFDictionary, &result)
+            #else
+            return errSecUnimplemented
+            #endif
+        },
+        fileKeychainDeleteItem: { ref in
+            #if os(macOS)
+            LegacyFileKeychain.deleteItem(ref)
+            #else
+            errSecUnimplemented
+            #endif
         }
     )
 }
+
+#if os(macOS)
+/// The deliberately-contained legacy-keychain surface (expect deprecation warnings here — they
+/// are the point). `SecKeychainItem*` is deprecated, but it is the only remaining public way to
+/// (a) tell a file-keychain item from a Data Protection one — only file items are
+/// `SecKeychainItemRef`-backed, and the macOS 26 SDK removed `SecKeychainCopySearchList` /
+/// `SecKeychainCopyDefault`, so `kSecMatchSearchList` scoping is no longer constructible — and
+/// (b) delete exactly ONE file item: `SecItemDelete` without `kSecUseDataProtectionKeychain`
+/// deletes matching items from BOTH keychain implementations, which is precisely the MOB-1485
+/// wallet-destroying regression. See docs/macos/KEYCHAIN_SE_HARDENING.md.
+private enum LegacyFileKeychain {
+    static func isKeychainItemRef(_ ref: CFTypeRef) -> Bool {
+        CFGetTypeID(ref) == SecKeychainItemGetTypeID()
+    }
+
+    static func deleteItem(_ ref: CFTypeRef) -> OSStatus {
+        guard isKeychainItemRef(ref) else { return errSecParam }
+        return SecKeychainItemDelete(unsafeDowncast(ref, to: SecKeychainItem.self))
+    }
+}
+#endif

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
@@ -12,12 +12,16 @@
 import Foundation
 import Security
 
-extension OSStatus: Error {}
-
 /// Once-per-process outcome of the keychain relocation.
 enum KeychainRelocationState: Equatable, Sendable {
     case notStarted
     case done
+    case failed(OSStatus)
+}
+
+/// Outcome of the file-keychain discovery scan.
+enum LegacyScanOutcome: Equatable {
+    case found([WalletStorage.LegacyItem])
     case failed(OSStatus)
 }
 
@@ -70,9 +74,9 @@ extension WalletStorage {
         }
         let leftovers: [LegacyItem]
         switch legacyFileKeychainItems() {
-        case .failure(let status):
+        case .failed(let status):
             return KeychainRelocationState.failed(status)
-        case .success(let items):
+        case .found(let items):
             leftovers = items
         }
         for item in leftovers {
@@ -86,7 +90,7 @@ extension WalletStorage {
     /// Attribute-only scan of the FILE keychain for items whose service belongs to this ZODL
     /// flavor. Attribute reads are never ACL-gated, so this is promptless. Sorted for
     /// deterministic processing order.
-    func legacyFileKeychainItems() -> Result<[LegacyItem], OSStatus> {
+    func legacyFileKeychainItems() -> LegacyScanOutcome {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
@@ -95,10 +99,10 @@ extension WalletStorage {
         var result: AnyObject?
         let status = secItem.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
-            return .success([])
+            return .found([])
         }
         guard status == errSecSuccess, let items = result as? [[String: Any]] else {
-            return .failure(status)
+            return .failed(status)
         }
         let owned = items.compactMap { attributes -> LegacyItem? in
             guard
@@ -108,7 +112,7 @@ extension WalletStorage {
             let account = attributes[kSecAttrAccount as String] as? String ?? ""
             return LegacyItem(service: service, account: account)
         }
-        return .success(owned.sorted())
+        return .found(owned.sorted())
     }
 
     /// Whether a file-keychain service string belongs to THIS flavor of ZODL. The flavor prefix

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
@@ -251,4 +251,15 @@ extension WalletStorage {
             _ = secItem.delete(query as CFDictionary)
         }
     }
+
+    /// After a reset, a previously-failed relocation is stale: the sweep just emptied the file
+    /// keychain of our items, so the next access must re-derive the gate from reality (trivially
+    /// `done` after a successful sweep; a genuine retry if the scan could not run). Without this,
+    /// the sticky failure would outlive the reset and Root's post-reset verification read would
+    /// mis-report a successful wipe as an error.
+    func resetRelocationGate() {
+        relocationGate.withLock { state in
+            state = KeychainRelocationState.notStarted
+        }
+    }
 }

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 import Security
+import os
 
 /// Once-per-process outcome of the keychain relocation.
 enum KeychainRelocationState: Equatable, Sendable {

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
@@ -231,4 +231,23 @@ extension WalletStorage {
         }
         return nil
     }
+
+    /// macOS: after a reset wipes the DP keychain, also delete any of OUR items still sitting in
+    /// the legacy FILE keychain (un-relocated / half-relocated / failed relocation states).
+    /// Deletes never read item data, so this is promptless; foreign items are never touched.
+    /// Best-effort by design — reset is the escape hatch and must not throw over legacy leftovers.
+    func sweepLegacyFileKeychainItems() {
+        guard useDataProtectionKeychain else { return }
+        guard case .found(let leftovers) = legacyFileKeychainItems() else { return }
+        for item in leftovers {
+            var query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: item.service
+            ]
+            if !item.account.isEmpty {
+                query[kSecAttrAccount as String] = item.account
+            }
+            _ = secItem.delete(query as CFDictionary)
+        }
+    }
 }

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
@@ -1,0 +1,230 @@
+//
+//  WalletStorage+KeychainRelocation.swift
+//  Zashi
+//
+//  MOB-1485: one-time relocation of every ZODL keychain item from the legacy file-based login
+//  keychain into the Data Protection keychain (macOS only). The login keychain gates each item
+//  behind a code-signature ACL, so differently-signed builds (Xcode vs Developer ID vs
+//  TestFlight) threw password dialogs at launch; the DP keychain authorizes silently from the
+//  code signature. See docs/macos/KEYCHAIN_SE_HARDENING.md, "Data Protection keychain relocation".
+//
+
+import Foundation
+import Security
+
+extension OSStatus: Error {}
+
+/// Once-per-process outcome of the keychain relocation.
+enum KeychainRelocationState: Equatable, Sendable {
+    case notStarted
+    case done
+    case failed(OSStatus)
+}
+
+extension WalletStorage {
+    /// A ZODL-owned item still sitting in the file keychain.
+    struct LegacyItem: Equatable, Comparable {
+        let service: String
+        let account: String
+
+        static func < (lhs: LegacyItem, rhs: LegacyItem) -> Bool {
+            (lhs.service, lhs.account) < (rhs.service, rhs.account)
+        }
+    }
+
+    /// Throwing relocation gate — the first statement of every throwing public accessor. After a
+    /// failed relocation this keeps throwing `KeychainError.unknown(status)`, which Root's
+    /// `walletInitializationState` maps to the OSStatusError screen: a denied relocation must
+    /// never read as "no wallet", or a real wallet would be routed to onboarding.
+    func ensureRelocated() throws {
+        let outcome = relocationGate.withLock { state in
+            if state == KeychainRelocationState.notStarted {
+                state = runRelocation()
+            }
+            return state
+        }
+        if case .failed(let status) = outcome {
+            throw KeychainError.unknown(status)
+        }
+    }
+
+    /// Best-effort gate for the non-throwing convenience accessors (reminder/flag getters): on a
+    /// failed relocation they degrade to their empty value. Safe, because every wallet-presence /
+    /// seed / metadata path is throwing and a failed relocation parks the launch on the error
+    /// screen before any of these matter.
+    func ensureRelocatedBestEffort() {
+        relocationGate.withLock { state in
+            if state == KeychainRelocationState.notStarted {
+                state = runRelocation()
+            }
+        }
+    }
+
+    /// Moves every ZODL item found in the file keychain into the DP keychain. Runs at most once
+    /// per process, while holding the gate lock — concurrent first accessors simply wait, exactly
+    /// as they used to wait on the login-keychain ACL prompts these same reads produced. Uses
+    /// `secItem` primitives directly (never the public accessors), so it cannot re-enter the gate.
+    private func runRelocation() -> KeychainRelocationState {
+        guard useDataProtectionKeychain else {
+            return KeychainRelocationState.done
+        }
+        let leftovers: [LegacyItem]
+        switch legacyFileKeychainItems() {
+        case .failure(let status):
+            return KeychainRelocationState.failed(status)
+        case .success(let items):
+            leftovers = items
+        }
+        for item in leftovers {
+            if let status = relocate(item) {
+                return KeychainRelocationState.failed(status)
+            }
+        }
+        return KeychainRelocationState.done
+    }
+
+    /// Attribute-only scan of the FILE keychain for items whose service belongs to this ZODL
+    /// flavor. Attribute reads are never ACL-gated, so this is promptless. Sorted for
+    /// deterministic processing order.
+    func legacyFileKeychainItems() -> Result<[LegacyItem], OSStatus> {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: kCFBooleanTrue as Any
+        ]
+        var result: AnyObject?
+        let status = secItem.copyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            return .success([])
+        }
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            return .failure(status)
+        }
+        let owned = items.compactMap { attributes -> LegacyItem? in
+            guard
+                let service = attributes[kSecAttrService as String] as? String,
+                isOwnedService(service)
+            else { return nil }
+            let account = attributes[kSecAttrAccount as String] as? String ?? ""
+            return LegacyItem(service: service, account: account)
+        }
+        return .success(owned.sorted())
+    }
+
+    /// Whether a file-keychain service string belongs to THIS flavor of ZODL. The flavor prefix
+    /// must match first (testnet items carry `testnet_`, mainnet items are bare), then the bare
+    /// name must be one of our known items — exact names or the per-account `_`-suffixed families.
+    /// Everything else (other apps, the other flavor) is foreign and must never be touched.
+    func isOwnedService(_ service: String) -> Bool {
+        guard service.hasPrefix(zcashStoredWalletPrefix) else { return false }
+        let bare = String(service.dropFirst(zcashStoredWalletPrefix.count))
+        let exactNames: Set<String> = [
+            Constants.zcashStoredWallet,
+            Constants.zcashStoredWalletSeed,
+            Constants.zcashStoredWalletMeta,
+            Constants.zcashStorageVersion,
+            Constants.zcashStoredAdressBookEncryptionKeys,
+            Constants.zcashStoredWalletBackupReminder,
+            Constants.zcashStoredWalletBackupAcknowledged,
+            Constants.zcashStoredShieldingAcknowledged,
+            Constants.zcashStoredTorSetupFlag,
+            Constants.zcashStoredZodlAnnouncementFlag,
+            Constants.zcashStoredVotingHotkey
+        ]
+        if exactNames.contains(bare) {
+            return true
+        }
+        let prefixFamilies = [
+            "\(Constants.zcashStoredUserMetadataEncryptionKeys)_",
+            "\(Constants.zcashStoredShieldingReminder)_",
+            "\(Constants.zcashStoredVotingHotkey)_"
+        ]
+        return prefixFamilies.contains { bare.hasPrefix($0) }
+    }
+
+    /// Moves one item: read file bytes → write into DP (file bytes win over a crashed run's
+    /// duplicate) → read back and verify → only then delete the file original. Returns nil on
+    /// success, the failing OSStatus otherwise. The file data read is the only step a
+    /// login-keychain ACL can gate — on cross-signature installs this is the one final prompt.
+    private func relocate(_ item: LegacyItem) -> OSStatus? {
+        var fileQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: item.service,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: kCFBooleanTrue as Any
+        ]
+        if !item.account.isEmpty {
+            fileQuery[kSecAttrAccount as String] = item.account
+        }
+        var fileResult: AnyObject?
+        let readStatus = secItem.copyMatching(fileQuery as CFDictionary, &fileResult)
+        if readStatus == errSecItemNotFound {
+            return nil
+        }
+        guard readStatus == errSecSuccess else {
+            return readStatus
+        }
+        guard let payload = fileResult as? Data else {
+            return errSecDecode
+        }
+
+        let addAttributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: item.service,
+            kSecAttrAccount as String: item.account,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecValueData as String: payload
+        ]
+        var addResult: AnyObject?
+        let addStatus = secItem.add(addAttributes as CFDictionary, &addResult)
+        if addStatus == errSecDuplicateItem {
+            var matchQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: item.service,
+                kSecUseDataProtectionKeychain as String: true
+            ]
+            if !item.account.isEmpty {
+                matchQuery[kSecAttrAccount as String] = item.account
+            }
+            let updateStatus = secItem.update(matchQuery as CFDictionary, [kSecValueData as String: payload] as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                return updateStatus
+            }
+        } else if addStatus != errSecSuccess {
+            return addStatus
+        }
+
+        var verifyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: item.service,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: kCFBooleanTrue as Any,
+            kSecUseDataProtectionKeychain as String: true
+        ]
+        if !item.account.isEmpty {
+            verifyQuery[kSecAttrAccount as String] = item.account
+        }
+        var verifyResult: AnyObject?
+        let verifyStatus = secItem.copyMatching(verifyQuery as CFDictionary, &verifyResult)
+        guard verifyStatus == errSecSuccess else {
+            return verifyStatus
+        }
+        guard let verified = verifyResult as? Data, verified == payload else {
+            return errSecDecode
+        }
+
+        var deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: item.service
+        ]
+        if !item.account.isEmpty {
+            deleteQuery[kSecAttrAccount as String] = item.account
+        }
+        let deleteStatus = secItem.delete(deleteQuery as CFDictionary)
+        guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+            return deleteStatus
+        }
+        return nil
+    }
+}

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage+KeychainRelocation.swift
@@ -8,6 +8,14 @@
 //  TestFlight) threw password dialogs at launch; the DP keychain authorizes silently from the
 //  code signature. See docs/macos/KEYCHAIN_SE_HARDENING.md, "Data Protection keychain relocation".
 //
+//  PLATFORM RULE (learned the hard way, verified via secd's log on a real Mac): on macOS,
+//  SecItem calls WITHOUT `kSecUseDataProtectionKeychain` are NOT scoped to the file keychain —
+//  SecItemCopyMatching sees, and SecItemDelete deletes, Data Protection items too. Every
+//  file-keychain operation here therefore goes through the `fileKeychain*` client primitives,
+//  which the live client scopes via `SecKeychainItemRef`. An unscoped call would re-discover the
+//  app's own DP items as "legacy leftovers" and the delete-the-original step would destroy the
+//  freshly relocated DP copy — the wallet would vanish on every relaunch.
+//
 
 import Foundation
 import Security
@@ -31,6 +39,14 @@ extension WalletStorage {
     struct LegacyItem: Equatable, Comparable {
         let service: String
         let account: String
+        /// The legacy engine's handle (`SecKeychainItemRef`) for THIS file-keychain item — the
+        /// only way to read or delete exactly the file copy and never a same-named DP item.
+        /// Excluded from equality/ordering: it is an opaque handle, not identity.
+        let ref: CFTypeRef
+
+        static func == (lhs: LegacyItem, rhs: LegacyItem) -> Bool {
+            (lhs.service, lhs.account) == (rhs.service, rhs.account)
+        }
 
         static func < (lhs: LegacyItem, rhs: LegacyItem) -> Bool {
             (lhs.service, lhs.account) < (rhs.service, rhs.account)
@@ -88,17 +104,13 @@ extension WalletStorage {
         return KeychainRelocationState.done
     }
 
-    /// Attribute-only scan of the FILE keychain for items whose service belongs to this ZODL
-    /// flavor. Attribute reads are never ACL-gated, so this is promptless. Sorted for
-    /// deterministic processing order.
+    /// Attribute-only scan for FILE-keychain items whose service belongs to this ZODL flavor.
+    /// Attribute reads are never ACL-gated, so this is promptless. The client primitive returns
+    /// only genuinely file-backed items (each with its `SecKeychainItemRef`), so items already in
+    /// the DP keychain can never be re-discovered here. Sorted for deterministic processing order.
     func legacyFileKeychainItems() -> LegacyScanOutcome {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: kCFBooleanTrue as Any
-        ]
-        var result: AnyObject?
-        let status = secItem.copyMatching(query as CFDictionary, &result)
+        var result: CFTypeRef?
+        let status = secItem.fileKeychainItems(&result)
         if status == errSecItemNotFound {
             return .found([])
         }
@@ -108,10 +120,11 @@ extension WalletStorage {
         let owned = items.compactMap { attributes -> LegacyItem? in
             guard
                 let service = attributes[kSecAttrService as String] as? String,
-                isOwnedService(service)
+                isOwnedService(service),
+                let ref = attributes[kSecValueRef as String]
             else { return nil }
             let account = attributes[kSecAttrAccount as String] as? String ?? ""
-            return LegacyItem(service: service, account: account)
+            return LegacyItem(service: service, account: account, ref: ref as CFTypeRef)
         }
         return .found(owned.sorted())
     }
@@ -147,22 +160,15 @@ extension WalletStorage {
         return prefixFamilies.contains { bare.hasPrefix($0) }
     }
 
-    /// Moves one item: read file bytes → write into DP (file bytes win over a crashed run's
+    /// Moves one item: read the file bytes → write into DP (file bytes win over a crashed run's
     /// duplicate) → read back and verify → only then delete the file original. Returns nil on
-    /// success, the failing OSStatus otherwise. The file data read is the only step a
-    /// login-keychain ACL can gate — on cross-signature installs this is the one final prompt.
+    /// success, the failing OSStatus otherwise. The file read and delete are pinned to the item's
+    /// `SecKeychainItemRef` — a service-name query without the DP flag would also hit the DP copy
+    /// this very function just wrote. The file data read is the only step a login-keychain ACL
+    /// can gate — on cross-signature installs this is the one final prompt.
     private func relocate(_ item: LegacyItem) -> OSStatus? {
-        var fileQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: item.service,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecReturnData as String: kCFBooleanTrue as Any
-        ]
-        if !item.account.isEmpty {
-            fileQuery[kSecAttrAccount as String] = item.account
-        }
-        var fileResult: AnyObject?
-        let readStatus = secItem.copyMatching(fileQuery as CFDictionary, &fileResult)
+        var fileResult: CFTypeRef?
+        let readStatus = secItem.fileKeychainReadData(item.ref, &fileResult)
         if readStatus == errSecItemNotFound {
             return nil
         }
@@ -219,14 +225,7 @@ extension WalletStorage {
             return errSecDecode
         }
 
-        var deleteQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: item.service
-        ]
-        if !item.account.isEmpty {
-            deleteQuery[kSecAttrAccount as String] = item.account
-        }
-        let deleteStatus = secItem.delete(deleteQuery as CFDictionary)
+        let deleteStatus = secItem.fileKeychainDeleteItem(item.ref)
         guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
             return deleteStatus
         }
@@ -235,20 +234,14 @@ extension WalletStorage {
 
     /// macOS: after a reset wipes the DP keychain, also delete any of OUR items still sitting in
     /// the legacy FILE keychain (un-relocated / half-relocated / failed relocation states).
-    /// Deletes never read item data, so this is promptless; foreign items are never touched.
-    /// Best-effort by design — reset is the escape hatch and must not throw over legacy leftovers.
+    /// Deletes go by `SecKeychainItemRef` (file-only, never read item data), so this is promptless
+    /// and can never touch the DP keychain; foreign items are never touched. Best-effort by
+    /// design — reset is the escape hatch and must not throw over legacy leftovers.
     func sweepLegacyFileKeychainItems() {
         guard useDataProtectionKeychain else { return }
         guard case .found(let leftovers) = legacyFileKeychainItems() else { return }
         for item in leftovers {
-            var query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: item.service
-            ]
-            if !item.account.isEmpty {
-                query[kSecAttrAccount as String] = item.account
-            }
-            _ = secItem.delete(query as CFDictionary)
+            _ = secItem.fileKeychainDeleteItem(item.ref)
         }
     }
 

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -459,6 +459,7 @@ struct WalletStorage {
         }
         try? deleteData(forKey: Constants.zcashStoredVotingHotkey)
         sweepLegacyFileKeychainItems()
+        resetRelocationGate()
     }
     
     func importAddressBookEncryptionKeys(_ keys: AddressBookEncryptionKeys) throws {

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -458,6 +458,7 @@ struct WalletStorage {
             try? deleteData(forKey: key)
         }
         try? deleteData(forKey: Constants.zcashStoredVotingHotkey)
+        sweepLegacyFileKeychainItems()
     }
     
     func importAddressBookEncryptionKeys(_ keys: AddressBookEncryptionKeys) throws {

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os
 @preconcurrency import MnemonicSwift
 @preconcurrency import ZcashLightClientKit
 
@@ -81,7 +82,7 @@ struct WalletStorage {
         case unsupportedLanguage(MnemonicLanguageType)
     }
 
-    private let secItem: SecItemClient
+    let secItem: SecItemClient
     /// Non-nil only on macOS: the seed is wrapped by a non-extractable Secure Enclave key instead of
     /// being stored as plaintext. Nil on iOS and in tests, where the legacy plaintext path is used.
     private let secureEnclave: SecureEnclaveClient?
@@ -92,6 +93,11 @@ struct WalletStorage {
     /// password dialogs at differently-signed builds (Xcode vs Developer ID vs TestFlight).
     /// Existing items are relocated once by WalletStorage+KeychainRelocation. Never set on iOS.
     var useDataProtectionKeychain = false
+
+    /// Once-per-process relocation gate (WalletStorage+KeychainRelocation.swift). Copies of an
+    /// `OSAllocatedUnfairLock` share one underlying allocation, so every dependency closure that
+    /// holds a copy of the live storage shares this single gate.
+    let relocationGate = OSAllocatedUnfairLock<KeychainRelocationState>(initialState: KeychainRelocationState.notStarted)
 
     /// Restore/create primes the just-supplied seed here (macOS / Secure-Enclave only) so the first-init
     /// burst — `prepare` plus the seed-derived metadata / address-book keys — reuses it instead of

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -86,6 +86,12 @@ struct WalletStorage {
     /// being stored as plaintext. Nil on iOS and in tests, where the legacy plaintext path is used.
     private let secureEnclave: SecureEnclaveClient?
     var zcashStoredWalletPrefix = ""
+    /// macOS live wiring sets this (WalletStorageLiveKey): every keychain query then targets the
+    /// iOS-style Data Protection keychain — access decided silently from the code signature —
+    /// instead of the legacy file-based login keychain, whose per-item signature ACLs throw
+    /// password dialogs at differently-signed builds (Xcode vs Developer ID vs TestFlight).
+    /// Existing items are relocated once by WalletStorage+KeychainRelocation. Never set on iOS.
+    var useDataProtectionKeychain = false
 
     /// Restore/create primes the just-supplied seed here (macOS / Secure-Enclave only) so the first-init
     /// burst — `prepare` plus the seed-derived metadata / address-book keys — reuses it instead of
@@ -730,7 +736,7 @@ struct WalletStorage {
     }
     
     func baseQuery(forAccount account: String = "", andKey forKey: String) -> [String: Any] {
-        let query: [String: AnyObject] = [
+        var query: [String: AnyObject] = [
             /// Uniquely identify this keychain accessor
             kSecAttrService as String: (zcashStoredWalletPrefix + forKey) as AnyObject,
             kSecAttrAccount as String: account as AnyObject,
@@ -741,6 +747,10 @@ struct WalletStorage {
             /// Thus, after restoring from a backup of a different device, these items will not be present.
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
+
+        if useDataProtectionKeychain {
+            query[kSecUseDataProtectionKeychain as String] = true as AnyObject
+        }
 
         return query
     }
@@ -771,6 +781,9 @@ struct WalletStorage {
         if !account.isEmpty {
             query[kSecAttrAccount as String] = account
         }
+        if useDataProtectionKeychain {
+            query[kSecUseDataProtectionKeychain as String] = true
+        }
         return query
     }
 
@@ -790,11 +803,14 @@ struct WalletStorage {
     /// per-account items whose suffixes aren't known statically.
     func keychainKeys(withPrefix keyPrefix: String) -> [String] {
         let fullPrefix = zcashStoredWalletPrefix + keyPrefix
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecReturnAttributes as String: kCFBooleanTrue as Any
         ]
+        if useDataProtectionKeychain {
+            query[kSecUseDataProtectionKeychain as String] = true
+        }
         var result: AnyObject?
         let status = secItem.copyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess, let items = result as? [[String: Any]] else {

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -157,6 +157,7 @@ struct WalletStorage {
         language: MnemonicLanguageType = .english,
         hasUserPassedPhraseBackupTest: Bool = false
     ) throws {
+        try ensureRelocated()
         // Future-proof of the bundle to potentially avoid migration. We enforce english mnemonic.
         guard language == .english else {
             throw WalletStorageError.unsupportedLanguage(language)
@@ -223,6 +224,7 @@ struct WalletStorage {
     /// (spend / export / first init). For birthday / backup-flag / existence use `exportWalletMetadata`
     /// / `areKeysPresent`, which never decrypt.
     func exportWallet(reason: String? = nil) async throws -> StoredWallet {
+        try ensureRelocated()
         // Restore/create primed the seed — reuse it once instead of an SE decrypt (and its prompt).
         if secureEnclave != nil, let primed = consumePrimedSeed() {
             return primed
@@ -293,6 +295,7 @@ struct WalletStorage {
     /// Reads the non-secret wallet metadata WITHOUT decrypting the seed (no biometric prompt). On macOS
     /// this is the separate plaintext item; on iOS it is projected from the single blob.
     func exportWalletMetadata() throws -> WalletMetadata {
+        try ensureRelocated()
         let reqData: Data?
 
         if secureEnclave != nil {
@@ -311,6 +314,7 @@ struct WalletStorage {
     }
 
     func areKeysPresent() throws -> Bool {
+        try ensureRelocated()
         let key = secureEnclave != nil ? Constants.zcashStoredWalletSeed : Constants.zcashStoredWallet
         let present = itemExists(forKey: key)
         return present
@@ -325,6 +329,7 @@ struct WalletStorage {
     }
 
     func updateBirthday(_ height: BlockHeight) throws {
+        try ensureRelocated()
         if secureEnclave != nil {
             var meta = try exportWalletMetadata()
             meta.birthday = Birthday(height)
@@ -343,6 +348,7 @@ struct WalletStorage {
     }
 
     func markUserPassedPhraseBackupTest(_ flag: Bool = true) throws {
+        try ensureRelocated()
         if secureEnclave != nil {
             var meta = try exportWalletMetadata()
             meta.hasUserPassedPhraseBackupTest = flag
@@ -368,6 +374,7 @@ struct WalletStorage {
     /// launch — no-op on iOS, and an auth-free version check short-circuits once migrated. So existing
     /// testers upgrade invisibly instead of landing on onboarding. See docs/macos/KEYCHAIN_SE_HARDENING.md.
     func migrateToSecureEnclaveIfNeeded() async throws {
+        try ensureRelocated()
         guard let secureEnclave, secureEnclave.isAvailable() else {
             return
         }
@@ -423,6 +430,8 @@ struct WalletStorage {
         }
     }
 
+    /// Deliberately NOT gated on `ensureRelocated()`: reset is the escape hatch out of a failed
+    /// relocation. It only deletes (deletes are never ACL-gated) and wipes BOTH keychains on macOS.
     func resetZashi() throws {
         clearPrimedSeed()
         try? deleteData(forKey: Constants.zcashStorageVersion)
@@ -452,6 +461,7 @@ struct WalletStorage {
     }
     
     func importAddressBookEncryptionKeys(_ keys: AddressBookEncryptionKeys) throws {
+        try ensureRelocated()
         do {
             guard let data = try encode(object: keys) else {
                 throw KeychainError.encoding
@@ -466,8 +476,9 @@ struct WalletStorage {
     }
     
     func exportAddressBookEncryptionKeys() throws -> AddressBookEncryptionKeys {
+        try ensureRelocated()
         let reqData: Data?
-        
+
         do {
             reqData = try data(forKey: Constants.zcashStoredAdressBookEncryptionKeys)
         } catch KeychainError.noDataFound {
@@ -488,6 +499,7 @@ struct WalletStorage {
     }
     
     func importUserMetadataEncryptionKeys(_ keys: UserMetadataEncryptionKeys, account: Account) throws {
+        try ensureRelocated()
         do {
             guard let data = try encode(object: keys) else {
                 throw KeychainError.encoding
@@ -502,8 +514,9 @@ struct WalletStorage {
     }
     
     func exportUserMetadataEncryptionKeys(account: Account) throws -> UserMetadataEncryptionKeys {
+        try ensureRelocated()
         let reqData: Data?
-        
+
         do {
             reqData = try data(forKey: Constants.accountMetadataFilename(account: account))
         } catch KeychainError.noDataFound {
@@ -524,12 +537,14 @@ struct WalletStorage {
     }
     
     func clearEncryptionKeys(_ account: Account) throws {
+        try ensureRelocated()
         try deleteData(forKey: Constants.accountMetadataFilename(account: account))
     }
     
     // MARK: - Remind Me
     
     func importWalletBackupReminder(_ reminder: ReminedMeTimestamp) throws {
+        try ensureRelocated()
         guard let data = try? encode(object: reminder) else {
             throw KeychainError.encoding
         }
@@ -544,8 +559,9 @@ struct WalletStorage {
     }
     
     func exportWalletBackupReminder() -> ReminedMeTimestamp? {
+        ensureRelocatedBestEffort()
         let reqData: Data?
-        
+
         do {
             reqData = try data(forKey: Constants.zcashStoredWalletBackupReminder)
         } catch {
@@ -560,6 +576,7 @@ struct WalletStorage {
     }
 
     func importShieldingReminder(_ reminder: ReminedMeTimestamp, accountName: String) throws {
+        try ensureRelocated()
         guard let data = try? encode(object: reminder) else {
             throw KeychainError.encoding
         }
@@ -574,8 +591,9 @@ struct WalletStorage {
     }
     
     func exportShieldingReminder(accountName: String) -> ReminedMeTimestamp? {
+        ensureRelocatedBestEffort()
         let reqData: Data?
-        
+
         do {
             reqData = try data(forKey: Constants.zcashStoredShieldingReminder(accountName: accountName))
         } catch {
@@ -590,6 +608,7 @@ struct WalletStorage {
     }
     
     func resetShieldingReminder(accountName: String) {
+        ensureRelocatedBestEffort()
         try? deleteData(forKey: Constants.zcashStoredShieldingReminder(accountName: accountName))
 
     }
@@ -597,6 +616,7 @@ struct WalletStorage {
     // MARK: - Acknowledged flags
     
     func importWalletBackupAcknowledged(_ acknowledged: Bool) throws {
+        try ensureRelocated()
         guard let data = try? encode(object: acknowledged) else {
             throw KeychainError.encoding
         }
@@ -611,8 +631,9 @@ struct WalletStorage {
     }
     
     func exportWalletBackupAcknowledged() -> Bool {
+        ensureRelocatedBestEffort()
         let reqData: Data?
-        
+
         do {
             reqData = try data(forKey: Constants.zcashStoredWalletBackupAcknowledged)
         } catch {
@@ -627,6 +648,7 @@ struct WalletStorage {
     }
     
     func importShieldingAcknowledged(_ acknowledged: Bool) throws {
+        try ensureRelocated()
         guard let data = try? encode(object: acknowledged) else {
             throw KeychainError.encoding
         }
@@ -641,8 +663,9 @@ struct WalletStorage {
     }
     
     func exportShieldingAcknowledged() -> Bool {
+        ensureRelocatedBestEffort()
         let reqData: Data?
-        
+
         do {
             reqData = try data(forKey: Constants.zcashStoredShieldingAcknowledged)
         } catch {
@@ -657,6 +680,7 @@ struct WalletStorage {
     }
 
     func importTorSetupFlag(_ enabled: Bool) throws {
+        try ensureRelocated()
         guard let data = try? encode(object: enabled) else {
             throw KeychainError.encoding
         }
@@ -671,8 +695,9 @@ struct WalletStorage {
     }
     
     func exportTorSetupFlag() -> Bool? {
+        ensureRelocatedBestEffort()
         let reqData: Data?
-        
+
         do {
             reqData = try data(forKey: Constants.zcashStoredTorSetupFlag)
         } catch {
@@ -689,6 +714,7 @@ struct WalletStorage {
     // MARK: - Voting Hotkey
 
     func importVotingHotkey(_ phrase: String, accountId: AccountUUID) throws {
+        try ensureRelocated()
         let hotkey = StoredVotingHotkey(seedPhrase: SeedPhrase(phrase), version: Constants.zcashKeychainVersion)
         let key = Constants.zcashStoredVotingHotkey(accountId: accountId)
         do {
@@ -702,6 +728,7 @@ struct WalletStorage {
     }
 
     func exportVotingHotkey(accountId: AccountUUID) throws -> StoredVotingHotkey {
+        try ensureRelocated()
         let key = Constants.zcashStoredVotingHotkey(accountId: accountId)
         let reqData: Data?
         do {

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageLiveKey.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageLiveKey.swift
@@ -111,6 +111,9 @@ extension WalletStorage {
     static var liveStorage: WalletStorage {
 #if os(macOS)
         var storage = WalletStorage(secItem: .live, secureEnclave: .liveValue)
+        // Data Protection keychain (MOB-1485): silent signature-based access instead of the login
+        // keychain's per-item ACL password dialogs. Existing items relocate once on first access.
+        storage.useDataProtectionKeychain = true
 #else
         var storage = WalletStorage(secItem: .live)
 #endif

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowStore.swift
@@ -24,7 +24,7 @@ struct RestoreWalletCoordFlow {
     }
     
     @ObservableState
-    struct State {
+    struct State: Equatable {
         @Presents var alert: AlertState<Action>?
         var birthday: BlockHeight? = nil
         var isHelpSheetPresented = false
@@ -53,7 +53,7 @@ struct RestoreWalletCoordFlow {
         init() { }
     }
 
-    enum Action: BindableAction {
+    enum Action: BindableAction, Equatable {
         case alert(PresentationAction<Action>)
         case binding(BindingAction<RestoreWalletCoordFlow.State>)
         case commitRestore
@@ -233,3 +233,6 @@ extension AlertState where Action == RestoreWalletCoordFlow.Action {
         }
     }
 }
+
+extension RestoreWalletCoordFlow.Path.State: Equatable {}
+extension RestoreWalletCoordFlow.Path.Action: Equatable {}

--- a/secant/Sources/Features/OSStatusError/OSStatusErrorStore.swift
+++ b/secant/Sources/Features/OSStatusError/OSStatusErrorStore.swift
@@ -44,6 +44,10 @@ struct OSStatusError {
         case sendSupportMail
         case sendSupportMailFinished
         case shareFinished
+        /// macOS: the failed-relocation recovery affordance (MOB-1485). Root intercepts
+        /// `.osStatusError(.startOverTapped)`, presents the `wipeRequest` confirmation, and runs
+        /// the standard reset flow.
+        case startOverTapped
     }
 
     init() {}
@@ -73,6 +77,10 @@ struct OSStatusError {
                 
             case .shareFinished:
                 state.isExportingData = false
+                return .none
+
+            case .startOverTapped:
+                // Root intercepts this (RootInitialization) — nothing to do locally.
                 return .none
             }
         }

--- a/secant/Sources/Features/OSStatusError/OSStatusErrorView.swift
+++ b/secant/Sources/Features/OSStatusError/OSStatusErrorView.swift
@@ -58,6 +58,17 @@ struct OSStatusErrorView: View {
                         store.send(.sendSupportMail)
                     }
                     .padding(.bottom, 24)
+
+                    #if os(macOS)
+                    // Failed-relocation recovery (MOB-1485): relaunching retries the keychain
+                    // migration automatically, but if the state is genuinely stuck this is the
+                    // reset escape hatch — Root confirms via the wipeRequest alert, then runs
+                    // the standard resetZashi flow (wipes both keychains + SDK data).
+                    ZashiButton(String(localizable: .settingsDeleteZashi), type: .destructive1) {
+                        store.send(.startOverTapped)
+                    }
+                    .padding(.bottom, 24)
+                    #endif
                 }
                 
                 if let supportData = store.supportData {

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -622,6 +622,12 @@ extension Root {
                 }
                 .cancellable(id: state.CancelId, cancelInFlight: true)
                 
+            case .osStatusError(.startOverTapped):
+                // macOS OSStatusError screen's "Reset Zodl" (MOB-1485): confirm before wiping —
+                // the alert's destructive button runs the standard resetZashi flow.
+                state.alert = AlertState.wipeRequest()
+                return .none
+
             case .initialization(.resetZashiRequest(let areMetadataPreserved)):
                 state.areMetadataPreserved = areMetadataPreserved
                 return .send(.initialization(.resetZashi))

--- a/zodlTests/BackupFlowTests/RecoveryPhraseDisplayTests.swift
+++ b/zodlTests/BackupFlowTests/RecoveryPhraseDisplayTests.swift
@@ -51,7 +51,7 @@ import ComposableArchitecture
             RecoveryPhraseDisplay()
         } withDependencies: {
             $0.localAuthentication = .mockAuthenticationSucceeded
-            $0.walletStorage.exportWallet = { StoredWallet.placeholder }
+            $0.walletStorage.exportWallet = { _ in StoredWallet.placeholder }
         }
 
         await store.send(.recoveryPhraseUnhideRequested)
@@ -73,7 +73,7 @@ import ComposableArchitecture
             RecoveryPhraseDisplay()
         } withDependencies: {
             $0.localAuthentication = .mockAuthenticationSucceeded
-            $0.walletStorage.exportWallet = { throw ZcashError.synchronizerNotPrepared }
+            $0.walletStorage.exportWallet = { _ in throw ZcashError.synchronizerNotPrepared }
         }
 
         await store.send(.recoveryPhraseUnhideRequested)

--- a/zodlTests/RootTests/RestoreSeedGuardTests.swift
+++ b/zodlTests/RootTests/RestoreSeedGuardTests.swift
@@ -33,7 +33,9 @@ import ComposableArchitecture
         store.dependencies.mainQueue = .immediate
         store.dependencies.zcashSDKEnvironment = .testnet
         store.dependencies.walletStorage = .noOp
-        store.dependencies.databaseFiles.areDbFilesPresentFor = { _ in dbPresent }
+        var databaseFiles = DatabaseFilesClient.noOp
+        databaseFiles.areDbFilesPresentFor = { _ in dbPresent }
+        store.dependencies.databaseFiles = databaseFiles
         store.dependencies.mnemonic = .liveValue
         store.dependencies.mnemonic.isValid = { _ in }
         store.dependencies.mnemonic.toSeed = { _ in [UInt8](repeating: 0, count: 32) }

--- a/zodlTests/UtilTests/InMemorySecItemStore.swift
+++ b/zodlTests/UtilTests/InMemorySecItemStore.swift
@@ -1,0 +1,205 @@
+//
+//  InMemorySecItemStore.swift
+//  zodlTests
+//
+//  Stateful in-memory keychain double for WalletStorage tests (the fake deferred in
+//  WalletStoragePureTests). Two independent stores model macOS routing: queries carrying
+//  kSecUseDataProtectionKeychain hit the "data protection" store, all others the "file"
+//  (login-keychain) store. Item identity is (service, account), like the real keychain.
+//  Injected read errors simulate a denied login-keychain ACL prompt: they fire only on
+//  DATA reads (kSecReturnData) — attribute scans stay promptless, like the real thing.
+//
+
+import Foundation
+import Security
+import os
+@testable import zodl_internal
+
+final class InMemorySecItemStore: Sendable {
+    struct ItemKey: Hashable, Sendable {
+        let service: String
+        let account: String
+    }
+
+    private struct Stores: Sendable {
+        var file: [ItemKey: Data] = [:]
+        var dataProtection: [ItemKey: Data] = [:]
+        var fileReadErrors: [ItemKey: OSStatus] = [:]
+        var dataProtectionReadErrors: [ItemKey: OSStatus] = [:]
+        var dataReads: [String: Int] = [:]
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: Stores())
+
+    var client: SecItemClient {
+        SecItemClient(
+            copyMatching: { [self] query, result in copyMatching(query, &result) },
+            add: { [self] attributes, result in add(attributes, &result) },
+            update: { [self] query, attributes in update(query, attributes) },
+            delete: { [self] query in delete(query) }
+        )
+    }
+
+    // MARK: - Seeding & inspection
+
+    func seedFile(service: String, account: String = "", data: Data) {
+        state.withLock { $0.file[ItemKey(service: service, account: account)] = data }
+    }
+
+    func seedDataProtection(service: String, account: String = "", data: Data) {
+        state.withLock { $0.dataProtection[ItemKey(service: service, account: account)] = data }
+    }
+
+    func injectFileReadError(service: String, account: String = "", status: OSStatus) {
+        state.withLock { $0.fileReadErrors[ItemKey(service: service, account: account)] = status }
+    }
+
+    func injectDataProtectionReadError(service: String, account: String = "", status: OSStatus) {
+        state.withLock { $0.dataProtectionReadErrors[ItemKey(service: service, account: account)] = status }
+    }
+
+    func clearInjectedErrors() {
+        state.withLock {
+            $0.fileReadErrors = [:]
+            $0.dataProtectionReadErrors = [:]
+        }
+    }
+
+    func fileItems() -> [ItemKey: Data] {
+        state.withLock { $0.file }
+    }
+
+    func dataProtectionItems() -> [ItemKey: Data] {
+        state.withLock { $0.dataProtection }
+    }
+
+    func dataReadCount(service: String, account: String = "", dataProtection: Bool) -> Int {
+        let key = Self.readCounterKey(service: service, account: account, dataProtection: dataProtection)
+        return state.withLock { $0.dataReads[key] ?? 0 }
+    }
+
+    private static func readCounterKey(service: String, account: String, dataProtection: Bool) -> String {
+        "\(dataProtection ? "dp" : "file"):\(service):\(account)"
+    }
+
+    // MARK: - SecItem semantics
+
+    private static func fields(_ raw: CFDictionary) -> [String: Any]? {
+        (raw as NSDictionary) as? [String: Any]
+    }
+
+    private func copyMatching(_ rawQuery: CFDictionary, _ result: inout CFTypeRef?) -> OSStatus {
+        guard let query = Self.fields(rawQuery) else { return errSecParam }
+        let isDP = query[kSecUseDataProtectionKeychain as String] as? Bool == true
+        let wantsData = query[kSecReturnData as String] as? Bool == true
+        let wantsAttributes = query[kSecReturnAttributes as String] as? Bool == true
+        let matchAll = (query[kSecMatchLimit as String] as? String) == (kSecMatchLimitAll as String)
+        let service = query[kSecAttrService as String] as? String
+        let account = query[kSecAttrAccount as String] as? String
+
+        // withLockUnchecked: the closure writes the caller's non-Sendable `inout CFTypeRef?`, which
+        // the checked `withLock` (a `@Sendable` closure) rejects under Swift 6 strict concurrency.
+        return state.withLockUnchecked { stores in
+            let table = isDP ? stores.dataProtection : stores.file
+            let matches = table
+                .filter { key, _ in
+                    (service == nil || key.service == service) && (account == nil || key.account == account)
+                }
+                .sorted { ($0.key.service, $0.key.account) < ($1.key.service, $1.key.account) }
+            guard let first = matches.first else { return errSecItemNotFound }
+
+            if wantsAttributes && matchAll {
+                let attributes = matches.map { key, _ -> [String: Any] in
+                    [
+                        kSecAttrService as String: key.service,
+                        kSecAttrAccount as String: key.account
+                    ]
+                }
+                result = attributes as CFTypeRef
+                return errSecSuccess
+            }
+
+            if wantsData {
+                let errors = isDP ? stores.dataProtectionReadErrors : stores.fileReadErrors
+                if let injected = errors[first.key] {
+                    return injected
+                }
+                let counter = Self.readCounterKey(service: first.key.service, account: first.key.account, dataProtection: isDP)
+                stores.dataReads[counter, default: 0] += 1
+                result = first.value as CFTypeRef
+            }
+            return errSecSuccess
+        }
+    }
+
+    private func add(_ rawAttributes: CFDictionary, _ result: inout CFTypeRef?) -> OSStatus {
+        guard
+            let attributes = Self.fields(rawAttributes),
+            let service = attributes[kSecAttrService as String] as? String,
+            let data = attributes[kSecValueData as String] as? Data
+        else { return errSecParam }
+        let isDP = attributes[kSecUseDataProtectionKeychain as String] as? Bool == true
+        let account = attributes[kSecAttrAccount as String] as? String ?? ""
+        let key = ItemKey(service: service, account: account)
+        return state.withLock { stores in
+            if isDP {
+                if stores.dataProtection[key] != nil { return errSecDuplicateItem }
+                stores.dataProtection[key] = data
+            } else {
+                if stores.file[key] != nil { return errSecDuplicateItem }
+                stores.file[key] = data
+            }
+            return errSecSuccess
+        }
+    }
+
+    private func update(_ rawQuery: CFDictionary, _ rawAttributes: CFDictionary) -> OSStatus {
+        guard
+            let query = Self.fields(rawQuery),
+            let attributes = Self.fields(rawAttributes),
+            let newData = attributes[kSecValueData as String] as? Data
+        else { return errSecParam }
+        let isDP = query[kSecUseDataProtectionKeychain as String] as? Bool == true
+        let service = query[kSecAttrService as String] as? String
+        let account = query[kSecAttrAccount as String] as? String
+        return state.withLock { stores in
+            var table = isDP ? stores.dataProtection : stores.file
+            let keys = table.keys.filter {
+                (service == nil || $0.service == service) && (account == nil || $0.account == account)
+            }
+            guard !keys.isEmpty else { return errSecItemNotFound }
+            for key in keys {
+                table[key] = newData
+            }
+            if isDP {
+                stores.dataProtection = table
+            } else {
+                stores.file = table
+            }
+            return errSecSuccess
+        }
+    }
+
+    private func delete(_ rawQuery: CFDictionary) -> OSStatus {
+        guard let query = Self.fields(rawQuery) else { return errSecParam }
+        let isDP = query[kSecUseDataProtectionKeychain as String] as? Bool == true
+        let service = query[kSecAttrService as String] as? String
+        let account = query[kSecAttrAccount as String] as? String
+        return state.withLock { stores in
+            var table = isDP ? stores.dataProtection : stores.file
+            let keys = table.keys.filter {
+                (service == nil || $0.service == service) && (account == nil || $0.account == account)
+            }
+            guard !keys.isEmpty else { return errSecItemNotFound }
+            for key in keys {
+                table[key] = nil
+            }
+            if isDP {
+                stores.dataProtection = table
+            } else {
+                stores.file = table
+            }
+            return errSecSuccess
+        }
+    }
+}

--- a/zodlTests/UtilTests/InMemorySecItemStore.swift
+++ b/zodlTests/UtilTests/InMemorySecItemStore.swift
@@ -3,11 +3,17 @@
 //  zodlTests
 //
 //  Stateful in-memory keychain double for WalletStorage tests (the fake deferred in
-//  WalletStoragePureTests). Two independent stores model macOS routing: queries carrying
-//  kSecUseDataProtectionKeychain hit the "data protection" store, all others the "file"
-//  (login-keychain) store. Item identity is (service, account), like the real keychain.
-//  Injected read errors simulate a denied login-keychain ACL prompt: they fire only on
-//  DATA reads (kSecReturnData) — attribute scans stay promptless, like the real thing.
+//  WalletStoragePureTests). Two independent stores model REAL macOS SecItem routing, verified
+//  against a live Mac (MOB-1485 regression):
+//    - queries carrying `kSecUseDataProtectionKeychain: true` hit ONLY the "data protection" store;
+//    - queries WITHOUT the flag are NOT file-only — SecItemCopyMatching consults, and
+//      SecItemDelete deletes from, BOTH implementations (file first, then data protection);
+//    - only the dedicated `fileKeychain*` client primitives are scoped to the file (login
+//      keychain) store, mirroring the live client's SecKeychainItemRef-based scoping.
+//  File items surface an opaque ref token under `kSecValueRef` (data-protection items never do),
+//  like the real unflagged scan. Item identity is (service, account), like the real keychain.
+//  Injected read errors simulate a denied login-keychain ACL prompt: they fire only on DATA
+//  reads (attribute scans stay promptless, like the real thing).
 //
 
 import Foundation
@@ -29,6 +35,10 @@ final class InMemorySecItemStore: Sendable {
         var dataReads: [String: Int] = [:]
     }
 
+    /// ASCII unit separator — cannot collide with the test suites' service/account strings.
+    private static let refSeparator: Character = "\u{1F}"
+    private static let refPrefix = "fileref\(refSeparator)"
+
     private let state = OSAllocatedUnfairLock(initialState: Stores())
 
     var client: SecItemClient {
@@ -36,7 +46,10 @@ final class InMemorySecItemStore: Sendable {
             copyMatching: { [self] query, result in copyMatching(query, &result) },
             add: { [self] attributes, result in add(attributes, &result) },
             update: { [self] query, attributes in update(query, attributes) },
-            delete: { [self] query in delete(query) }
+            delete: { [self] query in delete(query) },
+            fileKeychainItems: { [self] result in fileKeychainItems(&result) },
+            fileKeychainReadData: { [self] ref, result in fileKeychainReadData(ref, &result) },
+            fileKeychainDeleteItem: { [self] ref in fileKeychainDeleteItem(ref) }
         )
     }
 
@@ -82,10 +95,32 @@ final class InMemorySecItemStore: Sendable {
         "\(dataProtection ? "dp" : "file"):\(service):\(account)"
     }
 
+    // MARK: - File-item ref tokens (stand-ins for SecKeychainItemRef)
+
+    private static func fileRef(_ key: ItemKey) -> CFTypeRef {
+        "\(refPrefix)\(key.service)\(refSeparator)\(key.account)" as NSString
+    }
+
+    private static func parseFileRef(_ ref: CFTypeRef) -> ItemKey? {
+        guard let token = ref as? String, token.hasPrefix(refPrefix) else { return nil }
+        let body = token.dropFirst(refPrefix.count)
+        guard let separator = body.firstIndex(of: refSeparator) else { return nil }
+        return ItemKey(
+            service: String(body[..<separator]),
+            account: String(body[body.index(after: separator)...])
+        )
+    }
+
     // MARK: - SecItem semantics
 
     private static func fields(_ raw: CFDictionary) -> [String: Any]? {
         (raw as NSDictionary) as? [String: Any]
+    }
+
+    /// The stores a query operates on (`true` = data protection), in real macOS routing order:
+    /// the flag scopes to the data-protection store alone; NO flag means BOTH stores, file first.
+    private static func routedStores(isDataProtection: Bool) -> [Bool] {
+        isDataProtection ? [true] : [false, true]
     }
 
     private func copyMatching(_ rawQuery: CFDictionary, _ result: inout CFTypeRef?) -> OSStatus {
@@ -100,33 +135,42 @@ final class InMemorySecItemStore: Sendable {
         // withLockUnchecked: the closure writes the caller's non-Sendable `inout CFTypeRef?`, which
         // the checked `withLock` (a `@Sendable` closure) rejects under Swift 6 strict concurrency.
         return state.withLockUnchecked { stores in
-            let table = isDP ? stores.dataProtection : stores.file
-            let matches = table
-                .filter { key, _ in
-                    (service == nil || key.service == service) && (account == nil || key.account == account)
-                }
-                .sorted { ($0.key.service, $0.key.account) < ($1.key.service, $1.key.account) }
+            var matches: [(key: ItemKey, data: Data, isDP: Bool)] = []
+            for isDPStore in Self.routedStores(isDataProtection: isDP) {
+                let items = isDPStore ? stores.dataProtection : stores.file
+                matches += items
+                    .filter { key, _ in
+                        (service == nil || key.service == service) && (account == nil || key.account == account)
+                    }
+                    .sorted { ($0.key.service, $0.key.account) < ($1.key.service, $1.key.account) }
+                    .map { (key: $0.key, data: $0.value, isDP: isDPStore) }
+            }
             guard let first = matches.first else { return errSecItemNotFound }
 
             if wantsAttributes && matchAll {
-                let attributes = matches.map { key, _ -> [String: Any] in
-                    [
-                        kSecAttrService as String: key.service,
-                        kSecAttrAccount as String: key.account
+                let attributes = matches.map { match -> [String: Any] in
+                    var item: [String: Any] = [
+                        kSecAttrService as String: match.key.service,
+                        kSecAttrAccount as String: match.key.account
                     ]
+                    // Only file-keychain items are SecKeychainItemRef-backed.
+                    if !match.isDP {
+                        item[kSecValueRef as String] = Self.fileRef(match.key)
+                    }
+                    return item
                 }
                 result = attributes as CFTypeRef
                 return errSecSuccess
             }
 
             if wantsData {
-                let errors = isDP ? stores.dataProtectionReadErrors : stores.fileReadErrors
+                let errors = first.isDP ? stores.dataProtectionReadErrors : stores.fileReadErrors
                 if let injected = errors[first.key] {
                     return injected
                 }
-                let counter = Self.readCounterKey(service: first.key.service, account: first.key.account, dataProtection: isDP)
+                let counter = Self.readCounterKey(service: first.key.service, account: first.key.account, dataProtection: first.isDP)
                 stores.dataReads[counter, default: 0] += 1
-                result = first.value as CFTypeRef
+                result = first.data as CFTypeRef
             }
             return errSecSuccess
         }
@@ -142,6 +186,8 @@ final class InMemorySecItemStore: Sendable {
         let account = attributes[kSecAttrAccount as String] as? String ?? ""
         let key = ItemKey(service: service, account: account)
         return state.withLock { stores in
+            // Adds are the one verb that never spans stores: flagged → data protection,
+            // unflagged → the default file (login) keychain.
             if isDP {
                 if stores.dataProtection[key] != nil { return errSecDuplicateItem }
                 stores.dataProtection[key] = data
@@ -163,20 +209,23 @@ final class InMemorySecItemStore: Sendable {
         let service = query[kSecAttrService as String] as? String
         let account = query[kSecAttrAccount as String] as? String
         return state.withLock { stores in
-            var table = isDP ? stores.dataProtection : stores.file
-            let keys = table.keys.filter {
-                (service == nil || $0.service == service) && (account == nil || $0.account == account)
+            var updatedAny = false
+            for isDPStore in Self.routedStores(isDataProtection: isDP) {
+                var items = isDPStore ? stores.dataProtection : stores.file
+                let keys = items.keys.filter {
+                    (service == nil || $0.service == service) && (account == nil || $0.account == account)
+                }
+                for key in keys {
+                    items[key] = newData
+                    updatedAny = true
+                }
+                if isDPStore {
+                    stores.dataProtection = items
+                } else {
+                    stores.file = items
+                }
             }
-            guard !keys.isEmpty else { return errSecItemNotFound }
-            for key in keys {
-                table[key] = newData
-            }
-            if isDP {
-                stores.dataProtection = table
-            } else {
-                stores.file = table
-            }
-            return errSecSuccess
+            return updatedAny ? errSecSuccess : errSecItemNotFound
         }
     }
 
@@ -186,19 +235,65 @@ final class InMemorySecItemStore: Sendable {
         let service = query[kSecAttrService as String] as? String
         let account = query[kSecAttrAccount as String] as? String
         return state.withLock { stores in
-            var table = isDP ? stores.dataProtection : stores.file
-            let keys = table.keys.filter {
-                (service == nil || $0.service == service) && (account == nil || $0.account == account)
+            var deletedAny = false
+            for isDPStore in Self.routedStores(isDataProtection: isDP) {
+                var items = isDPStore ? stores.dataProtection : stores.file
+                let keys = items.keys.filter {
+                    (service == nil || $0.service == service) && (account == nil || $0.account == account)
+                }
+                for key in keys {
+                    items[key] = nil
+                    deletedAny = true
+                }
+                if isDPStore {
+                    stores.dataProtection = items
+                } else {
+                    stores.file = items
+                }
             }
-            guard !keys.isEmpty else { return errSecItemNotFound }
-            for key in keys {
-                table[key] = nil
+            return deletedAny ? errSecSuccess : errSecItemNotFound
+        }
+    }
+
+    // MARK: - File-keychain-only primitives (mirroring the live SecKeychainItemRef scoping)
+
+    private func fileKeychainItems(_ result: inout CFTypeRef?) -> OSStatus {
+        state.withLockUnchecked { stores in
+            guard !stores.file.isEmpty else { return errSecItemNotFound }
+            let attributes = stores.file
+                .sorted { ($0.key.service, $0.key.account) < ($1.key.service, $1.key.account) }
+                .map { key, _ -> [String: Any] in
+                    [
+                        kSecAttrService as String: key.service,
+                        kSecAttrAccount as String: key.account,
+                        kSecValueRef as String: Self.fileRef(key)
+                    ]
+                }
+            result = attributes as CFTypeRef
+            return errSecSuccess
+        }
+    }
+
+    private func fileKeychainReadData(_ ref: CFTypeRef, _ result: inout CFTypeRef?) -> OSStatus {
+        guard let key = Self.parseFileRef(ref) else { return errSecParam }
+        return state.withLockUnchecked { stores in
+            guard let data = stores.file[key] else { return errSecItemNotFound }
+            if let injected = stores.fileReadErrors[key] {
+                return injected
             }
-            if isDP {
-                stores.dataProtection = table
-            } else {
-                stores.file = table
-            }
+            let counter = Self.readCounterKey(service: key.service, account: key.account, dataProtection: false)
+            stores.dataReads[counter, default: 0] += 1
+            result = data as CFTypeRef
+            return errSecSuccess
+        }
+    }
+
+    private func fileKeychainDeleteItem(_ ref: CFTypeRef) -> OSStatus {
+        guard let key = Self.parseFileRef(ref) else { return errSecParam }
+        return state.withLock { stores in
+            stores.file[key] = nil
+            // SecKeychainItemDelete on an already-gone item "does nothing and returns
+            // errSecSuccess" (SecKeychainItem.h) — model the same.
             return errSecSuccess
         }
     }

--- a/zodlTests/UtilTests/InMemorySecItemStoreTests.swift
+++ b/zodlTests/UtilTests/InMemorySecItemStoreTests.swift
@@ -95,4 +95,71 @@ import Security
         ]
         #expect(fake.client.delete(query as CFDictionary) == errSecItemNotFound)
     }
+
+    /// Real macOS routing (the MOB-1485 regression): a delete WITHOUT the DP flag removes
+    /// matching items from BOTH keychain implementations.
+    @Test func unflaggedDeleteRemovesFromBothStores() {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "svc", data: Data([1]))
+        fake.seedDataProtection(service: "svc", data: Data([2]))
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "svc"
+        ]
+        #expect(fake.client.delete(query as CFDictionary) == errSecSuccess)
+        #expect(fake.fileItems().isEmpty)
+        #expect(fake.dataProtectionItems().isEmpty)
+    }
+
+    /// Unflagged attribute scans see BOTH stores; only file items carry a `kSecValueRef` handle
+    /// (the live discriminator for what is genuinely a legacy file item).
+    @Test func unflaggedScanSeesBothStoresButOnlyFileItemsCarryRefs() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "file-svc", data: Data([1]))
+        fake.seedDataProtection(service: "dp-svc", data: Data([2]))
+
+        let scan: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: kCFBooleanTrue as Any
+        ]
+        var result: CFTypeRef?
+        #expect(fake.client.copyMatching(scan as CFDictionary, &result) == errSecSuccess)
+        let items = try #require(result as? [[String: Any]])
+        #expect(items.count == 2)
+        for item in items {
+            let service = item[kSecAttrService as String] as? String
+            let hasRef = item[kSecValueRef as String] != nil
+            #expect(hasRef == (service == "file-svc"))
+        }
+    }
+
+    /// The dedicated file-keychain primitives are scoped to the file store alone.
+    @Test func fileKeychainPrimitivesTouchOnlyTheFileStore() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "svc", data: Data([1]))
+        fake.seedDataProtection(service: "svc", data: Data([2]))
+
+        var scanResult: CFTypeRef?
+        #expect(fake.client.fileKeychainItems(&scanResult) == errSecSuccess)
+        let items = try #require(scanResult as? [[String: Any]])
+        #expect(items.count == 1)
+        let ref = try #require(items[0][kSecValueRef as String].map { $0 as CFTypeRef })
+
+        var readResult: CFTypeRef?
+        #expect(fake.client.fileKeychainReadData(ref, &readResult) == errSecSuccess)
+        #expect(readResult as? Data == Data([1]))
+
+        #expect(fake.client.fileKeychainDeleteItem(ref) == errSecSuccess)
+        #expect(fake.fileItems().isEmpty)
+        #expect(fake.dataProtectionItems()[InMemorySecItemStore.ItemKey(service: "svc", account: "")] == Data([2]))
+
+        // Deleting an already-gone item succeeds, like SecKeychainItemDelete.
+        #expect(fake.client.fileKeychainDeleteItem(ref) == errSecSuccess)
+
+        // Empty file store scans as errSecItemNotFound, like the real thing.
+        var emptyResult: CFTypeRef?
+        #expect(fake.client.fileKeychainItems(&emptyResult) == errSecItemNotFound)
+    }
 }

--- a/zodlTests/UtilTests/InMemorySecItemStoreTests.swift
+++ b/zodlTests/UtilTests/InMemorySecItemStoreTests.swift
@@ -1,0 +1,98 @@
+//
+//  InMemorySecItemStoreTests.swift
+//  zodlTests
+//
+//  Smoke tests for the in-memory SecItem double itself: store routing by the DP key, duplicate
+//  detection, wildcard matching, and injected ACL-denial errors firing only on data reads.
+//
+
+import Testing
+import Foundation
+import Security
+@testable import zodl_internal
+
+@Suite struct InMemorySecItemStoreTests {
+    @Test func dataProtectionKeyRoutesToSeparateStore() {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "svc", data: Data([1]))
+
+        var fileQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "svc",
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: kCFBooleanTrue as Any
+        ]
+        var result: CFTypeRef?
+        #expect(fake.client.copyMatching(fileQuery as CFDictionary, &result) == errSecSuccess)
+        #expect(result as? Data == Data([1]))
+
+        fileQuery[kSecUseDataProtectionKeychain as String] = true
+        result = nil
+        #expect(fake.client.copyMatching(fileQuery as CFDictionary, &result) == errSecItemNotFound)
+    }
+
+    @Test func addDetectsDuplicatesPerStore() {
+        let fake = InMemorySecItemStore()
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "svc",
+            kSecAttrAccount as String: "",
+            kSecValueData as String: Data([7])
+        ]
+        var result: CFTypeRef?
+        #expect(fake.client.add(attributes as CFDictionary, &result) == errSecSuccess)
+        #expect(fake.client.add(attributes as CFDictionary, &result) == errSecDuplicateItem)
+
+        var dpAttributes = attributes
+        dpAttributes[kSecUseDataProtectionKeychain as String] = true
+        #expect(fake.client.add(dpAttributes as CFDictionary, &result) == errSecSuccess)
+    }
+
+    @Test func queriesWithoutAccountMatchAnyAccount() {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "svc", account: "acc-1", data: Data([3]))
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "svc",
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: kCFBooleanTrue as Any
+        ]
+        var result: CFTypeRef?
+        #expect(fake.client.copyMatching(query as CFDictionary, &result) == errSecSuccess)
+        #expect(result as? Data == Data([3]))
+    }
+
+    @Test func injectedReadErrorFiresOnDataReadsOnly() {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "svc", data: Data([9]))
+        fake.injectFileReadError(service: "svc", status: errSecAuthFailed)
+
+        let scan: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: kCFBooleanTrue as Any
+        ]
+        var result: CFTypeRef?
+        #expect(fake.client.copyMatching(scan as CFDictionary, &result) == errSecSuccess)
+
+        let read: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "svc",
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: kCFBooleanTrue as Any
+        ]
+        result = nil
+        #expect(fake.client.copyMatching(read as CFDictionary, &result) == errSecAuthFailed)
+        #expect(fake.dataReadCount(service: "svc", dataProtection: false) == 0)
+    }
+
+    @Test func deleteMissingItemReturnsNotFound() {
+        let fake = InMemorySecItemStore()
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "absent"
+        ]
+        #expect(fake.client.delete(query as CFDictionary) == errSecItemNotFound)
+    }
+}

--- a/zodlTests/UtilTests/KeychainRelocationTests.swift
+++ b/zodlTests/UtilTests/KeychainRelocationTests.swift
@@ -1,0 +1,168 @@
+//
+//  KeychainRelocationTests.swift
+//  zodlTests
+//
+//  MOB-1485: the once-per-process relocation of ZODL keychain items from the legacy file
+//  (login) keychain into the Data Protection keychain. Crash-safe (verify-then-delete, file
+//  bytes win on duplicates), self-healing (leftovers finish next run), sticky on failure
+//  (a denied ACL prompt must surface as an error — never as "no wallet").
+//
+
+import Testing
+import Foundation
+import Security
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct KeychainRelocationTests {
+    private func makeStorage(_ fake: InMemorySecItemStore, prefix: String = "") -> WalletStorage {
+        var storage = WalletStorage(secItem: fake.client)
+        storage.useDataProtectionKeychain = true
+        storage.zcashStoredWalletPrefix = prefix
+        return storage
+    }
+
+    @Test func movesAllOwnedItemsToDataProtectionStore() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.seedFile(service: "zcashStoredWalletMeta", data: Data([2]))
+        fake.seedFile(service: "zcashStorageVersion", data: Data([3]))
+        fake.seedFile(service: "zcashStoredVotingHotkey_0101", data: Data([4]))
+        fake.seedFile(service: "zcashStoredMetadataEncryptionKeys_zashi", data: Data([5]))
+        let storage = makeStorage(fake)
+
+        try storage.ensureRelocated()
+
+        #expect(fake.fileItems().isEmpty)
+        let moved = fake.dataProtectionItems()
+        #expect(moved[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")] == Data([1]))
+        #expect(moved[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletMeta", account: "")] == Data([2]))
+        #expect(moved[InMemorySecItemStore.ItemKey(service: "zcashStorageVersion", account: "")] == Data([3]))
+        #expect(moved[InMemorySecItemStore.ItemKey(service: "zcashStoredVotingHotkey_0101", account: "")] == Data([4]))
+        #expect(moved[InMemorySecItemStore.ItemKey(service: "zcashStoredMetadataEncryptionKeys_zashi", account: "")] == Data([5]))
+    }
+
+    @Test func preservesAccountAttribute() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", account: "acc-1", data: Data([1]))
+        let storage = makeStorage(fake)
+
+        try storage.ensureRelocated()
+
+        #expect(fake.dataProtectionItems()[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "acc-1")] == Data([1]))
+    }
+
+    @Test func leavesForeignItemsUntouchedAndUnread() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "com.other.app.token", data: Data([9]))
+        fake.seedFile(service: "zcashStoredWalletX", data: Data([8]))
+        let storage = makeStorage(fake)
+
+        try storage.ensureRelocated()
+
+        #expect(fake.fileItems().count == 2)
+        #expect(fake.dataProtectionItems().isEmpty)
+        #expect(fake.dataReadCount(service: "com.other.app.token", dataProtection: false) == 0)
+        #expect(fake.dataReadCount(service: "zcashStoredWalletX", dataProtection: false) == 0)
+    }
+
+    @Test func mainnetLeavesTestnetItemsAlone() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "testnet_zcashStoredWalletSeed", data: Data([1]))
+        let storage = makeStorage(fake, prefix: "")
+
+        try storage.ensureRelocated()
+
+        #expect(fake.fileItems().count == 1)
+        #expect(fake.dataProtectionItems().isEmpty)
+    }
+
+    @Test func testnetMovesOnlyItsOwnItems() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "testnet_zcashStoredWalletMeta", data: Data([1]))
+        fake.seedFile(service: "zcashStoredWalletMeta", data: Data([2]))
+        let storage = makeStorage(fake, prefix: "testnet_")
+
+        try storage.ensureRelocated()
+
+        #expect(fake.dataProtectionItems() == [InMemorySecItemStore.ItemKey(service: "testnet_zcashStoredWalletMeta", account: ""): Data([1])])
+        #expect(fake.fileItems() == [InMemorySecItemStore.ItemKey(service: "zcashStoredWalletMeta", account: ""): Data([2])])
+    }
+
+    @Test func freshInstallIsNoOp() throws {
+        let fake = InMemorySecItemStore()
+        let storage = makeStorage(fake)
+
+        try storage.ensureRelocated()
+
+        #expect(fake.fileItems().isEmpty)
+        #expect(fake.dataProtectionItems().isEmpty)
+    }
+
+    @Test func successIsMemoizedPerProcess() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletMeta", data: Data([2]))
+        let storage = makeStorage(fake)
+
+        try storage.ensureRelocated()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        try storage.ensureRelocated()
+
+        #expect(fake.fileItems().count == 1)
+    }
+
+    @Test func deniedReadFailsStickyAndLeavesEverything() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStorageVersion", data: Data([3]))
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.injectFileReadError(service: "zcashStorageVersion", status: errSecAuthFailed)
+        let storage = makeStorage(fake)
+
+        #expect(throws: WalletStorage.KeychainError.unknown(errSecAuthFailed)) {
+            try storage.ensureRelocated()
+        }
+        #expect(fake.fileItems().count == 2)
+        #expect(fake.dataProtectionItems().isEmpty)
+
+        fake.clearInjectedErrors()
+        #expect(throws: WalletStorage.KeychainError.unknown(errSecAuthFailed)) {
+            try storage.ensureRelocated()
+        }
+        #expect(fake.fileItems().count == 2)
+    }
+
+    @Test func bestEffortGateDoesNotThrowOnFailure() {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.injectFileReadError(service: "zcashStoredWalletSeed", status: errSecAuthFailed)
+        let storage = makeStorage(fake)
+
+        storage.ensureRelocatedBestEffort()
+
+        #expect(fake.fileItems().count == 1)
+    }
+
+    @Test func verifyFailureLeavesFileOriginal() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.injectDataProtectionReadError(service: "zcashStoredWalletSeed", status: errSecIO)
+        let storage = makeStorage(fake)
+
+        #expect(throws: WalletStorage.KeychainError.unknown(errSecIO)) {
+            try storage.ensureRelocated()
+        }
+        #expect(fake.fileItems()[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")] == Data([1]))
+    }
+
+    @Test func duplicateFromCrashedRunResolvedFileBytesWin() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedDataProtection(service: "zcashStoredWalletSeed", data: Data([9, 9]))
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        let storage = makeStorage(fake)
+
+        try storage.ensureRelocated()
+
+        #expect(fake.dataProtectionItems()[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")] == Data([1]))
+        #expect(fake.fileItems().isEmpty)
+    }
+}

--- a/zodlTests/UtilTests/KeychainRelocationTests.swift
+++ b/zodlTests/UtilTests/KeychainRelocationTests.swift
@@ -165,4 +165,42 @@ import Security
         #expect(fake.dataProtectionItems()[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")] == Data([1]))
         #expect(fake.fileItems().isEmpty)
     }
+
+    /// THE shipped regression (caught on a real Mac via secd's log): on macOS, SecItem calls
+    /// WITHOUT `kSecUseDataProtectionKeychain` operate on BOTH keychain implementations. The
+    /// original engine scanned and deleted unscoped, so every launch re-discovered the app's own
+    /// DP items as "legacy file leftovers" and the delete-the-original step destroyed the freshly
+    /// written DP copy — the wallet vanished on every relaunch.
+    @Test func relocatedWalletSurvivesRelaunches() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        let seedKey = InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")
+
+        let firstLaunch = makeStorage(fake)
+        try firstLaunch.ensureRelocated()
+        #expect(fake.dataProtectionItems()[seedKey] == Data([1]))
+        #expect(fake.fileItems().isEmpty)
+
+        // Relaunch = fresh process = fresh once-per-process gate over the same keychain state.
+        let secondLaunch = makeStorage(fake)
+        try secondLaunch.ensureRelocated()
+        #expect(fake.dataProtectionItems()[seedKey] == Data([1]))
+
+        let thirdLaunch = makeStorage(fake)
+        try thirdLaunch.ensureRelocated()
+        #expect(fake.dataProtectionItems()[seedKey] == Data([1]))
+    }
+
+    /// A wallet living purely in the DP keychain (fresh install, or any launch after relocation)
+    /// must be invisible to the legacy scan: no re-relocation, no reads, no deletes.
+    @Test func scanIgnoresDataProtectionItems() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedDataProtection(service: "zcashStoredWalletSeed", data: Data([7]))
+        let storage = makeStorage(fake)
+
+        try storage.ensureRelocated()
+
+        #expect(fake.dataProtectionItems()[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")] == Data([7]))
+        #expect(fake.dataReadCount(service: "zcashStoredWalletSeed", dataProtection: true) == 0)
+    }
 }

--- a/zodlTests/UtilTests/WalletStorageDataProtectionQueryTests.swift
+++ b/zodlTests/UtilTests/WalletStorageDataProtectionQueryTests.swift
@@ -1,0 +1,46 @@
+//
+//  WalletStorageDataProtectionQueryTests.swift
+//  zodlTests
+//
+//  MOB-1485: with `useDataProtectionKeychain` set (macOS live wiring), every WalletStorage keychain
+//  query must carry kSecUseDataProtectionKeychain so items live in the DP keychain (silent
+//  signature-based access) instead of the legacy login keychain (password-dialog ACLs). With the
+//  flag off (iOS default) the queries must stay byte-identical to today.
+//
+
+import Testing
+import Foundation
+import Security
+@testable import zodl_internal
+
+@Suite struct WalletStorageDataProtectionQueryTests {
+    @Test func buildersOmitDataProtectionKeyByDefault() {
+        let storage = WalletStorage(secItem: SecItemClient())
+        #expect(storage.baseQuery(andKey: "k")[kSecUseDataProtectionKeychain as String] == nil)
+        #expect(storage.mutationQuery(andKey: "k")[kSecUseDataProtectionKeychain as String] == nil)
+        #expect(storage.restoreQuery(andKey: "k")[kSecUseDataProtectionKeychain as String] == nil)
+    }
+
+    @Test func buildersCarryDataProtectionKeyWhenEnabled() {
+        var storage = WalletStorage(secItem: SecItemClient())
+        storage.useDataProtectionKeychain = true
+        #expect(storage.baseQuery(andKey: "k")[kSecUseDataProtectionKeychain as String] as? Bool == true)
+        #expect(storage.mutationQuery(andKey: "k")[kSecUseDataProtectionKeychain as String] as? Bool == true)
+        #expect(storage.restoreQuery(andKey: "k")[kSecUseDataProtectionKeychain as String] as? Bool == true)
+    }
+
+    @Test func keychainKeysScanCarriesDataProtectionKeyWhenEnabled() throws {
+        final class Box: @unchecked Sendable { var query: [String: Any]? }
+        let box = Box()
+        var storage = WalletStorage(
+            secItem: SecItemClient(copyMatching: { query, _ in
+                box.query = (query as NSDictionary) as? [String: Any]
+                return errSecItemNotFound
+            })
+        )
+        storage.useDataProtectionKeychain = true
+        _ = storage.keychainKeys(withPrefix: "x")
+        let query = try #require(box.query)
+        #expect(query[kSecUseDataProtectionKeychain as String] as? Bool == true)
+    }
+}

--- a/zodlTests/UtilTests/WalletStorageRelocationGatingTests.swift
+++ b/zodlTests/UtilTests/WalletStorageRelocationGatingTests.swift
@@ -1,0 +1,97 @@
+//
+//  WalletStorageRelocationGatingTests.swift
+//  zodlTests
+//
+//  MOB-1485: every public WalletStorage accessor passes the relocation gate first, so ANY first
+//  keychain touch (including SplashView's areKeysPresent, which runs before all Root logic)
+//  relocates legacy items — and a failed relocation surfaces as KeychainError.unknown instead of
+//  ever reading as "no wallet". Also proves composition with the Secure-Enclave migration: a v1
+//  plaintext wallet relocates as-is, then splits into SE ciphertext + metadata inside the DP
+//  keychain, exactly as on a real un-migrated install.
+//
+
+import Testing
+import Foundation
+import Security
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct WalletStorageRelocationGatingTests {
+    private func makeStorage(_ fake: InMemorySecItemStore, secureEnclave: SecureEnclaveClient? = nil) -> WalletStorage {
+        var storage = WalletStorage(secItem: fake.client, secureEnclave: secureEnclave)
+        storage.useDataProtectionKeychain = true
+        return storage
+    }
+
+    private var reversingSecureEnclave: SecureEnclaveClient {
+        SecureEnclaveClient(
+            isAvailable: { true },
+            encryptSeed: { plaintext in Data(plaintext.reversed()) },
+            decryptSeed: { ciphertext, _ in Data(ciphertext.reversed()) },
+            deleteKey: { }
+        )
+    }
+
+    @Test func areKeysPresentTriggersRelocation() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        let storage = makeStorage(fake)
+
+        let present = try storage.areKeysPresent()
+
+        #expect(present)
+        #expect(fake.fileItems().isEmpty)
+        #expect(fake.dataProtectionItems()[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")] == Data([1]))
+    }
+
+    @Test func throwingAccessorsThrowAfterDeniedRelocation() {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.injectFileReadError(service: "zcashStoredWalletSeed", status: errSecAuthFailed)
+        let storage = makeStorage(fake)
+
+        #expect(throws: WalletStorage.KeychainError.unknown(errSecAuthFailed)) {
+            _ = try storage.areKeysPresent()
+        }
+        #expect(throws: WalletStorage.KeychainError.unknown(errSecAuthFailed)) {
+            _ = try storage.exportWalletMetadata()
+        }
+        #expect(fake.fileItems().count == 1)
+    }
+
+    @Test func nonThrowingAccessorsDegradeAfterDeniedRelocation() {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.seedFile(service: "zcashStoredWalletBackupAcknowledged", data: Data([1]))
+        fake.injectFileReadError(service: "zcashStoredWalletSeed", status: errSecAuthFailed)
+        let storage = makeStorage(fake)
+
+        #expect(storage.exportWalletBackupAcknowledged() == false)
+        #expect(storage.exportTorSetupFlag() == nil)
+        #expect(fake.fileItems().count == 2)
+    }
+
+    @Test func v1PlaintextWalletRelocatesThenMigratesToSecureEnclave() async throws {
+        let fake = InMemorySecItemStore()
+
+        var legacyStorage = WalletStorage(secItem: fake.client)
+        legacyStorage.useDataProtectionKeychain = false
+        try legacyStorage.importWallet(bip39: "quick brown fox", birthday: 2_700_000)
+        #expect(fake.fileItems().count == 1)
+
+        let storage = makeStorage(fake, secureEnclave: reversingSecureEnclave)
+        let present = try storage.areKeysPresent()
+        #expect(present == false)
+
+        try await storage.migrateToSecureEnclaveIfNeeded()
+
+        let dpItems = fake.dataProtectionItems()
+        #expect(dpItems[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")] != nil)
+        #expect(dpItems[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletMeta", account: "")] != nil)
+        #expect(dpItems[InMemorySecItemStore.ItemKey(service: "zcashStoredWallet", account: "")] == nil)
+        #expect(fake.fileItems().isEmpty)
+
+        let wallet = try await storage.exportWallet()
+        #expect(wallet.seedPhrase.value() == "quick brown fox")
+    }
+}

--- a/zodlTests/UtilTests/WalletStorageRelocationGatingTests.swift
+++ b/zodlTests/UtilTests/WalletStorageRelocationGatingTests.swift
@@ -34,14 +34,14 @@ import Security
 
     @Test func areKeysPresentTriggersRelocation() throws {
         let fake = InMemorySecItemStore()
-        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.seedFile(service: "zcashStoredWallet", data: Data([1]))
         let storage = makeStorage(fake)
 
         let present = try storage.areKeysPresent()
 
         #expect(present)
         #expect(fake.fileItems().isEmpty)
-        #expect(fake.dataProtectionItems()[InMemorySecItemStore.ItemKey(service: "zcashStoredWalletSeed", account: "")] == Data([1]))
+        #expect(fake.dataProtectionItems()[InMemorySecItemStore.ItemKey(service: "zcashStoredWallet", account: "")] == Data([1]))
     }
 
     @Test func throwingAccessorsThrowAfterDeniedRelocation() {
@@ -63,7 +63,7 @@ import Security
         let fake = InMemorySecItemStore()
         fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
         fake.seedFile(service: "zcashStoredWalletBackupAcknowledged", data: Data([1]))
-        fake.injectFileReadError(service: "zcashStoredWalletSeed", status: errSecAuthFailed)
+        fake.injectFileReadError(service: "zcashStoredWalletBackupAcknowledged", status: errSecAuthFailed)
         let storage = makeStorage(fake)
 
         #expect(storage.exportWalletBackupAcknowledged() == false)

--- a/zodlTests/UtilTests/WalletStorageResetSweepTests.swift
+++ b/zodlTests/UtilTests/WalletStorageResetSweepTests.swift
@@ -58,4 +58,25 @@ import Security
 
         #expect(fake.fileItems().isEmpty)
     }
+
+    @Test func resetAfterFailedRelocationClearsStickyGate() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.injectFileReadError(service: "zcashStoredWalletSeed", status: errSecAuthFailed)
+        let storage = makeStorage(fake)
+
+        #expect(throws: WalletStorage.KeychainError.unknown(errSecAuthFailed)) {
+            _ = try storage.areKeysPresent()
+        }
+
+        try storage.resetZashi()
+
+        // The sweep emptied the file keychain, so the failed gate is stale — a successful reset
+        // re-derives it and the storage works again as a fresh, walletless install. Without this,
+        // the post-reset verification read in Root's resetZashiFinishProcessing would rethrow the
+        // stale failure and mis-report a successful wipe as "corrupted data".
+        #expect(try storage.areKeysPresent() == false)
+        try storage.importWalletBackupAcknowledged(true)
+        #expect(storage.exportWalletBackupAcknowledged() == true)
+    }
 }

--- a/zodlTests/UtilTests/WalletStorageResetSweepTests.swift
+++ b/zodlTests/UtilTests/WalletStorageResetSweepTests.swift
@@ -1,0 +1,61 @@
+//
+//  WalletStorageResetSweepTests.swift
+//  zodlTests
+//
+//  MOB-1485: resetZashi wipes BOTH keychains on macOS — the DP keychain (its normal deletes) and
+//  any ZODL leftovers in the legacy file keychain — and it must keep working even when relocation
+//  failed (it is the escape hatch, so it is deliberately not gated).
+//
+
+import Testing
+import Foundation
+import Security
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct WalletStorageResetSweepTests {
+    private func makeStorage(_ fake: InMemorySecItemStore) -> WalletStorage {
+        var storage = WalletStorage(
+            secItem: fake.client,
+            secureEnclave: SecureEnclaveClient(
+                isAvailable: { true },
+                encryptSeed: { plaintext in Data(plaintext.reversed()) },
+                decryptSeed: { ciphertext, _ in Data(ciphertext.reversed()) },
+                deleteKey: { }
+            )
+        )
+        storage.useDataProtectionKeychain = true
+        return storage
+    }
+
+    @Test func resetWipesBothKeychainsAndSparesForeignItems() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedDataProtection(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.seedDataProtection(service: "zcashStoredWalletMeta", data: Data([2]))
+        fake.seedDataProtection(service: "zcashStoredVotingHotkey_0101", data: Data([3]))
+        fake.seedFile(service: "zcashStoredWallet", data: Data([4]))
+        fake.seedFile(service: "zcashStoredTorSetupFlag", data: Data([5]))
+        fake.seedFile(service: "com.other.app.token", data: Data([6]))
+        let storage = makeStorage(fake)
+
+        try storage.resetZashi()
+
+        #expect(fake.dataProtectionItems().isEmpty)
+        #expect(fake.fileItems() == [InMemorySecItemStore.ItemKey(service: "com.other.app.token", account: ""): Data([6])])
+    }
+
+    @Test func resetWorksAfterFailedRelocation() throws {
+        let fake = InMemorySecItemStore()
+        fake.seedFile(service: "zcashStoredWalletSeed", data: Data([1]))
+        fake.injectFileReadError(service: "zcashStoredWalletSeed", status: errSecAuthFailed)
+        let storage = makeStorage(fake)
+
+        #expect(throws: WalletStorage.KeychainError.unknown(errSecAuthFailed)) {
+            _ = try storage.areKeysPresent()
+        }
+
+        try storage.resetZashi()
+
+        #expect(fake.fileItems().isEmpty)
+    }
+}


### PR DESCRIPTION
Implements [MOB-1485](https://linear.app/zodl/issue/MOB-1485/macos-move-wallet-keychain-items-to-the-data-protection-keychain): on macOS, all ZODL wallet keychain items move from the legacy file-based login keychain (whose code-signature-bound ACLs threw password dialogs at every differently-signed build — Xcode vs DMG vs TestFlight) into the **Data Protection keychain**, where access is decided silently from the code signature. First launch over an existing install performs a one-time, crash-safe relocation. End state: **zero password dialogs, one biometric** (ZODL's own app-lock / Secure-Enclave gate, unchanged).

## What changed

- **`WalletStorage` DP flag** — `useDataProtectionKeychain`, wired `true` only in macOS live storage; every keychain query (`baseQuery` / `mutationQuery` / `restoreQuery` / `keychainKeys`) carries `kSecUseDataProtectionKeychain` when set. iOS: flag off, queries byte-identical (pinned by tests).
- **One-time relocation** (`WalletStorage+KeychainRelocation.swift`) — lazy once-per-process gate ahead of *every* public accessor (so even Splash's pre-Root `areKeysPresent` relocates first, by construction). Promptless attribute-only discovery filtered to ZODL's own items (exact names + per-account prefix families, flavor-prefix aware); per item: read file bytes → write DP (file bytes win over crashed-run duplicates) → read-back verify → only then delete the original. Self-healing across crashes; no storage-version bump; composes with the v2 SE migration with zero special-casing (a v1 plaintext wallet relocates as-is, then splits inside the DP keychain).
- **⚠️ Found-and-fixed on a real Mac (`fbaed013`): every file-keychain operation is `SecKeychainItemRef`-scoped.** On macOS, SecItem calls *without* `kSecUseDataProtectionKeychain` are **not** file-scoped — `SecItemCopyMatching` sees, and `SecItemDelete` deletes, DP items too (proven from `secd`'s log). The first cut scanned and deleted unscoped, so every launch re-discovered the app's own DP items as "legacy leftovers" and destroyed the freshly relocated copies — the wallet vanished on every relaunch. Now the scan keeps only ref-backed (genuinely file) items, and the per-item read/delete go by that exact ref (`kSecMatchItemList` / `SecKeychainItemDelete`); the test fake models the real both-domains routing so any unscoped regression fails 18 tests.
- **Failure can never read as "no wallet"** — denial/failure is sticky per process; throwing accessors throw `KeychainError.unknown(status)`, which the existing `walletInitializationState` routes to the OSStatusError screen. Relaunch retries. Nobody gets sent to onboarding over a still-recoverable wallet.
- **`resetZashi` stays the escape hatch** — deliberately ungated (deletes only; deletes never prompt), sweeps ZODL leftovers out of the file keychain, and clears the sticky gate afterwards so a successful reset is never mis-reported by the post-reset verification read.
- **"Reset Zodl" recovery action on the macOS keychain-error screen** — the escape hatch is now reachable from exactly the failed-relocation state it exists for: a destructive button (existing `settingsDeleteZashi` string) behind the existing `wipeRequest` confirmation alert, running the standard reset flow. macOS only; iOS UI untouched.
- **Untouched by design:** the SE wrapping key (token-backed keys already live in the DP domain), entitlements/provisioning, bundle IDs; `kSecAttrAccessGroup` is never set (internal/testnet stay isolated).
- **Test infrastructure** — new stateful in-memory `SecItemClient` fake with independent file/DP stores (fulfils the TODO deferred in `WalletStoragePureTests`), plus 22 new Swift Testing tests across relocation, gating, reset-sweep, and query suites.
- **Task 0: `zodlTests` compiles and runs again** — the target had been compile-blocked (pre-existing): `RestoreWalletCoordFlow` lacked the `Equatable` conformances its guard tests' `TestStore` requires; `RecoveryPhraseDisplayTests` had stale zero-arg `exportWallet` closures; `RestoreSeedGuardTests` read the live-only `databaseFiles` client via get-modify-set. All fixed with test semantics preserved.
- Docs: `CHANGELOG.md` entry + "Data Protection keychain relocation" design record in `docs/macos/KEYCHAIN_SE_HARDENING.md`.

## Verification

- Full suite: **674 tests / 113 suites** — failures are exactly the **4 pre-existing baseline reds** (below), **zero new**; all 31 MOB-1485 tests green (incl. the `relocatedWalletSurvivesRelaunches` / `scanIgnoresDataProtectionItems` regression tests, written red-first against the reality-modeled fake).
- `zodlmac-internal` and `zodlmac-testnet` both **BUILD SUCCEEDED**; iOS builds via the test runs.
- Real-Mac forensics + probe: the wallet-destroying routing was diagnosed from `secd`'s unified log on a live install, and the fix's `SecKeychainItemRef` mechanics (ref discrimination, `kSecMatchItemList`-scoped read, `SecKeychainItemDelete`) were verified against the real login keychain with a standalone probe before landing.
- Final whole-branch review (independent, strongest model): **ready to merge**, no Critical/Important findings; per-task spec+quality reviews on every commit range, two review-loop fixes landed (a retroactive `OSStatus: Error` conformance replaced by a purpose-built `LegacyScanOutcome` enum; two plan-authored test-setup bugs). The `SecKeychainItemRef` scoping fix (`fbaed013`) landed after that review, driven by the real-Mac regression above.

## Pre-existing red tests (NOT this PR — first visible now that the suite runs at all)

- `WalletConfigTests.allFeatureFlagsDisabledByDefault` — `.useSlipstreamSynchronizer` is deliberately enabled-by-default on this demo branch.
- `ServerSetupStoreTests` ×3 (`manualSaveSwitchesPersistsAndFlagsManual`, `modeOnlyChangeSerializesThroughTransactionGuard`, `automaticSaveFlagsAutomatic`) — assertion-level drift in an unrelated subsystem.

## Ship notes

- Existing cross-signature installs (dev-built wallet, then DMG) see **one final round** of ACL prompts during relocation; after that, never again. Same-signature installs relocate silently.
- **Downgrade caveat:** once relocated, older (file-keychain era) builds can't see the wallet — going back means restoring from the mnemonic. Mac testers only.
- Suggested smoke test: launch a DMG build of this branch over an existing legacy (file-keychain) wallet → one final round of ACL prompts during relocation → wallet appears → quit, relaunch → **wallet persists**, zero password dialogs, one biometric. (Do **not** launch a pre-`fbaed013` build of this branch over a wallet you care about — it destroys the wallet's keychain items on relaunch.)
- The final review's follow-up candidate (no recovery affordance on the error screen) is implemented in this PR — see the "Reset Zodl" bullet above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
