### PR TITLE
[MOB-1475] Stop implying refunds always come back as USDC on NEAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Fixed
 - [PRO-325] Swaps out of ZEC and CrossPays that fail on the swap provider's side now show "Swap Failed" / "Payment Failed" (with the contact-support option) instead of appearing to stay in progress forever. Long-running swaps in this direction also correctly show their processing state.
+- [MOB-1475] The refund address explainer no longer reads like "USDC on NEAR" is a fixed destination for every refund — it now says the refund returns in the source currency on the same network, since that's true for any swap, not just NEAR-based ones.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -16957,13 +16957,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The refunded amount will be returned to your wallet in the source currency - USDC on NEAR. Please enter a valid address to avoid loss of funds."
+            "value" : "The refunded amount will be returned to your wallet in the source currency on the same network. Please enter a valid address to avoid loss of funds."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El monto reembolsado será devuelto a tu wallet en la moneda de origen - USDC en NEAR. Ingresa una dirección válida para evitar la pérdida de fondos."
+            "value" : "El monto reembolsado será devuelto a tu wallet en la moneda de origen en la misma red. Ingresa una dirección válida para evitar la pérdida de fondos."
           }
         }
       }


### PR DESCRIPTION
## Summary
- The refund-address explainer used "USDC on NEAR" as an illustrative example of the source currency/network, but users reported reading it as a literal, fixed refund destination and feared their funds would be sent to the wrong asset/network.
- Changes the wording (en + es) to "in the source currency on the same network," which is true for any swap.

Fixes MOB-1475.

## Test plan
- [x] Verified Localizable.xcstrings is still valid JSON
- [x] String is static (no format args) at its one call site in SwapComponents.swift