### PR TITLE
[MOB-1507] Hide the Beta: Coinholder Polling option in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Changed
+- [MOB-1507] Temporarily hidden the Beta: Coinholder Polling option in Settings behind a feature flag. Nothing was removed — the feature can be re-enabled by flipping the flag.
+
 ### Added
 - [MOB-1458] The app now builds against the Ironwood-capable Zcash SDK (local development path) and can sync with the new Slipstream engine, selected by a feature flag that is on by default on this line. Funds in the Ironwood pool are counted in all shielded balances (spendable, pending, and total).
 - [MOB-1459] Groundwork for the Orchard → Ironwood migration: data models and the stubbed migration SDK interface. No user-visible changes yet.

--- a/secant/Sources/Features/Settings/SettingsCoordinator.swift
+++ b/secant/Sources/Features/Settings/SettingsCoordinator.swift
@@ -235,6 +235,9 @@ extension Settings {
                 return .none
 
             case .coinholderPollingTapped:
+                // MOB-1507: the row is hidden behind the flag; the guard keeps a stray or
+                // replayed action from opening the hidden flow.
+                guard state.featureFlags.coinholderPolling else { return .none }
                 guard let account = state.selectedWalletAccount else { return .none }
                 var votingState = VotingCoordFlow.State()
                 votingState.isKeystoneUser = state.isKeystoneAccount

--- a/secant/Sources/Features/Settings/SettingsView.swift
+++ b/secant/Sources/Features/Settings/SettingsView.swift
@@ -34,11 +34,13 @@ struct SettingsView: View {
                                 }
                             }
                             
-                            ActionRow(
-                                icon: Asset.Assets.Icons.checkVerified.image,
-                                title: String(localizable: .settingsCoinholderPolling)
-                            ) {
-                                store.send(.coinholderPollingTapped)
+                            if store.featureFlags.coinholderPolling {
+                                ActionRow(
+                                    icon: Asset.Assets.Icons.checkVerified.image,
+                                    title: String(localizable: .settingsCoinholderPolling)
+                                ) {
+                                    store.send(.coinholderPollingTapped)
+                                }
                             }
 
                             ActionRow(

--- a/secant/Sources/Models/FeatureFlags.swift
+++ b/secant/Sources/Models/FeatureFlags.swift
@@ -8,17 +8,20 @@
 struct FeatureFlags: Equatable {
     let addUAtoMemo: Bool
     let appLaunchBiometric: Bool
+    let coinholderPolling: Bool
     let flexa: Bool
     let selectText: Bool
 
     init(
         addUAtoMemo: Bool = false,
         appLaunchBiometric: Bool = true,
+        coinholderPolling: Bool = false,
         flexa: Bool = true,
         selectText: Bool = true
     ) {
         self.addUAtoMemo = addUAtoMemo
         self.appLaunchBiometric = appLaunchBiometric
+        self.coinholderPolling = coinholderPolling
         self.flexa = flexa
         self.selectText = selectText
     }

--- a/zodlTests/ModelsTests/FeatureFlagsTests.swift
+++ b/zodlTests/ModelsTests/FeatureFlagsTests.swift
@@ -13,6 +13,7 @@ import Testing
         let flags = FeatureFlags()
         #expect(!flags.addUAtoMemo)
         #expect(flags.appLaunchBiometric)
+        #expect(!flags.coinholderPolling)
         #expect(flags.flexa)
         #expect(flags.selectText)
     }

--- a/zodlTests/SettingsTests/SettingsCoinholderPollingTests.swift
+++ b/zodlTests/SettingsTests/SettingsCoinholderPollingTests.swift
@@ -1,0 +1,58 @@
+//
+//  SettingsCoinholderPollingTests.swift
+//  zodlTests
+//
+//  MOB-1507 — the Beta: Coinholder Polling entry is gated behind
+//  FeatureFlags.coinholderPolling (Features/Settings/SettingsCoordinator.swift).
+//  The row itself is flag-gated in SettingsView; these tests pin the reducer-side
+//  guard so the hidden flow cannot open from a stray or replayed action.
+//
+//  Settings.State is not Equatable, so TestStore cannot host it — a plain Store
+//  with withState probes is used instead; both actions return .none, so sends
+//  settle synchronously on the main actor.
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) @MainActor struct SettingsCoinholderPollingTests {
+    @Test func tapIsIgnoredWhileFlagIsOff() {
+        var state = Settings.State()
+        state.$featureFlags.withLock { $0 = FeatureFlags() }
+        state.$selectedWalletAccount.withLock { $0 = keystoneAccount() }
+        let store = Store(initialState: state) {
+            Settings()
+        }
+        store.send(.coinholderPollingTapped)
+        #expect(store.withState { $0.votingCoordFlow } == nil)
+    }
+
+    @Test func tapOpensVotingFlowWhileFlagIsOn() {
+        let account = keystoneAccount()
+        var state = Settings.State()
+        state.$featureFlags.withLock { $0 = FeatureFlags(coinholderPolling: true) }
+        state.$selectedWalletAccount.withLock { $0 = account }
+        let store = Store(initialState: state) {
+            Settings()
+        }
+        store.send(.coinholderPollingTapped)
+        let voting = store.withState { $0.votingCoordFlow }
+        #expect(voting != nil)
+        #expect(voting?.isKeystoneUser == true)
+        #expect(voting?.walletId == account.id.id.map { String(format: "%02x", $0) }.joined())
+    }
+
+    private func keystoneAccount() -> WalletAccount {
+        WalletAccount(Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: "Keystone",
+            keySource: String(localizable: .accountsKeystone).lowercased(),
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Hides the **Beta: Coinholder Polling** entry in Settings behind a feature flag, per [MOB-1507](https://linear.app/zodl/issue/MOB-1507/hide-the-beta-coinholder-polling-voting-option-in-settings). Disable-only: no Voting code is removed, and flipping the flag restores the feature.

- `FeatureFlags.coinholderPolling` (default **off**) — the established compile-time flag mechanism (`flexa`/`selectText` precedent).
- The Settings `ActionRow` renders only when the flag is on.
- Belt: the `.coinholderPollingTapped` coordinator case guards on the same flag, so a stray or replayed action cannot present the hidden flow.
- Untouched: `Features/Voting/**`, `VotingCoordFlow`, the fullScreenCover wiring, strings, dependencies.

## Tests

- `SettingsCoinholderPollingTests` (new): tap ignored while the flag is off; flow opens with correct `isKeystoneUser`/`walletId` while on. (`Settings.State` is not Equatable, so these use a plain `Store` with `withState` probes.)
- `FeatureFlagsTests.defaultValues` extended with the new flag.
- Full `zodlTests` suite green at the branch tip.

## Gate

- Full suite: `xcodebuild test`, scheme `zodl-internal`, iPhone 17 Pro simulator — **1596 tests / 149 suites passed** (1 known issue: the expected MOB-1364 row), TEST SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
