### PR TITLE
[MOB-1509] Per-account hardening for parallel software + Keystone migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Changed
 - [MOB-1507] Temporarily hidden the Beta: Coinholder Polling option in Settings behind a feature flag. Nothing was removed — the feature can be re-enabled by flipping the flag.
 - [MOB-1508] The "Find out more" link on the Move to Ironwood screen now opens the migration support article in the browser. Gated behind Ironwood network activation and not yet in a released build.
+- [MOB-1509] Running the ZODL software wallet and a Keystone wallet migration in parallel is now fully independent: each account keeps its own migration mode, delivery style, and locked-dust state, and switching wallets always shows the selected account's migration UI. Gated behind Ironwood network activation and not yet in a released build.
 
 ### Added
 - [MOB-1458] The app now builds against the Ironwood-capable Zcash SDK (local development path) and can sync with the new Slipstream engine, selected by a feature flag that is on by default on this line. Funds in the Ironwood pool are counted in all shielded balances (spendable, pending, and total).

--- a/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationBGScheduler/MigrationBGSchedulerLiveKey.swift
@@ -142,7 +142,9 @@ final class MigrationBGSchedulerImpl: @unchecked Sendable {
 
         let action = WakeupAction.decide(
             state: plan.representativeState,
-            isManualDelivery: migrationManager.isManualDelivery(),
+            // MOB-1509: the manual-delivery flag follows the WINNING account (whose transfer this
+            // wakeup serves); nil (no winner, e.g. a sync-only wakeup) resolves the selected one.
+            isManualDelivery: migrationManager.isManualDelivery(plan.winnerAccountUUID),
             window: window,
             nextTransferNumber: plan.nextTransferNumber,
             accountUUID: winnerAccountUUIDString

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
@@ -52,18 +52,22 @@ struct MigrationManagerClient: Sendable {
     // through to their LIVE impl, not these no-ops.
     var recordCommittedSchedule: @Sendable (_ accountUUID: AccountUUID?, _ schedule: MigrationSchedule) async -> Void = { _, _ in }
     var recordTransferBroadcast: @Sendable (_ accountUUID: AccountUUID?, _ result: MigrationTransferResult) async -> Void = { _, _ in }
-    // Dust resolution (MOB-1487/MOB-1496: relocated — app persistence, not SDK calls).
-    var lockMigrationDust: @Sendable () async throws -> Void
-    var isMigrationDustLocked: @Sendable () -> Bool = { false }
+    // Dust resolution (MOB-1487/MOB-1496: relocated — app persistence, not SDK calls). MOB-1509:
+    // per-account (`nil` resolves the selected account) — two parallel migrations must not share
+    // one lock verdict.
+    var lockMigrationDust: @Sendable (_ accountUUID: AccountUUID?) async throws -> Void
+    var isMigrationDustLocked: @Sendable (_ accountUUID: AccountUUID?) -> Bool = { _ in false }
     // Per-account migration-state stream (MOB-1496: relocated from SDKSynchronizerClient's
     // `migrationStateStream`) — emits on `reconcile()` and whenever a store reports a completed
     // migration op. `nil` accountUUID resolves the selected account internally.
     var stateEvents: @Sendable (_ accountUUID: AccountUUID?) -> AnyPublisher<MigrationState, Never> = { _ in Empty().eraseToAnyPublisher() }
-    // Persistence (UserDefaults-backed; keys in SharedStateKeys.swift)
-    var migrationMode: @Sendable () -> MigrationMode?
-    var setMigrationMode: @Sendable (MigrationMode) -> Void
-    var isManualDelivery: @Sendable () -> Bool = { false }
-    var setManualDelivery: @Sendable (Bool) -> Void
+    // Persistence (UserDefaults-backed; keys in SharedStateKeys.swift). MOB-1509: mode and manual
+    // delivery are per-account (`nil` resolves the selected account) — concurrently migrating
+    // accounts choose independently.
+    var migrationMode: @Sendable (_ accountUUID: AccountUUID?) -> MigrationMode?
+    var setMigrationMode: @Sendable (_ accountUUID: AccountUUID?, _ mode: MigrationMode) -> Void
+    var isManualDelivery: @Sendable (_ accountUUID: AccountUUID?) -> Bool = { _ in false }
+    var setManualDelivery: @Sendable (_ accountUUID: AccountUUID?, _ isManual: Bool) -> Void
     // MOB-1496 (W4): ensure-or-read the run's atomic network snapshot (Tor + sync provider/endpoint +
     // broadcast provider/endpoint — see `MigrationNetworkSnapshot`) for `accountUUID` (`nil` resolves
     // the selected account, same convention as `migrationSummary`/`migrationTransfers` above), mapped

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -117,13 +117,13 @@ extension MigrationManagerClient: DependencyKey {
             recordTransferBroadcast: { accountUUID, result in
                 await impl.recordTransferBroadcast(accountUUID: accountUUID, result: result)
             },
-            lockMigrationDust: { try await impl.lockMigrationDust() },
-            isMigrationDustLocked: { impl.isMigrationDustLocked() },
+            lockMigrationDust: { try await impl.lockMigrationDust(accountUUID: $0) },
+            isMigrationDustLocked: { impl.isMigrationDustLocked(accountUUID: $0) },
             stateEvents: { accountUUID in impl.stateEvents(accountUUID: accountUUID) },
-            migrationMode: { impl.gateStorage.migrationMode() },
-            setMigrationMode: { impl.gateStorage.setMigrationMode($0) },
-            isManualDelivery: { impl.gateStorage.isManualDelivery() },
-            setManualDelivery: { impl.gateStorage.setManualDelivery($0) },
+            migrationMode: { impl.migrationMode(accountUUID: $0) },
+            setMigrationMode: { impl.setMigrationMode(accountUUID: $0, mode: $1) },
+            isManualDelivery: { impl.isManualDelivery(accountUUID: $0) },
+            setManualDelivery: { impl.setManualDelivery(accountUUID: $0, isManual: $1) },
             migrationNetworkOptions: { accountUUID in await impl.migrationNetworkOptions(accountUUID: accountUUID) },
             formNetworkSnapshot: { accountUUID in await impl.formNetworkSnapshot(accountUUID: accountUUID) },
             networkSnapshot: { accountUUID in await impl.networkSnapshot(accountUUID: accountUUID) },
@@ -307,7 +307,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
             isIronwoodActivated: isIronwoodActivated(),
             state: state,
             hasOverdue: hasOverdue,
-            isManualDelivery: gateStorage.isManualDelivery(),
+            isManualDelivery: gateStorage.isManualDelivery(for: resolvedAccountUUID),
             isNextTransferDue: isNextTransferDue(progress: progress),
             orchardBalance: balance,
             isCompleteAcknowledged: gateStorage.isCompleteAcknowledged(for: resolvedAccountUUID),
@@ -376,7 +376,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
             state: state,
             hasInvalid: hasInvalid,
             hasOverdue: hasOverdue,
-            isManualDelivery: gateStorage.isManualDelivery(),
+            isManualDelivery: gateStorage.isManualDelivery(for: accountUUID),
             isNextTransferDue: isNextTransferDue(progress: progress),
             isCompleteAcknowledged: gateStorage.isCompleteAcknowledged(for: accountUUID),
             progress: progress
@@ -586,7 +586,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
     /// "Locking balance" in-flight state observable, matching the pre-relocation
     /// `SDKSynchronizerClient` stub. Simulator reach-around mirrors the engine's own (shorter)
     /// simulated latency, matching its pre-relocation wiring in `SDKSynchronizerClient+Simulated`.
-    func lockMigrationDust() async throws {
+    func lockMigrationDust(accountUUID: AccountUUID?) async throws {
         if MigrationSimulatorFlag.isEnabled && MigrationSimulatorClient.sharedEngine.isActive {
             try await Task.sleep(for: .seconds(0.5))
             MigrationSimulatorClient.sharedEngine.lockDust()
@@ -594,14 +594,42 @@ final class MigrationManagerImpl: @unchecked Sendable {
         }
 
         try await Task.sleep(nanoseconds: 800_000_000)
-        gateStorage.setDustLocked(true)
+        // MOB-1509: per-account — see `MigrationGateStorage.dustLockedStorage`. An unresolvable
+        // account (nothing passed, nothing selected) has no remainder to lock; storing nothing
+        // keeps the failure path identical to the pre-per-account behavior.
+        guard let resolvedAccountUUID = accountUUID ?? selectedWalletAccount?.id else { return }
+        gateStorage.setDustLocked(true, for: resolvedAccountUUID)
     }
 
-    func isMigrationDustLocked() -> Bool {
+    func isMigrationDustLocked(accountUUID: AccountUUID?) -> Bool {
         if MigrationSimulatorFlag.isEnabled && MigrationSimulatorClient.sharedEngine.isActive {
             return MigrationSimulatorClient.sharedEngine.isDustLocked()
         }
-        return gateStorage.isDustLocked()
+        guard let resolvedAccountUUID = accountUUID ?? selectedWalletAccount?.id else { return false }
+        return gateStorage.isDustLocked(for: resolvedAccountUUID)
+    }
+
+    /// MOB-1509: per-account persisted prefs (mode, manual delivery) — `nil` resolves the selected
+    /// account, same convention as `migrationSummary`/`stateEvents`. An unresolvable account reads
+    /// the defaults and writes nowhere.
+    func migrationMode(accountUUID: AccountUUID?) -> MigrationMode? {
+        guard let resolvedAccountUUID = accountUUID ?? selectedWalletAccount?.id else { return nil }
+        return gateStorage.migrationMode(for: resolvedAccountUUID)
+    }
+
+    func setMigrationMode(accountUUID: AccountUUID?, mode: MigrationMode) {
+        guard let resolvedAccountUUID = accountUUID ?? selectedWalletAccount?.id else { return }
+        gateStorage.setMigrationMode(mode, for: resolvedAccountUUID)
+    }
+
+    func isManualDelivery(accountUUID: AccountUUID?) -> Bool {
+        guard let resolvedAccountUUID = accountUUID ?? selectedWalletAccount?.id else { return false }
+        return gateStorage.isManualDelivery(for: resolvedAccountUUID)
+    }
+
+    func setManualDelivery(accountUUID: AccountUUID?, isManual: Bool) {
+        guard let resolvedAccountUUID = accountUUID ?? selectedWalletAccount?.id else { return }
+        gateStorage.setManualDelivery(isManual, for: resolvedAccountUUID)
     }
 
     /// MOB-1496: per-account replacement for the old wallet-wide `migrationStateStream`. `nil`
@@ -1314,6 +1342,9 @@ final class MigrationManagerImpl: @unchecked Sendable {
         for accountUUID in accountUUIDs {
             gateStorage.clearAcknowledgedComplete(for: accountUUID)
             gateStorage.clearRemainderPending(for: accountUUID)
+            gateStorage.clearDustLocked(for: accountUUID)
+            gateStorage.clearMigrationMode(for: accountUUID)
+            gateStorage.clearManualDelivery(for: accountUUID)
             scheduleStorage.clear(for: accountUUID)
             snapshotStorage.clear(for: accountUUID)
             failureRoutingStorage.clear(for: accountUUID)
@@ -1783,6 +1814,17 @@ final class MigrationGateStorage: @unchecked Sendable {
     /// is exactly the tri-state `remainderPending(for:)` below needs to preserve. Same generic
     /// storage / hex-key idiom as `acknowledgedStorage` beside it.
     private let remainderStorage: PerAccountCodableStorage<Bool>
+    /// MOB-1509: per-account now, like `acknowledgedStorage` beside it — the previous wallet-wide
+    /// flag let one account's "Lock balance" mark every other account's own dust remainder locked.
+    /// Same reuse-the-legacy-key-as-prefix idiom; the bare key is only ever deleted for hygiene
+    /// (`resetPersistedFlags()`), never read. No migration of the old value: the feature is
+    /// unreleased (dev/QA installs only).
+    private let dustLockedStorage: PerAccountCodableStorage<Bool>
+    /// MOB-1509: per-account — two concurrently migrating accounts (software + Keystone) choose
+    /// their migration mode and delivery style independently; the old wallet-wide keys let the
+    /// second account's choice clobber the first's. Same legacy-key-as-prefix idiom as above.
+    private let modeStorage: PerAccountCodableStorage<MigrationMode>
+    private let manualDeliveryStorage: PerAccountCodableStorage<Bool>
 
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
@@ -1794,6 +1836,21 @@ final class MigrationGateStorage: @unchecked Sendable {
         self.remainderStorage = PerAccountCodableStorage<Bool>(
             keyPrefix: .migrationRemainderPending,
             corruptLogTag: "MigrationGateStorage.remainderStorage",
+            userDefaults: userDefaults
+        )
+        self.dustLockedStorage = PerAccountCodableStorage<Bool>(
+            keyPrefix: .migrationDustLocked,
+            corruptLogTag: "MigrationGateStorage.dustLockedStorage",
+            userDefaults: userDefaults
+        )
+        self.modeStorage = PerAccountCodableStorage<MigrationMode>(
+            keyPrefix: .migrationMode,
+            corruptLogTag: "MigrationGateStorage.modeStorage",
+            userDefaults: userDefaults
+        )
+        self.manualDeliveryStorage = PerAccountCodableStorage<Bool>(
+            keyPrefix: .migrationManualDelivery,
+            corruptLogTag: "MigrationGateStorage.manualDeliveryStorage",
             userDefaults: userDefaults
         )
     }
@@ -1834,21 +1891,28 @@ final class MigrationGateStorage: @unchecked Sendable {
 
     // MARK: Mode / manual delivery / network privacy / acknowledge / dust-lock
 
-    func migrationMode() -> MigrationMode? {
-        guard let rawValue = userDefaults.string(forKey: .migrationMode) else { return nil }
-        return MigrationMode(rawValue: rawValue)
+    func migrationMode(for accountUUID: AccountUUID) -> MigrationMode? {
+        modeStorage.read(for: accountUUID)
     }
 
-    func setMigrationMode(_ mode: MigrationMode) {
-        userDefaults.set(mode.rawValue, forKey: .migrationMode)
+    func setMigrationMode(_ mode: MigrationMode, for accountUUID: AccountUUID) {
+        modeStorage.write(mode, for: accountUUID)
     }
 
-    func isManualDelivery() -> Bool {
-        userDefaults.bool(forKey: .migrationManualDelivery)
+    func clearMigrationMode(for accountUUID: AccountUUID) {
+        modeStorage.clear(for: accountUUID)
     }
 
-    func setManualDelivery(_ isManual: Bool) {
-        userDefaults.set(isManual, forKey: .migrationManualDelivery)
+    func isManualDelivery(for accountUUID: AccountUUID) -> Bool {
+        manualDeliveryStorage.read(for: accountUUID) ?? false
+    }
+
+    func setManualDelivery(_ isManual: Bool, for accountUUID: AccountUUID) {
+        manualDeliveryStorage.write(isManual, for: accountUUID)
+    }
+
+    func clearManualDelivery(for accountUUID: AccountUUID) {
+        manualDeliveryStorage.clear(for: accountUUID)
     }
 
     /// Only `useTor` is persisted — see `PersistedNetworkPrivacyOptions`'s doc.
@@ -1918,12 +1982,16 @@ final class MigrationGateStorage: @unchecked Sendable {
     /// marked unspendable and the complete screen re-enters on its locked confirmation instead of
     /// re-offering resolution. Relocated here from the (inert, pre-real-SDK) `SDKSynchronizerClient`
     /// stub — this was always app-only bookkeeping, never an SDK call.
-    func isDustLocked() -> Bool {
-        userDefaults.bool(forKey: .migrationDustLocked)
+    func isDustLocked(for accountUUID: AccountUUID) -> Bool {
+        dustLockedStorage.read(for: accountUUID) ?? false
     }
 
-    func setDustLocked(_ isLocked: Bool) {
-        userDefaults.set(isLocked, forKey: .migrationDustLocked)
+    func setDustLocked(_ isLocked: Bool, for accountUUID: AccountUUID) {
+        dustLockedStorage.write(isLocked, for: accountUUID)
+    }
+
+    func clearDustLocked(for accountUUID: AccountUUID) {
+        dustLockedStorage.clear(for: accountUUID)
     }
 
     /// Clears every WALLET-WIDE persisted migration flag this storage owns: mode, manual delivery,

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -303,7 +303,7 @@ extension MigrationCoordFlow {
 
             case .entry(.delegate(.chose(let mode))):
                 state.mode = mode
-                migrationManager.setMigrationMode(mode)
+                migrationManager.setMigrationMode(state.selectedWalletAccount?.id, mode)
 
                 switch mode {
                 case .immediate:
@@ -510,7 +510,7 @@ extension MigrationCoordFlow {
 
             case .path(.element(id: _, action: .backgroundDelivery(.delegate(.continued(let backgroundAllowed))))):
                 if !backgroundAllowed {
-                    migrationManager.setManualDelivery(true)
+                    migrationManager.setManualDelivery(state.selectedWalletAccount?.id, true)
                 }
                 return .run { send in
                     await send(.pushNextPermissionStep(await nextPermissionStepResult()))
@@ -560,11 +560,13 @@ extension MigrationCoordFlow {
 
             case .path(.element(id: _, action: .transferPlan(.delegate(.keystoneSignRequested(let pczts))))):
                 state.pendingKeystoneSigning = .planCommit
+                state.pendingKeystoneSigningAccountUUID = state.selectedWalletAccount?.id
                 state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: pczts)))
                 return .none
 
             case .path(.element(id: _, action: .reviewTransfer(.delegate(.keystoneSignRequested(let pczts))))):
                 state.pendingKeystoneSigning = .immediateReview
+                state.pendingKeystoneSigningAccountUUID = state.selectedWalletAccount?.id
                 state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: pczts)))
                 return .none
 
@@ -674,6 +676,7 @@ extension MigrationCoordFlow {
 
             case .keystoneSignRejected:
                 state.pendingKeystoneSigning = nil
+                state.pendingKeystoneSigningAccountUUID = nil
                 let _ = state.path.popLast()
                 return .none
 
@@ -694,6 +697,7 @@ extension MigrationCoordFlow {
                 // sent this action.
                 let hadPendingCeremony = state.pendingKeystoneSigning != nil
                 state.pendingKeystoneSigning = nil
+                state.pendingKeystoneSigningAccountUUID = nil
                 // MOB-1496 (C-1 fix): as well as the real round-trip's re-pair-failure guard above
                 // (`.scan` always on top there — pop 2, unchanged), this now also fires from the
                 // split-store-failure branch of EITHER Keystone store effect above, including the
@@ -898,6 +902,7 @@ extension MigrationCoordFlow {
                 // the existing Keystone signing context/machinery (scan -> re-pair -> store) handles
                 // it uniformly alongside the schedule/review lanes.
                 state.pendingKeystoneSigning = .dust(schedule)
+                state.pendingKeystoneSigningAccountUUID = state.selectedWalletAccount?.id
                 state.path.append(.keystoneSign(MigrationKeystoneSign.State(pczts: pczts)))
                 return .none
 
@@ -984,6 +989,7 @@ extension MigrationCoordFlow {
         state: inout MigrationCoordFlow.State
     ) -> Effect<MigrationCoordFlow.Action> {
         state.pendingKeystoneSigning = nil
+        state.pendingKeystoneSigningAccountUUID = nil
         let topElementIsScan = state.path.last?.is(\.scan) == true
         state.path.removeLast(topElementIsScan ? 2 : 1)
 
@@ -1379,7 +1385,7 @@ extension MigrationCoordFlow {
         if await userNotifications.authorizationStatus() == .notDetermined {
             // MOB-1478 (W8): mirrors `freshPlanVariant()`'s ternary — today `.manual` was
             // unreachable since this always defaulted to `.scheduled`.
-            let variant: MigrationNotifications.State.Variant = migrationManager.isManualDelivery() ? .manual : .scheduled
+            let variant: MigrationNotifications.State.Variant = migrationManager.isManualDelivery(nil) ? .manual : .scheduled
             return MigrationCoordFlow.PermissionStepResult(pathState: .notifications(MigrationNotifications.State(variant: variant)))
         }
 
@@ -1391,7 +1397,7 @@ extension MigrationCoordFlow {
     /// Fresh-entry plan variant: manual delivery (background delivery declined) shows the manual
     /// copy and its confirm sends the first transfer now (§6.3); otherwise the scheduled variant.
     private func freshPlanVariant() -> MigrationTransferPlan.State.Variant {
-        migrationManager.isManualDelivery() ? .manual : .scheduled
+        migrationManager.isManualDelivery(nil) ? .manual : .scheduled
     }
 
     // MARK: - MOB-1497 (T2): identity-custom classification
@@ -1550,7 +1556,7 @@ extension MigrationCoordFlow {
             isFlowRoot: isFlowRoot,
             // MOB-1487: a previously locked remainder re-enters on the locked confirmation
             // instead of re-offering resolution (offered/none derive from `dust` otherwise).
-            dustResolution: migrationManager.isMigrationDustLocked()
+            dustResolution: migrationManager.isMigrationDustLocked(accountUUID)
                 ? MigrationComplete.State.DustResolution.locked
                 : nil
         )

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
@@ -187,6 +187,11 @@ struct MigrationCoordFlow {
         /// cleared once the QR round-trip resolves (either resumed via `foundPCZTBatch` or backed
         /// out via `.rejected`).
         var pendingKeystoneSigning: KeystoneSigningContext?
+        /// MOB-1509: the account that OWNS the pending ceremony — recorded beside
+        /// `pendingKeystoneSigning` at its three setters and cleared with it, so an external
+        /// teardown that runs AFTER an account switch (the cross-account notification tap) still
+        /// cancels the stranded run on the account that built it, not the newly selected one.
+        var pendingKeystoneSigningAccountUUID: AccountUUID?
         /// MOB-1478 (W2): the Tor bottom sheet's own state — always present (not optional), toggled
         /// on screen via `isTorSheetPresented`, mirroring the `ServerSetup`/`serverSetupViewBinding`
         /// precedent in `Root` rather than an `@Presents`/`ifLet` destination (there's exactly one

--- a/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
+++ b/secant/Sources/Features/Migration/MigrationComplete/MigrationCompleteStore.swift
@@ -129,7 +129,9 @@ struct MigrationComplete {
                 state.dustResolution = .locking
                 return .run { send in
                     do {
-                        try await migrationManager.lockMigrationDust()
+                        // MOB-1509: nil resolves the selected account — the Complete screen only
+                        // ever shows for the selected account's own migration.
+                        try await migrationManager.lockMigrationDust(nil)
                         await send(.lockDustSucceeded)
                     } catch {
                         await send(.lockDustFailed(error.toZcashError()))

--- a/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
+++ b/secant/Sources/Features/Migration/MigrationNoteSplit/MigrationNoteSplitStore.swift
@@ -253,7 +253,7 @@ struct MigrationNoteSplit {
             case .proceedWithoutTorTapped:
                 // R7-review fix (Minor-3): see `MigrationSending`'s identical guard for the rationale.
                 guard state.failureKind == MigrationBroadcastFailureRoute.torFirstRunChoice else { return .none }
-                let usesFullBalanceCopy = migrationManager.migrationMode() == MigrationMode.immediate
+                let usesFullBalanceCopy = migrationManager.migrationMode(state.selectedWalletAccount?.id) == MigrationMode.immediate
                 state.alert = AlertState.migrationTorOffWarning(usesFullBalanceCopy: usesFullBalanceCopy, proceedAction: .offWarningProceedTapped)
                 return .none
 

--- a/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
+++ b/secant/Sources/Features/Migration/MigrationSending/MigrationSendingStore.swift
@@ -257,7 +257,7 @@ struct MigrationSending {
                 // `.torFirstRunChoice`; this closes the same gap at the reducer, where it actually
                 // matters (a raw `.send`/programmatic dispatch bypasses the view entirely).
                 guard state.failureKind == MigrationBroadcastFailureRoute.torFirstRunChoice else { return .none }
-                let usesFullBalanceCopy = migrationManager.migrationMode() == MigrationMode.immediate
+                let usesFullBalanceCopy = migrationManager.migrationMode(state.selectedWalletAccount?.id) == MigrationMode.immediate
                 state.alert = AlertState.migrationTorOffWarning(usesFullBalanceCopy: usesFullBalanceCopy, proceedAction: .offWarningProceedTapped)
                 return .none
 

--- a/secant/Sources/Features/MigrationSimulatorPanel/MigrationSimulatorPanelStore.swift
+++ b/secant/Sources/Features/MigrationSimulatorPanel/MigrationSimulatorPanelStore.swift
@@ -129,7 +129,7 @@ struct MigrationSimulatorPanel {
                 // Every preset (not just the complete ones) aligns the manual-delivery flag — the
                 // engine itself has no notion of "manual delivery", only the panel knows which
                 // presets need it.
-                migrationManager.setManualDelivery(preset.requiresManualDelivery)
+                migrationManager.setManualDelivery(nil, preset.requiresManualDelivery)
                 return .send(.refresh)
 
             case .readoutLoaded(let readout):

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -32,10 +32,23 @@ extension Root {
                 guard state.selectedWalletAccount != walletAccount else {
                     return .none
                 }
+                // MOB-1509 (defensive): no UI path reaches the switcher while a migration coord
+                // flow covers Home today, but any future dispatcher of this action would silently
+                // repoint the flow's live handlers (they read `selectedWalletAccount` fresh) at the
+                // new account mid-run. Tear the flow down first — the shared helper cancels a
+                // stranded Keystone ceremony on its recorded owner and clears the run's snapshots —
+                // then apply the switch.
+                var migrationTeardownEffect = Effect<Root.Action>.none
+                if state.path == Root.State.Path.migrationCoordFlow {
+                    migrationTeardownEffect = tearDownMigrationCoordFlow(state: &state)
+                    state.migrationCoordFlowState = MigrationCoordFlow.State.initial
+                    state.path = nil
+                }
                 state.$selectedWalletAccount.withLock { $0 = walletAccount }
                 state.homeState.transactionListState.isInvalidated = true
                 state.autoUpdateSwapCandidates.removeAll()
                 return .merge(
+                    migrationTeardownEffect,
                     .send(.home(.smartBanner(.walletAccountChanged))),
                     .send(.home(.walletBalances(.updateBalances))),
                     .send(.loadContacts),

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -2121,9 +2121,14 @@ extension Root {
     /// twin). Read BEFORE the caller resets/replaces `migrationCoordFlowState`. Fire-and-forget: a
     /// failure here just leaves the stray run for the next attempt to encounter and cancel itself,
     /// same as today.
+    /// MOB-1509: the run is cancelled on its RECORDED owner (`pendingKeystoneSigningAccountUUID`,
+    /// stamped when the ceremony's PCZTs were built) — the cross-account notification tap switches
+    /// `selectedWalletAccount` BEFORE this runs, so re-reading the selection here would target the
+    /// wrong account's engine state. The selection is only a fallback for state predating the field.
     func cancelAbandonedKeystoneMigrationRun(state: Root.State) -> Effect<Root.Action> {
         guard state.migrationCoordFlowState.pendingKeystoneSigning != nil,
-              let accountUUID = state.selectedWalletAccount?.id else {
+              let accountUUID = state.migrationCoordFlowState.pendingKeystoneSigningAccountUUID
+                ?? state.selectedWalletAccount?.id else {
             return .none
         }
 

--- a/zodlTests/MigrationSimulatorTests/MigrationSimulatorPanelTests.swift
+++ b/zodlTests/MigrationSimulatorTests/MigrationSimulatorPanelTests.swift
@@ -200,7 +200,7 @@ import ComposableArchitecture
             $0.migrationSimulator.applyPreset = { preset in
                 callLog.withValue { $0.append("applyPreset(\(preset.rawValue))") }
             }
-            $0.migrationManager.setManualDelivery = { isManual in
+            $0.migrationManager.setManualDelivery = { _, isManual in
                 callLog.withValue { $0.append("setManualDelivery(\(isManual))") }
             }
             $0.migrationSimulator.readout = { readout }
@@ -223,7 +223,7 @@ import ComposableArchitecture
         } withDependencies: {
             $0.migrationManager.resetPersistedFlags = { callLog.withValue { $0.append("resetPersistedFlags") } }
             $0.migrationSimulator.applyPreset = { _ in callLog.withValue { $0.append("applyPreset") } }
-            $0.migrationManager.setManualDelivery = { isManual in
+            $0.migrationManager.setManualDelivery = { _, isManual in
                 callLog.withValue { $0.append("setManualDelivery(\(isManual))") }
             }
             $0.migrationSimulator.readout = { readout }
@@ -246,7 +246,7 @@ import ComposableArchitecture
         } withDependencies: {
             $0.migrationManager.resetPersistedFlags = { callLog.withValue { $0.append("resetPersistedFlags") } }
             $0.migrationSimulator.applyPreset = { _ in callLog.withValue { $0.append("applyPreset") } }
-            $0.migrationManager.setManualDelivery = { isManual in
+            $0.migrationManager.setManualDelivery = { _, isManual in
                 callLog.withValue { $0.append("setManualDelivery(\(isManual))") }
             }
             $0.migrationSimulator.readout = { readout }
@@ -270,7 +270,7 @@ import ComposableArchitecture
         } withDependencies: {
             $0.migrationManager.resetPersistedFlags = { resetFlagsCalls.withValue { $0 += 1 } }
             $0.migrationSimulator.applyPreset = { _ in callLog.withValue { $0.append("applyPreset") } }
-            $0.migrationManager.setManualDelivery = { isManual in
+            $0.migrationManager.setManualDelivery = { _, isManual in
                 callLog.withValue { $0.append("setManualDelivery(\(isManual))") }
             }
             $0.migrationSimulator.readout = { readout }

--- a/zodlTests/MigrationSimulatorTests/SimulatedSDKSynchronizerTests.swift
+++ b/zodlTests/MigrationSimulatorTests/SimulatedSDKSynchronizerTests.swift
@@ -495,8 +495,8 @@ import URKit
 
 @Suite(.serialized)
 struct MigrationManagerResetPersistedFlagsTests {
-    @Test func gateStorageResetPersistedFlagsClearsEveryNamedFlagButLeavesTheSyncGateWindow() throws {
-        let suiteName = "testGateStorageResetPersistedFlagsClearsEveryNamedFlagButLeavesTheSyncGateWindow"
+    @Test func gateStorageResetPersistedFlagsClearsWalletWideFlagsButLeavesPerAccountOnesAndTheSyncGateWindow() throws {
+        let suiteName = "testGateStorageResetPersistedFlagsClearsWalletWideFlagsButLeavesPerAccountOnes"
         let userDefaults = try #require(
             UserDefaults(suiteName: suiteName),
             "MigrationGateStorage: UserDefaults failed to initialize"
@@ -505,25 +505,29 @@ struct MigrationManagerResetPersistedFlagsTests {
 
         let storage = MigrationGateStorage(userDefaults: userDefaults)
         let accountUUID = AccountUUID(id: [UInt8](repeating: 1, count: 16))
-        storage.setMigrationMode(MigrationMode.immediate)
-        storage.setManualDelivery(true)
+        storage.setMigrationMode(MigrationMode.immediate, for: accountUUID)
+        storage.setManualDelivery(true, for: accountUUID)
         storage.setTorEnabledForMigration(true)
         storage.acknowledgeComplete(for: accountUUID)
-        storage.setDustLocked(true)
+        storage.setDustLocked(true, for: accountUUID)
         storage.recordSyncCompleted(at: Date())
 
         storage.resetPersistedFlags()
 
-        #expect(storage.migrationMode() == nil)
-        #expect(storage.isManualDelivery() == false)
+        // MOB-1509: mode/manual/dust-locked are per-account now (the acknowledged flag's R8-T3
+        // transition) — the storage-level reset only deletes the dead legacy wallet-wide keys, so
+        // per-account values survive; clearing them per KNOWN account is
+        // `MigrationManagerImpl.resetPersistedFlags()`'s job (see the twin test below).
+        #expect(storage.migrationMode(for: accountUUID) == MigrationMode.immediate)
+        #expect(storage.isManualDelivery(for: accountUUID) == true)
+        #expect(storage.isDustLocked(for: accountUUID) == true)
         // MOB-1497 (R1): the stored choice is genuinely gone (see the raw-key check below) — it just
         // reads back `true` now, the new never-written default, rather than `false`.
         #expect(storage.isTorEnabledForMigration() == true)
         #expect(userDefaults.data(forKey: .migrationNetworkPrivacyOptions) == nil)
-        #expect(storage.isDustLocked() == false)
         // R8-T3 (S2): the acknowledged flag is per-account now — `MigrationGateStorage
         // .resetPersistedFlags()` only clears the dead legacy (wallet-wide, unsuffixed) key; see
-        // `MigrationManagerTests.resetPersistedFlagsClearsDustLockedAlongWithEveryOtherFlag`'s
+        // `MigrationManagerTests.resetPersistedFlagsClearsWalletWideFlagsAndLeavesPerAccountFlags`'s
         // twin assertion for the full explanation.
         #expect(storage.isCompleteAcknowledged(for: accountUUID) == true)
 
@@ -545,14 +549,34 @@ struct MigrationManagerResetPersistedFlagsTests {
         )
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
 
-        let storage = MigrationGateStorage(userDefaults: userDefaults)
-        storage.setMigrationMode(MigrationMode.privateScheduled)
-        storage.setManualDelivery(true)
+        // MOB-1509: mode/manual/dust are per-account — the Impl-level reset is what clears every
+        // KNOWN account's flags (the storage-level reset alone leaves them, see the test above),
+        // so a selected account must exist for the candidate set to contain it.
+        withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let storage = MigrationGateStorage(userDefaults: userDefaults)
+            let account = WalletAccount(Account(
+                id: AccountUUID(id: [UInt8](repeating: 7, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            ))
+            @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+            $selectedWalletAccount.withLock { $0 = account }
+            storage.setMigrationMode(MigrationMode.privateScheduled, for: account.id)
+            storage.setManualDelivery(true, for: account.id)
+            storage.setDustLocked(true, for: account.id)
 
-        let impl = MigrationManagerImpl(gateStorage: storage)
-        impl.resetPersistedFlags()
+            let impl = MigrationManagerImpl(gateStorage: storage)
+            impl.resetPersistedFlags()
 
-        #expect(storage.migrationMode() == nil)
-        #expect(storage.isManualDelivery() == false)
+            #expect(storage.migrationMode(for: account.id) == nil)
+            #expect(storage.isManualDelivery(for: account.id) == false)
+            #expect(storage.isDustLocked(for: account.id) == false)
+        }
     }
 }

--- a/zodlTests/MigrationTests/MigrationBGSchedulerTests.swift
+++ b/zodlTests/MigrationTests/MigrationBGSchedulerTests.swift
@@ -285,7 +285,7 @@ import ComposableArchitecture
             $walletAccounts.withLock { $0 = [] }
 
             await withDependencies {
-                $0.migrationManager.isManualDelivery = { true }
+                $0.migrationManager.isManualDelivery = { _ in true }
                 $0.userNotifications.scheduleMigrationNotification = { _, _, _ in scheduleCalls.withValue { $0 += 1 } }
             } operation: {
                 let impl = MigrationBGSchedulerImpl()
@@ -317,7 +317,7 @@ import ComposableArchitecture
             $walletAccounts.withLock { $0 = [selected, second] }
 
             await withDependencies {
-                $0.migrationManager.isManualDelivery = { true }
+                $0.migrationManager.isManualDelivery = { _ in true }
                 $0.sdkSynchronizer = .noOp
                 $0.sdkSynchronizer.getMigrationState = { accountUUID in
                     accountUUID == selected.id ? MigrationState.inProgress(laterProgress) : MigrationState.inProgress(earlierProgress)
@@ -370,7 +370,7 @@ import ComposableArchitecture
             $walletAccounts.withLock { $0 = [selected, second] }
 
             await withDependencies {
-                $0.migrationManager.isManualDelivery = { false }
+                $0.migrationManager.isManualDelivery = { _ in false }
                 $0.sdkSynchronizer = .noOp
                 $0.sdkSynchronizer.getMigrationState = { accountUUID in
                     accountUUID == selected.id ? MigrationState.complete : MigrationState.notStarted
@@ -411,7 +411,7 @@ import ComposableArchitecture
             $walletAccounts.withLock { $0 = [selected, second] }
 
             await withDependencies {
-                $0.migrationManager.isManualDelivery = { true }
+                $0.migrationManager.isManualDelivery = { _ in true }
                 $0.sdkSynchronizer = .noOp
                 $0.sdkSynchronizer.getMigrationState = { accountUUID in
                     if accountUUID == selected.id {
@@ -449,7 +449,7 @@ import ComposableArchitecture
             $walletAccounts.withLock { $0 = [selected] }
 
             await withDependencies {
-                $0.migrationManager.isManualDelivery = { true }
+                $0.migrationManager.isManualDelivery = { _ in true }
                 $0.sdkSynchronizer = .noOp
                 $0.sdkSynchronizer.getMigrationState = { _ in throw ArmTestReadFailure() }
                 $0.userNotifications.scheduleMigrationNotification = { _, _, _ in scheduleCalls.withValue { $0 += 1 } }

--- a/zodlTests/MigrationTests/MigrationCompleteTests.swift
+++ b/zodlTests/MigrationTests/MigrationCompleteTests.swift
@@ -131,7 +131,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationComplete.State(dust: Zatoshi(31_000))) {
             MigrationComplete()
         } withDependencies: {
-            $0.migrationManager.lockMigrationDust = { }
+            $0.migrationManager.lockMigrationDust = { _ in }
         }
 
         #expect(store.state.dustResolution == MigrationComplete.State.DustResolution.offered)
@@ -150,7 +150,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationComplete.State(dust: Zatoshi(31_000))) {
             MigrationComplete()
         } withDependencies: {
-            $0.migrationManager.lockMigrationDust = { throw LockDustFailure() }
+            $0.migrationManager.lockMigrationDust = { _ in throw LockDustFailure() }
         }
         store.exhaustivity = .off
 

--- a/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowTests.swift
@@ -473,7 +473,7 @@ import ComposableArchitecture
             $0.migrationManager.reentryRoute = { .complete }
             $0.sdkSynchronizer = .noOp
             $0.migrationManager.migrationSummary = { _ in summary }
-            $0.migrationManager.isMigrationDustLocked = { true }
+            $0.migrationManager.isMigrationDustLocked = { _ in true }
         }
         store.exhaustivity = .off
 
@@ -542,7 +542,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { mode in setMigrationModeCalls.withValue { $0.append(mode) } }
+            $0.migrationManager.setMigrationMode = { _, mode in setMigrationModeCalls.withValue { $0.append(mode) } }
             $0.migrationManager.setNetworkPrivacyOptions = { useTor in setOptionsCalls.withValue { $0.append(useTor) } }
             $0.migrationManager.formNetworkSnapshot = { accountUUID in formNetworkSnapshotCalls.withValue { $0.append(accountUUID) } }
             $0.sdkSynchronizer = .noOp
@@ -601,7 +601,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationManager.setMigrationMode = { _, _ in }
             $0.migrationManager.isSyncServerIdentityCustom = { false }
             $0.migrationManager.setNetworkPrivacyOptions = { useTor in callLog.withValue { $0.append(.persist(useTor)) } }
             $0.migrationManager.formNetworkSnapshot = { _ in callLog.withValue { $0.append(.form) } }
@@ -636,7 +636,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationManager.setMigrationMode = { _, _ in }
             $0.migrationManager.isSyncServerIdentityCustom = { true }
             $0.migrationManager.setNetworkPrivacyOptions = { useTor in setOptionsCalls.withValue { $0.append(useTor) } }
             $0.migrationManager.formNetworkSnapshot = { _ in formNetworkSnapshotCalls.withValue { $0 += 1 } }
@@ -674,7 +674,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationManager.setMigrationMode = { _, _ in }
             $0.migrationManager.isSyncServerIdentityCustom = { true }
             $0.migrationManager.setNetworkPrivacyOptions = { useTor in setOptionsCalls.withValue { $0.append(useTor) } }
             $0.migrationManager.formNetworkSnapshot = { _ in }
@@ -712,7 +712,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationManager.setMigrationMode = { _, _ in }
             $0.migrationManager.formNetworkSnapshot = { _ in formNetworkSnapshotCalls.withValue { $0 += 1 } }
             $0.migrationManager.networkSnapshot = { _ in Self.someProviderNetworkSnapshot() }
             $0.sdkSynchronizer = .noOp
@@ -749,7 +749,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationManager.setMigrationMode = { _, _ in }
             $0.migrationManager.formNetworkSnapshot = { _ in }
             $0.migrationManager.networkSnapshot = { _ in Self.someCustomNetworkSnapshot() }
             $0.sdkSynchronizer = .noOp
@@ -782,7 +782,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationManager.setMigrationMode = { _, _ in }
             $0.migrationManager.formNetworkSnapshot = { _ in }
             $0.migrationManager.networkSnapshot = { _ in Self.someSameServerProviderNetworkSnapshot() }
             $0.sdkSynchronizer = .noOp
@@ -815,7 +815,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationManager.setMigrationMode = { _, _ in }
             $0.migrationManager.formNetworkSnapshot = { _ in formNetworkSnapshotCalls.withValue { $0 += 1 } }
             $0.migrationManager.networkSnapshot = { _ in Self.someProviderNetworkSnapshot() }
             $0.sdkSynchronizer = .noOp
@@ -1066,7 +1066,7 @@ import ComposableArchitecture
             $0.migrationManager.setNetworkPrivacyOptions = { useTor in setOptionsCalls.withValue { $0.append(useTor) } }
             $0.migrationManager.formNetworkSnapshot = { _ in formNetworkSnapshotCalls.withValue { $0 += 1 } }
             $0.migrationManager.confirmProvisionalTorChoice = { _, useTor in confirmProvisionalCalls.withValue { $0.append(useTor) } }
-            $0.migrationManager.isManualDelivery = { false }
+            $0.migrationManager.isManualDelivery = { _ in false }
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .authorized }
             $0.sdkSynchronizer = .noOp
@@ -1105,7 +1105,7 @@ import ComposableArchitecture
         } withDependencies: {
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .authorized }
-            $0.migrationManager.isManualDelivery = { true }
+            $0.migrationManager.isManualDelivery = { _ in true }
             // MOB-1497 (T2): every fresh `.transferPlan` construction reads the (non-forming) R13
             // disclosure peek now — see `nextPermissionStepResult`'s doc.
             $0.migrationManager.networkSnapshot = { _ in nil }
@@ -1191,7 +1191,9 @@ import ComposableArchitecture
     // MARK: - MOB-1468: Keystone signing — signRequested sets context + pushes keystoneSign
 
     @MainActor @Test func transferPlanKeystoneSignRequestedSetsPlanCommitContextAndPushesKeystoneSign() async {
+        let account = walletAccount(keystone: true, idByte: 21)
         var state = MigrationCoordFlow.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
         state.path.append(.transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
         let store = TestStore(initialState: state) {
             MigrationCoordFlow()
@@ -1205,6 +1207,9 @@ import ComposableArchitecture
         await store.send(.path(.element(id: 0, action: .transferPlan(.delegate(.keystoneSignRequested(pczts))))))
 
         #expect(store.state.pendingKeystoneSigning == MigrationCoordFlow.KeystoneSigningContext.planCommit)
+        // MOB-1509: the ceremony's OWNER is recorded beside the context — external teardowns
+        // cancel the stranded run on this account even after the selection has moved on.
+        #expect(store.state.pendingKeystoneSigningAccountUUID == account.id)
         guard case let .keystoneSign(signState) = try? #require(store.state.path.last) else {
             Issue.record("Expected .keystoneSign pushed on top")
             return
@@ -1213,7 +1218,9 @@ import ComposableArchitecture
     }
 
     @MainActor @Test func reviewTransferKeystoneSignRequestedSetsImmediateReviewContextAndPushesKeystoneSign() async {
+        let account = walletAccount(keystone: true, idByte: 22)
         var state = MigrationCoordFlow.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
         state.path.append(.reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
         let store = TestStore(initialState: state) {
             MigrationCoordFlow()
@@ -1224,6 +1231,8 @@ import ComposableArchitecture
         await store.send(.path(.element(id: 0, action: .reviewTransfer(.delegate(.keystoneSignRequested(pczts))))))
 
         #expect(store.state.pendingKeystoneSigning == MigrationCoordFlow.KeystoneSigningContext.immediateReview)
+        // MOB-1509: owner recorded beside the context (see the planCommit twin above).
+        #expect(store.state.pendingKeystoneSigningAccountUUID == account.id)
         guard case let .keystoneSign(signState) = try? #require(store.state.path.last) else {
             Issue.record("Expected .keystoneSign pushed on top")
             return
@@ -2254,7 +2263,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: MigrationCoordFlow.State()) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setMigrationMode = { _ in }
+            $0.migrationManager.setMigrationMode = { _, _ in }
             $0.sdkSynchronizer = .noOp
             $0.sdkSynchronizer.isNoteSplitNeeded = { _ in true }
         }
@@ -2289,7 +2298,7 @@ import ComposableArchitecture
             $0.migrationManager.formNetworkSnapshot = { _ in formNetworkSnapshotCalls.withValue { $0 += 1 } }
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .authorized }
-            $0.migrationManager.isManualDelivery = { false }
+            $0.migrationManager.isManualDelivery = { _ in false }
             $0.sdkSynchronizer = .noOp
         }
         store.exhaustivity = .off
@@ -2335,7 +2344,7 @@ import ComposableArchitecture
             $0.migrationManager.networkSnapshot = { _ in Self.someProviderNetworkSnapshot() }
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .authorized }
-            $0.migrationManager.isManualDelivery = { false }
+            $0.migrationManager.isManualDelivery = { _ in false }
             $0.sdkSynchronizer = .noOp
         }
         store.exhaustivity = .off
@@ -2406,7 +2415,7 @@ import ComposableArchitecture
             $0.migrationManager.networkSnapshot = { _ in Self.someCustomNetworkSnapshot() }
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .authorized }
-            $0.migrationManager.isManualDelivery = { false }
+            $0.migrationManager.isManualDelivery = { _ in false }
             $0.sdkSynchronizer = .noOp
         }
         store.exhaustivity = .off
@@ -2503,7 +2512,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: state) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setManualDelivery = { allowed in setManualDeliveryCalls.withValue { $0.append(allowed) } }
+            $0.migrationManager.setManualDelivery = { _, allowed in setManualDeliveryCalls.withValue { $0.append(allowed) } }
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .notDetermined }
         }
@@ -2527,10 +2536,10 @@ import ComposableArchitecture
         let store = TestStore(initialState: state) {
             MigrationCoordFlow()
         } withDependencies: {
-            $0.migrationManager.setManualDelivery = { _ in }
+            $0.migrationManager.setManualDelivery = { _, _ in }
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .notDetermined }
-            $0.migrationManager.isManualDelivery = { true }
+            $0.migrationManager.isManualDelivery = { _ in true }
         }
         store.exhaustivity = .off
 
@@ -2554,7 +2563,7 @@ import ComposableArchitecture
         } withDependencies: {
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .authorized }
-            $0.migrationManager.isManualDelivery = { false }
+            $0.migrationManager.isManualDelivery = { _ in false }
             $0.migrationManager.networkSnapshot = { _ in nil }
             $0.sdkSynchronizer = .noOp
         }
@@ -2578,7 +2587,7 @@ import ComposableArchitecture
         } withDependencies: {
             $0.migrationBGScheduler.backgroundRefreshStatus = { .available }
             $0.userNotifications.authorizationStatus = { .denied }
-            $0.migrationManager.isManualDelivery = { false }
+            $0.migrationManager.isManualDelivery = { _ in false }
             $0.migrationManager.networkSnapshot = { _ in nil }
             $0.sdkSynchronizer = .noOp
         }

--- a/zodlTests/MigrationTests/MigrationManagerTests.swift
+++ b/zodlTests/MigrationTests/MigrationManagerTests.swift
@@ -1215,14 +1215,23 @@ struct MigrationManagerTests {
         defer { userDefaults.removePersistentDomain(forName: "testMigrationModePersistenceRoundTrip") }
 
         let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let accountA = AccountUUID(id: [UInt8](repeating: 1, count: 16))
+        let accountB = AccountUUID(id: [UInt8](repeating: 2, count: 16))
 
-        #expect(storage.migrationMode() == nil)
+        #expect(storage.migrationMode(for: accountA) == nil)
 
-        storage.setMigrationMode(MigrationMode.immediate)
-        #expect(storage.migrationMode() == MigrationMode.immediate)
+        storage.setMigrationMode(MigrationMode.immediate, for: accountA)
+        #expect(storage.migrationMode(for: accountA) == MigrationMode.immediate)
+        // MOB-1509: per-account isolation — A's choice must never leak into B's.
+        #expect(storage.migrationMode(for: accountB) == nil)
 
-        storage.setMigrationMode(MigrationMode.privateScheduled)
-        #expect(storage.migrationMode() == MigrationMode.privateScheduled)
+        storage.setMigrationMode(MigrationMode.privateScheduled, for: accountB)
+        #expect(storage.migrationMode(for: accountA) == MigrationMode.immediate)
+        #expect(storage.migrationMode(for: accountB) == MigrationMode.privateScheduled)
+
+        storage.clearMigrationMode(for: accountA)
+        #expect(storage.migrationMode(for: accountA) == nil)
+        #expect(storage.migrationMode(for: accountB) == MigrationMode.privateScheduled)
     }
 
     @Test func manualDeliveryPersistenceRoundTrip() throws {
@@ -1233,14 +1242,22 @@ struct MigrationManagerTests {
         defer { userDefaults.removePersistentDomain(forName: "testManualDeliveryPersistenceRoundTrip") }
 
         let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let accountA = AccountUUID(id: [UInt8](repeating: 1, count: 16))
+        let accountB = AccountUUID(id: [UInt8](repeating: 2, count: 16))
 
-        #expect(storage.isManualDelivery() == false)
+        #expect(storage.isManualDelivery(for: accountA) == false)
 
-        storage.setManualDelivery(true)
-        #expect(storage.isManualDelivery() == true)
+        storage.setManualDelivery(true, for: accountA)
+        #expect(storage.isManualDelivery(for: accountA) == true)
+        // MOB-1509: per-account isolation — A's delivery style must never leak into B's.
+        #expect(storage.isManualDelivery(for: accountB) == false)
 
-        storage.setManualDelivery(false)
-        #expect(storage.isManualDelivery() == false)
+        storage.setManualDelivery(false, for: accountA)
+        #expect(storage.isManualDelivery(for: accountA) == false)
+
+        storage.setManualDelivery(true, for: accountB)
+        storage.clearManualDelivery(for: accountB)
+        #expect(storage.isManualDelivery(for: accountB) == false)
     }
 
     /// MOB-1496: the SDK's `MigrationNetworkPrivacyOptions` isn't `Codable` (it carries a
@@ -1277,43 +1294,54 @@ struct MigrationManagerTests {
         defer { userDefaults.removePersistentDomain(forName: "testDustLockedPersistenceRoundTrip") }
 
         let storage = MigrationGateStorage(userDefaults: userDefaults)
+        let accountA = AccountUUID(id: [UInt8](repeating: 1, count: 16))
+        let accountB = AccountUUID(id: [UInt8](repeating: 2, count: 16))
 
-        #expect(storage.isDustLocked() == false)
+        #expect(storage.isDustLocked(for: accountA) == false)
 
-        storage.setDustLocked(true)
-        #expect(storage.isDustLocked() == true)
+        storage.setDustLocked(true, for: accountA)
+        #expect(storage.isDustLocked(for: accountA) == true)
+        // MOB-1509: per-account isolation — A locking its remainder must never mark B's locked.
+        #expect(storage.isDustLocked(for: accountB) == false)
 
-        storage.setDustLocked(false)
-        #expect(storage.isDustLocked() == false)
+        storage.setDustLocked(false, for: accountA)
+        #expect(storage.isDustLocked(for: accountA) == false)
+
+        storage.setDustLocked(true, for: accountB)
+        storage.clearDustLocked(for: accountB)
+        #expect(storage.isDustLocked(for: accountB) == false)
     }
 
-    @Test func resetPersistedFlagsClearsDustLockedAlongWithEveryOtherFlag() throws {
+    @Test func resetPersistedFlagsClearsWalletWideFlagsAndLeavesPerAccountFlags() throws {
         let userDefaults = try #require(
-            UserDefaults(suiteName: "testResetPersistedFlagsClearsDustLockedAlongWithEveryOtherFlag"),
+            UserDefaults(suiteName: "testResetPersistedFlagsClearsWalletWideFlagsAndLeavesPerAccountFlags"),
             "MigrationGateStorage: UserDefaults failed to initialize"
         )
         defer {
-            userDefaults.removePersistentDomain(forName: "testResetPersistedFlagsClearsDustLockedAlongWithEveryOtherFlag")
+            userDefaults.removePersistentDomain(forName: "testResetPersistedFlagsClearsWalletWideFlagsAndLeavesPerAccountFlags")
         }
 
         let storage = MigrationGateStorage(userDefaults: userDefaults)
         let accountUUID = AccountUUID(id: [UInt8](repeating: 1, count: 16))
-        storage.setMigrationMode(MigrationMode.immediate)
-        storage.setManualDelivery(true)
+        storage.setMigrationMode(MigrationMode.immediate, for: accountUUID)
+        storage.setManualDelivery(true, for: accountUUID)
         storage.setTorEnabledForMigration(true)
         storage.acknowledgeComplete(for: accountUUID)
-        storage.setDustLocked(true)
+        storage.setDustLocked(true, for: accountUUID)
         storage.recordSyncCompleted(at: Date(timeIntervalSince1970: 5_000_000))
 
         storage.resetPersistedFlags()
 
-        #expect(storage.migrationMode() == nil)
-        #expect(storage.isManualDelivery() == false)
+        // MOB-1509: mode/manual/dust-locked are per-account now (same transition the acknowledged
+        // flag went through in R8-T3) — the storage-level reset only deletes the dead legacy
+        // wallet-wide keys, so every per-account value survives it.
+        #expect(storage.migrationMode(for: accountUUID) == MigrationMode.immediate)
+        #expect(storage.isManualDelivery(for: accountUUID) == true)
+        #expect(storage.isDustLocked(for: accountUUID) == true)
         // MOB-1497 (R1): the stored choice is genuinely gone (see the raw-key check below) — it just
         // reads back `true` now, the new never-written default, rather than `false`.
         #expect(storage.isTorEnabledForMigration() == true)
         #expect(userDefaults.data(forKey: .migrationNetworkPrivacyOptions) == nil)
-        #expect(storage.isDustLocked() == false)
         // R8-T3 (S2): the acknowledged flag is per-account now — `MigrationGateStorage
         // .resetPersistedFlags()` only clears the dead legacy (wallet-wide, unsuffixed) key.
         // Clearing every KNOWN account's own flag is `MigrationManagerImpl.resetPersistedFlags()`'s

--- a/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
+++ b/zodlTests/MigrationTests/MigrationNoteSplitTests.swift
@@ -1036,7 +1036,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: state) {
             MigrationNoteSplit()
         } withDependencies: {
-            $0.migrationManager.migrationMode = { MigrationMode.privateScheduled }
+            $0.migrationManager.migrationMode = { _ in MigrationMode.privateScheduled }
         }
 
         await store.send(.proceedWithoutTorTapped) {
@@ -1050,7 +1050,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: state) {
             MigrationNoteSplit()
         } withDependencies: {
-            $0.migrationManager.migrationMode = { MigrationMode.immediate }
+            $0.migrationManager.migrationMode = { _ in MigrationMode.immediate }
         }
 
         await store.send(.proceedWithoutTorTapped) {

--- a/zodlTests/MigrationTests/MigrationSendingTests.swift
+++ b/zodlTests/MigrationTests/MigrationSendingTests.swift
@@ -1305,7 +1305,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: state) {
             MigrationSending()
         } withDependencies: {
-            $0.migrationManager.migrationMode = { MigrationMode.privateScheduled }
+            $0.migrationManager.migrationMode = { _ in MigrationMode.privateScheduled }
         }
 
         await store.send(.proceedWithoutTorTapped) {
@@ -1319,7 +1319,7 @@ import ComposableArchitecture
         let store = TestStore(initialState: state) {
             MigrationSending()
         } withDependencies: {
-            $0.migrationManager.migrationMode = { MigrationMode.immediate }
+            $0.migrationManager.migrationMode = { _ in MigrationMode.immediate }
         }
 
         await store.send(.proceedWithoutTorTapped) {

--- a/zodlTests/MigrationTests/RootMigrationBackgroundTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationBackgroundTests.swift
@@ -3222,9 +3222,9 @@ private func baseNoOpDependencies(_ values: inout DependencyValues) {
     values.migrationManager.bannerVariant = { _ in nil }
     values.migrationManager.isIronwoodActivated = { true }
     values.migrationManager.reentryRoute = { .entry }
-    values.migrationManager.migrationMode = { nil }
-    values.migrationManager.setMigrationMode = { _ in }
-    values.migrationManager.setManualDelivery = { _ in }
+    values.migrationManager.migrationMode = { _ in nil }
+    values.migrationManager.setMigrationMode = { _, _ in }
+    values.migrationManager.setManualDelivery = { _, _ in }
     values.migrationManager.setNetworkPrivacyOptions = { _ in }
     values.migrationManager.formNetworkSnapshot = { _ in }
     values.migrationManager.markNetworkSnapshotCommitted = { _ in }

--- a/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
+++ b/zodlTests/MigrationTests/RootMigrationRoutingTests.swift
@@ -149,6 +149,89 @@ import ComposableArchitecture
         }
     }
 
+    /// MOB-1509: a migration notification for account B tapped while account A's Keystone ceremony
+    /// is still live must cancel the stray run on A — the ceremony's RECORDED owner — not on B,
+    /// which the tap path has already switched the selection to by the time the teardown runs.
+    @Test func crossAccountNotificationTapCancelsStrayRunOnCeremonyOwner() async {
+        let restartCalls = LockIsolated<[(AccountUUID, Bool)]>([])
+        let accountA = Self.walletAccount(idByte: 44)
+        let accountB = Self.walletAccount(idByte: 45)
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.appInitializationState = InitializationState.initialized
+            initialState.path = Root.State.Path.migrationCoordFlow
+            initialState.$selectedWalletAccount.withLock { $0 = accountA }
+            initialState.$walletAccounts.withLock { $0 = [accountA, accountB] }
+            initialState.migrationCoordFlowState.pendingKeystoneSigning = MigrationCoordFlow.KeystoneSigningContext.planCommit
+            initialState.migrationCoordFlowState.pendingKeystoneSigningAccountUUID = accountA.id
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.restartCurrentMigrationStep = { accountUUID, includeResidual in
+                    restartCalls.withValue { $0.append((accountUUID, includeResidual)) }
+                    return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+                }
+            }
+
+            let accountBHex = Data(accountB.id.id).hexEncodedString()
+            store.send(.initialization(.appDelegate(.migrationNotificationTapped(accountUUID: accountBHex))))
+            await waitForRootStore { restartCalls.withValue { $0.count } >= 1 }
+            await waitForRootStore { store.state.selectedWalletAccount == accountB }
+            await waitForRootStore { store.state.path == Root.State.Path.migrationCoordFlow }
+
+            // Exactly one cancel, on the OWNER: the switch's defensive teardown fires it for A and
+            // clears the ceremony, so the flow-open's own cancel pass finds nothing left to cancel.
+            #expect(restartCalls.withValue { $0.count } == 1)
+            #expect(restartCalls.withValue { $0.first?.0 } == accountA.id)
+            #expect(restartCalls.withValue { $0.first?.1 } == false)
+            #expect(store.state.migrationCoordFlowState.pendingKeystoneSigning == nil)
+        }
+    }
+
+    /// MOB-1509 (defensive): any account switch that fires while the migration coord flow is open
+    /// tears the flow down first — cancelling a live ceremony on its recorded owner — instead of
+    /// silently repointing the flow's live handlers at the newly selected account.
+    @Test func walletAccountSwitchWithOpenMigrationFlowTearsDownAndCancelsOwnersCeremony() async {
+        let restartCalls = LockIsolated<[(AccountUUID, Bool)]>([])
+        let accountA = Self.walletAccount(idByte: 46)
+        let accountB = Self.walletAccount(idByte: 47)
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = Root.State.initial
+            initialState.path = Root.State.Path.migrationCoordFlow
+            initialState.$selectedWalletAccount.withLock { $0 = accountA }
+            initialState.$walletAccounts.withLock { $0 = [accountA, accountB] }
+            initialState.migrationCoordFlowState.pendingKeystoneSigning = MigrationCoordFlow.KeystoneSigningContext.planCommit
+            initialState.migrationCoordFlowState.pendingKeystoneSigningAccountUUID = accountA.id
+
+            let store = Store(initialState: initialState) {
+                Root()
+            } withDependencies: {
+                baseNoOpDependencies(&$0)
+                $0.sdkSynchronizer.restartCurrentMigrationStep = { accountUUID, includeResidual in
+                    restartCalls.withValue { $0.append((accountUUID, includeResidual)) }
+                    return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
+                }
+            }
+
+            store.send(.home(.walletAccountTapped(accountB)))
+            await waitForRootStore { store.state.path == nil }
+            await waitForRootStore { restartCalls.withValue { $0.count } == 1 }
+
+            #expect(store.state.selectedWalletAccount == accountB)
+            #expect(store.state.path == nil)
+            #expect(store.state.migrationCoordFlowState.pendingKeystoneSigning == nil)
+            #expect(store.state.migrationCoordFlowState.pendingKeystoneSigningAccountUUID == nil)
+            #expect(restartCalls.withValue { $0.first?.0 } == accountA.id)
+            #expect(restartCalls.withValue { $0.first?.1 } == false)
+        }
+    }
+
     /// Twin of the test above with no live ceremony (the ordinary case — `.flowFinished` following
     /// the Sending store's own successful exit, or any other flow-root close that never touched
     /// Keystone signing at all) — must never call `restartCurrentMigrationStep`.
@@ -860,9 +943,9 @@ private func baseNoOpDependencies(_ values: inout DependencyValues) {
     values.migrationBGScheduler.cancelAll = { }
     values.migrationManager.bannerVariant = { _ in nil }
     values.migrationManager.reentryRoute = { .entry }
-    values.migrationManager.migrationMode = { nil }
-    values.migrationManager.setMigrationMode = { _ in }
-    values.migrationManager.setManualDelivery = { _ in }
+    values.migrationManager.migrationMode = { _ in nil }
+    values.migrationManager.setMigrationMode = { _, _ in }
+    values.migrationManager.setManualDelivery = { _, _ in }
     values.migrationManager.setNetworkPrivacyOptions = { _ in }
     values.migrationManager.formNetworkSnapshot = { _ in }
     values.migrationManager.markNetworkSnapshotCommitted = { _ in }

--- a/zodlTests/MigrationTests/RootTorFailurePromptTests.swift
+++ b/zodlTests/MigrationTests/RootTorFailurePromptTests.swift
@@ -528,9 +528,9 @@ private func baseNoOpDependencies(_ values: inout DependencyValues) {
     values.migrationManager.bannerVariant = { _ in nil }
     values.migrationManager.isIronwoodActivated = { true }
     values.migrationManager.reentryRoute = { .entry }
-    values.migrationManager.migrationMode = { nil }
-    values.migrationManager.setMigrationMode = { _ in }
-    values.migrationManager.setManualDelivery = { _ in }
+    values.migrationManager.migrationMode = { _ in nil }
+    values.migrationManager.setMigrationMode = { _, _ in }
+    values.migrationManager.setManualDelivery = { _, _ in }
     values.migrationManager.setNetworkPrivacyOptions = { _ in }
     values.migrationManager.formNetworkSnapshot = { _ in }
     values.migrationManager.markNetworkSnapshotCommitted = { _ in }


### PR DESCRIPTION
## Summary

Per-account hardening so a ZODL software wallet and a Keystone wallet can migrate **in parallel** with fully independent state, per [MOB-1509](https://linear.app/zodl/issue/MOB-1509/parallel-migrations-per-account-hardening-for-software-keystone). The SDK already supports this topology (account-keyed store, MOB-1495 R5); switching, the SmartBanner, notifications, and the BG tree were verified per-account already — this PR closes the four real gaps found:

1. **Dust-lock, migration mode, and manual delivery are per-account now** (`PerAccountCodableStorage`, the acknowledged flag's R8-T3 pattern). Previously account A's "Lock balance" showed B's Complete screen as locked, and mode/delivery choices clobbered each other. The wallet-wide reset deletes only the dead legacy keys; per-account clears ride `MigrationManagerImpl.resetPersistedFlags()`. No data migration — the feature is in no released build.
2. **The BG scheduler reads the WINNING account's manual-delivery flag** (was: wallet-wide read regardless of whose transfer the wakeup serves).
3. **A pending Keystone ceremony records its OWNER account** (`pendingKeystoneSigningAccountUUID`, stamped at the three `pendingKeystoneSigning` setters). External teardowns now cancel the stranded run on that owner — the cross-account notification tap previously re-read the selection AFTER switching and mistargeted the cancel.
4. **Defensive teardown on account switch**: `.home(.walletAccountTapped)` with the migration coord flow open tears the flow down first (cancelling the owner's ceremony, clearing snapshots) instead of silently repointing ~15 live handlers at the new account. Unreachable via UI today; structural protection for any future dispatcher.

Left as-is (documented in the ticket): the process-global send-wait/sync-gate flags (correct for one wallet-wide synchronizer) and the pre-run global Tor default.

## Tests

- Per-account isolation matrices for mode / manual delivery / dust-lock (A's writes never leak into B), including the reset-semantics flip (storage-level reset leaves per-account values; Impl-level reset clears every known account's).
- New routing tests: cross-account notification tap cancels the stray run on the ceremony OWNER (exactly one cancel); account switch with the flow open tears down + cancels on the owner.
- Ceremony setter tests pin the owner recording.
- ~44 existing override sites mechanically updated to the new per-account arities.

## Gate

- Full suite: **1596 tests / 148 suites passed** (1 known issue: the expected MOB-1364 row), TEST SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
