### PR TITLE
[MOB-1508] Open the migration support article from the Find out more link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Changed
 - [MOB-1507] Temporarily hidden the Beta: Coinholder Polling option in Settings behind a feature flag. Nothing was removed — the feature can be re-enabled by flipping the flag.
+- [MOB-1508] The "Find out more" link on the Move to Ironwood screen now opens the migration support article in the browser. Gated behind Ironwood network activation and not yet in a released build.
 
 ### Added
 - [MOB-1458] The app now builds against the Ironwood-capable Zcash SDK (local development path) and can sync with the new Slipstream engine, selected by a feature flag that is on by default on this line. Funds in the Ironwood pool are counted in all shielded balances (spendable, pending, and total).

--- a/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
+++ b/secant/Sources/Features/Migration/MigrationEntry/MigrationEntryStore.swift
@@ -9,6 +9,7 @@
 //
 
 import ComposableArchitecture
+import Foundation
 @preconcurrency import ZcashLightClientKit
 
 @Reducer
@@ -44,7 +45,8 @@ struct MigrationEntry {
         /// no-op here — the coordinator consumes this and exits the flow via `flowFinished`
         /// (mirrors `SendForm.dismissRequired`).
         case dismissRequired
-        /// Inert for now; the "Find out more" destination (O-7) is undecided.
+        /// Opens the Ironwood migration support article (O-7 destination, MOB-1508) in the
+        /// system browser.
         case findOutMoreTapped
         case modeTapped(MigrationMode)
         case nextTapped
@@ -55,7 +57,10 @@ struct MigrationEntry {
         }
     }
 
+    static let findOutMoreURLString = "https://support.zodl.com/article/42-moving-your-funds-to-ironwood"
+
     @Dependency(\.migrationManager) var migrationManager
+    @Dependency(\.openURL) var openURL
 
     init() { }
 
@@ -73,7 +78,8 @@ struct MigrationEntry {
                 return .none
 
             case .findOutMoreTapped:
-                return .none
+                guard let url = URL(string: MigrationEntry.findOutMoreURLString) else { return .none }
+                return .run { _ in await openURL(url) }
 
             case .modeTapped(let mode):
                 state.selectedMode = mode

--- a/zodlTests/MigrationTests/MigrationEntryTests.swift
+++ b/zodlTests/MigrationTests/MigrationEntryTests.swift
@@ -89,14 +89,6 @@ import ComposableArchitecture
         await store.receive(.delegate(.chose(.immediate)))
     }
 
-    @MainActor @Test func findOutMoreTappedProducesNoStateChangeOrEffects() async {
-        let store = TestStore(initialState: MigrationEntry.State()) {
-            MigrationEntry()
-        }
-
-        await store.send(.findOutMoreTapped)
-    }
-
     @MainActor @Test func delegateActionProducesNoStateChangeOrEffects() async {
         let store = TestStore(initialState: MigrationEntry.State()) {
             MigrationEntry()
@@ -140,5 +132,21 @@ import ComposableArchitecture
         await store.receive(\.balanceLoaded) {
             $0.orchardBalance = Zatoshi(1_245_800_000)
         }
+    }
+
+    @MainActor @Test func findOutMoreOpensSupportArticle() async {
+        let opened = LockIsolated<[URL]>([])
+        let store = TestStore(initialState: MigrationEntry.State()) {
+            MigrationEntry()
+        } withDependencies: {
+            $0.openURL = OpenURLEffect { url in
+                opened.withValue { $0.append(url) }
+                return true
+            }
+        }
+
+        await store.send(.findOutMoreTapped)
+        await store.finish()
+        #expect(opened.value == [URL(string: "https://support.zodl.com/article/42-moving-your-funds-to-ironwood")])
     }
 }


### PR DESCRIPTION
## Summary

Wires the intro screen's "Find out more" link to the migration support article, per [MOB-1508](https://linear.app/zodl/issue/MOB-1508/wire-the-migration-find-out-more-link-to-the-support-article).

- `.findOutMoreTapped` was deliberately inert while the O-7 destination was undecided; it now opens `https://support.zodl.com/article/42-moving-your-funds-to-ironwood` in the system browser via the `openURL` dependency (store-level, so it's testable).
- This is the only "Find out more" occurrence in the app (verified sweep — the intro screen; no other migration screen renders it).

## Tests

- New `findOutMoreOpensSupportArticle` (captures the opened URL through an `OpenURLEffect` override).
- The stale `findOutMoreTappedProducesNoStateChangeOrEffects` test pinned the old inert behavior and is superseded/removed.
- Full `zodlTests` suite green at the tip: **1594 tests / 148 suites** (1 known issue: the expected MOB-1364 row), TEST SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
