### PR TITLE
[#1920] Handle Keystone hardware wallet connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Fixed
+- [#1920] Connecting a Keystone hardware wallet that fails now shows a clear "Connection Failed" message (with Try Again and Contact Support options) instead of silently doing nothing. The support message includes a safe error identifier and never exposes any wallet keys.
 - [PRO-325] Swaps out of ZEC and CrossPays that fail on the swap provider's side now show "Swap Failed" / "Payment Failed" (with the contact-support option) instead of appearing to stay in progress forever. Long-running swaps in this direction also correctly show their processing state.
 
 ## 3.7.3 build 1 (20026-07-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Fixed
-- [#1920] Connecting a Keystone hardware wallet that fails now shows a clear "Connection Failed" message (with Try Again, Contact Support, and Cancel options) instead of silently doing nothing. Cancel leaves the flow so the user is never stuck on the connection screen. The support message includes a safe error identifier and never exposes any wallet keys.
+- [#1920] Connecting a Keystone hardware wallet that fails now shows a clear "Connection Failed" message (with Contact Support and Cancel options) instead of silently doing nothing. Cancel leaves the flow so the user is never stuck on the connection screen. The support message includes a safe error identifier and never exposes any wallet keys.
+- [#1920] The "Connection Failed" sheet no longer appears on top of the success screen when connecting a Keystone device actually succeeds. Tapping the connect/OK button again while the import was still running started a duplicate import whose failure surfaced as a bogus error; the button now shows a progress indicator and extra taps are ignored.
 - [PRO-325] Swaps out of ZEC and CrossPays that fail on the swap provider's side now show "Swap Failed" / "Payment Failed" (with the contact-support option) instead of appearing to stay in progress forever. Long-running swaps in this direction also correctly show their processing state.
 
 ## 3.7.3 build 1 (20026-07-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Fixed
-- [#1920] Connecting a Keystone hardware wallet that fails now shows a clear "Connection Failed" message (with Try Again and Contact Support options) instead of silently doing nothing. The support message includes a safe error identifier and never exposes any wallet keys.
+- [#1920] Connecting a Keystone hardware wallet that fails now shows a clear "Connection Failed" message (with Try Again, Contact Support, and Cancel options) instead of silently doing nothing. Cancel leaves the flow so the user is never stuck on the connection screen. The support message includes a safe error identifier and never exposes any wallet keys.
 - [PRO-325] Swaps out of ZEC and CrossPays that fail on the swap provider's side now show "Swap Failed" / "Payment Failed" (with the contact-support option) instead of appearing to stay in progress forever. Long-running swaps in this direction also correctly show their processing state.
 
 ## 3.7.3 build 1 (20026-07-12)

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -1,18722 +1,18742 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "keystone.addHWWallet.contactSupport": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact Support"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contactar Soporte"
+  "sourceLanguage" : "en",
+  "strings" : {
+    " %@" : {
+
+    },
+    "#%@" : {
+
+    },
+    "%" : {
+
+    },
+    "%@" : {
+
+    },
+    "%@ · " : {
+
+    },
+    "%@ / %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ / %2$@"
           }
         }
       }
     },
-    "keystone.addHWWallet.failureDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Could not connect your Keystone wallet. Your funds are safe. Please check that you are running the latest firmware."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo conectar tu wallet Keystone. Tus fondos están seguros. Verifica que tengas el firmware más reciente instalado."
+    "%@ %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@"
           }
         }
       }
     },
-    "keystone.addHWWallet.failureTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection Failed"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error de Conexión"
+    "%@ ZEC" : {
+
+    },
+    "%@..." : {
+
+    },
+    "%@%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@"
           }
         }
       }
     },
-    " %@": {},
-    "#%@": {},
-    "%": {},
-    "%@": {},
-    "%@ · ": {},
-    "%@ / %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@ / %2$@"
+    "%@%%" : {
+
+    },
+    "~%@ %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "~%1$@ %2$@"
           }
         }
       }
     },
-    "%@ %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@ %2$@"
+    "about.additionalInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Developed by the team that set the industry standard for onchain privacy, the original developers of the Zcash protocol."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desarrollada por el equipo que estableció el estándar de la industria en privacidad en cadena (on-chain), los desarrolladores originales del protocolo Zcash."
           }
         }
       }
     },
-    "%@ ZEC": {},
-    "%@...": {},
-    "%@%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@%2$@"
+    "about.info" : {
+      "comment" : "MARK: - About",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl is a Zcash-powered mobile wallet, built for unstoppable private payments. It’s optimized for storage and real-world use of shielded $ZEC—the truly private cryptocurrency."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl es una wallet móvil impulsada por Zcash, creada para pagos privados imparables. Está optimizada para almacenar y usar en el mundo real $ZEC protegido: la criptomoneda verdaderamente privada."
+          }
         }
       }
     },
-    "%@%%": {},
-    "~%@ %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "~%1$@ %2$@"
+    "about.privacyPolicy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy Policy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Política de privacidad"
           }
         }
       }
     },
-    "about.additionalInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Developed by the team that set the industry standard for onchain privacy, the original developers of the Zcash protocol."
+    "about.termsOfUse" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terms of Service"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desarrollada por el equipo que estableció el estándar de la industria en privacidad en cadena (on-chain), los desarrolladores originales del protocolo Zcash."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Términos del Servicio"
           }
         }
       }
     },
-    "about.info": {
-      "comment": "MARK: - About",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl is a Zcash-powered mobile wallet, built for unstoppable private payments. It’s optimized for storage and real-world use of shielded $ZEC—the truly private cryptocurrency."
+    "about.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introducing Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl es una wallet móvil impulsada por Zcash, creada para pagos privados imparables. Está optimizada para almacenar y usar en el mundo real $ZEC protegido: la criptomoneda verdaderamente privada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presentando Zodl"
           }
         }
       }
     },
-    "about.privacyPolicy": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy Policy"
+    "accounts.addressBook.contacts" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address Book Contacts"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Política de privacidad"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contactos del Libro de Direcciones"
           }
         }
       }
     },
-    "about.termsOfUse": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terms of Service"
+    "accounts.addressBook.your" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Wallets"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Términos del Servicio"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus Billeteras"
           }
         }
       }
     },
-    "about.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Introducing Zodl"
+    "accounts.keystone" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Presentando Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone"
           }
         }
       }
     },
-    "accounts.addressBook.contacts": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address Book Contacts"
+    "accounts.keystone.shieldedAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash Shielded Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contactos del Libro de Direcciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección Protegida de Zcash"
           }
         }
       }
     },
-    "accounts.addressBook.your": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Wallets"
+    "accounts.keystone.transparentAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash Transparent Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus Billeteras"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección Transparente de Zcash"
           }
         }
       }
     },
-    "accounts.keystone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone"
+    "accounts.sendingFrom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send from"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviando desde"
           }
         }
       }
     },
-    "accounts.keystone.shieldedAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash Shielded Address"
+    "accounts.zashi" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección Protegida de Zcash"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl"
           }
         }
       }
     },
-    "accounts.keystone.transparentAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash Transparent Address"
+    "accounts.zashi.shieldedAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash Shielded Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección Transparente de Zcash"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección Protegida de Zcash"
           }
         }
       }
     },
-    "accounts.sendingFrom": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send from"
+    "accounts.zashi.transparentAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash Transparent Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviando desde"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección Transparente de Zcash"
           }
         }
       }
     },
-    "accounts.zashi": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl"
+    "addressBook.addNewContact" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add New Contact"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar nuevo contacto"
           }
         }
       }
     },
-    "accounts.zashi.shieldedAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash Shielded Address"
+    "addressBook.alert.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You are about to delete this contact. This cannot be undone."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección Protegida de Zcash"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estás a punto de eliminar este contacto. Esto no se puede deshacer."
           }
         }
       }
     },
-    "accounts.zashi.transparentAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash Transparent Address"
+    "addressBook.alert.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección Transparente de Zcash"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Estás seguro?"
           }
         }
       }
     },
-    "addressBook.addNewContact": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add New Contact"
+    "addressBook.empty" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your address book is empty"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agregar nuevo contacto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu libreta de direcciones está vacía"
           }
         }
       }
     },
-    "addressBook.alert.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You are about to delete this contact. This cannot be undone."
+    "addressBook.error.addressExists" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An address with this chain is already in your Address Book."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estás a punto de eliminar este contacto. Esto no se puede deshacer."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya existe una dirección con esta cadena en tu libreta de direcciones."
           }
         }
       }
     },
-    "addressBook.alert.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure?"
+    "addressBook.error.invalidAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid address."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Estás seguro?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección no válida."
           }
         }
       }
     },
-    "addressBook.empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your address book is empty"
+    "addressBook.error.nameExists" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This contact name is already in use. Please choose a different name."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu libreta de direcciones está vacía"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este nombre de contacto ya está en uso. Por favor, elige un nombre diferente."
           }
         }
       }
     },
-    "addressBook.error.addressExists": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An address with this chain is already in your Address Book."
+    "addressBook.error.nameLength" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This contact name exceeds the 32-character limit. Please shorten the name."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ya existe una dirección con esta cadena en tu libreta de direcciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este nombre de contacto supera el límite de 32 caracteres. Por favor, acorta el nombre."
           }
         }
       }
     },
-    "addressBook.error.invalidAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid address."
+    "addressBook.manualEntry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manual Entry"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección no válida."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrada manual"
           }
         }
       }
     },
-    "addressBook.error.nameExists": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This contact name is already in use. Please choose a different name."
+    "addressBook.newContact.address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este nombre de contacto ya está en uso. Por favor, elige un nombre diferente."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de la billetera"
           }
         }
       }
     },
-    "addressBook.error.nameLength": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This contact name exceeds the 32-character limit. Please shorten the name."
+    "addressBook.newContact.addressPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter wallet address..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este nombre de contacto supera el límite de 32 caracteres. Por favor, acorta el nombre."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresa la dirección de la billetera..."
           }
         }
       }
     },
-    "addressBook.manualEntry": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manual Entry"
+    "addressBook.newContact.name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact Name"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entrada manual"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre del contacto"
           }
         }
       }
     },
-    "addressBook.newContact.address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Address"
+    "addressBook.newContact.namePlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter contact name..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección de la billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresa el nombre del contacto..."
           }
         }
       }
     },
-    "addressBook.newContact.addressPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter wallet address..."
+    "addressBook.savedAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saved Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingresa la dirección de la billetera..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección guardada"
           }
         }
       }
     },
-    "addressBook.newContact.name": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact Name"
+    "addressBook.scanAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan QR code"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nombre del contacto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanear código QR"
           }
         }
       }
     },
-    "addressBook.newContact.namePlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter contact name..."
+    "addressBook.selectRecipient" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select recipient"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingresa el nombre del contacto..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar destinatario"
           }
         }
       }
     },
-    "addressBook.savedAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saved Address"
+    "addressBook.title" : {
+      "comment" : "MARK: - Address Book",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address Book"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección guardada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libreta de Direcciones"
           }
         }
       }
     },
-    "addressBook.scanAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan QR code"
+    "addressDetails.copyAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escanear código QR"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar Dirección"
           }
         }
       }
     },
-    "addressBook.selectRecipient": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select recipient"
+    "addressDetails.shareDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hi, scan this QR code to send me a ZEC payment!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar destinatario"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hola, ¡escanea este código QR para enviarme un pago en ZEC!"
           }
         }
       }
     },
-    "addressBook.title": {
-      "comment": "MARK: - Address Book",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address Book"
+    "addressDetails.shareQR" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share QR Code"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Libreta de Direcciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir Código QR"
           }
         }
       }
     },
-    "addressDetails.copyAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Address"
+    "addressDetails.shareTitle" : {
+      "comment" : "MARK: - Address Details",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "My Zodl ZEC Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar Dirección"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mi Dirección ZEC de Zodl"
           }
         }
       }
     },
-    "addressDetails.shareDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hi, scan this QR code to send me a ZEC payment!"
+    "annotation.add" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add note"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hola, ¡escanea este código QR para enviarme un pago en ZEC!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar nota"
           }
         }
       }
     },
-    "addressDetails.shareQR": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share QR Code"
+    "annotation.addArticle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add a note"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartir Código QR"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar nota"
           }
         }
       }
     },
-    "addressDetails.shareTitle": {
-      "comment": "MARK: - Address Details",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "My Zodl ZEC Address"
+    "annotation.chars" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@/%@ characters"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mi Dirección ZEC de Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@/%@ caracteres"
           }
         }
       }
     },
-    "annotation.add": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add note"
+    "annotation.delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete note"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agregar nota"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar nota"
           }
         }
       }
     },
-    "annotation.addArticle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add a note"
+    "annotation.edit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit a note"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agregar nota"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar nota"
           }
         }
       }
     },
-    "annotation.chars": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@/%@ characters"
+    "annotation.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Write an optional note to describe this transaction..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@/%@ caracteres"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribe una nota opcional para describir esta transacción..."
           }
         }
       }
     },
-    "annotation.delete": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete note"
+    "annotation.save" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save note"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar nota"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar nota"
           }
         }
       }
     },
-    "annotation.edit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit a note"
+    "annotation.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editar nota"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota"
           }
         }
       }
     },
-    "annotation.placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Write an optional note to describe this transaction..."
+    "autoShieldingHelpContent" : {
+
+    },
+    "balance.availableTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spendable:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe una nota opcional para describir esta transacción..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gastable:"
           }
         }
       }
     },
-    "annotation.save": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save note"
+    "balances.dismiss" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardar nota"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descartar"
           }
         }
       }
     },
-    "annotation.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note"
+    "balances.everythingDone" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All your funds are shielded and spendable."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nota"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos tus fondos están protegidos y son gastables."
           }
         }
       }
     },
-    "autoShieldingHelpContent": {},
-    "balance.availableTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spendable:"
+    "balances.infoPending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending receipt of change from a prior transaction."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gastable:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendiente de recibir el cambio de una transacción anterior."
           }
         }
       }
     },
-    "balances.dismiss": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dismiss"
+    "balances.infoShielding" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shield your transparent ZEC to make it spendable and private. Doing so will create a shielding in-wallet transaction, consolidating your transparent and shielded funds. (Typical fee: %@)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descartar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protege tus ZEC transparentes para hacerlos gastables y privados. Esto creará una transacción de protección en la billetera, consolidando tus fondos transparentes y protegidos. (Tarifa típica: %@)"
           }
         }
       }
     },
-    "balances.everythingDone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All your funds are shielded and spendable."
+    "balances.infoSyncing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl is scanning the blockchain to make sure your balances are displayed correctly."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todos tus fondos están protegidos y son gastables."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl está escaneando la blockchain para asegurarse de que tus balances se muestren correctamente."
           }
         }
       }
     },
-    "balances.infoPending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending receipt of change from a prior transaction."
+    "balances.pending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendiente de recibir el cambio de una transacción anterior."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendiente"
           }
         }
       }
     },
-    "balances.infoShielding": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shield your transparent ZEC to make it spendable and private. Doing so will create a shielding in-wallet transaction, consolidating your transparent and shielded funds. (Typical fee: %@)"
+    "balances.spendableBalance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shielded (Spendable)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protege tus ZEC transparentes para hacerlos gastables y privados. Esto creará una transacción de protección en la billetera, consolidando tus fondos transparentes y protegidos. (Tarifa típica: %@)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protegido (Gastable)"
           }
         }
       }
     },
-    "balances.infoSyncing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl is scanning the blockchain to make sure your balances are displayed correctly."
+    "balances.spendableBalance.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spendable Balance"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl está escaneando la blockchain para asegurarse de que tus balances se muestren correctamente."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balance Gastable"
           }
         }
       }
     },
-    "balances.pending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
+    "balances.synced" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synced"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizado"
           }
         }
       }
     },
-    "balances.spendableBalance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shielded (Spendable)"
+    "balances.syncing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protegido (Gastable)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando"
           }
         }
       }
     },
-    "balances.spendableBalance.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spendable Balance"
+    "coinVote.common.abstain" : {
+      "comment" : "MARK: - Coin Vote",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abstain"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Balance Gastable"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abstain"
           }
         }
       }
     },
-    "balances.synced": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Synced"
+    "coinVote.common.back" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sincronizado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
           }
         }
       }
     },
-    "balances.syncing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Syncing"
+    "coinVote.common.blockNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Block #%@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sincronizando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Block #%@"
           }
         }
       }
     },
-    "coinVote.common.abstain": {
-      "comment": "MARK: - Coin Vote",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abstain"
+    "coinVote.common.cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abstain"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         }
       }
     },
-    "coinVote.common.back": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back"
+    "coinVote.common.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         }
       }
     },
-    "coinVote.common.blockNumber": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Block #%@"
+    "coinVote.common.confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Block #%@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm"
           }
         }
       }
     },
-    "coinVote.common.cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+    "coinVote.common.confirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmation"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmation"
           }
         }
       }
     },
-    "coinVote.common.close": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+    "coinVote.common.continue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
           }
         }
       }
     },
-    "coinVote.common.confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm"
+    "coinVote.common.dismiss" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss"
           }
         }
       }
     },
-    "coinVote.common.confirmation": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmation"
+    "coinVote.common.done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmation"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         }
       }
     },
-    "coinVote.common.continue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
+    "coinVote.common.endsDate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ends %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ends %@"
           }
         }
       }
     },
-    "coinVote.common.dismiss": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dismiss"
+    "coinVote.common.goBack" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go back"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dismiss"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go back"
           }
         }
       }
     },
-    "coinVote.common.done": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
+    "coinVote.common.gotIt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got it"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got it"
           }
         }
       }
     },
-    "coinVote.common.endsDate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ends %@"
+    "coinVote.common.governanceTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Governance"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ends %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Governance"
           }
         }
       }
     },
-    "coinVote.common.goBack": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Go back"
+    "coinVote.common.next" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Go back"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
           }
         }
       }
     },
-    "coinVote.common.gotIt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Got it"
+    "coinVote.common.oppose" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oppose"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Got it"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oppose"
           }
         }
       }
     },
-    "coinVote.common.governanceTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Governance"
+    "coinVote.common.pollDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll Description"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Governance"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll Description"
           }
         }
       }
     },
-    "coinVote.common.next": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Next"
+    "coinVote.common.refresh" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Next"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
           }
         }
       }
     },
-    "coinVote.common.oppose": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oppose"
+    "coinVote.common.retry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oppose"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
           }
         }
       }
     },
-    "coinVote.common.pollDescription": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll Description"
+    "coinVote.common.save" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll Description"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         }
       }
     },
-    "coinVote.common.refresh": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refresh"
+    "coinVote.common.screenTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coinholder Polling"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refresh"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coinholder Polling"
           }
         }
       }
     },
-    "coinVote.common.retry": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
+    "coinVote.common.submission" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submission"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submission"
           }
         }
       }
     },
-    "coinVote.common.save": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+    "coinVote.common.support" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Support"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Support"
           }
         }
       }
     },
-    "coinVote.common.screenTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coinholder Polling"
+    "coinVote.common.tryAgain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coinholder Polling"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
           }
         }
       }
     },
-    "coinVote.common.submission": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submission"
+    "coinVote.common.viewLess" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View less"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submission"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View less"
           }
         }
       }
     },
-    "coinVote.common.support": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Support"
+    "coinVote.common.viewMore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View more"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Support"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View more"
           }
         }
       }
     },
-    "coinVote.common.tryAgain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try again"
+    "coinVote.common.viewResults" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View results"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try again"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View results"
           }
         }
       }
     },
-    "coinVote.common.viewLess": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View less"
+    "coinVote.common.voted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voted"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View less"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voted"
           }
         }
       }
     },
-    "coinVote.common.viewMore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View more"
+    "coinVote.common.votedDate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voted %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View more"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voted %@"
           }
         }
       }
     },
-    "coinVote.common.viewResults": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View results"
+    "coinVote.common.votingPower" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting Power %@ ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View results"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting Power %@ ZEC"
           }
         }
       }
     },
-    "coinVote.common.voted": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voted"
+    "coinVote.common.zecValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voted"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC"
           }
         }
       }
     },
-    "coinVote.common.votedDate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voted %@"
+    "coinVote.common.zipPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ZIP-TBD"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voted %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ZIP-TBD"
           }
         }
       }
     },
-    "coinVote.common.votingPower": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting Power %@ ZEC"
+    "coinVote.components.commitment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "commitment: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting Power %@ ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "commitment: %@"
           }
         }
       }
     },
-    "coinVote.common.zecValue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ZEC"
+    "coinVote.components.expectedBy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expected by %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expected by %@"
           }
         }
       }
     },
-    "coinVote.common.zipPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ZIP-TBD"
+    "coinVote.components.finishingUp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finishing up…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ZIP-TBD"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finishing up…"
           }
         }
       }
     },
-    "coinVote.components.commitment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "commitment: %@"
+    "coinVote.components.notVoted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not voted"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "commitment: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not voted"
           }
         }
       }
     },
-    "coinVote.components.expectedBy": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expected by %@"
+    "coinVote.components.preparingNoteWitnesses" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing note witnesses..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expected by %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing note witnesses..."
           }
         }
       }
     },
-    "coinVote.components.finishingUp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Finishing up…"
+    "coinVote.components.preparingVotingAuthorization" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing voting authorization... %@%%"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Finishing up…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing voting authorization... %@%%"
           }
         }
       }
     },
-    "coinVote.components.notVoted": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not voted"
+    "coinVote.components.privacyExplanation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Each share is sent at different times across various servers throughout the vote period to further protect your privacy. Each value is encrypted, and only the total amount across all voters will be revealed at the end of the vote period."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not voted"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Each share is sent at different times across various servers throughout the vote period to further protect your privacy. Each value is encrypted, and only the total amount across all voters will be revealed at the end of the vote period."
           }
         }
       }
     },
-    "coinVote.components.preparingNoteWitnesses": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing note witnesses..."
+    "coinVote.components.prototypeBanner" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prototype — some features are mocked"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing note witnesses..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prototype — some features are mocked"
           }
         }
       }
     },
-    "coinVote.components.preparingVotingAuthorization": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing voting authorization... %@%%"
+    "coinVote.components.prototypeVcStub" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prototype VC Stub"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing voting authorization... %@%%"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prototype VC Stub"
           }
         }
       }
     },
-    "coinVote.components.privacyExplanation": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Each share is sent at different times across various servers throughout the vote period to further protect your privacy. Each value is encrypted, and only the total amount across all voters will be revealed at the end of the vote period."
+    "coinVote.components.readyToVote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ready to vote"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Each share is sent at different times across various servers throughout the vote period to further protect your privacy. Each value is encrypted, and only the total amount across all voters will be revealed at the end of the vote period."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ready to vote"
           }
         }
       }
     },
-    "coinVote.components.prototypeBanner": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prototype — some features are mocked"
+    "coinVote.components.shareInfoSubtitleConfirmed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All shares have been confirmed on-chain."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prototype — some features are mocked"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All shares have been confirmed on-chain."
           }
         }
       }
     },
-    "coinVote.components.prototypeVcStub": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prototype VC Stub"
+    "coinVote.components.shareInfoSubtitleSubmitting" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote is being submitted in multiple shares to protect your privacy."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prototype VC Stub"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote is being submitted in multiple shares to protect your privacy."
           }
         }
       }
     },
-    "coinVote.components.readyToVote": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ready to vote"
+    "coinVote.components.shareInfoTitleConfirmed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote Confirmed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ready to vote"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote Confirmed"
           }
         }
       }
     },
-    "coinVote.components.shareInfoSubtitleConfirmed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All shares have been confirmed on-chain."
+    "coinVote.components.shareInfoTitleSubmitting" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting Vote"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All shares have been confirmed on-chain."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting Vote"
           }
         }
       }
     },
-    "coinVote.components.shareInfoSubtitleSubmitting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your vote is being submitted in multiple shares to protect your privacy."
+    "coinVote.components.submittingVote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting vote"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your vote is being submitted in multiple shares to protect your privacy."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting vote"
           }
         }
       }
     },
-    "coinVote.components.shareInfoTitleConfirmed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote Confirmed"
+    "coinVote.components.transaction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tx: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote Confirmed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tx: %@"
           }
         }
       }
     },
-    "coinVote.components.shareInfoTitleSubmitting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting Vote"
+    "coinVote.components.vanNullifier" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "van nullifier: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting Vote"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "van nullifier: %@"
           }
         }
       }
     },
-    "coinVote.components.submittingVote": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting vote"
+    "coinVote.components.voteConfirmed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote confirmed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting vote"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote confirmed"
           }
         }
       }
     },
-    "coinVote.components.transaction": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "tx: %@"
+    "coinVote.configError.decodeFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting config decode failed: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "tx: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting config decode failed: %@"
           }
         }
       }
     },
-    "coinVote.components.vanNullifier": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "van nullifier: %@"
+    "coinVote.configError.invalidConfig" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting config is invalid."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "van nullifier: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting config is invalid."
           }
         }
       }
     },
-    "coinVote.components.voteConfirmed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote confirmed"
+    "coinVote.configError.proposalsHashMismatch" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting config proposals don't match the active round. Please update the wallet."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote confirmed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting config proposals don't match the active round. Please update the wallet."
           }
         }
       }
     },
-    "coinVote.configError.decodeFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting config decode failed: %@"
+    "coinVote.configError.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Update Required"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting config decode failed: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Update Required"
           }
         }
       }
     },
-    "coinVote.configError.invalidConfig": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting config is invalid."
+    "coinVote.configError.unsupportedVersion" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet does not support %@ version \"%@\". Please update the wallet."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting config is invalid."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet does not support %@ version \"%@\". Please update the wallet."
           }
         }
       }
     },
-    "coinVote.configError.proposalsHashMismatch": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting config proposals don't match the active round. Please update the wallet."
+    "coinVote.configSettings.accessibilityActions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source actions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting config proposals don't match the active round. Please update the wallet."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source actions"
           }
         }
       }
     },
-    "coinVote.configError.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Update Required"
+    "coinVote.configSettings.accessibilityClose" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Update Required"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         }
       }
     },
-    "coinVote.configError.unsupportedVersion": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet does not support %@ version \"%@\". Please update the wallet."
+    "coinVote.configSettings.accessibilityDefault" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default data source"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet does not support %@ version \"%@\". Please update the wallet."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default data source"
           }
         }
       }
     },
-    "coinVote.configSettings.accessibilityActions": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source actions"
+    "coinVote.configSettings.accessibilitySelectChain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source actions"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select %@"
           }
         }
       }
     },
-    "coinVote.configSettings.accessibilityClose": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+    "coinVote.configSettings.addCustomSource" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add custom source"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add custom source"
           }
         }
       }
     },
-    "coinVote.configSettings.accessibilityDefault": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Default data source"
+    "coinVote.configSettings.bundledName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coinholder Poll"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Default data source"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coinholder Poll"
           }
         }
       }
     },
-    "coinVote.configSettings.accessibilitySelectChain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select %@"
+    "coinVote.configSettings.customChainFallbackName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom chain"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom chain"
           }
         }
       }
     },
-    "coinVote.configSettings.addCustomSource": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add custom source"
+    "coinVote.configSettings.defaultBadge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add custom source"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default"
           }
         }
       }
     },
-    "coinVote.configSettings.bundledName": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coinholder Poll"
+    "coinVote.configSettings.delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coinholder Poll"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
           }
         }
       }
     },
-    "coinVote.configSettings.customChainFallbackName": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom chain"
+    "coinVote.configSettings.edit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom chain"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
           }
         }
       }
     },
-    "coinVote.configSettings.defaultBadge": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Default"
+    "coinVote.configSettings.errorDuplicateUrl" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This source URL is already added."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Default"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This source URL is already added."
           }
         }
       }
     },
-    "coinVote.configSettings.delete": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
+    "coinVote.configSettings.errorInvalidUrl" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enter a valid URL (e.g. https://zodl.com/polls)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enter a valid URL (e.g. https://zodl.com/polls)"
           }
         }
       }
     },
-    "coinVote.configSettings.edit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit"
+    "coinVote.configSettings.errorTitleTooLong" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title must be 15 characters or less, including spaces."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title must be 15 characters or less, including spaces."
           }
         }
       }
     },
-    "coinVote.configSettings.errorDuplicateUrl": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This source URL is already added."
+    "coinVote.configSettings.headerAddBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add a poll source that isn't listed by default. You'll need a valid chain URL from the provider hosting the poll."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This source URL is already added."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add a poll source that isn't listed by default. You'll need a valid chain URL from the provider hosting the poll."
           }
         }
       }
     },
-    "coinVote.configSettings.errorInvalidUrl": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please enter a valid URL (e.g. https://zodl.com/polls)"
+    "coinVote.configSettings.headerAddTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Custom Source"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please enter a valid URL (e.g. https://zodl.com/polls)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Custom Source"
           }
         }
       }
     },
-    "coinVote.configSettings.errorTitleTooLong": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Title must be 15 characters or less, including spaces."
+    "coinVote.configSettings.headerEditBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update the title or URL for this custom poll source. You'll need a valid chain URL from the provider hosting the poll."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Title must be 15 characters or less, including spaces."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update the title or URL for this custom poll source. You'll need a valid chain URL from the provider hosting the poll."
           }
         }
       }
     },
-    "coinVote.configSettings.headerAddBody": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add a poll source that isn't listed by default. You'll need a valid chain URL from the provider hosting the poll."
+    "coinVote.configSettings.headerEditTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Custom Source"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add a poll source that isn't listed by default. You'll need a valid chain URL from the provider hosting the poll."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Custom Source"
           }
         }
       }
     },
-    "coinVote.configSettings.headerAddTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Custom Source"
+    "coinVote.configSettings.menuCopyUrl" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Data Source URL"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Custom Source"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Data Source URL"
           }
         }
       }
     },
-    "coinVote.configSettings.headerEditBody": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update the title or URL for this custom poll source. You'll need a valid chain URL from the provider hosting the poll."
+    "coinVote.configSettings.save" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update the title or URL for this custom poll source. You'll need a valid chain URL from the provider hosting the poll."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         }
       }
     },
-    "coinVote.configSettings.headerEditTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Custom Source"
+    "coinVote.configSettings.saveChanges" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save changes"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Custom Source"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save changes"
           }
         }
       }
     },
-    "coinVote.configSettings.menuCopyUrl": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Data Source URL"
+    "coinVote.configSettings.screenTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Data Source"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Data Source URL"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Data Source"
           }
         }
       }
     },
-    "coinVote.configSettings.save": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+    "coinVote.configSettings.sectionSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick a poll source, or add your own."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick a poll source, or add your own."
           }
         }
       }
     },
-    "coinVote.configSettings.saveChanges": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save changes"
+    "coinVote.configSettings.sectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll Data Source"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save changes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll Data Source"
           }
         }
       }
     },
-    "coinVote.configSettings.screenTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Data Source"
+    "coinVote.configSettings.titleField" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Data Source"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title"
           }
         }
       }
     },
-    "coinVote.configSettings.sectionSubtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pick a poll source, or add your own."
+    "coinVote.configSettings.toolbarAdd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ADD SOURCE"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pick a poll source, or add your own."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ADD SOURCE"
           }
         }
       }
     },
-    "coinVote.configSettings.sectionTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll Data Source"
+    "coinVote.configSettings.toolbarEdit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EDIT SOURCE"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll Data Source"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EDIT SOURCE"
           }
         }
       }
     },
-    "coinVote.configSettings.titleField": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Title"
+    "coinVote.configSettings.urlField" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Title"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
           }
         }
       }
     },
-    "coinVote.configSettings.toolbarAdd": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ADD SOURCE"
+    "coinVote.configSettings.urlPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ADD SOURCE"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter..."
           }
         }
       }
     },
-    "coinVote.configSettings.toolbarEdit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "EDIT SOURCE"
+    "coinVote.configSettings.validating" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validating..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "EDIT SOURCE"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validating..."
           }
         }
       }
     },
-    "coinVote.configSettings.urlField": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
+    "coinVote.confirmSubmission.authorizationFailedMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't authorize your vote.\nCheck your connection and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't authorize your vote.\nCheck your connection and try again."
           }
         }
       }
     },
-    "coinVote.configSettings.urlPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter..."
+    "coinVote.confirmSubmission.authorizationFailedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorization Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorization Failed"
           }
         }
       }
     },
-    "coinVote.configSettings.validating": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating..."
+    "coinVote.confirmSubmission.bundleProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bundle %@ of %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bundle %@ of %@"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.authorizationFailedMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We couldn't authorize your vote.\nCheck your connection and try again."
+    "coinVote.confirmSubmission.confirmWithKeystone" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm with Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We couldn't authorize your vote.\nCheck your connection and try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm with Keystone"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.authorizationFailedTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization Failed"
+    "coinVote.confirmSubmission.detailAmount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization Failed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.bundleProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bundle %@ of %@"
+    "coinVote.confirmSubmission.detailAmountValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.00000001 ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bundle %@ of %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.00000001 ZEC"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.confirmWithKeystone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm with Keystone"
+    "coinVote.confirmSubmission.detailFee" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm with Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailAmount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount"
+    "coinVote.confirmSubmission.detailFeeValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0 ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0 ZEC"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailAmountValue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0.00000001 ZEC"
+    "coinVote.confirmSubmission.detailMemo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memo"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0.00000001 ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memo"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailFee": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee"
+    "coinVote.confirmSubmission.detailPoll" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailFeeValue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0 ZEC"
+    "coinVote.confirmSubmission.detailVotingHotkey" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting hotkey"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0 ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting hotkey"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailMemo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Memo"
+    "coinVote.confirmSubmission.detailVotingPower" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting power"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Memo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting power"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailPoll": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll"
+    "coinVote.confirmSubmission.detailVotingPowerValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailVotingHotkey": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting hotkey"
+    "coinVote.confirmSubmission.headerSubmittedCountMultiple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitted %@ votes with voting power %@."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting hotkey"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitted %@ votes with voting power %@."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailVotingPower": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting power"
+    "coinVote.confirmSubmission.headerSubmittedCountSingle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitted %@ vote with voting power %@."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting power"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitted %@ vote with voting power %@."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailVotingPowerValue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ZEC"
+    "coinVote.confirmSubmission.headerSubmittingCountMultiple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting %@ votes with voting power %@."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting %@ votes with voting power %@."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubmittedCountMultiple": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitted %@ votes with voting power %@."
+    "coinVote.confirmSubmission.headerSubmittingCountSingle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting %@ vote with voting power %@."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitted %@ votes with voting power %@."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting %@ vote with voting power %@."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubmittedCountSingle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitted %@ vote with voting power %@."
+    "coinVote.confirmSubmission.headerSubtitleCompleted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote was successfully published and cannot be changed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitted %@ vote with voting power %@."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote was successfully published and cannot be changed."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubmittingCountMultiple": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting %@ votes with voting power %@."
+    "coinVote.confirmSubmission.headerSubtitleIdle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review before confirming the voting authorization. This is final. Your vote will be published and cannot be changed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting %@ votes with voting power %@."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review before confirming the voting authorization. This is final. Your vote will be published and cannot be changed."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubmittingCountSingle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting %@ vote with voting power %@."
+    "coinVote.confirmSubmission.headerSubtitleIdleKeystone" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review before signing the voting authorization with your Keystone. This is final. Your vote will be published and cannot be changed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting %@ vote with voting power %@."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review before signing the voting authorization with your Keystone. This is final. Your vote will be published and cannot be changed."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubtitleCompleted": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your vote was successfully published and cannot be changed."
+    "coinVote.confirmSubmission.headerSubtitleSubmitting" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote submission is in progress, please don’t leave this screen until it is finished."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your vote was successfully published and cannot be changed."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote submission is in progress, please don’t leave this screen until it is finished."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubtitleIdle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review before confirming the voting authorization. This is final. Your vote will be published and cannot be changed."
+    "coinVote.confirmSubmission.headerTitleCompleted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submission Confirmed!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review before confirming the voting authorization. This is final. Your vote will be published and cannot be changed."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submission Confirmed!"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubtitleIdleKeystone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review before signing the voting authorization with your Keystone. This is final. Your vote will be published and cannot be changed."
+    "coinVote.confirmSubmission.headerTitleIdle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm & Submit"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review before signing the voting authorization with your Keystone. This is final. Your vote will be published and cannot be changed."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm & Submit"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubtitleSubmitting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote submission is in progress, please don’t leave this screen until it is finished."
+    "coinVote.confirmSubmission.headerTitleSubmitting" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting vote..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote submission is in progress, please don’t leave this screen until it is finished."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting vote..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerTitleCompleted": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submission Confirmed!"
+    "coinVote.confirmSubmission.memoMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submission Confirmed!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerTitleIdle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm & Submit"
+    "coinVote.confirmSubmission.progressAuthorizing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorizing..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm & Submit"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorizing..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerTitleSubmitting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting vote..."
+    "coinVote.confirmSubmission.progressSubmittingVoteCount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting vote %@ of %@..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting vote..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting vote %@ of %@..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.memoMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
+    "coinVote.confirmSubmission.progressTimeRemainingMany" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About %@ minutes left..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About %@ minutes left..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.progressAuthorizing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorizing..."
+    "coinVote.confirmSubmission.progressTimeRemainingOne" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About 1 minute left..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorizing..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About 1 minute left..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.progressSubmittingVoteCount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting vote %@ of %@..."
+    "coinVote.confirmSubmission.submissionFailedMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote couldn't be submitted\nCheck your connection and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting vote %@ of %@..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote couldn't be submitted\nCheck your connection and try again."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.progressTimeRemainingMany": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About %@ minutes left..."
+    "coinVote.confirmSubmission.submissionFailedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submission Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About %@ minutes left..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submission Failed"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.progressTimeRemainingOne": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About 1 minute left..."
+    "coinVote.confirmSubmission.submitCTA" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submit"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About 1 minute left..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submit"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.submissionFailedMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your vote couldn't be submitted\nCheck your connection and try again."
+    "coinVote.confirmSubmission.voteProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote %@ of %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your vote couldn't be submitted\nCheck your connection and try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote %@ of %@"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.submissionFailedTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submission Failed"
+    "coinVote.delegation.insufficientSnapshotBalance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your shielded balance at the snapshot (%@ ZEC) is below the minimum required to vote (%@ ZEC)."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submission Failed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your shielded balance at the snapshot (%@ ZEC) is below the minimum required to vote (%@ ZEC)."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.submitCTA": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submit"
+    "coinVote.delegation.restoreVotingStateFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to restore voting state: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submit"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to restore voting state: %@"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.voteProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote %@ of %@"
+    "coinVote.delegationSigning.awaitingWeightSummary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC signed · %@ ZEC awaiting"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote %@ of %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC signed · %@ ZEC awaiting"
           }
         }
       }
     },
-    "coinVote.delegation.insufficientSnapshotBalance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your shielded balance at the snapshot (%@ ZEC) is below the minimum required to vote (%@ ZEC)."
+    "coinVote.delegationSigning.buildingBundleRequest" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building bundle %@ of %@..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your shielded balance at the snapshot (%@ ZEC) is below the minimum required to vote (%@ ZEC)."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building bundle %@ of %@..."
           }
         }
       }
     },
-    "coinVote.delegation.restoreVotingStateFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to restore voting state: %@"
+    "coinVote.delegationSigning.buildingRequest" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building delegation request..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to restore voting state: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building delegation request..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.awaitingWeightSummary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ZEC signed · %@ ZEC awaiting"
+    "coinVote.delegationSigning.bundleProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign bundle %@ of %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ZEC signed · %@ ZEC awaiting"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign bundle %@ of %@"
           }
         }
       }
     },
-    "coinVote.delegationSigning.buildingBundleRequest": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building bundle %@ of %@..."
+    "coinVote.delegationSigning.currentBundleProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signature %@ of %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building bundle %@ of %@..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signature %@ of %@"
           }
         }
       }
     },
-    "coinVote.delegationSigning.buildingRequest": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building delegation request..."
+    "coinVote.delegationSigning.currentBundleWeight" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This bundle adds %@ ZEC of voting weight."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building delegation request..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This bundle adds %@ ZEC of voting weight."
           }
         }
       }
     },
-    "coinVote.delegationSigning.bundleProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign bundle %@ of %@"
+    "coinVote.delegationSigning.duplicateSignature" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That Keystone signature was already scanned for bundle %@ of %@. Sign the current bundle on Keystone, then scan the new QR."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign bundle %@ of %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That Keystone signature was already scanned for bundle %@ of %@. Sign the current bundle on Keystone, then scan the new QR."
           }
         }
       }
     },
-    "coinVote.delegationSigning.currentBundleProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signature %@ of %@"
+    "coinVote.delegationSigning.finalizingAuthorizationEllipsis" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizing voting authorization…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signature %@ of %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizing voting authorization…"
           }
         }
       }
     },
-    "coinVote.delegationSigning.currentBundleWeight": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This bundle adds %@ ZEC of voting weight."
+    "coinVote.delegationSigning.instruction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "After you have signed with Keystone, tap on the Scan Signature button below."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This bundle adds %@ ZEC of voting weight."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "After you have signed with Keystone, tap on the Scan Signature button below."
           }
         }
       }
     },
-    "coinVote.delegationSigning.duplicateSignature": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "That Keystone signature was already scanned for bundle %@ of %@. Sign the current bundle on Keystone, then scan the new QR."
+    "coinVote.delegationSigning.memo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memo"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "That Keystone signature was already scanned for bundle %@ of %@. Sign the current bundle on Keystone, then scan the new QR."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memo"
           }
         }
       }
     },
-    "coinVote.delegationSigning.finalizingAuthorizationEllipsis": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Finalizing voting authorization…"
+    "coinVote.delegationSigning.memoMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Finalizing voting authorization…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
           }
         }
       }
     },
-    "coinVote.delegationSigning.instruction": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "After you have signed with Keystone, tap on the Scan Signature button below."
+    "coinVote.delegationSigning.multiBundleInstruction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your voting weight is split into %@ Keystone signatures. After each signature, we'll prepare the next one."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "After you have signed with Keystone, tap on the Scan Signature button below."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your voting weight is split into %@ Keystone signatures. After each signature, we'll prepare the next one."
           }
         }
       }
     },
-    "coinVote.delegationSigning.memo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Memo"
+    "coinVote.delegationSigning.parsingSignatureEllipsis" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parsing signature…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Memo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parsing signature…"
           }
         }
       }
     },
-    "coinVote.delegationSigning.memoMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
+    "coinVote.delegationSigning.preparingNextBundle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bundle %@ signed. Preparing bundle %@ of %@..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bundle %@ signed. Preparing bundle %@ of %@..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.multiBundleInstruction": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your voting weight is split into %@ Keystone signatures. After each signature, we'll prepare the next one."
+    "coinVote.delegationSigning.preparingRequestEllipsis" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing signing request…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your voting weight is split into %@ Keystone signatures. After each signature, we'll prepare the next one."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing signing request…"
           }
         }
       }
     },
-    "coinVote.delegationSigning.parsingSignatureEllipsis": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parsing signature…"
+    "coinVote.delegationSigning.processing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parsing signature…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.preparingNextBundle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bundle %@ signed. Preparing bundle %@ of %@..."
+    "coinVote.delegationSigning.processingSignature" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing signature..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bundle %@ signed. Preparing bundle %@ of %@..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing signature..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.preparingRequestEllipsis": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing signing request…"
+    "coinVote.delegationSigning.qrEncodingFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "QR encoding failed. Tap Cancel and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing signing request…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "QR encoding failed. Tap Cancel and try again."
           }
         }
       }
     },
-    "coinVote.delegationSigning.processing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processing..."
+    "coinVote.delegationSigning.scanInstructions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan Keystone QR code\nto sign the transaction"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processing..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan Keystone QR code\nto sign the transaction"
           }
         }
       }
     },
-    "coinVote.delegationSigning.processingSignature": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processing signature..."
+    "coinVote.delegationSigning.scanSignature" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan signature"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processing signature..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan signature"
           }
         }
       }
     },
-    "coinVote.delegationSigning.qrEncodingFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "QR encoding failed. Tap Cancel and try again."
+    "coinVote.delegationSigning.scanSignedBundle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan Signed Bundle %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "QR encoding failed. Tap Cancel and try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan Signed Bundle %@"
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanInstructions": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan Keystone QR code\nto sign the transaction"
+    "coinVote.delegationSigning.scanSignedPCZTCTA" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan signed PCZT"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan Keystone QR code\nto sign the transaction"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan signed PCZT"
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanSignature": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan signature"
+    "coinVote.delegationSigning.scanSignedPCZTInstruction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open your Keystone device and scan the signed PCZT back to continue."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan signature"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open your Keystone device and scan the signed PCZT back to continue."
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanSignedBundle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan Signed Bundle %@"
+    "coinVote.delegationSigning.signatureRejectedOk" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan Signed Bundle %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanSignedPCZTCTA": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan signed PCZT"
+    "coinVote.delegationSigning.signatureRejectedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan signed PCZT"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanSignedPCZTInstruction": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open your Keystone device and scan the signed PCZT back to continue."
+    "coinVote.delegationSigning.signedProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ of %@ signed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open your Keystone device and scan the signed PCZT back to continue."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ of %@ signed"
           }
         }
       }
     },
-    "coinVote.delegationSigning.signatureRejectedOk": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+    "coinVote.delegationSigning.signedWeightSummary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC Signed · %@ ZEC Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ZEC Signed · %@ ZEC Pending"
           }
         }
       }
     },
-    "coinVote.delegationSigning.signatureRejectedTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Something Went Wrong"
+    "coinVote.delegationSigning.skipAlertCancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep Signing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Something Went Wrong"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep Signing"
           }
         }
       }
     },
-    "coinVote.delegationSigning.signedProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ of %@ signed"
+    "coinVote.delegationSigning.skipAlertMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You will vote with %@ ZEC from your signed bundles. The remaining %@ ZEC in unsigned bundles will not be included. This cannot be changed for this round."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ of %@ signed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You will vote with %@ ZEC from your signed bundles. The remaining %@ ZEC in unsigned bundles will not be included. This cannot be changed for this round."
           }
         }
       }
     },
-    "coinVote.delegationSigning.signedWeightSummary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ZEC Signed · %@ ZEC Pending"
+    "coinVote.delegationSigning.skipAlertPrimary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote with signed bundles only"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ZEC Signed · %@ ZEC Pending"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote with signed bundles only"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipAlertCancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep Signing"
+    "coinVote.delegationSigning.skipAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Signed Bundles Only?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep Signing"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Signed Bundles Only?"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipAlertMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You will vote with %@ ZEC from your signed bundles. The remaining %@ ZEC in unsigned bundles will not be included. This cannot be changed for this round."
+    "coinVote.delegationSigning.skipRemainingBundle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip Remaining %@ Bundle"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You will vote with %@ ZEC from your signed bundles. The remaining %@ ZEC in unsigned bundles will not be included. This cannot be changed for this round."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip Remaining %@ Bundle"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipAlertPrimary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote with signed bundles only"
+    "coinVote.delegationSigning.skipRemainingBundles" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip Remaining %@ Bundles"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote with signed bundles only"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip Remaining %@ Bundles"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipAlertTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Signed Bundles Only?"
+    "coinVote.delegationSigning.skipRemainingBundlesCTA" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip remaining bundles"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Signed Bundles Only?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip remaining bundles"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipRemainingBundle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skip Remaining %@ Bundle"
+    "coinVote.delegationSigning.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorize Vote"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skip Remaining %@ Bundle"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorize Vote"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipRemainingBundles": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skip Remaining %@ Bundles"
+    "coinVote.delegationSigning.useSignedBundlesOnly" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use signed bundles only"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skip Remaining %@ Bundles"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use signed bundles only"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipRemainingBundlesCTA": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skip remaining bundles"
+    "coinVote.delegationSigning.useSignedBundlesOnlySubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue without the remaining %@ ZEC."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skip remaining bundles"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue without the remaining %@ ZEC."
           }
         }
       }
     },
-    "coinVote.delegationSigning.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorize Vote"
+    "coinVote.delegationSigning.wrongSignature" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That signature is for a different bundle. Sign bundle %@ of %@ on Keystone, then scan the new QR."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorize Vote"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That signature is for a different bundle. Sign bundle %@ of %@ on Keystone, then scan the new QR."
           }
         }
       }
     },
-    "coinVote.delegationSigning.useSignedBundlesOnly": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use signed bundles only"
+    "coinVote.error.changeDataSource" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change data source"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use signed bundles only"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change data source"
           }
         }
       }
     },
-    "coinVote.delegationSigning.useSignedBundlesOnlySubtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue without the remaining %@ ZEC."
+    "coinVote.error.configUnavailableTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting unavailable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue without the remaining %@ ZEC."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting unavailable"
           }
         }
       }
     },
-    "coinVote.delegationSigning.wrongSignature": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "That signature is for a different bundle. Sign bundle %@ of %@ on Keystone, then scan the new QR."
+    "coinVote.error.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "That signature is for a different bundle. Sign bundle %@ of %@ on Keystone, then scan the new QR."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something Went Wrong"
           }
         }
       }
     },
-    "coinVote.error.changeDataSource": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Change data source"
+    "coinVote.howToVote.infoCard" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your balance at the snapshot time determines your voting weight. You don't need to move your funds anywhere."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Change data source"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your balance at the snapshot time determines your voting weight. You don't need to move your funds anywhere."
           }
         }
       }
     },
-    "coinVote.error.configUnavailableTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting unavailable"
+    "coinVote.howToVote.stepAuthorizeBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When you're ready, you'll confirm a small authorization transaction and submit your vote in one step. After submission, your vote cannot be changed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting unavailable"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When you're ready, you'll confirm a small authorization transaction and submit your vote in one step. After submission, your vote cannot be changed."
           }
         }
       }
     },
-    "coinVote.error.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Something Went Wrong"
+    "coinVote.howToVote.stepAuthorizeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorize and Submit"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Something Went Wrong"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorize and Submit"
           }
         }
       }
     },
-    "coinVote.howToVote.infoCard": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your balance at the snapshot time determines your voting weight. You don't need to move your funds anywhere."
+    "coinVote.howToVote.stepVotingBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your balance at the snapshot time determines your voting weight. You don't need to move your funds anywhere."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
           }
         }
       }
     },
-    "coinVote.howToVote.stepAuthorizeBody": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When you're ready, you'll confirm a small authorization transaction and submit your vote in one step. After submission, your vote cannot be changed."
+    "coinVote.howToVote.stepVotingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting on Proposals"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When you're ready, you'll confirm a small authorization transaction and submit your vote in one step. After submission, your vote cannot be changed."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting on Proposals"
           }
         }
       }
     },
-    "coinVote.howToVote.stepAuthorizeTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorize and Submit"
+    "coinVote.howToVote.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your ZEC gives you a voice. Shape the future of the Zcash network by voting on active proposals."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorize and Submit"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your ZEC gives you a voice. Shape the future of the Zcash network by voting on active proposals."
           }
         }
       }
     },
-    "coinVote.howToVote.stepVotingBody": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
+    "coinVote.howToVote.titleKeystone" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How to vote with Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How to vote with Keystone"
           }
         }
       }
     },
-    "coinVote.howToVote.stepVotingTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting on Proposals"
+    "coinVote.howToVote.titleZodl" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How to vote with Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting on Proposals"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How to vote with Zodl"
           }
         }
       }
     },
-    "coinVote.howToVote.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your ZEC gives you a voice. Shape the future of the Zcash network by voting on active proposals."
+    "coinVote.ineligible.balanceTooLowMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your shielded balance at the snapshot block was %@, which is below the 0.125 ZEC minimum required to vote."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your ZEC gives you a voice. Shape the future of the Zcash network by voting on active proposals."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your shielded balance at the snapshot block was %@, which is below the 0.125 ZEC minimum required to vote."
           }
         }
       }
     },
-    "coinVote.howToVote.titleKeystone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How to vote with Keystone"
+    "coinVote.ineligible.detailBallots" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ballots"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How to vote with Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ballots"
           }
         }
       }
     },
-    "coinVote.howToVote.titleZodl": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How to vote with Zodl"
+    "coinVote.ineligible.detailMinimum" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimum"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How to vote with Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimum"
           }
         }
       }
     },
-    "coinVote.ineligible.balanceTooLowMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your shielded balance at the snapshot block was %@, which is below the 0.125 ZEC minimum required to vote."
+    "coinVote.ineligible.detailMinimumValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.125 ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your shielded balance at the snapshot block was %@, which is below the 0.125 ZEC minimum required to vote."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.125 ZEC"
           }
         }
       }
     },
-    "coinVote.ineligible.detailBallots": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ballots"
+    "coinVote.ineligible.detailNotesFound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes found"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ballots"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes found"
           }
         }
       }
     },
-    "coinVote.ineligible.detailMinimum": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimum"
+    "coinVote.ineligible.detailSnapshot" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snapshot"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimum"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snapshot"
           }
         }
       }
     },
-    "coinVote.ineligible.detailMinimumValue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0.125 ZEC"
+    "coinVote.ineligible.detailYourBalance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your balance"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0.125 ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your balance"
           }
         }
       }
     },
-    "coinVote.ineligible.detailNotesFound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notes found"
+    "coinVote.ineligible.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To participate in future voting rounds, ensure you have at least 0.125 ZEC in shielded funds before the snapshot block."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notes found"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To participate in future voting rounds, ensure you have at least 0.125 ZEC in shielded funds before the snapshot block."
           }
         }
       }
     },
-    "coinVote.ineligible.detailSnapshot": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Snapshot"
+    "coinVote.ineligible.noNotesMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet has no shielded notes from before the snapshot block. Only funds that existed at block #%@ are eligible for this voting round."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Snapshot"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet has no shielded notes from before the snapshot block. Only funds that existed at block #%@ are eligible for this voting round."
           }
         }
       }
     },
-    "coinVote.ineligible.detailYourBalance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your balance"
+    "coinVote.ineligible.snapshotBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your balance"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
           }
         }
       }
     },
-    "coinVote.ineligible.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To participate in future voting rounds, ensure you have at least 0.125 ZEC in shielded funds before the snapshot block."
+    "coinVote.ineligible.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Eligible for This Round"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To participate in future voting rounds, ensure you have at least 0.125 ZEC in shielded funds before the snapshot block."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Eligible for This Round"
           }
         }
       }
     },
-    "coinVote.ineligible.noNotesMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet has no shielded notes from before the snapshot block. Only funds that existed at block #%@ are eligible for this voting round."
+    "coinVote.ineligible.titleNoVote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can't vote in this round"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet has no shielded notes from before the snapshot block. Only funds that existed at block #%@ are eligible for this voting round."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can't vote in this round"
           }
         }
       }
     },
-    "coinVote.ineligible.snapshotBody": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
+    "coinVote.pollClosedSheet.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting period has ended.\nYour vote can no longer be submitted."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting period has ended.\nYour vote can no longer be submitted."
           }
         }
       }
     },
-    "coinVote.ineligible.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not Eligible for This Round"
+    "coinVote.pollClosedSheet.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll Closed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not Eligible for This Round"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll Closed"
           }
         }
       }
     },
-    "coinVote.ineligible.titleNoVote": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can't vote in this round"
+    "coinVote.pollClosedSheet.viewStatus" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View status"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can't vote in this round"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View status"
           }
         }
       }
     },
-    "coinVote.pollClosedSheet.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting period has ended.\nYour vote can no longer be submitted."
+    "coinVote.pollsList.approvedByZodl" : {
+      "comment" : "Accessibility label and badge text indicating that a poll is endorsed by Zodl.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approved by Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting period has ended.\nYour vote can no longer be submitted."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approved by Zodl"
           }
         }
       }
     },
-    "coinVote.pollClosedSheet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll Closed"
+    "coinVote.pollsList.chainConfigAccessibility" : {
+      "comment" : "Accessibility label for the voting chain config button on the polls list.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting chain config"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll Closed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting chain config"
           }
         }
       }
     },
-    "coinVote.pollClosedSheet.viewStatus": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View status"
+    "coinVote.pollsList.dateClosed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Closed %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View status"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Closed %@"
           }
         }
       }
     },
-    "coinVote.pollsList.approvedByZodl": {
-      "comment": "Accessibility label and badge text indicating that a poll is endorsed by Zodl.",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Approved by Zodl"
+    "coinVote.pollsList.dateCloses" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Closes %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Approved by Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Closes %@"
           }
         }
       }
     },
-    "coinVote.pollsList.chainConfigAccessibility": {
-      "comment": "Accessibility label for the voting chain config button on the polls list.",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting chain config"
+    "coinVote.pollsList.emptyMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There aren’t any active polls at the moment.\nCheck back later."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting chain config"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There aren’t any active polls at the moment.\nCheck back later."
           }
         }
       }
     },
-    "coinVote.pollsList.dateClosed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closed %@"
+    "coinVote.pollsList.emptyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No polls right now"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closed %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No polls right now"
           }
         }
       }
     },
-    "coinVote.pollsList.dateCloses": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closes %@"
+    "coinVote.pollsList.enterPoll" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter Poll"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closes %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter Poll"
           }
         }
       }
     },
-    "coinVote.pollsList.emptyMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There aren’t any active polls at the moment.\nCheck back later."
+    "coinVote.pollsList.insufficientBalanceMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There aren’t any active polls at the moment.\nCheck back later."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
           }
         }
       }
     },
-    "coinVote.pollsList.emptyTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No polls right now"
+    "coinVote.pollsList.insufficientBalanceTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insufficient Balance"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No polls right now"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insufficient Balance"
           }
         }
       }
     },
-    "coinVote.pollsList.enterPoll": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter Poll"
+    "coinVote.pollsList.loadErrorMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check your connection and try again. If the problem persists, come back later."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter Poll"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check your connection and try again. If the problem persists, come back later."
           }
         }
       }
     },
-    "coinVote.pollsList.insufficientBalanceMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
+    "coinVote.pollsList.loadErrorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load polls"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load polls"
           }
         }
       }
     },
-    "coinVote.pollsList.insufficientBalanceTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient Balance"
+    "coinVote.pollsList.review" : {
+      "comment" : "Poll card action label for a round the user has already voted in.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient Balance"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review"
           }
         }
       }
     },
-    "coinVote.pollsList.loadErrorMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check your connection and try again. If the problem persists, come back later."
+    "coinVote.pollsList.statusActive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check your connection and try again. If the problem persists, come back later."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
           }
         }
       }
     },
-    "coinVote.pollsList.loadErrorTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't load polls"
+    "coinVote.pollsList.statusClosed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Closed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't load polls"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Closed"
           }
         }
       }
     },
-    "coinVote.pollsList.review": {
-      "comment": "Poll card action label for a round the user has already voted in.",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review"
+    "coinVote.pollsList.unverifiedSheetMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
           }
         }
       }
     },
-    "coinVote.pollsList.statusActive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active"
+    "coinVote.pollsList.unverifiedSheetProceed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proceed anyway"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proceed anyway"
           }
         }
       }
     },
-    "coinVote.pollsList.statusClosed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closed"
+    "coinVote.pollsList.unverifiedSheetTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unverified Poll"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unverified Poll"
           }
         }
       }
     },
-    "coinVote.pollsList.unverifiedSheetMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
+    "coinVote.pollsList.viewMyVotes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View My Votes"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View My Votes"
           }
         }
       }
     },
-    "coinVote.pollsList.unverifiedSheetProceed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proceed anyway"
+    "coinVote.proposalDetail.notFound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proposal not found"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proceed anyway"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proposal not found"
           }
         }
       }
     },
-    "coinVote.pollsList.unverifiedSheetTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unverified Poll"
+    "coinVote.proposalDetail.position" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ OF %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unverified Poll"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ OF %@"
           }
         }
       }
     },
-    "coinVote.pollsList.viewMyVotes": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View My Votes"
+    "coinVote.proposalDetail.skippedMessageMultiple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have not responded to %@ questions. Confirm to skip these questions or go back to respond."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View My Votes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have not responded to %@ questions. Confirm to skip these questions or go back to respond."
           }
         }
       }
     },
-    "coinVote.proposalDetail.notFound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proposal not found"
+    "coinVote.proposalDetail.skippedMessageSingle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have not responded to %@ question. Confirm to skip this question or go back to respond."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proposal not found"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have not responded to %@ question. Confirm to skip this question or go back to respond."
           }
         }
       }
     },
-    "coinVote.proposalDetail.position": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ OF %@"
+    "coinVote.proposalDetail.unansweredMessageMultiple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have not responded to %@ questions. Confirm to abstain from these questions or go back to respond."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ OF %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have not responded to %@ questions. Confirm to abstain from these questions or go back to respond."
           }
         }
       }
     },
-    "coinVote.proposalDetail.skippedMessageMultiple": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You have not responded to %@ questions. Confirm to skip these questions or go back to respond."
+    "coinVote.proposalDetail.unansweredMessageSingle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have not responded to %@ question. Confirm to abstain from this question or go back to respond."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You have not responded to %@ questions. Confirm to skip these questions or go back to respond."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have not responded to %@ question. Confirm to abstain from this question or go back to respond."
           }
         }
       }
     },
-    "coinVote.proposalDetail.skippedMessageSingle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You have not responded to %@ question. Confirm to skip this question or go back to respond."
+    "coinVote.proposalDetail.unansweredTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unanswered Questions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You have not responded to %@ question. Confirm to skip this question or go back to respond."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unanswered Questions"
           }
         }
       }
     },
-    "coinVote.proposalDetail.unansweredMessageMultiple": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You have not responded to %@ questions. Confirm to abstain from these questions or go back to respond."
+    "coinVote.proposalDetail.viewForumDiscussion" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View Forum Discussion"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You have not responded to %@ questions. Confirm to abstain from these questions or go back to respond."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View Forum Discussion"
           }
         }
       }
     },
-    "coinVote.proposalDetail.unansweredMessageSingle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You have not responded to %@ question. Confirm to abstain from this question or go back to respond."
+    "coinVote.proposalList.ctaConfirmSubmit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm & Submit"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You have not responded to %@ question. Confirm to abstain from this question or go back to respond."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm & Submit"
           }
         }
       }
     },
-    "coinVote.proposalDetail.unansweredTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unanswered Questions"
+    "coinVote.proposalList.ctaContinueVoting" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue Voting"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unanswered Questions"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue Voting"
           }
         }
       }
     },
-    "coinVote.proposalDetail.viewForumDiscussion": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View Forum Discussion"
+    "coinVote.proposalList.ctaReviewAnswers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review Answers"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View Forum Discussion"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review Answers"
           }
         }
       }
     },
-    "coinVote.proposalList.ctaConfirmSubmit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm & Submit"
+    "coinVote.proposalList.ctaStartVoting" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start Voting"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm & Submit"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start Voting"
           }
         }
       }
     },
-    "coinVote.proposalList.ctaContinueVoting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue Voting"
+    "coinVote.proposalList.headerEndsAt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ends %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue Voting"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ends %@"
           }
         }
       }
     },
-    "coinVote.proposalList.ctaReviewAnswers": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review Answers"
+    "coinVote.proposalList.noActiveRoundMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There are no voting rounds in progress. Rounds are created by governance administrators — check back later."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review Answers"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There are no voting rounds in progress. Rounds are created by governance administrators — check back later."
           }
         }
       }
     },
-    "coinVote.proposalList.ctaStartVoting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start Voting"
+    "coinVote.proposalList.noActiveRoundTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Active Voting Round"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start Voting"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Active Voting Round"
           }
         }
       }
     },
-    "coinVote.proposalList.headerEndsAt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ends %@"
+    "coinVote.proposalList.preparingVotingPower" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing your voting power…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ends %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing your voting power…"
           }
         }
       }
     },
-    "coinVote.proposalList.noActiveRoundMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There are no voting rounds in progress. Rounds are created by governance administrators — check back later."
+    "coinVote.proposalList.reviewSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap on the question to edit any of your answers. After you review your answers, tap on Confirm & Submit."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There are no voting rounds in progress. Rounds are created by governance administrators — check back later."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap on the question to edit any of your answers. After you review your answers, tap on Confirm & Submit."
           }
         }
       }
     },
-    "coinVote.proposalList.noActiveRoundTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Active Voting Round"
+    "coinVote.proposalList.reviewTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review and submit vote"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Active Voting Round"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review and submit vote"
           }
         }
       }
     },
-    "coinVote.proposalList.preparingVotingPower": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing your voting power…"
+    "coinVote.proposalList.submitVotesCount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submit votes (%@)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing your voting power…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submit votes (%@)"
           }
         }
       }
     },
-    "coinVote.proposalList.reviewSubtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap on the question to edit any of your answers. After you review your answers, tap on Confirm & Submit."
+    "coinVote.proposalList.viewForumDiscussions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View Forum Discussions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap on the question to edit any of your answers. After you review your answers, tap on Confirm & Submit."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View Forum Discussions"
           }
         }
       }
     },
-    "coinVote.proposalList.reviewTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review and submit vote"
+    "coinVote.proposalList.viewMore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View more"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review and submit vote"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View more"
           }
         }
       }
     },
-    "coinVote.proposalList.submitVotesCount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submit votes (%@)"
+    "coinVote.proposalList.votingPower" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting power: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submit votes (%@)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting power: %@"
           }
         }
       }
     },
-    "coinVote.proposalList.viewForumDiscussions": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View Forum Discussions"
+    "coinVote.proposalList.yourVote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View Forum Discussions"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your vote:"
           }
         }
       }
     },
-    "coinVote.proposalList.viewMore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View more"
+    "coinVote.results.approvedByZodl" : {
+      "comment" : "Accessibility label for the Zodl badge on the results header indicating an approved poll.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approved by Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View more"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approved by Zodl"
           }
         }
       }
     },
-    "coinVote.proposalList.votingPower": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting power: %@"
+    "coinVote.results.loadErrorMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check your connection and try again. If the problem persists, come back later."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting power: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check your connection and try again. If the problem persists, come back later."
           }
         }
       }
     },
-    "coinVote.proposalList.yourVote": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your vote:"
+    "coinVote.results.loadErrorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load results"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your vote:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load results"
           }
         }
       }
     },
-    "coinVote.results.approvedByZodl": {
-      "comment": "Accessibility label for the Zodl badge on the results header indicating an approved poll.",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Approved by Zodl"
+    "coinVote.results.loading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading results..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Approved by Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading results..."
           }
         }
       }
     },
-    "coinVote.results.loadErrorMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check your connection and try again. If the problem persists, come back later."
+    "coinVote.results.metaLine" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voted %@  ·  Voting Power %@ ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check your connection and try again. If the problem persists, come back later."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voted %@  ·  Voting Power %@ ZEC"
           }
         }
       }
     },
-    "coinVote.results.loadErrorTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't load results"
+    "coinVote.results.noProposalsInRound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No proposals in this round"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't load results"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No proposals in this round"
           }
         }
       }
     },
-    "coinVote.results.loading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading results..."
+    "coinVote.results.noVotesRecorded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No votes recorded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading results..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No votes recorded"
           }
         }
       }
     },
-    "coinVote.results.metaLine": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voted %@  ·  Voting Power %@ ZEC"
+    "coinVote.results.option" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Option %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voted %@  ·  Voting Power %@ ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Option %@"
           }
         }
       }
     },
-    "coinVote.results.noProposalsInRound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No proposals in this round"
+    "coinVote.results.percentValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%%"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No proposals in this round"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%%"
           }
         }
       }
     },
-    "coinVote.results.noVotesRecorded": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No votes recorded"
+    "coinVote.results.tie" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tie"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No votes recorded"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tie"
           }
         }
       }
     },
-    "coinVote.results.option": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Option %@"
+    "coinVote.results.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Results"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Option %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Results"
           }
         }
       }
     },
-    "coinVote.results.percentValue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@%%"
+    "coinVote.results.total" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@%%"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total: %@"
           }
         }
       }
     },
-    "coinVote.results.tie": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tie"
+    "coinVote.results.votedLine" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voted: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tie"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voted: %@"
           }
         }
       }
     },
-    "coinVote.results.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Results"
+    "coinVote.results.winnerLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Winner:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Results"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Winner:"
           }
         }
       }
     },
-    "coinVote.results.total": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total: %@"
+    "coinVote.store.error.delegationTxFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "delegation TX failed on-chain (code %@) or missing delegate_vote event%@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "delegation TX failed on-chain (code %@) or missing delegate_vote event%@"
           }
         }
       }
     },
-    "coinVote.results.votedLine": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voted: %@"
+    "coinVote.store.error.invalidDelegationSignature" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone delegation signature tuple (rk, sighash, sig) is inconsistent with the payload being submitted."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voted: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone delegation signature tuple (rk, sighash, sig) is inconsistent with the payload being submitted."
           }
         }
       }
     },
-    "coinVote.results.winnerLabel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Winner:"
+    "coinVote.store.error.missingActiveSession" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missing active voting session"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Winner:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missing active voting session"
           }
         }
       }
     },
-    "coinVote.store.error.delegationTxFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "delegation TX failed on-chain (code %@) or missing delegate_vote event%@"
+    "coinVote.store.error.missingHotkeyAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missing hotkey address for delegation PCZT"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "delegation TX failed on-chain (code %@) or missing delegate_vote event%@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missing hotkey address for delegation PCZT"
           }
         }
       }
     },
-    "coinVote.store.error.invalidDelegationSignature": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone delegation signature tuple (rk, sighash, sig) is inconsistent with the payload being submitted."
+    "coinVote.store.error.missingKeystoneBundleSignature" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Missing Keystone signature for one or more delegation bundles."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone delegation signature tuple (rk, sighash, sig) is inconsistent with the payload being submitted."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Missing Keystone signature for one or more delegation bundles."
           }
         }
       }
     },
-    "coinVote.store.error.missingActiveSession": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "missing active voting session"
+    "coinVote.store.error.missingPendingUnsignedPczt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missing pending unsigned delegation PCZT"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "missing active voting session"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missing pending unsigned delegation PCZT"
           }
         }
       }
     },
-    "coinVote.store.error.missingHotkeyAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "missing hotkey address for delegation PCZT"
+    "coinVote.store.error.missingSigningAccount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missing signing account for delegation PCZT"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "missing hotkey address for delegation PCZT"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missing signing account for delegation PCZT"
           }
         }
       }
     },
-    "coinVote.store.error.missingKeystoneBundleSignature": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing Keystone signature for one or more delegation bundles."
+    "coinVote.store.error.missingVoteCommitmentBundle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vote commitment build completed without a commitment bundle"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing Keystone signature for one or more delegation bundles."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vote commitment build completed without a commitment bundle"
           }
         }
       }
     },
-    "coinVote.store.error.missingPendingUnsignedPczt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "missing pending unsigned delegation PCZT"
+    "coinVote.store.error.voteCommitmentTxFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vote commitment TX failed on-chain (code %@)%@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "missing pending unsigned delegation PCZT"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vote commitment TX failed on-chain (code %@)%@"
           }
         }
       }
     },
-    "coinVote.store.error.missingSigningAccount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "missing signing account for delegation PCZT"
+    "coinVote.store.roundTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Round %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "missing signing account for delegation PCZT"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Round %@"
           }
         }
       }
     },
-    "coinVote.store.error.missingVoteCommitmentBundle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "vote commitment build completed without a commitment bundle"
+    "coinVote.store.submissionAuthorizingVote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorizing vote..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "vote commitment build completed without a commitment bundle"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorizing vote..."
           }
         }
       }
     },
-    "coinVote.store.error.voteCommitmentTxFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "vote commitment TX failed on-chain (code %@)%@"
+    "coinVote.store.submissionAuthorizingVoteProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorizing vote... %@%%"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "vote commitment TX failed on-chain (code %@)%@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorizing vote... %@%%"
           }
         }
       }
     },
-    "coinVote.store.roundTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Round %@"
+    "coinVote.store.submissionPreparingProof" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building vote proof..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Round %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building vote proof..."
           }
         }
       }
     },
-    "coinVote.store.submissionAuthorizingVote": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorizing vote..."
+    "coinVote.store.submissionPreparingProofProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building vote proof (%@/%@)..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorizing vote..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building vote proof (%@/%@)..."
           }
         }
       }
     },
-    "coinVote.store.submissionAuthorizingVoteProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorizing vote... %@%%"
+    "coinVote.store.submissionSendingShares" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending to vote servers..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorizing vote... %@%%"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending to vote servers..."
           }
         }
       }
     },
-    "coinVote.store.submissionPreparingProof": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building vote proof..."
+    "coinVote.store.submissionSendingSharesProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending to vote servers (%@/%@)..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building vote proof..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending to vote servers (%@/%@)..."
           }
         }
       }
     },
-    "coinVote.store.submissionPreparingProofProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building vote proof (%@/%@)..."
+    "coinVote.store.submissionWaitingForConfirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for confirmation..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building vote proof (%@/%@)..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for confirmation..."
           }
         }
       }
     },
-    "coinVote.store.submissionSendingShares": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending to vote servers..."
+    "coinVote.store.submissionWaitingForConfirmationProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for confirmation (%@/%@)..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending to vote servers..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for confirmation (%@/%@)..."
           }
         }
       }
     },
-    "coinVote.store.submissionSendingSharesProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending to vote servers (%@/%@)..."
+    "coinVote.store.userError.commitmentTreeNotGrown" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your transaction hasn't been confirmed yet. The network may be congested — please wait a moment and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending to vote servers (%@/%@)..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your transaction hasn't been confirmed yet. The network may be congested — please wait a moment and try again."
           }
         }
       }
     },
-    "coinVote.store.submissionWaitingForConfirmation": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for confirmation..."
+    "coinVote.store.userError.http5" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting server is temporarily unavailable. Please try again shortly."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for confirmation..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting server is temporarily unavailable. Please try again shortly."
           }
         }
       }
     },
-    "coinVote.store.submissionWaitingForConfirmationProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for confirmation (%@/%@)..."
+    "coinVote.store.userError.invalidAnchorHeight" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting state is out of sync. Please retry to use the latest data."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for confirmation (%@/%@)..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting state is out of sync. Please retry to use the latest data."
           }
         }
       }
     },
-    "coinVote.store.userError.commitmentTreeNotGrown": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your transaction hasn't been confirmed yet. The network may be congested — please wait a moment and try again."
+    "coinVote.store.userError.invalidProof" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your proof was rejected by the network. Please try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your transaction hasn't been confirmed yet. The network may be congested — please wait a moment and try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your proof was rejected by the network. Please try again."
           }
         }
       }
     },
-    "coinVote.store.userError.http5": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting server is temporarily unavailable. Please try again shortly."
+    "coinVote.store.userError.lightwalletdUnavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to reach the Zcash lightwalletd server. Please check your internet connection or try switching to a different server in Settings."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting server is temporarily unavailable. Please try again shortly."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to reach the Zcash lightwalletd server. Please check your internet connection or try switching to a different server in Settings."
           }
         }
       }
     },
-    "coinVote.store.userError.invalidAnchorHeight": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting state is out of sync. Please retry to use the latest data."
+    "coinVote.store.userError.noReachableVoteServers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to reach any vote server. Please check your internet connection and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting state is out of sync. Please retry to use the latest data."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to reach any vote server. Please check your internet connection and try again."
           }
         }
       }
     },
-    "coinVote.store.userError.invalidProof": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your proof was rejected by the network. Please try again."
+    "coinVote.store.userError.noTreeState" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting commitment tree is not available yet. The voting round may not have started or the chain has not processed any commitments."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your proof was rejected by the network. Please try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting commitment tree is not available yet. The voting round may not have started or the chain has not processed any commitments."
           }
         }
       }
     },
-    "coinVote.store.userError.lightwalletdUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to reach the Zcash lightwalletd server. Please check your internet connection or try switching to a different server in Settings."
+    "coinVote.store.userError.nullifierAlreadySpent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This wallet has already been registered for this voting round. If you have this wallet on multiple devices, please use the device where you originally started the voting process."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to reach the Zcash lightwalletd server. Please check your internet connection or try switching to a different server in Settings."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This wallet has already been registered for this voting round. If you have this wallet on multiple devices, please use the device where you originally started the voting process."
           }
         }
       }
     },
-    "coinVote.store.userError.noReachableVoteServers": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to reach any vote server. Please check your internet connection and try again."
+    "coinVote.store.userError.pirEndpointsMissing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting configuration is missing nullifier-service endpoints. Please update the app and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to reach any vote server. Please check your internet connection and try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting configuration is missing nullifier-service endpoints. Please update the app and try again."
           }
         }
       }
     },
-    "coinVote.store.userError.noTreeState": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting commitment tree is not available yet. The voting round may not have started or the chain has not processed any commitments."
+    "coinVote.store.userError.pirInvalidProofData" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The nullifier service returned invalid proof data. Please try again in a few minutes."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting commitment tree is not available yet. The voting round may not have started or the chain has not processed any commitments."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The nullifier service returned invalid proof data. Please try again in a few minutes."
           }
         }
       }
     },
-    "coinVote.store.userError.nullifierAlreadySpent": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This wallet has already been registered for this voting round. If you have this wallet on multiple devices, please use the device where you originally started the voting process."
+    "coinVote.store.userError.pirSnapshotMismatch" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The nullifier service is out of sync with the round's snapshot. Voting cannot proceed until a PIR server reports the matching snapshot. Please try again in a few minutes."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This wallet has already been registered for this voting round. If you have this wallet on multiple devices, please use the device where you originally started the voting process."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The nullifier service is out of sync with the round's snapshot. Voting cannot proceed until a PIR server reports the matching snapshot. Please try again in a few minutes."
           }
         }
       }
     },
-    "coinVote.store.userError.pirEndpointsMissing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting configuration is missing nullifier-service endpoints. Please update the app and try again."
+    "coinVote.store.userError.pirUnavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to reach the nullifier service. Please check your internet connection and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting configuration is missing nullifier-service endpoints. Please update the app and try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to reach the nullifier service. Please check your internet connection and try again."
           }
         }
       }
     },
-    "coinVote.store.userError.pirInvalidProofData": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The nullifier service returned invalid proof data. Please try again in a few minutes."
+    "coinVote.store.userError.proofGenerationFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proof generation failed. Please try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The nullifier service returned invalid proof data. Please try again in a few minutes."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proof generation failed. Please try again."
           }
         }
       }
     },
-    "coinVote.store.userError.pirSnapshotMismatch": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The nullifier service is out of sync with the round's snapshot. Voting cannot proceed until a PIR server reports the matching snapshot. Please try again in a few minutes."
+    "coinVote.store.userError.roundNotActive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This voting round is no longer accepting votes. It may have ended or is not yet open."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The nullifier service is out of sync with the round's snapshot. Voting cannot proceed until a PIR server reports the matching snapshot. Please try again in a few minutes."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This voting round is no longer accepting votes. It may have ended or is not yet open."
           }
         }
       }
     },
-    "coinVote.store.userError.pirUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to reach the nullifier service. Please check your internet connection and try again."
+    "coinVote.store.userError.roundNotFound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This voting round could not be found on the network."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to reach the nullifier service. Please check your internet connection and try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This voting round could not be found on the network."
           }
         }
       }
     },
-    "coinVote.store.userError.proofGenerationFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proof generation failed. Please try again."
+    "coinVote.submission.continuedProcessingMessageMultiple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending %@ votes to the network"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proof generation failed. Please try again."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending %@ votes to the network"
           }
         }
       }
     },
-    "coinVote.store.userError.roundNotActive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This voting round is no longer accepting votes. It may have ended or is not yet open."
+    "coinVote.submission.continuedProcessingMessageSingle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending %@ vote to the network"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This voting round is no longer accepting votes. It may have ended or is not yet open."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending %@ vote to the network"
           }
         }
       }
     },
-    "coinVote.store.userError.roundNotFound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This voting round could not be found on the network."
+    "coinVote.submission.continuedProcessingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting votes"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This voting round could not be found on the network."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submitting votes"
           }
         }
       }
     },
-    "coinVote.submission.continuedProcessingMessageMultiple": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending %@ votes to the network"
+    "coinVote.submission.genericBatchFailure" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some votes could not be submitted."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending %@ votes to the network"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some votes could not be submitted."
           }
         }
       }
     },
-    "coinVote.submission.continuedProcessingMessageSingle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending %@ vote to the network"
+    "coinVote.tallying.bodyInProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting has closed. Final results will appear here once the helpers finish tallying."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending %@ vote to the network"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voting has closed. Final results will appear here once the helpers finish tallying."
           }
         }
       }
     },
-    "coinVote.submission.continuedProcessingTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting votes"
+    "coinVote.tallying.detailEnded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ended"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting votes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ended"
           }
         }
       }
     },
-    "coinVote.submission.genericBatchFailure": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Some votes could not be submitted."
+    "coinVote.tallying.detailProposals" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proposals"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Some votes could not be submitted."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proposals"
           }
         }
       }
     },
-    "coinVote.tallying.bodyInProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting has closed. Final results will appear here once the helpers finish tallying."
+    "coinVote.tallying.detailRound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Round"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voting has closed. Final results will appear here once the helpers finish tallying."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Round"
           }
         }
       }
     },
-    "coinVote.tallying.detailEnded": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ended"
+    "coinVote.tallying.status" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallying"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ended"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallying"
           }
         }
       }
     },
-    "coinVote.tallying.detailProposals": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proposals"
+    "coinVote.tallying.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Results are being tallied. The election authority is decrypting the aggregate vote totals."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proposals"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Results are being tallied. The election authority is decrypting the aggregate vote totals."
           }
         }
       }
     },
-    "coinVote.tallying.detailRound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Round"
+    "coinVote.tallying.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votes Closed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Round"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votes Closed"
           }
         }
       }
     },
-    "coinVote.tallying.status": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tallying"
+    "coinVote.tallying.titleInProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallying in progress"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tallying"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tallying in progress"
           }
         }
       }
     },
-    "coinVote.tallying.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Results are being tallied. The election authority is decrypting the aggregate vote totals."
+    "coinVote.votingView.noRoundsMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There are no voting rounds available right now."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Results are being tallied. The election authority is decrypting the aggregate vote totals."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There are no voting rounds available right now."
           }
         }
       }
     },
-    "coinVote.tallying.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Votes Closed"
+    "coinVote.votingView.noRoundsTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Voting Rounds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Votes Closed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Voting Rounds"
           }
         }
       }
     },
-    "coinVote.tallying.titleInProgress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tallying in progress"
+    "coinVote.votingView.pollClosedMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting period has ended.\nYour vote can no longer be submitted."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tallying in progress"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The voting period has ended.\nYour vote can no longer be submitted."
           }
         }
       }
     },
-    "coinVote.votingView.noRoundsMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There are no voting rounds available right now."
+    "coinVote.votingView.pollClosedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll Closed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There are no voting rounds available right now."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poll Closed"
           }
         }
       }
     },
-    "coinVote.votingView.noRoundsTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Voting Rounds"
+    "coinVote.votingView.unverifiedPollMessage" : {
+      "comment" : "Body shown when the user is about to open a poll that is not Zodl-endorsed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This poll hasn't been verified. We can't confirm its legitimacy or how results will be used."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Voting Rounds"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This poll hasn't been verified. We can't confirm its legitimacy or how results will be used."
           }
         }
       }
     },
-    "coinVote.votingView.pollClosedMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting period has ended.\nYour vote can no longer be submitted."
+    "coinVote.votingView.unverifiedPollProceedAnyway" : {
+      "comment" : "Action label on the unverified-poll sheet that opens the poll despite the warning.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proceed anyway"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The voting period has ended.\nYour vote can no longer be submitted."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proceed anyway"
           }
         }
       }
     },
-    "coinVote.votingView.pollClosedTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll Closed"
+    "coinVote.votingView.unverifiedPollTitle" : {
+      "comment" : "Title of the sheet shown when the user is about to open a poll that is not Zodl-endorsed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unverified Poll"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poll Closed"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unverified Poll"
           }
         }
       }
     },
-    "coinVote.votingView.unverifiedPollMessage": {
-      "comment": "Body shown when the user is about to open a poll that is not Zodl-endorsed.",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This poll hasn't been verified. We can't confirm its legitimacy or how results will be used."
+    "coinVote.walletSyncing.catchingUp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catching up to round snapshot"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This poll hasn't been verified. We can't confirm its legitimacy or how results will be used."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catching up to round snapshot"
           }
         }
       }
     },
-    "coinVote.votingView.unverifiedPollProceedAnyway": {
-      "comment": "Action label on the unverified-poll sheet that opens the poll despite the warning.",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proceed anyway"
+    "coinVote.walletSyncing.detailBlocksRemaining" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blocks remaining"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proceed anyway"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blocks remaining"
           }
         }
       }
     },
-    "coinVote.votingView.unverifiedPollTitle": {
-      "comment": "Title of the sheet shown when the user is about to open a poll that is not Zodl-endorsed.",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unverified Poll"
+    "coinVote.walletSyncing.detailSnapshotBlock" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snapshot block"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unverified Poll"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snapshot block"
           }
         }
       }
     },
-    "coinVote.walletSyncing.catchingUp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Catching up to round snapshot"
+    "coinVote.walletSyncing.detailSyncedTo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet synced to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Catching up to round snapshot"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet synced to"
           }
         }
       }
     },
-    "coinVote.walletSyncing.detailBlocksRemaining": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Blocks remaining"
+    "coinVote.walletSyncing.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please wait for your wallet to finish syncing, then come back to vote."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Blocks remaining"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please wait for your wallet to finish syncing, then come back to vote."
           }
         }
       }
     },
-    "coinVote.walletSyncing.detailSnapshotBlock": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Snapshot block"
+    "coinVote.walletSyncing.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet needs to sync to the snapshot block height before you can participate in voting."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Snapshot block"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet needs to sync to the snapshot block height before you can participate in voting."
           }
         }
       }
     },
-    "coinVote.walletSyncing.detailSyncedTo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet synced to"
+    "coinVote.walletSyncing.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Syncing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet synced to"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Syncing"
           }
         }
       }
     },
-    "coinVote.walletSyncing.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please wait for your wallet to finish syncing, then come back to vote."
+    "component.lowPrivacy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Private"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please wait for your wallet to finish syncing, then come back to vote."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Público"
           }
         }
       }
     },
-    "coinVote.walletSyncing.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet needs to sync to the snapshot block height before you can participate in voting."
+    "component.maxPrivacy" : {
+      "comment" : "MARK: - UI Components",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Private"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet needs to sync to the snapshot block height before you can participate in voting."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privado"
           }
         }
       }
     },
-    "coinVote.walletSyncing.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Syncing"
+    "connectedHWInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you disconnect now, your Keystone will no longer be paired with your Zodl wallet."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Syncing"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si desconectas ahora, tu Keystone dejará de estar vinculado con tu billetera Zodl."
           }
         }
       }
     },
-    "component.lowPrivacy": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not Private"
+    "crosspay.help.desc1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make cross-chain payments in any NEAR-supported coin or token."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Público"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz pagos entre cadenas en cualquier moneda o token compatible con NEAR."
           }
         }
       }
     },
-    "component.maxPrivacy": {
-      "comment": "MARK: - UI Components",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Private"
+    "crosspay.help.desc2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If the actual slippage and network conditions result in your recipient receiving less than the promised amount, your transaction will be reversed. You will receive a full refund minus network fees."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si el deslizamiento real y las condiciones de la red resultan en que tu destinatario reciba menos de la cantidad prometida, tu transacción será revertida. Recibirás un reembolso completo menos las comisiones de red."
           }
         }
       }
     },
-    "connectedHWInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you disconnect now, your Keystone will no longer be paired with your Zodl wallet."
+    "crosspay.help.payWith" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrossPay with"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si desconectas ahora, tu Keystone dejará de estar vinculado con tu billetera Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrossPay con"
           }
         }
       }
     },
-    "crosspay.help.desc1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Make cross-chain payments in any NEAR-supported coin or token."
+    "crosspay.pay" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haz pagos entre cadenas en cualquier moneda o token compatible con NEAR."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar"
           }
         }
       }
     },
-    "crosspay.help.desc2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If the actual slippage and network conditions result in your recipient receiving less than the promised amount, your transaction will be reversed. You will receive a full refund minus network fees."
+    "crosspay.slippageSet1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You may pay up to "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si el deslizamiento real y las condiciones de la red resultan en que tu destinatario reciba menos de la cantidad prometida, tu transacción será revertida. Recibirás un reembolso completo menos las comisiones de red."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podrías pagar hasta "
           }
         }
       }
     },
-    "crosspay.help.payWith": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CrossPay with"
+    "crosspay.slippageSet2a" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@% (%@)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CrossPay con"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@% (%@)"
           }
         }
       }
     },
-    "crosspay.pay": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay"
+    "crosspay.slippageSet2b" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%"
           }
         }
       }
     },
-    "crosspay.slippageSet1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You may pay up to "
+    "crosspay.slippageSet3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " more, in addition to transaction fees."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Podrías pagar hasta "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " más, además de las comisiones de transacción."
           }
         }
       }
     },
-    "crosspay.slippageSet2a": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@% (%@)"
+    "crosspay.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrossPay"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@% (%@)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrossPay"
           }
         }
       }
     },
-    "crosspay.slippageSet2b": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@%"
+    "crosspay.total" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@%"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total"
           }
         }
       }
     },
-    "crosspay.slippageSet3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " more, in addition to transaction fees."
+    "currencyConversion.currencyLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currency"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " más, además de las comisiones de transacción."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moneda"
           }
         }
       }
     },
-    "crosspay.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CrossPay"
+    "currencyConversion.enable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CrossPay"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitar"
           }
         }
       }
     },
-    "crosspay.total": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total"
+    "currencyConversion.ipDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl's currency conversion feature doesn't compromise your IP address."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La función de conversión de moneda de Zodl no compromete tu dirección IP."
           }
         }
       }
     },
-    "currencyConversion.currencyLabel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currency"
+    "currencyConversion.ipTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP Address Protection"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Moneda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protección de Dirección IP"
           }
         }
       }
     },
-    "currencyConversion.enable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable"
+    "currencyConversion.learnMoreDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Display your balance and payment amounts in selected currency. For Swap and Pay, exchange rates will continue to be shown in USD. You can manage this feature in Advanced Settings."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Habilitar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra tu saldo y montos de pago en tu moneda seleccionada. Para Swap y Pay, los tipos de cambio se seguirán mostrando en USD. Puedes administrar esta función en Configuración avanzada."
           }
         }
       }
     },
-    "currencyConversion.ipDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl's currency conversion feature doesn't compromise your IP address."
+    "currencyConversion.learnMoreOptionDisable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La función de conversión de moneda de Zodl no compromete tu dirección IP."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deshabilitar"
           }
         }
       }
     },
-    "currencyConversion.ipTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IP Address Protection"
+    "currencyConversion.learnMoreOptionDisableDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don't show currency conversion."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protección de Dirección IP"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No mostrar la conversión de moneda."
           }
         }
       }
     },
-    "currencyConversion.learnMoreDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Display your balance and payment amounts in selected currency. For Swap and Pay, exchange rates will continue to be shown in USD. You can manage this feature in Advanced Settings."
+    "currencyConversion.learnMoreOptionEnableDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show currency conversion."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Muestra tu saldo y montos de pago en tu moneda seleccionada. Para Swap y Pay, los tipos de cambio se seguirán mostrando en USD. Puedes administrar esta función en Configuración avanzada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar la conversión de moneda."
           }
         }
       }
     },
-    "currencyConversion.learnMoreOptionDisable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disable"
+    "currencyConversion.note" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note for the super privacy-conscious: Because we pull the conversion rate from exchanges, an exchange might be able to see that the exchange rate was queried before a transaction occurred."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deshabilitar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota para los más conscientes de la privacidad: Debido a que obtenemos la tasa de conversión de los intercambios, un intercambio podría ver que la tasa de cambio fue consultada antes de que ocurriera una transacción."
           }
         }
       }
     },
-    "currencyConversion.learnMoreOptionDisableDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Don't show currency conversion."
+    "currencyConversion.refresh" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rate Refresh"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No mostrar la conversión de moneda."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar tasa"
           }
         }
       }
     },
-    "currencyConversion.learnMoreOptionEnableDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show currency conversion."
+    "currencyConversion.refreshDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The rate is refreshed automatically and can also be refreshed manually."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar la conversión de moneda."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La tasa se actualiza automáticamente y también se puede actualizar manualmente."
           }
         }
       }
     },
-    "currencyConversion.note": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note for the super privacy-conscious: Because we pull the conversion rate from exchanges, an exchange might be able to see that the exchange rate was queried before a transaction occurred."
+    "currencyConversion.saveBtn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save changes"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nota para los más conscientes de la privacidad: Debido a que obtenemos la tasa de conversión de los intercambios, un intercambio podría ver que la tasa de cambio fue consultada antes de que ocurriera una transacción."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar cambios"
           }
         }
       }
     },
-    "currencyConversion.refresh": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rate Refresh"
+    "currencyConversion.selectCurrencyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select currency"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar tasa"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar moneda"
           }
         }
       }
     },
-    "currencyConversion.refreshDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The rate is refreshed automatically and can also be refreshed manually."
+    "currencyConversion.settingsDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Display your balance and payment amounts in your selected currency. For Swap and Pay, exchange rates will continue to be shown in USD."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La tasa se actualiza automáticamente y también se puede actualizar manualmente."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra tu saldo y montos de pago en tu moneda seleccionada. Para Swap y Pay, los tipos de cambio se seguirán mostrando en USD."
           }
         }
       }
     },
-    "currencyConversion.saveBtn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save changes"
+    "currencyConversion.skipBtn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip for now"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardar cambios"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Omitir por ahora"
           }
         }
       }
     },
-    "currencyConversion.selectCurrencyTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select currency"
+    "currencyConversion.title" : {
+      "comment" : "MARK: Currency Conversion",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currency Conversion"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar moneda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conversión de Moneda"
           }
         }
       }
     },
-    "currencyConversion.settingsDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Display your balance and payment amounts in your selected currency. For Swap and Pay, exchange rates will continue to be shown in USD."
+    "currencyConversion.torOffInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you would like to protect your IP address, enable Tor Protection in Advanced Settings."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Muestra tu saldo y montos de pago en tu moneda seleccionada. Para Swap y Pay, los tipos de cambio se seguirán mostrando en USD."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si deseas proteger tu dirección IP, activa la Protección Tor en la Configuración Avanzada."
           }
         }
       }
     },
-    "currencyConversion.skipBtn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skip for now"
+    "currencyConversion.torOnInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disabling Tor Protection will also disable the Currency Conversion feature until re-enabled."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omitir por ahora"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar la Protección Tor también desactivará la función de Conversión de Moneda hasta que se vuelva a activar."
           }
         }
       }
     },
-    "currencyConversion.title": {
-      "comment": "MARK: Currency Conversion",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currency Conversion"
+    "currentlyConnected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currently connected"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conversión de Moneda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectado actualmente"
           }
         }
       }
     },
-    "currencyConversion.torOffInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you would like to protect your IP address, enable Tor Protection in Advanced Settings."
+    "deeplinkWarning.cta" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rescan in Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si deseas proteger tu dirección IP, activa la Protección Tor en la Configuración Avanzada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reescanear en Zodl"
           }
         }
       }
     },
-    "currencyConversion.torOnInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disabling Tor Protection will also disable the Currency Conversion feature until re-enabled."
+    "deeplinkWarning.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For better safety and security, rescan the QR code with Zodl."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desactivar la Protección Tor también desactivará la función de Conversión de Moneda hasta que se vuelva a activar."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para mayor seguridad y protección, vuelve a escanear el código QR con Zodl."
           }
         }
       }
     },
-    "currentlyConnected": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currently connected"
+    "deeplinkWarning.screenTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hello!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectado actualmente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Hola!"
           }
         }
       }
     },
-    "deeplinkWarning.cta": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rescan in Zodl"
+    "deeplinkWarning.title" : {
+      "comment" : "MARK: - Deeplink Warning",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Looks like you used a third-party app to scan for payment."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reescanear en Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parece que utilizaste una aplicación de terceros para escanear un pago."
           }
         }
       }
     },
-    "deeplinkWarning.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For better safety and security, rescan the QR code with Zodl."
+    "deleteKeystoneDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnecting your hardware wallet will permanently delete some local data that can’t be recovered from the blockchain."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Para mayor seguridad y protección, vuelve a escanear el código QR con Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconectar tu hardware wallet eliminará permanentemente algunos datos locales que no pueden recuperarse de la blockchain."
           }
         }
       }
     },
-    "deeplinkWarning.screenTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hello!"
+    "deleteKeystoneTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Hola!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconectar Keystone"
           }
         }
       }
     },
-    "deeplinkWarning.title": {
-      "comment": "MARK: - Deeplink Warning",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Looks like you used a third-party app to scan for payment."
+    "deleteWallet.actionButtonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parece que utilizaste una aplicación de terceros para escanear un pago."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer Zodl"
           }
         }
       }
     },
-    "deleteKeystoneDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnecting your hardware wallet will permanently delete some local data that can’t be recovered from the blockchain."
+    "deleteWallet.message2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make sure you have both your secret recovery phrase and wallet birthday height saved before you proceed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectar tu hardware wallet eliminará permanentemente algunos datos locales que no pueden recuperarse de la blockchain."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asegúrate de haber guardado tanto tu frase de recuperación secreta como la altura de cumpleaños de la billetera antes de continuar."
           }
         }
       }
     },
-    "deleteKeystoneTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnect Keystone"
+    "deleteWallet.message3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resetting the Zodl app will delete the app database and cached app data, and disconnect all connected hardware wallets."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectar Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer la aplicación Zodl eliminará la base de datos y los datos en caché de la aplicación, además de desconectar todas las billeteras de hardware conectadas."
           }
         }
       }
     },
-    "deleteWallet.actionButtonTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset Zodl"
+    "deleteWallet.message4" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Once you Reset Zodl, the only way to access your funds is through a wallet restore process that requires your Zodl Recovery Phrase and Wallet Birthday Height."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una vez que restablezcas Zodl, la única forma de acceder a tus fondos será mediante un proceso de restauración de billetera que requiere tu Frase de Recuperación de Zodl y la Altura de Cumpleaños de la Billetera."
           }
         }
       }
     },
-    "deleteWallet.message2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Make sure you have both your secret recovery phrase and wallet birthday height saved before you proceed."
+    "deleteWallet.metadataWarn1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep encrypted metadata backup - which includes contacts, notes, bookmarks, and swap/payment details."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Asegúrate de haber guardado tanto tu frase de recuperación secreta como la altura de cumpleaños de la billetera antes de continuar."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conserva la copia de seguridad cifrada de los metadatos, que incluye contactos, notas, marcadores y detalles de intercambios/pagos."
           }
         }
       }
     },
-    "deleteWallet.message3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resetting the Zodl app will delete the app database and cached app data, and disconnect all connected hardware wallets."
+    "deleteWallet.metadataWarn2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This data cannot be recovered during Restore."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer la aplicación Zodl eliminará la base de datos y los datos en caché de la aplicación, además de desconectar todas las billeteras de hardware conectadas."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estos datos no se podrán recuperar durante la restauración."
           }
         }
       }
     },
-    "deleteWallet.message4": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Once you Reset Zodl, the only way to access your funds is through a wallet restore process that requires your Zodl Recovery Phrase and Wallet Birthday Height."
+    "deleteWallet.screenTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Una vez que restablezcas Zodl, la única forma de acceder a tus fondos será mediante un proceso de restauración de billetera que requiere tu Frase de Recuperación de Zodl y la Altura de Cumpleaños de la Billetera."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer"
           }
         }
       }
     },
-    "deleteWallet.metadataWarn1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep encrypted metadata backup - which includes contacts, notes, bookmarks, and swap/payment details."
+    "deleteWallet.sheet.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resetting the app cannot be undone. You will need to restore your wallet using your secret recovery phrase."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conserva la copia de seguridad cifrada de los metadatos, que incluye contactos, notas, marcadores y detalles de intercambios/pagos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer la app no se puede deshacer. Necesitarás restaurar tu billetera usando tu frase secreta de recuperación."
           }
         }
       }
     },
-    "deleteWallet.metadataWarn2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This data cannot be recovered during Restore."
+    "deleteWallet.sheet.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estos datos no se podrán recuperar durante la restauración."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Estás seguro?"
           }
         }
       }
     },
-    "deleteWallet.screenTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset"
+    "deleteWallet.title" : {
+      "comment" : "MARK: - Delete Wallet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer Zodl"
           }
         }
       }
     },
-    "deleteWallet.sheet.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resetting the app cannot be undone. You will need to restore your wallet using your secret recovery phrase."
+    "depositFunds.alert.cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel swap"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer la app no se puede deshacer. Necesitarás restaurar tu billetera usando tu frase secreta de recuperación."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar swap"
           }
         }
       }
     },
-    "deleteWallet.sheet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure?"
+    "depositFunds.alert.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you've sent or intend to send the funds, tap 'I've sent the funds.' Or cancel the swap to return to the previous screen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Estás seguro?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si ya enviaste los fondos o tienes intención de hacerlo, toca ’Ya envié los fondos.’ O cancela el swap para volver a la pantalla anterior."
           }
         }
       }
     },
-    "deleteWallet.title": {
-      "comment": "MARK: - Delete Wallet",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset Zodl"
+    "depositFunds.alert.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to exit?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Estás seguro de que deseas salir?"
           }
         }
       }
     },
-    "depositFunds.alert.cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel swap"
+    "depositFunds.bulletPoint1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send the exact amount of the asset displayed. Sending less will result in a refund."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envía el monto exacto del activo que se muestra. Enviar menos resultará en un reembolso."
           }
         }
       }
     },
-    "depositFunds.alert.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you've sent or intend to send the funds, tap 'I've sent the funds.' Or cancel the swap to return to the previous screen."
+    "depositFunds.bulletPoint2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double-check that you are sending the correct asset on the correct network (e.g., USDC on Solana)."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si ya enviaste los fondos o tienes intención de hacerlo, toca ’Ya envié los fondos.’ O cancela el swap para volver a la pantalla anterior."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica que estás enviando el activo correcto en la red correcta (por ej., USDC en Solana)."
           }
         }
       }
     },
-    "depositFunds.alert.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure you want to exit?"
+    "depositFunds.bulletPoint3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "It’s best to send from a wallet you own. Sending from an exchange may result in delays or refunds."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Estás seguro de que deseas salir?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es mejor enviar desde una wallet que sea tuya. Enviar desde un exchange puede causar demoras o reembolsos."
           }
         }
       }
     },
-    "depositFunds.bulletPoint1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send the exact amount of the asset displayed. Sending less will result in a refund."
+    "depositFunds.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap into ZEC with any NEAR-supported asset."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envía el monto exacto del activo que se muestra. Enviar menos resultará en un reembolso."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz swap a ZEC con cualquier activo compatible con NEAR."
           }
         }
       }
     },
-    "depositFunds.bulletPoint2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Double-check that you are sending the correct asset on the correct network (e.g., USDC on Solana)."
+    "depositFunds.title" : {
+      "comment" : "MARK: Deposit funds",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deposit Funds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verifica que estás enviando el activo correcto en la red correcta (por ej., USDC en Solana)."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depositar fondos"
           }
         }
       }
     },
-    "depositFunds.bulletPoint3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "It’s best to send from a wallet you own. Sending from an exchange may result in delays or refunds."
+    "deposits.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deposits may take several minutes to confirm."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Es mejor enviar desde una wallet que sea tuya. Enviar desde un exchange puede causar demoras o reembolsos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los depósitos pueden tardar varios minutos en confirmarse."
           }
         }
       }
     },
-    "depositFunds.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap into ZEC with any NEAR-supported asset."
+    "disconnectHWWallet.bullet1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed or expired sends"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haz swap a ZEC con cualquier activo compatible con NEAR."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envíos fallidos o vencidos"
           }
         }
       }
     },
-    "depositFunds.title": {
-      "comment": "MARK: Deposit funds",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deposit Funds"
+    "disconnectHWWallet.bullet2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mempool transactions that never confirmed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depositar fondos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transacciones en el mempool que nunca se confirmaron"
           }
         }
       }
     },
-    "deposits.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deposits may take several minutes to confirm."
+    "disconnectHWWallet.bullet3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transactions later reversed in a chain reorg"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los depósitos pueden tardar varios minutos en confirmarse."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transacciones revertidas posteriormente en una reorganización de cadena"
           }
         }
       }
     },
-    "disconnectHWWallet.bullet1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed or expired sends"
+    "disconnectHWWallet.contactSupport" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact Support"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envíos fallidos o vencidos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contactar Soporte"
           }
         }
       }
     },
-    "disconnectHWWallet.bullet2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mempool transactions that never confirmed"
+    "disconnectHWWallet.cta" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Hardware"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transacciones en el mempool que nunca se confirmaron"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconectar Hardware"
           }
         }
       }
     },
-    "disconnectHWWallet.bullet3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transactions later reversed in a chain reorg"
+    "disconnectHWWallet.failureDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnecting the hardware wallet couldn't be finalized."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transacciones revertidas posteriormente en una reorganización de cadena"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo finalizar la desconexión del hardware wallet. "
           }
         }
       }
     },
-    "disconnectHWWallet.contactSupport": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact Support"
+    "disconnectHWWallet.failureTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contactar Soporte"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al Desconectar"
           }
         }
       }
     },
-    "disconnectHWWallet.cta": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnect Hardware"
+    "disconnectHWWallet.mayInclude" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This may include:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectar Hardware"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envíos fallidos o vencidos:"
           }
         }
       }
     },
-    "disconnectHWWallet.failureDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnecting the hardware wallet couldn't be finalized."
+    "disconnectHWWallet.sheetDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnecting the hardware wallet cannot be undone."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo finalizar la desconexión del hardware wallet. "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconectar el hardware wallet no se puede deshacer."
           }
         }
       }
     },
-    "disconnectHWWallet.failureTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnect Failed"
+    "disconnectHWWallet.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error al Desconectar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconectar"
           }
         }
       }
     },
-    "disconnectHWWallet.mayInclude": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This may include:"
+    "disconnectHWWallet.tryAgain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envíos fallidos o vencidos:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentar de nuevo"
           }
         }
       }
     },
-    "disconnectHWWallet.sheetDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnecting the hardware wallet cannot be undone."
+    "enhanceTransaction.btn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetch data"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectar el hardware wallet no se puede deshacer."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener datos"
           }
         }
       }
     },
-    "disconnectHWWallet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnect"
+    "enhanceTransaction.fieldTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transaction ID"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de transacción"
           }
         }
       }
     },
-    "disconnectHWWallet.tryAgain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try again"
+    "enhanceTransaction.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you confirm, Zodl will fetch transaction data for a transaction ID you provide."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intentar de nuevo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si confirmas, Zodl obtendrá datos de una transacción usando el ID que proporciones."
           }
         }
       }
     },
-    "enhanceTransaction.btn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetch data"
+    "enhanceTransaction.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter or paste..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obtener datos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresa o pega..."
           }
         }
       }
     },
-    "enhanceTransaction.fieldTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transaction ID"
+    "enhanceTransaction.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh Transaction Data"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID de transacción"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar datos de la transacción"
           }
         }
       }
+    },
+    "Error: %@" : {
+
     },
-    "enhanceTransaction.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you confirm, Zodl will fetch transaction data for a transaction ID you provide."
+    "errorPage.action.contactSupport" : {
+      "comment" : "MARK: - Error Pages",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact Support"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si confirmas, Zodl obtendrá datos de una transacción usando el ID que proporciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contactar Soporte"
           }
         }
       }
     },
-    "enhanceTransaction.placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter or paste..."
+    "exportLogs.alert.failed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingresa o pega..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         }
       }
     },
-    "enhanceTransaction.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refresh Transaction Data"
+    "exportLogs.alert.failed.title" : {
+      "comment" : "MARK: - Export logs",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error when exporting logs"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar datos de la transacción"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al exportar registros"
           }
         }
       }
     },
-    "Error: %@": {},
-    "errorPage.action.contactSupport": {
-      "comment": "MARK: - Error Pages",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact Support"
+    "filter.apply" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apply"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contactar Soporte"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar"
           }
         }
       }
     },
-    "exportLogs.alert.failed.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+    "filter.at" : {
+      "comment" : "example: Nov 29 at 4:15pm",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "at"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "a las"
           }
         }
       }
     },
-    "exportLogs.alert.failed.title": {
-      "comment": "MARK: - Export logs",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error when exporting logs"
+    "filter.bookmarked" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bookmarked"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error al exportar registros"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcado"
           }
         }
       }
     },
-    "filter.apply": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apply"
+    "filter.daysAgo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ days ago"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hace %@ días"
           }
         }
       }
     },
-    "filter.at": {
-      "comment": "example: Nov 29 at 4:15pm",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "at"
+    "filter.memos" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memos"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "a las"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memorandos"
           }
         }
       }
     },
-    "filter.bookmarked": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bookmarked"
+    "filter.noResults" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No results"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Marcado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin resultados"
           }
         }
       }
     },
-    "filter.daysAgo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ days ago"
+    "filter.notes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hace %@ días"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notas"
           }
         }
       }
     },
-    "filter.memos": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Memos"
+    "filter.previous7days" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous 7 days"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Memorandos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 7 días"
           }
         }
       }
     },
-    "filter.noResults": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No results"
+    "filter.previous30days" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous 30 days"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin resultados"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 30 días"
           }
         }
       }
     },
-    "filter.notes": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notes"
+    "filter.received" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Received"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recibido"
           }
         }
       }
     },
-    "filter.previous7days": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous 7 days"
+    "filter.reset" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Últimos 7 días"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer"
           }
         }
       }
     },
-    "filter.previous30days": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous 30 days"
+    "filter.search" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Últimos 30 días"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar"
           }
         }
       }
     },
-    "filter.received": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Received"
+    "filter.sent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recibido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviado"
           }
         }
       }
     },
-    "filter.reset": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset"
+    "filter.swap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swaps"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swaps"
           }
         }
       }
     },
-    "filter.search": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search"
+    "filter.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar"
           }
         }
       }
     },
-    "filter.sent": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sent"
+    "filter.today" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoy"
           }
         }
       }
     },
-    "filter.swap": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swaps"
+    "filter.weTried" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We tried but couldn’t find anything."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swaps"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo intentamos, pero no pudimos encontrar nada."
           }
         }
       }
     },
-    "filter.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Filter"
+    "filter.yesterday" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yesterday"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Filtrar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayer"
           }
         }
       }
     },
-    "filter.today": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Today"
+    "firstWalletTransactionSubtitleHWWallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entering the block height at which your wallet was created ensures that correct number of blocks will be scanned. If you're not sure, choose an earlier date."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hoy"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresar la altura del bloque en que se creó tu billetera garantiza que se escanee el número correcto de bloques. Si no estás seguro, elige una fecha anterior."
           }
         }
       }
     },
-    "filter.weTried": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We tried but couldn’t find anything."
+    "firstWalletTransactionSubtitleRestore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decide how far Zodl should scan. Enter a date before your first received transaction. If you’re not sure, choose an earlier date."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lo intentamos, pero no pudimos encontrar nada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decide hasta dónde debe escanear Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior."
           }
         }
       }
     },
-    "filter.yesterday": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yesterday"
+    "firstWalletTransactionSubtitleResync" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decide how far Zodl should resync. Enter a date before your first received transaction. If you’re not sure, choose an earlier date."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ayer"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decide hasta dónde debe resincronizarse Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior."
           }
         }
       }
     },
-    "firstWalletTransactionSubtitleHWWallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entering the block height at which your wallet was created ensures that correct number of blocks will be scanned. If you're not sure, choose an earlier date."
+    "general.activity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activity"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingresar la altura del bloque en que se creó tu billetera garantiza que se escanee el número correcto de bloques. Si no estás seguro, elige una fecha anterior."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad"
           }
         }
       }
     },
-    "firstWalletTransactionSubtitleRestore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Decide how far Zodl should scan. Enter a date before your first received transaction. If you’re not sure, choose an earlier date."
+    "general.alert.caution" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heads up"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Decide hasta dónde debe escanear Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso"
           }
         }
       }
     },
-    "firstWalletTransactionSubtitleResync": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Decide how far Zodl should resync. Enter a date before your first received transaction. If you’re not sure, choose an earlier date."
+    "general.alert.continue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Decide hasta dónde debe resincronizarse Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar"
           }
         }
       }
     },
-    "general.activity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activity"
+    "general.alert.ignore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignore"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actividad"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorar"
           }
         }
       }
     },
-    "general.alert.caution": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Heads up"
+    "general.alert.warning" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warning"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aviso"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Advertencia"
           }
         }
       }
     },
-    "general.alert.continue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
+    "general.back" : {
+      "comment" : "MARK: - Common & Shared",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atrás"
           }
         }
       }
     },
-    "general.alert.ignore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ignore"
+    "general.cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ignorar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
           }
         }
       }
     },
-    "general.alert.warning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warning"
+    "general.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advertencia"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar"
           }
         }
       }
     },
-    "general.back": {
-      "comment": "MARK: - Common & Shared",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back"
+    "general.confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atrás"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar"
           }
         }
       }
     },
-    "general.cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+    "general.copiedAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección %@ copiada"
           }
         }
       }
     },
-    "general.close": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+    "general.copiedAmount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied amount"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cerrar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto copiado"
           }
         }
       }
     },
-    "general.confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm"
+    "general.copiedToTheClipboard" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied to the clipboard!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Copiado al portapapeles!"
           }
         }
       }
     },
-    "general.copiedAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied %@"
+    "general.delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección %@ copiada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
           }
         }
       }
     },
-    "general.copiedAmount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied amount"
+    "general.done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monto copiado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hecho"
           }
         }
       }
     },
-    "general.copiedToTheClipboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied to the clipboard!"
+    "general.fee" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typical Fee < %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Copiado al portapapeles!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarifa Típica < %@"
           }
         }
       }
     },
-    "general.delete": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
+    "general.feeShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "< %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "< %@"
           }
         }
       }
     },
-    "general.done": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
+    "general.hide" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hecho"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar"
           }
         }
       }
     },
-    "general.fee": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Typical Fee < %@"
+    "general.hideBalancesLeast" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tarifa Típica < %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
           }
         }
       }
     },
-    "general.feeShort": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "< %@"
+    "general.hideBalancesMost" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "-----"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "< %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "-----"
           }
         }
       }
     },
-    "general.hide": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide"
+    "general.hideBalancesMostStandalone" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "-----"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocultar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "-----"
           }
         }
       }
     },
-    "general.hideBalancesLeast": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ""
+    "general.less" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Less"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ""
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menos"
           }
         }
       }
     },
-    "general.hideBalancesMost": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "-----"
+    "general.loading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "-----"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando"
           }
         }
       }
     },
-    "general.hideBalancesMostStandalone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "-----"
+    "general.more" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "-----"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más"
           }
         }
       }
     },
-    "general.less": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Less"
+    "general.next" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Menos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siguiente"
           }
         }
       }
     },
-    "general.loading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading"
+    "general.no" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cargando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
           }
         }
       }
     },
-    "general.more": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More"
+    "general.ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ok"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Más"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ok"
           }
         }
       }
     },
-    "general.next": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Next"
+    "general.request" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Siguiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitar"
           }
         }
       }
     },
-    "general.no": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No"
+    "general.save" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar"
           }
         }
       }
     },
-    "general.ok": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ok"
+    "general.send" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ok"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar"
           }
         }
       }
     },
-    "general.request": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request"
+    "general.share" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solicitar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir"
           }
         }
       }
     },
-    "general.save": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+    "general.show" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar"
           }
         }
       }
     },
-    "general.send": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send"
+    "general.unknown" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconocido"
           }
         }
       }
     },
-    "general.share": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share"
+    "general.yes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartir"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sí"
           }
         }
       }
     },
-    "general.show": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show"
+    "hardwareWalletExplainer.cta" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got It"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entendido"
           }
         }
       }
     },
-    "general.unknown": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown"
+    "hardwareWalletExplainer.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A hardware wallet (HW wallet) is a physical device that stores your cryptocurrency private keys offline, keeping them safe from online hackers and malware."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconocido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un hardware wallet es un dispositivo físico que almacena tus claves privadas de criptomonedas sin conexión a internet, manteniéndolas a salvo de hackers y malware."
           }
         }
       }
     },
-    "general.yes": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yes"
+    "hardwareWalletExplainer.featureDescription1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your keys never leave the device, even when signing transactions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sí"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus claves nunca salen del dispositivo, incluso al firmar transacciones"
           }
         }
       }
     },
-    "hardwareWalletExplainer.cta": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Got It"
+    "hardwareWalletExplainer.featureDescription2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immune to computer viruses and phishing attacks"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entendido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inmune a virus informáticos y ataques de phishing"
           }
         }
       }
     },
-    "hardwareWalletExplainer.description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A hardware wallet (HW wallet) is a physical device that stores your cryptocurrency private keys offline, keeping them safe from online hackers and malware."
+    "hardwareWalletExplainer.featureDescription3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You own your keys, you own your crypto"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Un hardware wallet es un dispositivo físico que almacena tus claves privadas de criptomonedas sin conexión a internet, manteniéndolas a salvo de hackers y malware."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus claves son tuyas, tu cripto es tuya"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureDescription1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your keys never leave the device, even when signing transactions"
+    "hardwareWalletExplainer.featureTitle1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum Security"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus claves nunca salen del dispositivo, incluso al firmar transacciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguridad Máxima"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureDescription2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Immune to computer viruses and phishing attacks"
+    "hardwareWalletExplainer.featureTitle2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protection from Malware"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inmune a virus informáticos y ataques de phishing"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protección contra Malware"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureDescription3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You own your keys, you own your crypto"
+    "hardwareWalletExplainer.featureTitle3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full Control"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus claves son tuyas, tu cripto es tuya"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Control Total"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureTitle1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maximum Security"
+    "hardwareWalletExplainer.infoBoxDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone is a popular hardware wallet brand that offers air-gapped security with QR code signing. It's one of many trusted hardware wallet options, alongside Ledger and others."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seguridad Máxima"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone es una marca popular de hardware wallet que ofrece seguridad air-gapped con firma mediante códigos QR. Es una de las muchas opciones confiables de hardware wallet, junto con Ledger y otros."
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureTitle2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protection from Malware"
+    "hardwareWalletExplainer.infoBoxTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protección contra Malware"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sobre Keystone"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureTitle3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Full Control"
+    "hardwareWalletExplainer.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What's a Hardware Wallet?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Control Total"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Qué es un Hardware Wallet?"
           }
         }
       }
     },
-    "hardwareWalletExplainer.infoBoxDescription": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone is a popular hardware wallet brand that offers air-gapped security with QR code signing. It's one of many trusted hardware wallet options, alongside Ledger and others."
+    "home.migratingDatabases" : {
+      "comment" : "MARK: - Home Screen",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upgrading databases…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone es una marca popular de hardware wallet que ofrece seguridad air-gapped con firma mediante códigos QR. Es una de las muchas opciones confiables de hardware wallet, junto con Ledger y otros."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizando bases de datos…"
           }
         }
       }
     },
-    "hardwareWalletExplainer.infoBoxTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About Keystone"
+    "homeScreen.moreDotted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sobre Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más..."
           }
         }
       }
     },
-    "hardwareWalletExplainer.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "What's a Hardware Wallet?"
+    "homeScreen.moreWarning" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Information you share with Zodl integration partners is subject to their privacy policies."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Qué es un Hardware Wallet?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La información que compartas con los socios de integración de Zodl está sujeta a sus políticas de privacidad."
           }
         }
       }
     },
-    "home.migratingDatabases": {
-      "comment": "MARK: - Home Screen",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrading databases…"
+    "importWallet.birthday.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet birthday height"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizando bases de datos…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de cumpleaños de la billetera"
           }
         }
       }
     },
-    "homeScreen.moreDotted": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More..."
+    "importWallet.button.restoreWallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Más..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurar"
           }
         }
       }
     },
-    "homeScreen.moreWarning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Information you share with Zodl integration partners is subject to their privacy policies."
+    "keepScreenOnRestoring" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep screen on while restoring"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La información que compartas con los socios de integración de Zodl está sujeta a sus políticas de privacidad."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener la pantalla encendida mientras se restaura."
           }
         }
       }
     },
-    "importWallet.birthday.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet birthday height"
+    "keepScreenOnResyncing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep screen on while resyncing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Altura de cumpleaños de la billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener la pantalla encendida mientras se resincroniza"
           }
         }
       }
     },
-    "importWallet.button.restoreWallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore"
+    "keepScreenOnSyncing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep screen on while syncing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restaurar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener la pantalla encendida mientras se sincroniza"
           }
         }
       }
     },
-    "keepScreenOnRestoring": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep screen on while restoring"
+    "keepZodlOpenInstructionsHWWallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to complete syncing. Follow these steps to prevent interruption:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantener la pantalla encendida mientras se restaura."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en sincronizarse. Sigue estos pasos para evitar interrupciones:"
           }
         }
       }
     },
-    "keepScreenOnResyncing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep screen on while resyncing"
+    "keepZodlOpenInstructionsRestoring" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to restore. Follow these steps to prevent interruption:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantener la pantalla encendida mientras se resincroniza"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en restaurarse. Sigue estos pasos para evitar interrupciones:"
           }
         }
       }
     },
-    "keepScreenOnSyncing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep screen on while syncing"
+    "keepZodlOpenInstructionsResyncing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to resync. Follow these steps to prevent interruption:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantener la pantalla encendida mientras se sincroniza"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en resincronizarse. Sigue estos pasos para evitar interrupciones:"
           }
         }
       }
     },
-    "keepZodlOpenInstructionsHWWallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to complete syncing. Follow these steps to prevent interruption:"
+    "keepZodlOpenSubtitleHWWallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet is being synced."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en sincronizarse. Sigue estos pasos para evitar interrupciones:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu billetera se está sincronizando."
           }
         }
       }
     },
-    "keepZodlOpenInstructionsRestoring": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to restore. Follow these steps to prevent interruption:"
+    "keepZodlOpenSubtitleRestore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet is being restored."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en restaurarse. Sigue estos pasos para evitar interrupciones:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu billetera se está restaurando."
           }
         }
       }
     },
-    "keepZodlOpenInstructionsResyncing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to resync. Follow these steps to prevent interruption:"
+    "keepZodlOpenSubtitleResync" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet is being resynced."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en resincronizarse. Sigue estos pasos para evitar interrupciones:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu billetera se está resincronizando."
           }
         }
       }
     },
-    "keepZodlOpenSubtitleHWWallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet is being synced."
+    "keepZodlOpenWarningHWWallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Warning:](style: 'boldPrimary') Your Zodl funds cannot be spent until your Keystone wallet is synced."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu billetera se está sincronizando."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos de Zodl hasta que tu billetera Keystone esté sincronizada."
           }
         }
       }
     },
-    "keepZodlOpenSubtitleRestore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet is being restored."
+    "keepZodlOpenWarningRestore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is restored."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu billetera se está restaurando."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera esté completamente restaurada."
           }
         }
       }
     },
-    "keepZodlOpenSubtitleResync": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet is being resynced."
+    "keepZodlOpenWarningResync" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is resynced."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu billetera se está resincronizando."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera se haya resincronizado."
           }
         }
       }
     },
-    "keepZodlOpenWarningHWWallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[Warning:](style: 'boldPrimary') Your Zodl funds cannot be spent until your Keystone wallet is synced."
+    "keystone.addHWWallet.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos de Zodl hasta que tu billetera Keystone esté sincronizada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar"
           }
         }
       }
     },
-    "keepZodlOpenWarningRestore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is restored."
+    "keystone.addHWWallet.contactSupport" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact Support"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera esté completamente restaurada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contactar Soporte"
           }
         }
       }
     },
-    "keepZodlOpenWarningResync": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is resynced."
+    "keystone.addHWWallet.failureDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not connect your Keystone wallet. Your funds are safe. Please check that you are running the latest firmware."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera se haya resincronizado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo conectar tu wallet Keystone. Tus fondos están seguros. Verifica que tengas el firmware más reciente instalado."
           }
         }
       }
     },
-    "keystone.addHWWallet.close": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+    "keystone.addHWWallet.failureTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connection Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cerrar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de Conexión"
           }
         }
       }
     },
-    "keystone.addHWWallet.connect": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect"
+    "keystone.addHWWallet.connect" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar"
           }
         }
       }
     },
-    "keystone.addHWWallet.connectActive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect active device"
+    "keystone.addHWWallet.connectActive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect active device"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectar dispositivo activo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar dispositivo activo"
           }
         }
       }
     },
-    "keystone.addHWWallet.connected": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connected!"
+    "keystone.addHWWallet.connected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connected!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Keystone Conectado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keystone Conectado"
           }
         }
       }
     },
-    "keystone.addHWWallet.connectedDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Keystone hardware wallet has been successfully connected."
+    "keystone.addHWWallet.connectedDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Keystone hardware wallet has been successfully connected."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Tu billetera de hardware Keystone se ha conectado correctamente. Ahora puedes firmar transacciones de forma inalámbrica."
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tu billetera de hardware Keystone se ha conectado correctamente. Ahora puedes firmar transacciones de forma inalámbrica."
           }
         }
       }
     },
-    "keystone.addHWWallet.connectNew": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect new device"
+    "keystone.addHWWallet.connectNew" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect new device"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectar nuevo dispositivo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar nuevo dispositivo"
           }
         }
       }
     },
-    "keystone.addHWWallet.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select the wallet you'd like to connect to proceed. Once connected, you’ll be able to wirelessly sign transactions with your hardware wallet."
+    "keystone.addHWWallet.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select the wallet you'd like to connect to proceed. Once connected, you’ll be able to wirelessly sign transactions with your hardware wallet."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecciona la billetera que deseas conectar para continuar. Una vez conectada, podrás firmar transacciones de manera inalámbrica con tu billetera de hardware."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona la billetera que deseas conectar para continuar. Una vez conectada, podrás firmar transacciones de manera inalámbrica con tu billetera de hardware."
           }
         }
       }
     },
-    "keystone.addHWWallet.deviceDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting to a hardware wallet that was previously connected to Zashi will require synchronization to discover your transaction history. We'll guide you through it."
+    "keystone.addHWWallet.deviceDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecting to a hardware wallet that was previously connected to Zashi will require synchronization to discover your transaction history. We'll guide you through it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectarse a una billetera de hardware que ya estaba conectada a Zashi requerirá sincronización para descubrir tu historial de transacciones. Te guiaremos en el proceso."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectarse a una billetera de hardware que ya estaba conectada a Zashi requerirá sincronización para descubrir tu historial de transacciones. Te guiaremos en el proceso."
           }
         }
       }
     },
-    "keystone.addHWWallet.deviceQuestion": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New or Active Device?"
+    "keystone.addHWWallet.deviceQuestion" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New or Active Device?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Dispositivo nuevo o activo?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Dispositivo nuevo o activo?"
           }
         }
       }
     },
-    "keystone.addHWWallet.enterManually": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter block height"
+    "keystone.addHWWallet.enterManually" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter block height"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingresar altura de bloque"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresar altura de bloque"
           }
         }
       }
     },
-    "keystone.addHWWallet.howTo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instructions:"
+    "keystone.addHWWallet.howTo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instructions:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instrucciones:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instrucciones:"
           }
         }
       }
     },
-    "keystone.addHWWallet.readyToScan": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ready to Scan"
+    "keystone.addHWWallet.readyToScan" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ready to Scan"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Listo para Escanear"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo para Escanear"
           }
         }
       }
     },
-    "keystone.addHWWallet.scan": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan your device’s QR code to connect."
+    "keystone.addHWWallet.scan" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan your device’s QR code to connect."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escanea el código QR de tu dispositivo para conectarte."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanea el código QR de tu dispositivo para conectarte."
           }
         }
       }
     },
-    "keystone.addHWWallet.step1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unlock your Keystone"
+    "keystone.addHWWallet.step1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unlock your Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desbloquea tu Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desbloquea tu Keystone"
           }
         }
       }
     },
-    "keystone.addHWWallet.step2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap the menu icon"
+    "keystone.addHWWallet.step2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the menu icon"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca el ícono del menú"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca el ícono del menú"
           }
         }
       }
     },
-    "keystone.addHWWallet.step3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap on Connect Software Wallet"
+    "keystone.addHWWallet.step3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap on Connect Software Wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecciona 'Conectar Billetera de Software'"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona 'Conectar Billetera de Software'"
           }
         }
       }
     },
-    "keystone.addHWWallet.step4": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Zodl app and scan QR code"
+    "keystone.addHWWallet.step4" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Zodl app and scan QR code"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Selecciona la app Zodl y escanea el código QR"
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Selecciona la app Zodl y escanea el código QR"
           }
         }
       }
     },
-    "keystone.addHWWallet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm Account to Access"
+    "keystone.addHWWallet.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm Account to Access"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmar Cuenta para Acceder"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar Cuenta para Acceder"
           }
         }
       }
     },
-    "keystone.addHWWallet.tutorial": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View Keystone tutorial"
+    "keystone.addHWWallet.tutorial" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View Keystone tutorial"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver tutorial de Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver tutorial de Keystone"
           }
         }
       }
     },
-    "keystone.confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm with Keystone"
+    "keystone.confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm with Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirma con Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirma con Keystone"
           }
         }
       }
     },
-    "keystone.confirmPay": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay with Keystone"
+    "keystone.confirmPay" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay with Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagar with Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar with Keystone"
           }
         }
       }
     },
-    "keystone.confirmSwap": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap with Keystone"
+    "keystone.confirmSwap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap with Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap con Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap con Keystone"
           }
         }
       }
     },
-    "keystone.connect": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect Hardware Wallet"
+    "keystone.connect" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect Hardware Wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectar Billetera de Hardware"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar Billetera de Hardware"
           }
         }
       }
     },
-    "keystone.drawer.banner.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Get 5%% off airgapped hardware wallet. Promo code \"Zodl\"."
+    "keystone.drawer.banner.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get 5%% off airgapped hardware wallet. Promo code \"Zodl\"."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obtén un 5%% de descuento en una billetera de hardware aislada. Código promocional: 'Zodl'."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtén un 5%% de descuento en una billetera de hardware aislada. Código promocional: 'Zodl'."
           }
         }
       }
     },
-    "keystone.drawer.banner.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone Hardware Wallet"
+    "keystone.drawer.banner.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone Hardware Wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Billetera de Hardware Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Billetera de Hardware Keystone"
           }
         }
       }
     },
-    "keystone.drawer.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallets & Hardware"
+    "keystone.drawer.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallets & Hardware"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Billeteras y Dispositivos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Billeteras y Dispositivos"
           }
         }
       }
     },
-    "keystone.scanInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan Keystone wallet QR code"
+    "keystone.scanInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan Keystone wallet QR code"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escanea el código QR de tu billetera Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanea el código QR de tu billetera Keystone"
           }
         }
       }
     },
-    "keystone.signWith.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "After you have signed with Keystone, tap on the Get Signature button below."
+    "keystone.signWith.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "After you have signed with Keystone, tap on the Get Signature button below."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Después de firmar con Keystone, toca el botón 'Obtener Firma' abajo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Después de firmar con Keystone, toca el botón 'Obtener Firma' abajo."
           }
         }
       }
     },
-    "keystone.signWith.getSignature": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Get Signature"
+    "keystone.signWith.getSignature" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get Signature"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obtener Firma"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener Firma"
           }
         }
       }
     },
-    "keystone.signWith.hardware": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hardware"
+    "keystone.signWith.hardware" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hardware"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hardware"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hardware"
           }
         }
       }
     },
-    "keystone.signWith.reject": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reject"
+    "keystone.signWith.reject" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reject"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechazar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechazar"
           }
         }
       }
     },
-    "keystone.signWith.signTransaction": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign Transaction"
+    "keystone.signWith.signTransaction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign Transaction"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Firmar Transacción"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Firmar Transacción"
           }
         }
       }
     },
-    "keystone.signWith.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan with your Keystone wallet"
+    "keystone.signWith.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan with your Keystone wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escanea con tu billetera Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanea con tu billetera Keystone"
           }
         }
       }
     },
-    "keystone.wallet": {
-      "comment": "MARK: Keystone integration",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone Wallet"
+    "keystone.wallet" : {
+      "comment" : "MARK: Keystone integration",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone Wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Billetera Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Billetera Keystone"
           }
         }
       }
     },
-    "keystoneHW": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone Hardware"
+    "keystoneHW" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone Hardware"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hardware Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hardware Keystone"
           }
         }
       }
     },
-    "keystoneTransactionReject.goBack": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Go back"
+    "keystoneTransactionReject.goBack" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go back"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Volver"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver"
           }
         }
       }
     },
-    "keystoneTransactionReject.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rejecting the signature will cancel the transaction, and you’ll need to start over if you want to proceed."
+    "keystoneTransactionReject.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rejecting the signature will cancel the transaction, and you’ll need to start over if you want to proceed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechazar la firma cancelará la transacción y tendrás que empezar de nuevo si deseas continuar."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechazar la firma cancelará la transacción y tendrás que empezar de nuevo si deseas continuar."
           }
         }
       }
     },
-    "keystoneTransactionReject.rejectSig": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reject Signature"
+    "keystoneTransactionReject.rejectSig" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reject Signature"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechazar firma"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechazar firma"
           }
         }
       }
     },
-    "keystoneTransactionReject.title": {
-      "comment": "Keystone iteration 1",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure?"
+    "keystoneTransactionReject.title" : {
+      "comment" : "Keystone iteration 1",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Estás seguro?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Estás seguro?"
           }
         }
       }
     },
-    "localAuthentication.reason": {
-      "comment": "MARK: - Local authentication",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The Following content requires authentication."
+    "localAuthentication.reason" : {
+      "comment" : "MARK: - Local authentication",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Following content requires authentication."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El siguiente contenido requiere autenticación."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El siguiente contenido requiere autenticación."
           }
         }
       }
     },
-    "messageEditor.addUA": {
-      "comment": "MARK: - Message Editor",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reply-to: Include my address in the memo"
+    "messageEditor.addUA" : {
+      "comment" : "MARK: - Message Editor",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reply-to: Include my address in the memo"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Responder a: Incluir mi dirección en el memo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responder a: Incluir mi dirección en el memo"
           }
         }
       }
     },
-    "messageEditor.addUAformat": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\n>>> reply-to: %@"
+    "messageEditor.addUAformat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\n>>> reply-to: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\n>>> responder a: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\n>>> responder a: %@"
           }
         }
       }
     },
-    "messageEditor.removeUA": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your address is included in the memo"
+    "messageEditor.removeUA" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your address is included in the memo"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu dirección está incluida en el memo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu dirección está incluida en el memo"
           }
         }
       }
     },
-    "notEnoughFreeSpace.dataAvailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ MB available. "
+    "notEnoughFreeSpace.dataAvailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ MB available. "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ MB disponibles. "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ MB disponibles. "
           }
         }
       }
     },
-    "notEnoughFreeSpace.messagePost": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Syncing will stay paused until more space is available."
+    "notEnoughFreeSpace.messagePost" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing will stay paused until more space is available."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La sincronización permanecerá pausada hasta que haya más espacio disponible."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sincronización permanecerá pausada hasta que haya más espacio disponible."
           }
         }
       }
     },
-    "notEnoughFreeSpace.messagePre": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl requires %@ GB of space to synchronize the Zcash blockchain but there is only "
+    "notEnoughFreeSpace.messagePre" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl requires %@ GB of space to synchronize the Zcash blockchain but there is only "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl requiere %@ GB de espacio para sincronizar la blockchain de Zcash, pero solo hay "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl requiere %@ GB de espacio para sincronizar la blockchain de Zcash, pero solo hay "
           }
         }
       }
     },
-    "notEnoughFreeSpace.requiredSpace": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "~%@ MB of additional space required to continue"
+    "notEnoughFreeSpace.requiredSpace" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%@ MB of additional space required to continue"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se requieren ~%@ MB de espacio adicional para continuar."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se requieren ~%@ MB de espacio adicional para continuar."
           }
         }
       }
     },
-    "notEnoughFreeSpace.title": {
-      "comment": "MARK: - Not Enogh Free Space",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not enough free space"
+    "notEnoughFreeSpace.title" : {
+      "comment" : "MARK: - Not Enogh Free Space",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not enough free space"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No hay suficiente espacio libre"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay suficiente espacio libre"
           }
         }
       }
     },
-    "osStatusError.error": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error code: %@"
+    "osStatusError.error" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error code: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Código de error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código de error: %@"
           }
         }
       }
     },
-    "osStatusError.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your funds are safe but something happened while we were trying to retrieve the Keychain data. Close the Zodl app, and give it a fresh launch, we will try again."
+    "osStatusError.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your funds are safe but something happened while we were trying to retrieve the Keychain data. Close the Zodl app, and give it a fresh launch, we will try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus fondos están seguros, pero algo ocurrió mientras intentábamos recuperar los datos del llavero. Cierra la aplicación de Zodl y ábrela de nuevo; lo intentaremos otra vez."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus fondos están seguros, pero algo ocurrió mientras intentábamos recuperar los datos del llavero. Cierra la aplicación de Zodl y ábrela de nuevo; lo intentaremos otra vez."
           }
         }
       }
     },
-    "osStatusError.title": {
-      "comment": "MARK: OSStatusError",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "It’s not you, it’s us."
+    "osStatusError.title" : {
+      "comment" : "MARK: OSStatusError",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "It’s not you, it’s us."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No eres tú, somos nosotros."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No eres tú, somos nosotros."
           }
         }
       }
     },
-    "partners.flexa.keystoneNotSupportedMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flexa payments require a ZODL account. Switch to a ZODL account to pay with Flexa."
+    "partners.flexa.keystoneNotSupportedMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flexa payments require a ZODL account. Switch to a ZODL account to pay with Flexa."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Los pagos con Flexa requieren una cuenta ZODL. Cambia a una cuenta ZODL para pagar con Flexa."
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Los pagos con Flexa requieren una cuenta ZODL. Cambia a una cuenta ZODL para pagar con Flexa."
           }
         }
       }
     },
-    "partners.flexa.transactionFailedMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We're sorry but something has failed. Please try again."
+    "partners.flexa.transactionFailedMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We're sorry but something has failed. Please try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lo sentimos, pero algo falló. Por favor, inténtalo de nuevo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo sentimos, pero algo falló. Por favor, inténtalo de nuevo."
           }
         }
       }
     },
-    "partners.flexa.transactionFailedTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transaction Failed"
+    "partners.flexa.transactionFailedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transaction Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transacción Fallida"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transacción Fallida"
           }
         }
       }
     },
-    "plainOnboarding.button.createNewWallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create new wallet"
+    "plainOnboarding.button.createNewWallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create new wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Crear nueva billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear nueva billetera"
           }
         }
       }
     },
-    "plainOnboarding.button.restoreWallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore existing wallet"
+    "plainOnboarding.button.restoreWallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore existing wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restaurar billetera existente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurar billetera existente"
           }
         }
       }
     },
-    "plainOnboarding.title": {
-      "comment": "MARK: - Plain Onboarding Flow",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash-powered mobile wallet built for financial sovereignty."
+    "plainOnboarding.title" : {
+      "comment" : "MARK: - Plain Onboarding Flow",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash-powered mobile wallet built for financial sovereignty."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Billetera móvil impulsada por Zcash, diseñada para la soberanía financiera."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Billetera móvil impulsada por Zcash, diseñada para la soberanía financiera."
           }
         }
       }
     },
-    "privateDataConsent.confirmation": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I agree to Zodl's Export Private Data Policies and Privacy Policy"
+    "privateDataConsent.confirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I agree to Zodl's Export Private Data Policies and Privacy Policy"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acepto las Políticas de Exportación de Datos Privados y la Política de Privacidad de Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acepto las Políticas de Exportación de Datos Privados y la Política de Privacidad de Zodl"
           }
         }
       }
     },
-    "privateDataConsent.message1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "By clicking \"I Agree\" below, you give your consent to export all of your wallets’ private data such as the entire history of your wallet(s), including any connected hardware wallets. All private information, memos, amounts, and recipient addresses, even for your shielded activity will be exported.*"
+    "privateDataConsent.message1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "By clicking \"I Agree\" below, you give your consent to export all of your wallets’ private data such as the entire history of your wallet(s), including any connected hardware wallets. All private information, memos, amounts, and recipient addresses, even for your shielded activity will be exported.*"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Al hacer clic en 'Estoy de Acuerdo', das tu consentimiento para exportar todos los datos privados de tus billeteras, como el historial completo de tus billeteras, incluyendo cualquier billetera de hardware conectada. Toda información privada, notas, montos y direcciones de destinatarios, incluso para tus actividades protegidas, serán exportadas.*"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al hacer clic en 'Estoy de Acuerdo', das tu consentimiento para exportar todos los datos privados de tus billeteras, como el historial completo de tus billeteras, incluyendo cualquier billetera de hardware conectada. Toda información privada, notas, montos y direcciones de destinatarios, incluso para tus actividades protegidas, serán exportadas.*"
           }
         }
       }
     },
-    "privateDataConsent.message2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The private data also gives the ability to see certain future actions you take with Zodl."
+    "privateDataConsent.message2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The private data also gives the ability to see certain future actions you take with Zodl."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los datos privados también permiten ver ciertas acciones futuras que realices con Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los datos privados también permiten ver ciertas acciones futuras que realices con Zodl."
           }
         }
       }
     },
-    "privateDataConsent.message3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sharing this private data is irrevocable - once you have shared this private data with someone, there is no way to revoke their access."
+    "privateDataConsent.message3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sharing this private data is irrevocable - once you have shared this private data with someone, there is no way to revoke their access."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartir estos datos privados es irrevocable: una vez que hayas compartido estos datos privados con alguien, no hay forma de revocar su acceso."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir estos datos privados es irrevocable: una vez que hayas compartido estos datos privados con alguien, no hay forma de revocar su acceso."
           }
         }
       }
     },
-    "privateDataConsent.message4": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "*Note that this private data does not give them the ability to spend your funds, only the ability to see what you do with your funds."
+    "privateDataConsent.message4" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "*Note that this private data does not give them the ability to spend your funds, only the ability to see what you do with your funds."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "*Ten en cuenta que estos datos privados no les dan la capacidad de gastar tus fondos, solo la capacidad de ver lo que haces con tus fondos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "*Ten en cuenta que estos datos privados no les dan la capacidad de gastar tus fondos, solo la capacidad de ver lo que haces con tus fondos."
           }
         }
       }
     },
-    "privateDataConsent.screenTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data Export"
+    "privateDataConsent.screenTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Export"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exportación de Datos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportación de Datos"
           }
         }
       }
     },
-    "privateDataConsent.title": {
-      "comment": "MARK: - Private Data Consent",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Consent for Exporting Private Data"
+    "privateDataConsent.title" : {
+      "comment" : "MARK: - Private Data Consent",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consent for Exporting Private Data"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Consentimiento para Exportar Datos Privados"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consentimiento para Exportar Datos Privados"
           }
         }
       }
     },
-    "proposalPartial.mailSubject": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TEX Transaction Error"
+    "proposalPartial.mailSubject" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TEX Transaction Error"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error de transacción TEX"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de transacción TEX"
           }
         }
       }
     },
-    "qrCodeFor": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "QR Code for %@"
+    "qrCodeFor" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "QR Code for %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Código QR para %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código QR para %@"
           }
         }
       }
     },
-    "receive.copy": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy"
+    "receive.copy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar"
           }
         }
       }
     },
-    "receive.error.cantExtractSaplingAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "could not extract sapling receiver from UA"
+    "receive.error.cantExtractSaplingAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "could not extract sapling receiver from UA"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "no se pudo extraer el receptor Sapling de la Dirección Unificada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "no se pudo extraer el receptor Sapling de la Dirección Unificada"
           }
         }
       }
     },
-    "receive.error.cantExtractTransparentAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "could not extract transparent receiver from UA"
+    "receive.error.cantExtractTransparentAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "could not extract transparent receiver from UA"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "no se pudo extraer el receptor transparente de la Dirección Unificada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "no se pudo extraer el receptor transparente de la Dirección Unificada"
           }
         }
       }
     },
-    "receive.error.cantExtractUnifiedAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "could not extract UA"
+    "receive.error.cantExtractUnifiedAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "could not extract UA"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "no se pudo extraer la Dirección Unificada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "no se pudo extraer la Dirección Unificada"
           }
         }
       }
     },
-    "receive.help.shielded.desc1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use this address to receive and store your ZEC privately. Transparent and shielded ZEC sent to this address will be received and stored as shielded ZEC."
+    "receive.help.shielded.desc1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use this address to receive and store your ZEC privately. Transparent and shielded ZEC sent to this address will be received and stored as shielded ZEC."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usa esta dirección para recibir y almacenar tus ZEC de forma privada. Los ZEC transparentes y protegidos enviados a esta dirección se recibirán y almacenarán como ZEC protegidos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa esta dirección para recibir y almacenar tus ZEC de forma privada. Los ZEC transparentes y protegidos enviados a esta dirección se recibirán y almacenarán como ZEC protegidos."
           }
         }
       }
     },
-    "receive.help.shielded.desc2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A new Zcash Shielded Address is generated each time you open the Receive screen."
+    "receive.help.shielded.desc2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A new Zcash Shielded Address is generated each time you open the Receive screen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se genera una nueva dirección protegida de Zcash cada vez que abres la pantalla de \"Recibir\"."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se genera una nueva dirección protegida de Zcash cada vez que abres la pantalla de \"Recibir\"."
           }
         }
       }
     },
-    "receive.help.shielded.desc3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All transactions sent to your different rotating Shielded Addresses will remain part of one wallet balance under the same seed phrase."
+    "receive.help.shielded.desc3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All transactions sent to your different rotating Shielded Addresses will remain part of one wallet balance under the same seed phrase."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todas las transacciones enviadas a tus diferentes direcciones protegidas rotativas formarán parte de un mismo saldo de billetera vinculado a tu frase semilla."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todas las transacciones enviadas a tus diferentes direcciones protegidas rotativas formarán parte de un mismo saldo de billetera vinculado a tu frase semilla."
           }
         }
       }
     },
-    "receive.help.shielded.desc4": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "While we recommend using a new address every time, each unique address can be reused."
+    "receive.help.shielded.desc4" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "While we recommend using a new address every time, each unique address can be reused."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aunque recomendamos usar una nueva dirección cada vez, cada dirección única se puede reutilizar."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aunque recomendamos usar una nueva dirección cada vez, cada dirección única se puede reutilizar."
           }
         }
       }
     },
-    "receive.help.shielded.title": {
-      "comment": "Receive help",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash Shielded Address (Rotating)"
+    "receive.help.shielded.title" : {
+      "comment" : "Receive help",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash Shielded Address (Rotating)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección protegida de Zcash (rotativa)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección protegida de Zcash (rotativa)"
           }
         }
       }
     },
-    "receive.help.transparent.desc1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This addresses type works just like Bitcoin addresses and offers NO PRIVACY. The details of transactions sent to this address will be public and visible on the blockchain."
+    "receive.help.transparent.desc1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This addresses type works just like Bitcoin addresses and offers NO PRIVACY. The details of transactions sent to this address will be public and visible on the blockchain."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este tipo de dirección funciona como una dirección de Bitcoin y NO OFRECE PRIVACIDAD. Los detalles de las transacciones enviadas a esta dirección serán públicos y visibles en la blockchain."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este tipo de dirección funciona como una dirección de Bitcoin y NO OFRECE PRIVACIDAD. Los detalles de las transacciones enviadas a esta dirección serán públicos y visibles en la blockchain."
           }
         }
       }
     },
-    "receive.help.transparent.desc2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We don't recommend using this address type unless the wallet or exchange from which ZEC is being sent doesn’t support sending funds to shielded Zcash addresses."
+    "receive.help.transparent.desc2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We don't recommend using this address type unless the wallet or exchange from which ZEC is being sent doesn’t support sending funds to shielded Zcash addresses."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No recomendamos usar este tipo de dirección a menos que la billetera o casa de cambio desde donde se envían los ZEC no admita direcciones protegidas de Zcash."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No recomendamos usar este tipo de dirección a menos que la billetera o casa de cambio desde donde se envían los ZEC no admita direcciones protegidas de Zcash."
           }
         }
       }
     },
-    "receive.help.transparent.desc3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To protect your privacy, Zodl will guide you to shield any transparent ZEC you receive with just one click."
+    "receive.help.transparent.desc3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To protect your privacy, Zodl will guide you to shield any transparent ZEC you receive with just one click."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Para proteger tu privacidad, Zodl te guiará para proteger cualquier ZEC transparente que recibas con un solo clic."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para proteger tu privacidad, Zodl te guiará para proteger cualquier ZEC transparente que recibas con un solo clic."
           }
         }
       }
     },
-    "receive.help.transparent.desc4": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You won't be able to spend your transparent ZEC until you shield it."
+    "receive.help.transparent.desc4" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You won't be able to spend your transparent ZEC until you shield it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No podrás gastar tus ZEC transparentes hasta que los protejas."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No podrás gastar tus ZEC transparentes hasta que los protejas."
           }
         }
       }
     },
-    "receive.help.transparent.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash Transparent Address (Static)"
+    "receive.help.transparent.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash Transparent Address (Static)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección transparente de Zcash (estática)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección transparente de Zcash (estática)"
           }
         }
       }
     },
-    "receive.qrCode": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "QR Code"
+    "receive.qrCode" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "QR Code"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Código QR"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código QR"
           }
         }
       }
     },
-    "receive.request": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request"
+    "receive.request" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solicitar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitar"
           }
         }
       }
     },
-    "receive.saplingAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash Sapling Address"
+    "receive.saplingAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash Sapling Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección Sapling de Zcash"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección Sapling de Zcash"
           }
         }
       }
     },
-    "receive.warning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For privacy, always use shielded address."
+    "receive.warning" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For privacy, always use shielded address."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Para privacidad, utilice siempre una dirección protegida."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para privacidad, utilice siempre una dirección protegida."
           }
         }
       }
     },
-    "recoverFunds.btn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan address"
+    "recoverFunds.btn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escanear dirección"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanear dirección"
           }
         }
       }
     },
-    "recoverFunds.fieldTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transparent Address"
+    "recoverFunds.fieldTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparent Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección transparente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección transparente"
           }
         }
       }
     },
-    "recoverFunds.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you confirm, Zodl will scan the transparent address you provide and discover its funds. This may take a few minutes."
+    "recoverFunds.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you confirm, Zodl will scan the transparent address you provide and discover its funds. This may take a few minutes."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si confirmas, Zodl escaneará la dirección transparente que proporciones y descubrirá sus fondos. Esto puede tardar unos minutos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si confirmas, Zodl escaneará la dirección transparente que proporciones y descubrirá sus fondos. Esto puede tardar unos minutos."
           }
         }
       }
     },
-    "recoverFunds.placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter or paste..."
+    "recoverFunds.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter or paste..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingresa o pega..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresa o pega..."
           }
         }
       }
     },
-    "recoverFunds.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discover Funds"
+    "recoverFunds.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discover Funds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descubrir fondos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descubrir fondos"
           }
         }
       }
     },
-    "recoverFunds.tor": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This operation requires Tor Protection. Please enable it in the Advanced Settings. "
+    "recoverFunds.tor" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This operation requires Tor Protection. Please enable it in the Advanced Settings. "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta operación requiere Protección Tor. Por favor, habilítala en la Configuración Avanzada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta operación requiere Protección Tor. Por favor, habilítala en la Configuración Avanzada."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.alert.failed.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attempt to load the stored wallet from the keychain failed. Error: %@"
+    "recoveryPhraseDisplay.alert.failed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attempt to load the stored wallet from the keychain failed. Error: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El intento de cargar la billetera almacenada desde el llavero falló. Error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El intento de cargar la billetera almacenada desde el llavero falló. Error: %@"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.alert.failed.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to load stored wallet"
+    "recoveryPhraseDisplay.alert.failed.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to load stored wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo cargar la billetera almacenada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo cargar la billetera almacenada"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.birthdayTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Birthday Height"
+    "recoveryPhraseDisplay.birthdayTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Birthday Height"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Altura de Cumpleaños de la Billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de Cumpleaños de la Billetera"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.button.remindMeLater": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remind me later"
+    "recoveryPhraseDisplay.button.remindMeLater" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remind me later"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recuérdame más tarde"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recuérdame más tarde"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.button.wroteItDown": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I've saved it"
+    "recoveryPhraseDisplay.button.wroteItDown" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I've saved it"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lo he guardado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo he guardado"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "These words are the only way to recover your funds! Make sure to save them in the correct order."
+    "recoveryPhraseDisplay.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "These words are the only way to recover your funds! Make sure to save them in the correct order."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Estas palabras son la única manera de recuperar tus fondos! Asegúrate de guardarlas en el orden correcto."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Estas palabras son la única manera de recuperar tus fondos! Asegúrate de guardarlas en el orden correcto."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.hide": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide security details"
+    "recoveryPhraseDisplay.hide" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide security details"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocultar detalles de seguridad"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar detalles de seguridad"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.noWords": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The keys are missing. No backup phrase is stored in the keychain."
+    "recoveryPhraseDisplay.noWords" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The keys are missing. No backup phrase is stored in the keychain."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Faltan las claves. No hay ninguna frase de respaldo almacenada en el llavero."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faltan las claves. No hay ninguna frase de respaldo almacenada en el llavero."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.proceedWarning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep this phrase securely hidden. Don’t take screenshots of it or store it on your phone!"
+    "recoveryPhraseDisplay.proceedWarning" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep this phrase securely hidden. Don’t take screenshots of it or store it on your phone!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantén esta frase de manera segura oculta. ¡No tomes capturas de pantalla ni la guardes en tu teléfono!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantén esta frase de manera segura oculta. ¡No tomes capturas de pantalla ni la guardes en tu teléfono!"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.reveal": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reveal security details"
+    "recoveryPhraseDisplay.reveal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reveal security details"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar detalles de seguridad"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar detalles de seguridad"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.screenTitle": {
-      "comment": "MARK: - Secret Recovery Phrase Display",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recovery Phrase"
+    "recoveryPhraseDisplay.screenTitle" : {
+      "comment" : "MARK: - Secret Recovery Phrase Display",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovery Phrase"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frase de Recuperación"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frase de Recuperación"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Secret Recovery Phrase"
+    "recoveryPhraseDisplay.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secret Recovery Phrase"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frase de Recuperación Secreta"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frase de Recuperación Secreta"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningControl.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use it to access your funds from other devices and Zcash wallets."
+    "recoveryPhraseDisplay.warningControl.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use it to access your funds from other devices and Zcash wallets."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Úsala para acceder a tus fondos desde otros dispositivos y billeteras Zcash."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Úsala para acceder a tus fondos desde otros dispositivos y billeteras Zcash."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningControl.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Control your wallet"
+    "recoveryPhraseDisplay.warningControl.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Control your wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Controla tu billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controla tu billetera"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningHeight.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The block height at which your wallet was created can significantly speed up the wallet recovery process."
+    "recoveryPhraseDisplay.warningHeight.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The block height at which your wallet was created can significantly speed up the wallet recovery process."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La altura del bloque en el que se creó tu billetera puede acelerar significativamente el proceso de recuperación de la billetera."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La altura del bloque en el que se creó tu billetera puede acelerar significativamente el proceso de recuperación de la billetera."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningHeight.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet birthday height"
+    "recoveryPhraseDisplay.warningHeight.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet birthday height"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Altura de cumpleaños de la billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de cumpleaños de la billetera"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your secret recovery phrase is a unique set of 24 words, appearing in a precise order. It protects access to your funds."
+    "recoveryPhraseDisplay.warningInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your secret recovery phrase is a unique set of 24 words, appearing in a precise order. It protects access to your funds."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu frase de recuperación secreta es un conjunto único de 24 palabras, que aparecen en un orden preciso. Protege el acceso a tus fondos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu frase de recuperación secreta es un conjunto único de 24 palabras, que aparecen en un orden preciso. Protege el acceso a tus fondos."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningKeep.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Don't share it with anyone! It can be used to gain full control of your funds."
+    "recoveryPhraseDisplay.warningKeep.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don't share it with anyone! It can be used to gain full control of your funds."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡No la compartas con nadie! Puede usarse para obtener control total de tus fondos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡No la compartas con nadie! Puede usarse para obtener control total de tus fondos."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningKeep.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep it private"
+    "recoveryPhraseDisplay.warningKeep.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep it private"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manténla privada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manténla privada"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningStore.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We don’t have access to it and will never ask for it. If you lose it, it cannot be recovered."
+    "recoveryPhraseDisplay.warningStore.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We don’t have access to it and will never ask for it. If you lose it, it cannot be recovered."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No tenemos acceso a ella y nunca te pediremos que la compartas. Si la pierdes, no puede ser recuperada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No tenemos acceso a ella y nunca te pediremos que la compartas. Si la pierdes, no puede ser recuperada."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningStore.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Store it securely"
+    "recoveryPhraseDisplay.warningStore.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Store it securely"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guárdala de manera segura"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guárdala de manera segura"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Secret Recovery Phrase"
+    "recoveryPhraseDisplay.warningTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Secret Recovery Phrase"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu Frase de Recuperación Secreta"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu Frase de Recuperación Secreta"
           }
         }
       }
     },
-    "reportSwap.contact": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact Support"
+    "reportSwap.contact" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact Support"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contactar soporte"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contactar soporte"
           }
         }
       }
     },
-    "reportSwap.depositAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deposit Address: "
+    "reportSwap.depositAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deposit Address: "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección de depósito: "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de depósito: "
           }
         }
       }
     },
-    "reportSwap.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapping the button below will send details about this swap (like the deposit address and target asset) to the Zodl support team so they can help resolve your issue. The transaction info is included automatically."
+    "reportSwap.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tapping the button below will send details about this swap (like the deposit address and target asset) to the Zodl support team so they can help resolve your issue. The transaction info is included automatically."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Al tocar el botón de abajo, se enviarán detalles de este swap (como la dirección de depósito y el activo destino) al equipo de soporte de Zodl para que puedan ayudarte a resolver tu problema. La información de la transacción se incluye automáticamente."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al tocar el botón de abajo, se enviarán detalles de este swap (como la dirección de depósito y el activo destino) al equipo de soporte de Zodl para que puedan ayudarte a resolver tu problema. La información de la transacción se incluye automáticamente."
           }
         }
       }
     },
-    "reportSwap.please": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please describe your issue here: "
+    "reportSwap.please" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please describe your issue here: "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Por favor describe tu problema aquí: "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor describe tu problema aquí: "
           }
         }
       }
     },
-    "reportSwap.report": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Report Issue"
+    "reportSwap.report" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report Issue"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reportar problema"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reportar problema"
           }
         }
       }
     },
-    "reportSwap.sourceAsset": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source Asset: %@ on %@\n"
+    "reportSwap.sourceAsset" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source Asset: %@ on %@\n"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activo de origen: %@ en %@\n"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activo de origen: %@ en %@\n"
           }
         }
       }
     },
-    "reportSwap.swapDetails": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Details:"
+    "reportSwap.swapDetails" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Details:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detalles del swap:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles del swap:"
           }
         }
       }
     },
-    "reportSwap.targetAsset": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Target Asset: %@ on %@\n"
+    "reportSwap.targetAsset" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Target Asset: %@ on %@\n"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activo destino: %@ en %@\n"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activo destino: %@ en %@\n"
           }
         }
       }
     },
-    "reportSwap.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Report Swap Issue"
+    "reportSwap.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report Swap Issue"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reportar problema con swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reportar problema con swap"
           }
         }
       }
     },
-    "requestZec.summary.shareDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hi, I have generated a ZEC payment request for you using the Zodl app!"
+    "requestZec.summary.shareDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hi, I have generated a ZEC payment request for you using the Zodl app!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hola, he generado una solicitud de pago en ZEC para ti utilizando la aplicación Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hola, he generado una solicitud de pago en ZEC para ti utilizando la aplicación Zodl."
           }
         }
       }
     },
-    "requestZec.summary.shareMsg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(download link: https://apps.apple.com/app/zashi-zcash-wallet/id1672392439)"
+    "requestZec.summary.shareMsg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(download link: https://apps.apple.com/app/zashi-zcash-wallet/id1672392439)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(enlace de descarga: https://apps.apple.com/app/zashi-zcash-wallet/id1672392439)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(enlace de descarga: https://apps.apple.com/app/zashi-zcash-wallet/id1672392439)"
           }
         }
       }
     },
-    "requestZec.summary.shareQR": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share QR Code"
+    "requestZec.summary.shareQR" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share QR Code"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartir Código QR"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir Código QR"
           }
         }
       }
     },
-    "requestZec.summary.shareTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request ZEC"
+    "requestZec.summary.shareTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solicitar ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitar ZEC"
           }
         }
       }
     },
-    "requestZec.title": {
-      "comment": "MARK: - Request ZEC",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Request"
+    "requestZec.title" : {
+      "comment" : "MARK: - Request ZEC",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Request"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solicitud de Pago"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitud de Pago"
           }
         }
       }
     },
-    "requestZec.whatFor": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "What’s this for?"
+    "requestZec.whatFor" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What’s this for?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Para qué es esto?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Para qué es esto?"
           }
         }
       }
     },
-    "restoreInfo.gotIt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Got it!"
+    "restoreInfo.gotIt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got it!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Entendido!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Entendido!"
           }
         }
       }
     },
-    "restoreInfo.tip1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep the Zodl app open on an active phone screen."
+    "restoreInfo.tip1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep the Zodl app open on an active phone screen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantén la app de Zodl abierta con la pantalla del teléfono activa."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantén la app de Zodl abierta con la pantalla del teléfono activa."
           }
         }
       }
     },
-    "restoreInfo.tip2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To prevent your phone screen from going dark, turn off power-saving mode and keep your phone plugged in."
+    "restoreInfo.tip2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To prevent your phone screen from going dark, turn off power-saving mode and keep your phone plugged in."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Para evitar que la pantalla se apague, desactiva el modo de ahorro de energía y mantén el teléfono conectado a la corriente."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para evitar que la pantalla se apague, desactiva el modo de ahorro de energía y mantén el teléfono conectado a la corriente."
           }
         }
       }
     },
-    "restoreInfo.title": {
-      "comment": "MARK: - Restore Info",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep Zodl open!"
+    "restoreInfo.title" : {
+      "comment" : "MARK: - Restore Info",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep Zodl open!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Mantén Zodl abierto!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Mantén Zodl abierto!"
           }
         }
       }
     },
-    "restoreWallet.birthday.estimate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estimate my block height"
+    "restoreWallet.birthday.estimate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estimate my block height"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estimar mi altura de bloque"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estimar mi altura de bloque"
           }
         }
       }
     },
-    "restoreWallet.birthday.estimated.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl will scan and recover all transactions made after the following block number."
+    "restoreWallet.birthday.estimated.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl will scan and recover all transactions made after the following block number."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
           }
         }
       }
     },
-    "restoreWallet.birthday.estimated.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estimated Block Height"
+    "restoreWallet.birthday.estimated.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estimated Block Height"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Altura de Bloque Estimada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de Bloque Estimada"
           }
         }
       }
     },
-    "restoreWallet.birthday.estimateDate.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "First Wallet Transaction"
+    "restoreWallet.birthday.estimateDate.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First Wallet Transaction"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Primera Transacción de la Billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primera Transacción de la Billetera"
           }
         }
       }
     },
-    "restoreWallet.birthday.fieldInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Birthday Height is the point in time when your wallet was created."
+    "restoreWallet.birthday.fieldInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Birthday Height is the point in time when your wallet was created."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La Altura de Cumpleaños de la Billetera es el momento en que se creó tu billetera."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La Altura de Cumpleaños de la Billetera es el momento en que se creó tu billetera."
           }
         }
       }
     },
-    "restoreWallet.birthday.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entering your Wallet Birthday Height helps speed up the restore process."
+    "restoreWallet.birthday.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entering your Wallet Birthday Height helps speed up the restore process."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingresar la Altura de Cumpleaños de tu Billetera ayuda a acelerar el proceso de restauración."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresar la Altura de Cumpleaños de tu Billetera ayuda a acelerar el proceso de restauración."
           }
         }
       }
     },
-    "restoreWallet.birthday.placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter number"
+    "restoreWallet.birthday.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter number"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ingresa el número"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresa el número"
           }
         }
       }
     },
-    "restoreWallet.birthday.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Block Height"
+    "restoreWallet.birthday.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Block Height"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Altura de Bloque"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de Bloque"
           }
         }
       }
     },
-    "restoreWallet.help.phrase": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[The Secret Recovery Phrase](style: 'boldPrimary') is a unique set of 24 words, appearing in a precise order. It can be used to gain full control of your funds from any device via any Zcash wallet app. Think of it as the master key to your wallet. It is stored in Zodl’s Advanced Settings."
+    "restoreWallet.help.phrase" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[The Secret Recovery Phrase](style: 'boldPrimary') is a unique set of 24 words, appearing in a precise order. It can be used to gain full control of your funds from any device via any Zcash wallet app. Think of it as the master key to your wallet. It is stored in Zodl’s Advanced Settings."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[La Frase de Recuperación Secreta](style: 'boldPrimary') es un conjunto único de 24 palabras, que aparecen en un orden preciso. Se puede usar para obtener control total de tus fondos desde cualquier dispositivo a través de cualquier aplicación de billetera Zcash. Piensa en ella como la llave maestra de tu billetera. Se guarda en la Configuración Avanzada de Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[La Frase de Recuperación Secreta](style: 'boldPrimary') es un conjunto único de 24 palabras, que aparecen en un orden preciso. Se puede usar para obtener control total de tus fondos desde cualquier dispositivo a través de cualquier aplicación de billetera Zcash. Piensa en ella como la llave maestra de tu billetera. Se guarda en la Configuración Avanzada de Zodl."
           }
         }
       }
     },
-    "restoreWallet.help.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Need to know more?"
+    "restoreWallet.help.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Need to know more?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Necesitas saber más?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Necesitas saber más?"
           }
         }
       }
     },
-    "restoreWallet.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please type in your 24-word secret recovery phrase in the correct order."
+    "restoreWallet.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please type in your 24-word secret recovery phrase in the correct order."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Por favor, ingresa tu frase secreta de recuperación de 24 palabras en el orden correcto."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor, ingresa tu frase secreta de recuperación de 24 palabras en el orden correcto."
           }
         }
       }
     },
-    "restoreWallet.title": {
-      "comment": "Onboarding: Restore Wallet",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Secret Recovery Phrase"
+    "restoreWallet.title" : {
+      "comment" : "Onboarding: Restore Wallet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secret Recovery Phrase"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frase de Recuperación Secreta"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frase de Recuperación Secreta"
           }
         }
       }
     },
-    "resyncEstimatedBlockHeightInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Zodl will scan and recover all transactions made after the following block number."
+    "resyncEstimatedBlockHeightInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Zodl will scan and recover all transactions made after the following block number."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
           }
         }
       }
     },
-    "resyncWallet.change": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Change"
+    "resyncWallet.change" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar"
           }
         }
       }
     },
-    "resyncWallet.confirmTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm Resync"
+    "resyncWallet.confirmTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm Resync"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmar Resincronización"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar Resincronización"
           }
         }
       }
     },
-    "resyncWallet.dateInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unless you specify otherwise below, Zodl will resync from the date displayed."
+    "resyncWallet.dateInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unless you specify otherwise below, Zodl will resync from the date displayed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A menos que especifiques lo contrario a continuación, Zodl se resincronizará desde la fecha mostrada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A menos que especifiques lo contrario a continuación, Zodl se resincronizará desde la fecha mostrada."
           }
         }
       }
     },
-    "resyncWallet.description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resync the current wallet without resetting the app. This can be used to troubleshoot issues that would normally require restoring your wallet like fixing your Keystone balance."
+    "resyncWallet.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resync the current wallet without resetting the app. This can be used to troubleshoot issues that would normally require restoring your wallet like fixing your Keystone balance."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resincroniza la billetera actual sin restablecer la app. Esto puede usarse para solucionar problemas que normalmente requerirían restaurar tu billetera como corregir tu balance de Keystone."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resincroniza la billetera actual sin restablecer la app. Esto puede usarse para solucionar problemas que normalmente requerirían restaurar tu billetera como corregir tu balance de Keystone."
           }
         }
       }
     },
-    "resyncWallet.failedDescription": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resync of the wallet couldn’t be finalized. Please try again or report an issue."
+    "resyncWallet.failedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resync of the wallet couldn’t be finalized. Please try again or report an issue."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo completar la resincronización de la billetera. Inténtalo de nuevo o informa del problema."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo completar la resincronización de la billetera. Inténtalo de nuevo o informa del problema."
           }
         }
       }
     },
-    "resyncWallet.failedTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resync Failed"
+    "resyncWallet.failedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resync Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error de resincronización"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de resincronización"
           }
         }
       }
     },
-    "resyncWallet.start": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start Resync"
+    "resyncWallet.start" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start Resync"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar resincronización"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar resincronización"
           }
         }
       }
     },
-    "resyncWallet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resync Wallet"
+    "resyncWallet.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resync Wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resincronizar Billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resincronizar Billetera"
           }
         }
       }
     },
-    "resyncWalletCurrentHeightInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Use the button below if you wish to change it."
+    "resyncWalletCurrentHeightInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Use the button below if you wish to change it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Usa el botón de abajo si deseas cambiarlo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Usa el botón de abajo si deseas cambiarlo."
           }
         }
       }
     },
-    "root.destination.alert.failedToProcessDeeplink.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deeplink: (%@))\nError: (%@) (code: %@)"
+    "root.destination.alert.failedToProcessDeeplink.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deeplink: (%@))\nError: (%@) (code: %@)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enlace profundo: (%@))\nError: (%@) (código: %@)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enlace profundo: (%@))\nError: (%@) (código: %@)"
           }
         }
       }
     },
-    "root.destination.alert.failedToProcessDeeplink.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to process deeplink."
+    "root.destination.alert.failedToProcessDeeplink.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to process deeplink."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo procesar el enlace profundo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo procesar el enlace profundo."
           }
         }
       }
     },
-    "root.existingWallet.Message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We identified a Zodl database backup on this device. If you create a new wallet, you will lose access to this database backup and if you try to restore later, some information may be lost."
+    "root.existingWallet.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We identified a Zodl database backup on this device. If you create a new wallet, you will lose access to this database backup and if you try to restore later, some information may be lost."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identificamos una copia de seguridad de la base de datos de Zodl en este dispositivo. Si creas una nueva billetera, perderás acceso a esta copia de seguridad de la base de datos y si intentas restaurarla más tarde, se podría perder información."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Identificamos una copia de seguridad de la base de datos de Zodl en este dispositivo. Si creas una nueva billetera, perderás acceso a esta copia de seguridad de la base de datos y si intentas restaurarla más tarde, se podría perder información."
           }
         }
       }
     },
-    "root.existingWallet.restore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore"
+    "root.existingWallet.restore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restaurar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurar"
           }
         }
       }
     },
-    "root.initialization.alert.cantCreateNewWallet.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't create new wallet. Error: %@"
+    "root.initialization.alert.cantCreateNewWallet.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Can't create new wallet. Error: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede crear una nueva billetera. Error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede crear una nueva billetera. Error: %@"
           }
         }
       }
     },
-    "root.initialization.alert.cantLoadSeedPhrase.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't load seed phrase from local storage."
+    "root.initialization.alert.cantLoadSeedPhrase.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Can't load seed phrase from local storage."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede cargar la frase semilla desde el almacenamiento local."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede cargar la frase semilla desde el almacenamiento local."
           }
         }
       }
     },
-    "root.initialization.alert.cantStoreThatUserPassedPhraseBackupTest.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't store information that user passed phrase backup test. Error: %@"
+    "root.initialization.alert.cantStoreThatUserPassedPhraseBackupTest.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Can't store information that user passed phrase backup test. Error: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede almacenar la información de que el usuario pasó la prueba de respaldo de frase. Error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede almacenar la información de que el usuario pasó la prueba de respaldo de frase. Error: %@"
           }
         }
       }
     },
-    "root.initialization.alert.error.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+    "root.initialization.alert.error.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         }
       }
     },
-    "root.initialization.alert.failed.title": {
-      "comment": "MARK: - Root",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet initialisation failed."
+    "root.initialization.alert.failed.title" : {
+      "comment" : "MARK: - Root",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet initialisation failed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falló la inicialización de la billetera."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falló la inicialización de la billetera."
           }
         }
       }
     },
-    "root.initialization.alert.sdkInitFailed.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to initialize the SDK"
+    "root.initialization.alert.sdkInitFailed.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to initialize the SDK"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo inicializar el SDK"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo inicializar el SDK"
           }
         }
       }
     },
-    "root.initialization.alert.walletStateFailed.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App initialisation state: %@."
+    "root.initialization.alert.walletStateFailed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App initialisation state: %@."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado de inicialización de la aplicación: %@."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de inicialización de la aplicación: %@."
           }
         }
       }
     },
-    "root.initialization.alert.wipe.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure?"
+    "root.initialization.alert.wipe.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Estás seguro?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Estás seguro?"
           }
         }
       }
     },
-    "root.initialization.alert.wipe.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wipe of the wallet"
+    "root.initialization.alert.wipe.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wipe of the wallet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrado de la billetera"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrado de la billetera"
           }
         }
       }
     },
-    "root.initialization.alert.wipeFailed.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet deletion only partially succeeded. Please retry to finish the resetting process."
+    "root.initialization.alert.wipeFailed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet deletion only partially succeeded. Please retry to finish the resetting process."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La eliminación de la billetera solo tuvo éxito parcialmente. Por favor, intenta de nuevo para completar el proceso de restablecimiento."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La eliminación de la billetera solo tuvo éxito parcialmente. Por favor, intenta de nuevo para completar el proceso de restablecimiento."
           }
         }
       }
     },
-    "root.initialization.alert.wipeFailed.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet deletion failed."
+    "root.initialization.alert.wipeFailed.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet deletion failed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La eliminación de la billetera falló"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La eliminación de la billetera falló"
           }
         }
       }
     },
-    "root.seedPhrase.differentSeed.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This recovery phrase doesn't match the Zodl database backup saved on this device. If you proceed, you will lose access to this database backup and if you try to restore later, some information may be lost."
+    "root.seedPhrase.differentSeed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This recovery phrase doesn't match the Zodl database backup saved on this device. If you proceed, you will lose access to this database backup and if you try to restore later, some information may be lost."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta frase de recuperación no coincide con la copia de seguridad de la base de datos de Zodl guardada en este dispositivo. Si continúas, perderás acceso a esta copia de seguridad de la base de datos y si intentas restaurarla más tarde, se podría perder información."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta frase de recuperación no coincide con la copia de seguridad de la base de datos de Zodl guardada en este dispositivo. Si continúas, perderás acceso a esta copia de seguridad de la base de datos y si intentas restaurarla más tarde, se podría perder información."
           }
         }
       }
     },
-    "root.seedPhrase.differentSeed.tryAgain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try Again"
+    "root.seedPhrase.differentSeed.tryAgain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intentar de nuevo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentar de nuevo"
           }
         }
       }
     },
-    "root.serviceUnavailable.Message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your current server is experiencing difficulties. Check your device connection, and/or navigate to Advanced Settings to choose a different server."
+    "root.serviceUnavailable.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your current server is experiencing difficulties. Check your device connection, and/or navigate to Advanced Settings to choose a different server."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu servidor actual está experimentando dificultades. Verifica la conexión de tu dispositivo y/o navega a Configuración Avanzada para elegir un servidor diferente."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu servidor actual está experimentando dificultades. Verifica la conexión de tu dispositivo y/o navega a Configuración Avanzada para elegir un servidor diferente."
           }
         }
       }
     },
-    "root.serviceUnavailable.switchServer": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Switch server"
+    "root.serviceUnavailable.switchServer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch server"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar servidor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar servidor"
           }
         }
       }
     },
-    "scan.cameraSettings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The camera is not authorized. Please go to the system settings of Zodl and turn it on."
+    "scan.cameraSettings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The camera is not authorized. Please go to the system settings of Zodl and turn it on."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La cámara no está autorizada. Por favor, ve a la configuración del sistema de Zodl y actívala."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La cámara no está autorizada. Por favor, ve a la configuración del sistema de Zodl y actívala."
           }
         }
       }
     },
-    "scan.invalidImage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This image doesn't contain a valid Zcash address."
+    "scan.invalidImage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This image doesn't contain a valid Zcash address."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta imagen no contiene una dirección Zcash válida."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta imagen no contiene una dirección Zcash válida."
           }
         }
       }
     },
-    "scan.invalidQR": {
-      "comment": "MARK: - Scan",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This QR code doesn't contain a valid Zcash address."
+    "scan.invalidQR" : {
+      "comment" : "MARK: - Scan",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This QR code doesn't contain a valid Zcash address."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este código QR no contiene una dirección Zcash válida."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este código QR no contiene una dirección Zcash válida."
           }
         }
       }
     },
-    "scan.openSettings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open settings"
+    "scan.openSettings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open settings"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir configuración"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir configuración"
           }
         }
       }
     },
-    "scan.severalCodesFound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This image contains several valid Zcash addresses."
+    "scan.severalCodesFound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This image contains several valid Zcash addresses."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta imagen contiene varias direcciones Zcash válidas."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta imagen contiene varias direcciones Zcash válidas."
           }
         }
       }
     },
-    "send.addressNotInBook": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add contact by tapping on Address Book icon."
+    "send.addressNotInBook" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add contact by tapping on Address Book icon."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agrega un contacto tocando el ícono de la libreta de direcciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agrega un contacto tocando el ícono de la libreta de direcciones."
           }
         }
       }
     },
-    "send.addressPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash Address"
+    "send.addressPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección de Zcash"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de Zcash"
           }
         }
       }
     },
-    "send.alert.failure.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+    "send.alert.failure.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         }
       }
     },
-    "send.alert.failure.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to send funds"
+    "send.alert.failure.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to send funds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo enviar fondos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo enviar fondos"
           }
         }
       }
     },
-    "send.amount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount"
+    "send.amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto"
           }
         }
       }
     },
-    "send.amountSummary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total Amount"
+    "send.amountSummary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total Amount"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monto Total"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto Total"
           }
         }
       }
     },
-    "send.confirmationTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmation"
+    "send.confirmationTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmation"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmación"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmación"
           }
         }
       }
     },
-    "send.currencyPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "USD"
+    "send.currencyPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "USD"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD"
           }
         }
       }
     },
-    "send.currencyUnavailable.continueInZEC": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue in ZEC"
+    "send.currencyUnavailable.continueInZEC" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue in ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuar en ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar en ZEC"
           }
         }
       }
     },
-    "send.currencyUnavailable.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Live rates for %@ can't be fetched right now. You can use USD as a fallback, or keep entering amounts in ZEC only."
+    "send.currencyUnavailable.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live rates for %@ can't be fetched right now. You can use USD as a fallback, or keep entering amounts in ZEC only."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pueden obtener las tasas en tiempo real de %@ en este momento. Puedes usar USD como alternativa o seguir ingresando montos solo en ZEC."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pueden obtener las tasas en tiempo real de %@ en este momento. Puedes usar USD como alternativa o seguir ingresando montos solo en ZEC."
           }
         }
       }
     },
-    "send.currencyUnavailable.switchToUSD": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Switch to USD"
+    "send.currencyUnavailable.switchToUSD" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch to USD"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar a USD"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar a USD"
           }
         }
       }
     },
-    "send.currencyUnavailable.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ conversion unavailable"
+    "send.currencyUnavailable.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ conversion unavailable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conversión de %@ no disponible"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conversión de %@ no disponible"
           }
         }
       }
     },
-    "send.error.insufficientFunds": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient funds"
+    "send.error.insufficientFunds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insufficient funds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fondos insuficientes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondos insuficientes"
           }
         }
       }
     },
-    "send.error.invalidAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid address"
+    "send.error.invalidAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección no válida"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección no válida"
           }
         }
       }
     },
-    "send.error.invalidAmount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid amount"
+    "send.error.invalidAmount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid amount"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monto no válido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto no válido"
           }
         }
       }
     },
-    "send.failure": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to send"
+    "send.failure" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to send"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo enviar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo enviar"
           }
         }
       }
     },
-    "send.failureAnchorInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet's chain state changed while preparing this transaction. Please wait for sync to complete and try again."
+    "send.failureAnchorInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet's chain state changed while preparing this transaction. Please wait for sync to complete and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El estado de la cadena cambió mientras se preparaba la transacción. Por favor, espera a que la sincronización termine e intenta de nuevo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El estado de la cadena cambió mientras se preparaba la transacción. Por favor, espera a que la sincronización termine e intenta de nuevo."
           }
         }
       }
     },
-    "send.failureInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There was an error attempting to send coins. Try it again, please."
+    "send.failureInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There was an error attempting to send coins. Try it again, please."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hubo un error al intentar enviar monedas. Por favor, inténtalo de nuevo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubo un error al intentar enviar monedas. Por favor, inténtalo de nuevo."
           }
         }
       }
     },
-    "send.failureShielding": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to shield"
+    "send.failureShielding" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to shield"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo proteger"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo proteger"
           }
         }
       }
     },
-    "send.failureShieldingInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There was an error attempting to shield your coins. Try it again, please."
+    "send.failureShieldingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There was an error attempting to shield your coins. Try it again, please."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hubo un error al intentar proteger tus monedas. Por favor, inténtalo de nuevo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubo un error al intentar proteger tus monedas. Por favor, inténtalo de nuevo."
           }
         }
       }
     },
-    "send.feeSummary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee"
+    "send.feeSummary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tarifa"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarifa"
           }
         }
       }
     },
-    "send.info.memo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transparent transactions can’t have memos"
+    "send.info.memo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparent transactions can’t have memos"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Las transacciones transparentes no pueden tener mensajes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las transacciones transparentes no pueden tener mensajes"
           }
         }
       }
     },
-    "send.memoPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Write encrypted message here..."
+    "send.memoPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Write encrypted message here..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe un mensaje que será enviado cifrado..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribe un mensaje que será enviado cifrado..."
           }
         }
       }
     },
-    "send.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Message"
+    "send.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Message"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mensaje"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensaje"
           }
         }
       }
     },
-    "send.partialFailureInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only some of the transactions were accepted. Please contact support so we can help verify and recover the remaining funds."
+    "send.partialFailureInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only some of the transactions were accepted. Please contact support so we can help verify and recover the remaining funds."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solo se aceptaron algunas de las transacciones. Contacta a soporte para que podamos ayudar a verificar y recuperar los fondos restantes."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo se aceptaron algunas de las transacciones. Contacta a soporte para que podamos ayudar a verificar y recuperar los fondos restantes."
           }
         }
       }
     },
-    "send.pendingInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your transaction is being processed."
+    "send.pendingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your transaction is being processed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu transacción se está procesando."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu transacción se está procesando."
           }
         }
       }
     },
-    "send.pendingShieldingInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your shielding transaction is being processed."
+    "send.pendingShieldingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your shielding transaction is being processed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus Fondos Protegidos se están procesando."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus Fondos Protegidos se están procesando."
           }
         }
       }
     },
-    "send.pendingShieldingTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shielding Pending"
+    "send.pendingShieldingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shielding Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fondos Protegidos Pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondos Protegidos Pendiente"
           }
         }
       }
     },
-    "send.pendingTimeoutInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timed out waiting for a server response. Your transaction may still have been broadcast."
+    "send.pendingTimeoutInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timed out waiting for a server response. Your transaction may still have been broadcast."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se agotó el tiempo de espera de la respuesta del servidor. Es posible que tu transacción aún se haya transmitido."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se agotó el tiempo de espera de la respuesta del servidor. Es posible que tu transacción aún se haya transmitido."
           }
         }
       }
     },
-    "send.pendingTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transaction Pending"
+    "send.pendingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transaction Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transacción Pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transacción Pendiente"
           }
         }
       }
     },
-    "send.report": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Report"
+    "send.report" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reportar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reportar"
           }
         }
       }
     },
-    "send.requestPayment.for": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For:"
+    "send.requestPayment.for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Para:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para:"
           }
         }
       }
     },
-    "send.requestPayment.requestedBy": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Requested By"
+    "send.requestPayment.requestedBy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requested By"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solicitado por"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitado por"
           }
         }
       }
     },
-    "send.requestPayment.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Request"
+    "send.requestPayment.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Request"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solicitud de Pago"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitud de Pago"
           }
         }
       }
     },
-    "send.requestPayment.total": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total"
+    "send.requestPayment.total" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total"
           }
         }
       }
     },
-    "send.review": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review"
+    "send.review" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Revisar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisar"
           }
         }
       }
     },
-    "send.sending": {
-      "comment": "MARK: - Send",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending..."
+    "send.sending" : {
+      "comment" : "MARK: - Send",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviando..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviando..."
           }
         }
       }
     },
-    "send.sendingInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your coins are being sent to"
+    "send.sendingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your coins are being sent to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus monedas están siendo enviados a"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus monedas están siendo enviados a"
           }
         }
       }
     },
-    "send.shielding": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shielding"
+    "send.shielding" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shielding"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protegiendo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protegiendo"
           }
         }
       }
     },
-    "send.shieldingInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your coins are getting shielded"
+    "send.shieldingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your coins are getting shielded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus monedas están siendo protegidos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus monedas están siendo protegidos"
           }
         }
       }
     },
-    "send.success": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sent!"
+    "send.success" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Enviado!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Enviado!"
           }
         }
       }
     },
-    "send.successInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your coins were successfully sent to"
+    "send.successInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your coins were successfully sent to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus monedas fueron enviados exitosamente a"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus monedas fueron enviados exitosamente a"
           }
         }
       }
     },
-    "send.successShielding": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shielded!"
+    "send.successShielding" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shielded!"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¡Protegidos!"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Protegidos!"
           }
         }
       }
     },
-    "send.successShieldingInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your coins have been successfully shielded"
+    "send.successShieldingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your coins have been successfully shielded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus monedas han sido protegidos con éxito"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus monedas han sido protegidos con éxito"
           }
         }
       }
     },
-    "send.to": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send to"
+    "send.to" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviar a"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar a"
           }
         }
       }
     },
-    "send.toSummary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send to"
+    "send.toSummary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviando a"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviando a"
           }
         }
       }
     },
-    "send.viewTransaction": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View Transaction"
+    "send.viewTransaction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View Transaction"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver Transacción"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver Transacción"
           }
         }
       }
     },
-    "sendFeedback.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please let us know about any problems you have had, or features you want to see in the future."
+    "sendFeedback.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please let us know about any problems you have had, or features you want to see in the future."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Por favor, háznos saber sobre cualquier problema que hayas tenido, o funciones que te gustaría ver en el futuro."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor, háznos saber sobre cualquier problema que hayas tenido, o funciones que te gustaría ver en el futuro."
           }
         }
       }
     },
-    "sendFeedback.hcwhPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I would like to ask about..."
+    "sendFeedback.hcwhPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I would like to ask about..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Me gustaría preguntar sobre..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Me gustaría preguntar sobre..."
           }
         }
       }
     },
-    "sendFeedback.howCanWeHelp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How can we help you?"
+    "sendFeedback.howCanWeHelp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How can we help you?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Cómo podemos ayudarte?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Cómo podemos ayudarte?"
           }
         }
       }
     },
-    "sendFeedback.ratingQuestion": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How is your Zodl experience?"
+    "sendFeedback.ratingQuestion" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How is your Zodl experience?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Cómo ha sido tu experiencia con Zodl?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Cómo ha sido tu experiencia con Zodl?"
           }
         }
       }
     },
-    "sendFeedback.screenTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Support"
+    "sendFeedback.screenTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Support"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Soporte"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soporte"
           }
         }
       }
     },
-    "sendFeedback.share.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl"
+    "sendFeedback.share.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl"
           }
         }
       }
     },
-    "sendFeedback.share.notAppleMailInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your device doesn’t have an Apple email set up, so we prepared this message for you to send using your preferred email client. Please send this message to:"
+    "sendFeedback.share.notAppleMailInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your device doesn’t have an Apple email set up, so we prepared this message for you to send using your preferred email client. Please send this message to:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu dispositivo no tiene configurado un correo de Apple, así que preparamos este mensaje para que lo envíes usando tu cliente de correo preferido. Por favor, envía este mensaje a:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu dispositivo no tiene configurado un correo de Apple, así que preparamos este mensaje para que lo envíes usando tu cliente de correo preferido. Por favor, envía este mensaje a:"
           }
         }
       }
     },
-    "sendFeedback.share.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Support message"
+    "sendFeedback.share.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Support message"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mensaje de soporte"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensaje de soporte"
           }
         }
       }
     },
-    "sendFeedback.title": {
-      "comment": "MARK: - Send Feedback",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send Us Feedback"
+    "sendFeedback.title" : {
+      "comment" : "MARK: - Send Feedback",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send Us Feedback"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envíanos tus Comentarios"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envíanos tus Comentarios"
           }
         }
       }
     },
-    "sendSelect.payWithNear": {
-      "comment": "CrossPay",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CrossPay with Near"
+    "sendSelect.payWithNear" : {
+      "comment" : "CrossPay",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrossPay with Near"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CrossPay con Near"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrossPay con Near"
           }
         }
       }
     },
-    "sendSelect.payWithNear.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use shielded ZEC to send private cross-chain payments."
+    "sendSelect.payWithNear.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use shielded ZEC to send private cross-chain payments."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use shielded ZEC to send private cross-chain payments."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use shielded ZEC to send private cross-chain payments."
           }
         }
       }
     },
-    "sendSelect.swapWithNear": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap ZEC with NEAR Intents"
+    "sendSelect.swapWithNear" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap ZEC with NEAR Intents"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap ZEC con NEAR Intents"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap ZEC con NEAR Intents"
           }
         }
       }
     },
-    "sendSelect.swapWithNear.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap ZEC with other cryptocurrencies."
+    "sendSelect.swapWithNear.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap ZEC with other cryptocurrencies."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haz swap de ZEC con otras criptomonedas."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz swap de ZEC con otras criptomonedas."
           }
         }
       }
     },
-    "sendSelect.zashi.send": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay in ZEC"
+    "sendSelect.zashi.send" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay in ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagar en ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar en ZEC"
           }
         }
       }
     },
-    "sendSelect.zashi.send.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay anyone by sending them ZEC."
+    "sendSelect.zashi.send.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay anyone by sending them ZEC."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paga a cualquiera enviándole ZEC."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paga a cualquiera enviándole ZEC."
           }
         }
       }
     },
-    "serverSetup.active": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active"
+    "serverSetup.active" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activo"
           }
         }
       }
     },
-    "serverSetup.alert.failed.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+    "serverSetup.alert.failed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         }
       }
     },
-    "serverSetup.alert.failed.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid endpoint"
+    "serverSetup.alert.failed.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid endpoint"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punto final no válido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Punto final no válido"
           }
         }
       }
     },
-    "serverSetup.allServers": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browse all servers"
+    "serverSetup.allServers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browse all servers"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Explorar todos los servidores"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar todos los servidores"
           }
         }
       }
     },
-    "serverSetup.automatic": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatic"
+    "serverSetup.automatic" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automático"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automático"
           }
         }
       }
     },
-    "serverSetup.connectionMode": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection mode"
+    "serverSetup.connectionMode" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connection mode"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modo de conexión"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de conexión"
           }
         }
       }
     },
-    "serverSetup.couldTakeTime": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This may take a moment..."
+    "serverSetup.couldTakeTime" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This may take a moment..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esto puede tardar un momento..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto puede tardar un momento..."
           }
         }
       }
     },
-    "serverSetup.custom": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "custom"
+    "serverSetup.custom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "custom"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "personalizado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "personalizado"
           }
         }
       }
     },
-    "serverSetup.default": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Default"
+    "serverSetup.default" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Predeterminado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predeterminado"
           }
         }
       }
     },
-    "serverSetup.fastestServers": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fastest servers"
+    "serverSetup.fastestServers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fastest servers"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Servidores más rápidos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidores más rápidos"
           }
         }
       }
     },
-    "serverSetup.manual": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manual"
+    "serverSetup.manual" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manual"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manual"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manual"
           }
         }
       }
     },
-    "serverSetup.multiServerInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We may use multiple servers to optimize performance. To reduce metadata exposure, choose Manual connection mode to select your single server of choice, and ensure Tor is enabled in Advanced Settings."
+    "serverSetup.multiServerInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We may use multiple servers to optimize performance. To reduce metadata exposure, choose Manual connection mode to select your single server of choice, and ensure Tor is enabled in Advanced Settings."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Podemos usar varios servidores para optimizar el rendimiento. Para reducir la exposición de metadatos, selecciona el modo de conexión Manual para elegir un único servidor de tu preferencia y asegúrate de que Tor esté habilitado en Configuración Avanzada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Podemos usar varios servidores para optimizar el rendimiento. Para reducir la exposición de metadatos, selecciona el modo de conexión Manual para elegir un único servidor de tu preferencia y asegúrate de que Tor esté habilitado en Configuración Avanzada."
           }
         }
       }
     },
-    "serverSetup.otherServers": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Other servers"
+    "serverSetup.otherServers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Other servers"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otros servidores"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otros servidores"
           }
         }
       }
     },
-    "serverSetup.performingTest": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Performing Server Test"
+    "serverSetup.performingTest" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Performing Server Test"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Realizando prueba de servidor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Realizando prueba de servidor"
           }
         }
       }
     },
-    "serverSetup.placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "<hostname>:<port>"
+    "serverSetup.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "<hostname>:<port>"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "<nombre del host>:<puerto>"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "<nombre del host>:<puerto>"
           }
         }
       }
     },
-    "serverSetup.refresh": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refresh"
+    "serverSetup.refresh" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar"
           }
         }
       }
     },
-    "serverSetup.save": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save selection"
+    "serverSetup.save" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save selection"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardar selección"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar selección"
           }
         }
       }
     },
-    "serverSetup.testing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testing"
+    "serverSetup.testing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Testing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Probando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Probando"
           }
         }
       }
     },
-    "serverSetup.title": {
-      "comment": "MARK: - Server Setup",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server"
+    "serverSetup.title" : {
+      "comment" : "MARK: - Server Setup",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Servidor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidor"
           }
         }
       }
     },
-    "settings.about": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About"
+    "settings.about" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acerca de"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de"
           }
         }
       }
     },
-    "settings.addressBook": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address Book"
+    "settings.addressBook" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address Book"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Libreta de Direcciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libreta de Direcciones"
           }
         }
       }
     },
-    "settings.advanced": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advanced Settings"
+    "settings.advanced" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Advanced Settings"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuración Avanzada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración Avanzada"
           }
         }
       }
     },
-    "settings.chooseServer": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose a Server"
+    "settings.chooseServer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose a Server"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elegir un Servidor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegir un Servidor"
           }
         }
       }
     },
-    "settings.coinholderPolling": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beta: Coinholder Polling"
+    "settings.coinholderPolling" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beta: Coinholder Polling"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beta: Coinholder Polling"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beta: Coinholder Polling"
           }
         }
       }
     },
-    "settings.deleteZashi": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset Zodl"
+    "settings.deleteZashi" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer Zodl"
           }
         }
       }
     },
-    "settings.deleteZashiWarning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You will be asked to confirm on the next screen"
+    "settings.deleteZashiWarning" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You will be asked to confirm on the next screen"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se te pedirá que confirmes en la siguiente pantalla"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se te pedirá que confirmes en la siguiente pantalla"
           }
         }
       }
     },
-    "settings.exportLogsOnly": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export logs only"
+    "settings.exportLogsOnly" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export logs only"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exportar solo registros"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar solo registros"
           }
         }
       }
     },
-    "settings.exportPrivateData": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export Private Data"
+    "settings.exportPrivateData" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export Private Data"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exportar Datos Privados"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar Datos Privados"
           }
         }
       }
     },
-    "settings.feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send Us Feedback"
+    "settings.feedback" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send Us Feedback"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envíanos tus Comentarios"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envíanos tus Comentarios"
           }
         }
       }
     },
-    "settings.flexa": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay with Flexa"
+    "settings.flexa" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay with Flexa"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagar con Flexa"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar con Flexa"
           }
         }
       }
     },
-    "settings.flexaDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spend ZEC at thousands of retail locations."
+    "settings.flexaDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spend ZEC at thousands of retail locations."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gasta ZEC en miles de establecimientos comerciales."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gasta ZEC en miles de establecimientos comerciales."
           }
         }
       }
     },
-    "settings.keystone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect Keystone"
+    "settings.keystone" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect Keystone"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectar Keystone"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar Keystone"
           }
         }
       }
     },
-    "settings.keystoneDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect airgapped hardware wallet to store shielded ZEC."
+    "settings.keystoneDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect airgapped hardware wallet to store shielded ZEC."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conecta una billetera de hardware aislada (air-gapped) para almacenar ZEC protegidos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conecta una billetera de hardware aislada (air-gapped) para almacenar ZEC protegidos."
           }
         }
       }
     },
-    "settings.private": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tor Protection"
+    "settings.private" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor Protection"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protección Tor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protección Tor"
           }
         }
       }
     },
-    "settings.recoveryPhrase": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl Recovery Phrase"
+    "settings.recoveryPhrase" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl Recovery Phrase"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frase de Recuperación de Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frase de Recuperación de Zodl"
           }
         }
       }
     },
-    "settings.title": {
-      "comment": "MARK: - Settings",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More"
+    "settings.title" : {
+      "comment" : "MARK: - Settings",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Más"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más"
           }
         }
       }
     },
-    "settings.version": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version %@ (%@)"
+    "settings.version" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version %@ (%@)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión %@ (%@)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión %@ (%@)"
           }
         }
       }
     },
-    "settings.whatsNew": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "What’s New"
+    "settings.whatsNew" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What’s New"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Novedades"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Novedades"
           }
         }
       }
     },
-    "sheet.insufficientBalance.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We couldn’t create this transaction for you. Your wallet doesn’t have enough balance to cover both the transaction amount and transaction fees. Please lower the transaction amount to account for the fees. "
+    "sheet.insufficientBalance.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn’t create this transaction for you. Your wallet doesn’t have enough balance to cover both the transaction amount and transaction fees. Please lower the transaction amount to account for the fees. "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No pudimos crear esta transacción. Tu billetera no tiene suficiente saldo para cubrir tanto el monto de la transacción como las comisiones. Por favor, reduce el monto para considerar las comisiones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No pudimos crear esta transacción. Tu billetera no tiene suficiente saldo para cubrir tanto el monto de la transacción como las comisiones. Por favor, reduce el monto para considerar las comisiones."
           }
         }
       }
     },
-    "sheet.insufficientBalance.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient Funds"
+    "sheet.insufficientBalance.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insufficient Funds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fondos insuficientes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondos insuficientes"
           }
         }
       }
     },
-    "sheet.syncTimeout.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There was an error trying to execute the last operation. Check your connection, VPN setting, restart the app, or try one of the following:"
+    "sheet.syncTimeout.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There was an error trying to execute the last operation. Check your connection, VPN setting, restart the app, or try one of the following:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocurrió un error al intentar ejecutar la última operación. Revisa tu conexión, la configuración de VPN, reinicia la app o prueba una de las siguientes opciones:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocurrió un error al intentar ejecutar la última operación. Revisa tu conexión, la configuración de VPN, reinicia la app o prueba una de las siguientes opciones:"
           }
         }
       }
     },
-    "sheet.syncTimeout.server": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Switch server"
+    "sheet.syncTimeout.server" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch server"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar servidor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar servidor"
           }
         }
       }
     },
-    "sheet.syncTimeout.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Something went wrong"
+    "sheet.syncTimeout.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something went wrong"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Algo salió mal"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algo salió mal"
           }
         }
       }
     },
-    "sheet.syncTimeout.tor": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disable Tor protection"
+    "sheet.syncTimeout.tor" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable Tor protection"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deshabilitar protección Tor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deshabilitar protección Tor"
           }
         }
       }
     },
-    "shieldFunds.error.failure.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An error happened during the last shielding transaction. You can try again later or report this issue if the problem persists. \n\n %@"
+    "shieldFunds.error.failure.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An error happened during the last shielding transaction. You can try again later or report this issue if the problem persists. \n\n %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocurrió un error durante la última transacción de protección. Puedes intentarlo nuevamente más tarde o reportar este problema si persiste. \n\n %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocurrió un error durante la última transacción de protección. Puedes intentarlo nuevamente más tarde o reportar este problema si persiste. \n\n %@"
           }
         }
       }
     },
-    "shieldFunds.error.gprc.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An error happened during the last shielding transaction. We will try to resubmit the transaction later. If it fails, you may need to repeat the shielding attempt at a later time."
+    "shieldFunds.error.gprc.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An error happened during the last shielding transaction. We will try to resubmit the transaction later. If it fails, you may need to repeat the shielding attempt at a later time."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocurrió un error durante la última transacción de protección. Intentaremos reenviar la transacción más tarde. Si falla, es posible que debas repetir el intento de protección más tarde."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocurrió un error durante la última transacción de protección. Intentaremos reenviar la transacción más tarde. Si falla, es posible que debas repetir el intento de protección más tarde."
           }
         }
       }
     },
-    "shieldFunds.error.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shielding Error"
+    "shieldFunds.error.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shielding Error"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error de Protección"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de Protección"
           }
         }
       }
     },
-    "smartBanner.content.autoShielding.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start"
+    "smartBanner.content.autoShielding.button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar"
           }
         }
       }
     },
-    "smartBanner.content.autoShielding.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable automatic shielding"
+    "smartBanner.content.autoShielding.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable automatic shielding"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activa la protección automática"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activa la protección automática"
           }
         }
       }
     },
-    "smartBanner.content.autoShielding.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Shielding"
+    "smartBanner.content.autoShielding.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-Shielding"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Protección"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-Protección"
           }
         }
       }
     },
-    "smartBanner.content.backup.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start"
+    "smartBanner.content.backup.button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar"
           }
         }
       }
     },
-    "smartBanner.content.backup.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prevent potential loss of funds"
+    "smartBanner.content.backup.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prevent potential loss of funds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evita la pérdida potencial de fondos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita la pérdida potencial de fondos"
           }
         }
       }
     },
-    "smartBanner.content.backup.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Backup Required"
+    "smartBanner.content.backup.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Backup Required"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respaldo de Billetera Requerido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respaldo de Billetera Requerido"
           }
         }
       }
     },
-    "smartBanner.content.currencyConversion.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start"
+    "smartBanner.content.currencyConversion.button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar"
           }
         }
       }
     },
-    "smartBanner.content.currencyConversion.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable to display fiat values"
+    "smartBanner.content.currencyConversion.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable to display fiat values"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activa para mostrar valores fiat"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activa para mostrar valores fiat"
           }
         }
       }
     },
-    "smartBanner.content.currencyConversion.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currency Conversion"
+    "smartBanner.content.currencyConversion.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currency Conversion"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conversión de Moneda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conversión de Moneda"
           }
         }
       }
     },
-    "smartBanner.content.disconnected.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check your connection and reload Zodl"
+    "smartBanner.content.disconnected.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check your connection and reload Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verifica tu conexión y recarga Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica tu conexión y recarga Zodl"
           }
         }
       }
     },
-    "smartBanner.content.disconnected.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Disconnected"
+    "smartBanner.content.disconnected.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Disconnected"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Billetera Desconectada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Billetera Desconectada"
           }
         }
       }
     },
-    "smartBanner.content.restore.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep Zodl open on active phone screen"
+    "smartBanner.content.restore.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep Zodl open on active phone screen"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantén Zodl abierta en una pantalla activa del teléfono"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantén Zodl abierta en una pantalla activa del teléfono"
           }
         }
       }
     },
-    "smartBanner.content.restore.infoSpendable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your funds are ready to be used now"
+    "smartBanner.content.restore.infoSpendable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your funds are ready to be used now"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus fondos están listos para ser utilizados ahora"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus fondos están listos para ser utilizados ahora"
           }
         }
       }
     },
-    "smartBanner.content.restore.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restoring Wallet • %@ Complete"
+    "smartBanner.content.restore.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring Wallet • %@ Complete"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restaurando Billetera • %@ Completo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurando Billetera • %@ Completo"
           }
         }
       }
     },
-    "smartBanner.content.shield.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shield"
+    "smartBanner.content.shield.button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shield"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proteger"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proteger"
           }
         }
       }
     },
-    "smartBanner.content.shield.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unshielded Balance"
+    "smartBanner.content.shield.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unshielded Balance"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saldo No Protegido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saldo No Protegido"
           }
         }
       }
     },
-    "smartBanner.content.sync.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your wallet is updating"
+    "smartBanner.content.sync.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your wallet is updating"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu billetera se está actualizando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu billetera se está actualizando"
           }
         }
       }
     },
-    "smartBanner.content.sync.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Syncing • %@ Complete"
+    "smartBanner.content.sync.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing • %@ Complete"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sincronizando • %@ Completo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando • %@ Completo"
           }
         }
       }
     },
-    "smartBanner.content.syncingError.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attempting to resolve"
+    "smartBanner.content.syncingError.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attempting to resolve"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intentando resolver"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentando resolver"
           }
         }
       }
     },
-    "smartBanner.content.syncingError.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error encountered while syncing"
+    "smartBanner.content.syncingError.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error encountered while syncing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error al sincronizar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al sincronizar"
           }
         }
       }
     },
-    "smartBanner.content.tor.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review"
+    "smartBanner.content.tor.button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Revisar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisar"
           }
         }
       }
     },
-    "smartBanner.content.tor.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protect your IP address"
+    "smartBanner.content.tor.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protect your IP address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protege tu dirección IP"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protege tu dirección IP"
           }
         }
       }
     },
-    "smartBanner.content.tor.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Tor Protection"
+    "smartBanner.content.tor.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Tor Protection"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar protección Tor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar protección Tor"
           }
         }
       }
     },
-    "smartBanner.content.updatingBalance.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for last transaction to process"
+    "smartBanner.content.updatingBalance.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for last transaction to process"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esperando a que la última transacción se procese"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esperando a que la última transacción se procese"
           }
         }
       }
     },
-    "smartBanner.content.updatingBalance.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating Balance..."
+    "smartBanner.content.updatingBalance.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Updating Balance..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizando Balance..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizando Balance..."
           }
         }
       }
     },
-    "smartBanner.help.backup.acknowledge": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I read and understand the risks of not backing up my wallet."
+    "smartBanner.help.backup.acknowledge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I read and understand the risks of not backing up my wallet."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "He leído y entiendo los riesgos de no respaldar mi billetera."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "He leído y entiendo los riesgos de no respaldar mi billetera."
           }
         }
       }
     },
-    "smartBanner.help.backup.info1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prevent potential loss of funds by securely backing up your wallet."
+    "smartBanner.help.backup.info1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prevent potential loss of funds by securely backing up your wallet."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evita la pérdida potencial de fondos respaldando tu billetera de forma segura."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita la pérdida potencial de fondos respaldando tu billetera de forma segura."
           }
         }
       }
     },
-    "smartBanner.help.backup.info2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back up access to your funds by backing up:"
+    "smartBanner.help.backup.info2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back up access to your funds by backing up:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respalda el acceso a tus fondos realizando un respaldo de:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respalda el acceso a tus fondos realizando un respaldo de:"
           }
         }
       }
     },
-    "smartBanner.help.backup.info3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In case you lose access to the app or to your device, knowing the Secret Recovery Phrase is the only way to recover your funds. We cannot see it and cannot help you recover it."
+    "smartBanner.help.backup.info3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In case you lose access to the app or to your device, knowing the Secret Recovery Phrase is the only way to recover your funds. We cannot see it and cannot help you recover it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "En caso de que pierdas acceso a la aplicación o a tu dispositivo, conocer la Frase de Recuperación Secreta es la única forma de recuperar tus fondos. No podemos verla ni podemos ayudarte a recuperarla."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En caso de que pierdas acceso a la aplicación o a tu dispositivo, conocer la Frase de Recuperación Secreta es la única forma de recuperar tus fondos. No podemos verla ni podemos ayudarte a recuperarla."
           }
         }
       }
     },
-    "smartBanner.help.backup.info4": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anyone with access to your Secret Recovery Phrase will have full control of your wallet, so keep it secure and never show it to anyone."
+    "smartBanner.help.backup.info4" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anyone with access to your Secret Recovery Phrase will have full control of your wallet, so keep it secure and never show it to anyone."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cualquiera que tenga acceso a tu Frase de Recuperación Secreta tendrá control total de tu billetera, así que mantenla segura y nunca la muestres a nadie."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cualquiera que tenga acceso a tu Frase de Recuperación Secreta tendrá control total de tu billetera, así que mantenla segura y nunca la muestres a nadie."
           }
         }
       }
     },
-    "smartBanner.help.backup.point1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Secret Recovery Phrase (a unique set of 24 words in a precise order) "
+    "smartBanner.help.backup.point1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secret Recovery Phrase (a unique set of 24 words in a precise order) "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frase de Recuperación Secreta (un conjunto único de 24 palabras en un orden preciso)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frase de Recuperación Secreta (un conjunto único de 24 palabras en un orden preciso)"
           }
         }
       }
     },
-    "smartBanner.help.backup.point2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Birthday Height (block height at which your wallet was created)"
+    "smartBanner.help.backup.point2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Birthday Height (block height at which your wallet was created)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Altura de Cumpleaños de la Billetera (altura de bloque en la que se creó tu billetera)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de Cumpleaños de la Billetera (altura de bloque en la que se creó tu billetera)"
           }
         }
       }
     },
-    "smartBanner.help.backup.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Backup Required"
+    "smartBanner.help.backup.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup Required"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respaldo Requerido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respaldo Requerido"
           }
         }
       }
     },
-    "smartBanner.help.diconnected.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You appear to be offline. Please restore your internet connection to use Zodl wallet."
+    "smartBanner.help.diconnected.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You appear to be offline. Please restore your internet connection to use Zodl wallet."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parece que estás offline. Por favor, restaura tu conexión a internet para usar la billetera Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parece que estás offline. Por favor, restaura tu conexión a internet para usar la billetera Zodl."
           }
         }
       }
     },
-    "smartBanner.help.diconnected.title": {
-      "comment": "Smart Banner",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Disconnected"
+    "smartBanner.help.diconnected.title" : {
+      "comment" : "Smart Banner",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Disconnected"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Billetera Desconectada"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Billetera Desconectada"
           }
         }
       }
     },
-    "smartBanner.help.remindMePhase1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remind me in 2 days"
+    "smartBanner.help.remindMePhase1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remind me in 2 days"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recuérdame en 2 días"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recuérdame en 2 días"
           }
         }
       }
     },
-    "smartBanner.help.remindMePhase2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remind me in 2 weeks"
+    "smartBanner.help.remindMePhase2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remind me in 2 weeks"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recuérdame en 2 semanas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recuérdame en 2 semanas"
           }
         }
       }
     },
-    "smartBanner.help.remindMePhase3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remind me next month"
+    "smartBanner.help.remindMePhase3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remind me next month"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recuérdame el próximo mes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recuérdame el próximo mes"
           }
         }
       }
     },
-    "smartBanner.help.restore.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to restore. Follow these steps to prevent interruption:"
+    "smartBanner.help.restore.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to restore. Follow these steps to prevent interruption:"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl está escaneando la blockchain para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en restaurarse. Sigue estos pasos para evitar interrupciones:"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl está escaneando la blockchain para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en restaurarse. Sigue estos pasos para evitar interrupciones:"
           }
         }
       }
     },
-    "smartBanner.help.restore.point1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep the Zodl app open on an active phone screen."
+    "smartBanner.help.restore.point1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep the Zodl app open on an active phone screen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantén la aplicación Zodl abierta en una pantalla activa del teléfono."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantén la aplicación Zodl abierta en una pantalla activa del teléfono."
           }
         }
       }
     },
-    "smartBanner.help.restore.point2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To prevent your phone screen from going dark, turn off power-saving mode and keep your phone plugged in."
+    "smartBanner.help.restore.point2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To prevent your phone screen from going dark, turn off power-saving mode and keep your phone plugged in."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Para evitar que la pantalla de tu teléfono se apague, desactiva el modo de ahorro de energía y mantén tu teléfono conectado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para evitar que la pantalla de tu teléfono se apague, desactiva el modo de ahorro de energía y mantén tu teléfono conectado."
           }
         }
       }
     },
-    "smartBanner.help.restore.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Restore in Progress"
+    "smartBanner.help.restore.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Restore in Progress"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restauración de Billetera en Progreso"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restauración de Billetera en Progreso"
           }
         }
       }
     },
-    "smartBanner.help.restore.warning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funds cannot be spent until your wallet is restored."
+    "smartBanner.help.restore.warning" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funds cannot be spent until your wallet is restored."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los fondos no pueden ser gastados hasta que tu billetera esté restaurada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los fondos no pueden ser gastados hasta que tu billetera esté restaurada."
           }
         }
       }
     },
-    "smartBanner.help.resync.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Resync in Progress"
+    "smartBanner.help.resync.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Resync in Progress"
           }
         }
       }
     },
-    "smartBanner.help.shield.doNotShowAgain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Do not show this message again"
+    "smartBanner.help.shield.doNotShowAgain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Do not show this message again"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No mostrar este mensaje de nuevo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No mostrar este mensaje de nuevo"
           }
         }
       }
     },
-    "smartBanner.help.shield.info1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To protect user privacy, Zodl doesn't support spending transparent ZEC. Tap the \"Shield\" button below to make your transparent funds spendable and your total Zodl balance private. "
+    "smartBanner.help.shield.info1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To protect user privacy, Zodl doesn't support spending transparent ZEC. Tap the \"Shield\" button below to make your transparent funds spendable and your total Zodl balance private. "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Para proteger la privacidad del usuario, Zodl no admite el gasto de ZEC transparente. Toca el botón \"Proteger\" abajo para hacer que tus fondos transparentes sean gastables y tu saldo total en Zodl sea privado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para proteger la privacidad del usuario, Zodl no admite el gasto de ZEC transparente. Toca el botón \"Proteger\" abajo para hacer que tus fondos transparentes sean gastables y tu saldo total en Zodl sea privado."
           }
         }
       }
     },
-    "smartBanner.help.shield.info2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This will create a shielding in-wallet transaction, consolidating your transparent and shielded funds. (Typical fee: %@)"
+    "smartBanner.help.shield.info2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will create a shielding in-wallet transaction, consolidating your transparent and shielded funds. (Typical fee: %@)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esto creará una transacción de protección en la billetera, consolidando tus fondos transparentes y protegidos. (Tarifa típica: %@)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto creará una transacción de protección en la billetera, consolidando tus fondos transparentes y protegidos. (Tarifa típica: %@)"
           }
         }
       }
     },
-    "smartBanner.help.shield.notNow": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not now"
+    "smartBanner.help.shield.notNow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not now"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ahora no"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ahora no"
           }
         }
       }
     },
-    "smartBanner.help.shield.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Always Shield Transparent Funds"
+    "smartBanner.help.shield.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Always Shield Transparent Funds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protege Siempre los Fondos Transparentes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protege Siempre los Fondos Transparentes"
           }
         }
       }
     },
-    "smartBanner.help.shield.transparent": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transparent"
+    "smartBanner.help.shield.transparent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparent"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transparente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparente"
           }
         }
       }
     },
-    "smartBanner.help.sync.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl is scanning the blockchain for your latest transactions to make sure your balances are displayed correctly. Keep the Zodl app open on an active phone screen to avoid interruptions."
+    "smartBanner.help.sync.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl is scanning the blockchain for your latest transactions to make sure your balances are displayed correctly. Keep the Zodl app open on an active phone screen to avoid interruptions."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl está escaneando la blockchain para tus últimas transacciones para asegurarse de que tus balances se muestren correctamente. Mantén la aplicación Zodl abierta en una pantalla activa del teléfono para evitar interrupciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl está escaneando la blockchain para tus últimas transacciones para asegurarse de que tus balances se muestren correctamente. Mantén la aplicación Zodl abierta en una pantalla activa del teléfono para evitar interrupciones."
           }
         }
       }
     },
-    "smartBanner.help.sync.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Sync in Progress"
+    "smartBanner.help.sync.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Sync in Progress"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sincronización de Billetera en Progreso"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronización de Billetera en Progreso"
           }
         }
       }
     },
-    "smartBanner.help.syncError.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Syncing Error"
+    "smartBanner.help.syncError.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing Error"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error de Sincronización"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de Sincronización"
           }
         }
       }
     },
-    "smartBanner.help.updatingBalance.info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your last transaction is getting mined and confirmed."
+    "smartBanner.help.updatingBalance.info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your last transaction is getting mined and confirmed."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu última transacción está siendo minada y confirmada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu última transacción está siendo minada y confirmada."
           }
         }
       }
     },
-    "smartBanner.help.updatingBalance.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating Balance"
+    "smartBanner.help.updatingBalance.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Updating Balance"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizando Balance"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizando Balance"
           }
         }
       }
     },
-    "smartBannerContentResyncing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resyncing"
+    "smartBannerContentResyncing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resyncing"
           }
         }
       }
     },
-    "splash.authFaceID": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap the face icon to use Face ID and unlock it."
+    "splash.authFaceID" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the face icon to use Face ID and unlock it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca el ícono de la cara para usar Face ID y desbloquear."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca el ícono de la cara para usar Face ID y desbloquear."
           }
         }
       }
     },
-    "splash.authPasscode": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap the key icon to enter your passcode and unlock it."
+    "splash.authPasscode" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the key icon to enter your passcode and unlock it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca el ícono de la llave para ingresar tu código y desbloquear."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca el ícono de la llave para ingresar tu código y desbloquear."
           }
         }
       }
     },
-    "splash.authTitle": {
-      "comment": "MARK: - Splash Screen",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Zodl account is secured."
+    "splash.authTitle" : {
+      "comment" : "MARK: - Splash Screen",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Zodl account is secured."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu cuenta Zodl está protegida."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu cuenta Zodl está protegida."
           }
         }
       }
     },
-    "splash.authTouchID": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap the print icon to use Touch ID and unlock it."
+    "splash.authTouchID" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the print icon to use Touch ID and unlock it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca el ícono de la huella para usar Touch ID y desbloquear."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca el ícono de la huella para usar Touch ID y desbloquear."
           }
         }
       }
     },
-    "supportData.appVersionItem.bundleIdentifier": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App identifier"
+    "supportData.appVersionItem.bundleIdentifier" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App identifier"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identificador de la aplicación"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Identificador de la aplicación"
           }
         }
       }
     },
-    "supportData.appVersionItem.version": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App version"
+    "supportData.appVersionItem.version" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App version"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión de la aplicación"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión de la aplicación"
           }
         }
       }
     },
-    "supportData.deviceModelItem.device": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Device"
+    "supportData.deviceModelItem.device" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dispositivo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dispositivo"
           }
         }
       }
     },
-    "supportData.freeDiskSpaceItem.freeDiskSpace": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usable storage"
+    "supportData.freeDiskSpaceItem.freeDiskSpace" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usable storage"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Almacenamiento disponible"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almacenamiento disponible"
           }
         }
       }
     },
-    "supportData.localeItem.decimalSeparator": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currency decimal separator"
+    "supportData.localeItem.decimalSeparator" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currency decimal separator"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Separador decimal de moneda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Separador decimal de moneda"
           }
         }
       }
     },
-    "supportData.localeItem.groupingSeparator": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currency grouping separator"
+    "supportData.localeItem.groupingSeparator" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currency grouping separator"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Separador de agrupación de moneda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Separador de agrupación de moneda"
           }
         }
       }
     },
-    "supportData.localeItem.locale": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Locale"
+    "supportData.localeItem.locale" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locale"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Región"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Región"
           }
         }
       }
     },
-    "supportData.permissionItem.camera": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Camera access"
+    "supportData.permissionItem.camera" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Camera access"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acceso a la cámara"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso a la cámara"
           }
         }
       }
     },
-    "supportData.permissionItem.faceID": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "FaceID available"
+    "supportData.permissionItem.faceID" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FaceID available"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "FaceID disponible"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FaceID disponible"
           }
         }
       }
     },
-    "supportData.permissionItem.permissions": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permissions"
+    "supportData.permissionItem.permissions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permissions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permisos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permisos"
           }
         }
       }
     },
-    "supportData.permissionItem.touchID": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TouchID available"
+    "supportData.permissionItem.touchID" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TouchID available"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TouchID disponible"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TouchID disponible"
           }
         }
       }
     },
-    "supportData.systemVersionItem.version": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS version"
+    "supportData.systemVersionItem.version" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS version"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión de iOS"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión de iOS"
           }
         }
       }
     },
-    "supportData.timeItem.time": {
-      "comment": "MARK: - Support Data",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Current time"
+    "supportData.timeItem.time" : {
+      "comment" : "MARK: - Support Data",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current time"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hora actual"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hora actual"
           }
         }
       }
     },
-    "swap.nearProvider": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "near"
+    "swap.nearProvider" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "near"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "near"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "near"
           }
         }
       }
     },
-    "swap.quoteUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We tried but couldn’t get a quote for a payment with your parameters. You can try to adjust the slippage or try again later."
+    "swap.quoteUnavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We tried but couldn’t get a quote for a payment with your parameters. You can try to adjust the slippage or try again later."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intentamos, pero no pudimos obtener una cotización para un pago con tus parámetros. Puedes ajustar el slippage o intentar más tarde."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentamos, pero no pudimos obtener una cotización para un pago con tus parámetros. Puedes ajustar el slippage o intentar más tarde."
           }
         }
       }
     },
-    "swap.quoteUnavailableSwap": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We tried but couldn’t get a quote for a swap with your parameters. You can try to adjust the slippage or try again later."
+    "swap.quoteUnavailableSwap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We tried but couldn’t get a quote for a swap with your parameters. You can try to adjust the slippage or try again later."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intentamos, pero no pudimos obtener una cotización para un swap con tus parámetros. Puedes ajustar el slippage o intentar más tarde."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentamos, pero no pudimos obtener una cotización para un swap con tus parámetros. Puedes ajustar el slippage o intentar más tarde."
           }
         }
       }
     },
-    "swapAndPay.address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address"
+    "swapAndPay.address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección"
           }
         }
       }
     },
-    "swapAndPay.addressBookNewContact": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add new contact"
+    "swapAndPay.addressBookNewContact" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add new contact"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agregar nuevo contacto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar nuevo contacto"
           }
         }
       }
     },
-    "swapAndPay.addressBookSelect": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select..."
+    "swapAndPay.addressBookSelect" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar..."
           }
         }
       }
     },
-    "swapAndPay.addressBookSelectChain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Chain"
+    "swapAndPay.addressBookSelectChain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Chain"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar cadena"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar cadena"
           }
         }
       }
     },
-    "swapAndPay.addressBookZcash": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash address is not allowed"
+    "swapAndPay.addressBookZcash" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash address is not allowed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección de Zcash no permitida"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de Zcash no permitida"
           }
         }
       }
     },
-    "swapAndPay.cancelDont": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Don’t cancel"
+    "swapAndPay.cancelDont" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don’t cancel"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No cancelar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No cancelar"
           }
         }
       }
     },
-    "swapAndPay.cancelMsg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you leave this screen, all the information you entered will be lost."
+    "swapAndPay.cancelMsg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you leave this screen, all the information you entered will be lost."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si sales de esta pantalla, toda la información ingresada se perderá."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si sales de esta pantalla, toda la información ingresada se perderá."
           }
         }
       }
     },
-    "swapAndPay.cancelPayment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel payment"
+    "swapAndPay.cancelPayment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel payment"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar pago"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar pago"
           }
         }
       }
     },
-    "swapAndPay.cancelSwap": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel swap"
+    "swapAndPay.cancelSwap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel swap"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar swap"
           }
         }
       }
     },
-    "swapAndPay.canceltitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure?"
+    "swapAndPay.canceltitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Estás seguro?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Estás seguro?"
           }
         }
       }
     },
-    "swapAndPay.checkStatus": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check status"
+    "swapAndPay.checkStatus" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check status"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver estado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver estado"
           }
         }
       }
     },
-    "swapAndPay.custom": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom"
+    "swapAndPay.custom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otro"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otro"
           }
         }
       }
     },
-    "swapAndPay.editPayment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit payment"
+    "swapAndPay.editPayment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit payment"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editar pago"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar pago"
           }
         }
       }
     },
-    "swapAndPay.editSwap": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit swap"
+    "swapAndPay.editSwap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit swap"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editar swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar swap"
           }
         }
       }
     },
-    "swapAndPay.emptyAssets.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We tried but couldn’t find anything."
+    "swapAndPay.emptyAssets.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We tried but couldn’t find anything."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lo intentamos pero no encontramos nada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo intentamos pero no encontramos nada."
           }
         }
       }
     },
-    "swapAndPay.emptyAssets.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No results"
+    "swapAndPay.emptyAssets.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No results"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin resultados"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin resultados"
           }
         }
       }
     },
-    "swapAndPay.executedSlippage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Realized slippage"
+    "swapAndPay.executedSlippage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Realized slippage"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deslizamiento realizado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deslizamiento realizado"
           }
         }
       }
     },
-    "swapAndPay.expiredMsg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This swap expired after its 24-hour validity window. If you didn't send funds, no action is needed. If you did send funds, contact support so we can help."
+    "swapAndPay.expiredMsg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This swap expired after its 24-hour validity window. If you didn't send funds, no action is needed. If you did send funds, contact support so we can help."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este intercambio venció tras su ventana de validez de 24 horas. Si no enviaste fondos, no es necesario hacer nada. Si enviaste fondos, contacta a soporte para que podamos ayudarte."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este intercambio venció tras su ventana de validez de 24 horas. Si no enviaste fondos, no es necesario hacer nada. Si enviaste fondos, contacta a soporte para que podamos ayudarte."
           }
         }
       }
     },
-    "swapAndPay.expiredTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Expired"
+    "swapAndPay.expiredTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Expired"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intercambio vencido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intercambio vencido"
           }
         }
       }
     },
-    "swapAndPay.failedMsg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This swap could not be completed. If you deposited funds and didn't receive your swap, contact support so we can help resolve it."
+    "swapAndPay.failedMsg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This swap could not be completed. If you deposited funds and didn't receive your swap, contact support so we can help resolve it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este intercambio no pudo completarse. Si depositaste fondos y no recibiste tu intercambio, contacta a soporte para que podamos resolverlo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este intercambio no pudo completarse. Si depositaste fondos y no recibiste tu intercambio, contacta a soporte para que podamos resolverlo."
           }
         }
       }
     },
-    "swapAndPay.failedTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Failed"
+    "swapAndPay.failedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intercambio fallido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intercambio fallido"
           }
         }
       }
     },
-    "swapAndPay.failure.laterDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please try again later."
+    "swapAndPay.failure.laterDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please try again later."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Por favor inténtalo más tarde."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor inténtalo más tarde."
           }
         }
       }
     },
-    "swapAndPay.failure.laterTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The service is unavailable"
+    "swapAndPay.failure.laterTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The service is unavailable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El servicio no está disponible"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El servicio no está disponible"
           }
         }
       }
     },
-    "swapAndPay.failure.retryDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please check your connection and try again."
+    "swapAndPay.failure.retryDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please check your connection and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Por favor revisa tu conexión e inténtalo de nuevo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor revisa tu conexión e inténtalo de nuevo."
           }
         }
       }
     },
-    "swapAndPay.failure.retryTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unexpected error"
+    "swapAndPay.failure.retryTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unexpected error"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error inesperado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error inesperado"
           }
         }
       }
     },
-    "swapAndPay.failure.tryAgain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try again"
+    "swapAndPay.failure.tryAgain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intentar de nuevo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentar de nuevo"
           }
         }
       }
     },
-    "swapAndPay.failure.wrong": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Something went wrong"
+    "swapAndPay.failure.wrong" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something went wrong"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Algo salió mal"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algo salió mal"
           }
         }
       }
     },
-    "swapAndPay.failure.wrongDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We couldn’t load the assets. Please check your connection and try again."
+    "swapAndPay.failure.wrongDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn’t load the assets. Please check your connection and try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No pudimos cargar los activos. Por favor revisa tu conexión e inténtalo de nuevo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No pudimos cargar los activos. Por favor revisa tu conexión e inténtalo de nuevo."
           }
         }
       }
     },
-    "swapAndPay.failurePayInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There was an error initiating a cross-chain payment. Try it again, please."
+    "swapAndPay.failurePayInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There was an error initiating a cross-chain payment. Try it again, please."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hubo un error al iniciar el pago entre cadenas. Inténtalo de nuevo, por favor."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubo un error al iniciar el pago entre cadenas. Inténtalo de nuevo, por favor."
           }
         }
       }
     },
-    "swapAndPay.failureSwapInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There was an error initiating a swap. Try it again, please."
+    "swapAndPay.failureSwapInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There was an error initiating a swap. Try it again, please."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hubo un error al iniciar el intercambio. Inténtalo de nuevo, por favor."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubo un error al iniciar el intercambio. Inténtalo de nuevo, por favor."
           }
         }
       }
     },
-    "swapAndPay.forcedOptIn.optionOne": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I understand that Zodl makes API requests to the NEAR API every time I interact with a Swap/Pay transaction."
+    "swapAndPay.forcedOptIn.optionOne" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I understand that Zodl makes API requests to the NEAR API every time I interact with a Swap/Pay transaction."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entiendo que Zodl realiza solicitudes a la API de NEAR cada vez que interactúo con una transacción de Intercambio/Pago."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entiendo que Zodl realiza solicitudes a la API de NEAR cada vez que interactúo con una transacción de Intercambio/Pago."
           }
         }
       }
     },
-    "swapAndPay.forcedOptIn.optionTwo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I understand that by not enabling Tor, my IP address will be leaked by the NEAR API."
+    "swapAndPay.forcedOptIn.optionTwo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I understand that by not enabling Tor, my IP address will be leaked by the NEAR API."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entiendo que al no habilitar Tor, mi dirección IP será expuesta por la API de NEAR."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entiendo que al no habilitar Tor, mi dirección IP será expuesta por la API de NEAR."
           }
         }
       }
     },
-    "swapAndPay.from": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "From"
+    "swapAndPay.from" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "From"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "De"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De"
           }
         }
       }
     },
-    "swapAndPay.getQuote": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Get a quote"
+    "swapAndPay.getQuote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get a quote"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obtener cotización"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener cotización"
           }
         }
       }
     },
-    "swapAndPay.help.swapDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap ZEC with any NEAR-supported token. "
+    "swapAndPay.help.swapDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap ZEC with any NEAR-supported token. "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haz swap de ZEC con cualquier token compatible con NEAR."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz swap de ZEC con cualquier token compatible con NEAR."
           }
         }
       }
     },
-    "swapAndPay.help.swapDesc1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If swapping TO ZEC, you will send funds from a 3rd party wallet and provide an address where change can be refunded."
+    "swapAndPay.help.swapDesc1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If swapping TO ZEC, you will send funds from a 3rd party wallet and provide an address where change can be refunded."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si haces swap HACIA ZEC, enviarás fondos desde una wallet de terceros y deberás proporcionar una dirección donde se pueda reembolsar el cambio."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si haces swap HACIA ZEC, enviarás fondos desde una wallet de terceros y deberás proporcionar una dirección donde se pueda reembolsar el cambio."
           }
         }
       }
     },
-    "swapAndPay.help.swapDesc2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If swapping FROM ZEC, you must provide a valid address for the asset you are swapping to."
+    "swapAndPay.help.swapDesc2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If swapping FROM ZEC, you must provide a valid address for the asset you are swapping to."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si haces swap DESDE ZEC, debes proporcionar una dirección válida para el activo al que haces swap."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si haces swap DESDE ZEC, debes proporcionar una dirección válida para el activo al que haces swap."
           }
         }
       }
     },
-    "swapAndPay.help.swapWith": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap with"
+    "swapAndPay.help.swapWith" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap with"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap con"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap con"
           }
         }
       }
     },
-    "swapAndPay.incompleteInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deposit an additional ^[%@ %@](style: 'boldPrimary') to complete this swap before ^[%@](style: 'boldPrimary'), or your deposit will be refunded."
+    "swapAndPay.incompleteInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deposit an additional ^[%@ %@](style: 'boldPrimary') to complete this swap before ^[%@](style: 'boldPrimary'), or your deposit will be refunded."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deposita ^[%@ %@](style: 'boldPrimary') adicionales para completar este intercambio antes del ^[%@](style: 'boldPrimary'), o tu depósito será reembolsado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deposita ^[%@ %@](style: 'boldPrimary') adicionales para completar este intercambio antes del ^[%@](style: 'boldPrimary'), o tu depósito será reembolsado."
           }
         }
       }
     },
-    "swapAndPay.max": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spendable: %@"
+    "swapAndPay.max" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spendable: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gastable: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gastable: %@"
           }
         }
       }
     },
-    "swapAndPay.maxAllowedSlippage1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please enter maximum slippage of"
+    "swapAndPay.maxAllowedSlippage1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enter maximum slippage of"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Por favor ingresa un deslizamiento máximo de"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor ingresa un deslizamiento máximo de"
           }
         }
       }
     },
-    "swapAndPay.maxAllowedSlippage2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " %@."
+    "swapAndPay.maxAllowedSlippage2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " %@."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " %@."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " %@."
           }
         }
       }
     },
-    "swapAndPay.maxSlippage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max slippage %@%"
+    "swapAndPay.maxSlippage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max slippage %@%"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Máx. deslizamiento %@%"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máx. deslizamiento %@%"
           }
         }
       }
     },
-    "swapAndPay.maxSlippageTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max slippage"
+    "swapAndPay.maxSlippageTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max slippage"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Máx. deslizamiento"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máx. deslizamiento"
           }
         }
       }
     },
-    "swapAndPay.oneZecRate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1 ZEC = %@ %@"
+    "swapAndPay.oneZecRate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 ZEC = %@ %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1 ZEC = %@ %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 ZEC = %@ %@"
           }
         }
       }
     },
-    "swapAndPay.optIn.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is powered by a third-party NEAR API. Zodl needs to make networking calls to fetch rates, quotes, execute transactions and check their status in the transaction history which can leak your IP address. We recommend you to allow Tor connection to protect your IP address at all times."
+    "swapAndPay.optIn.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This feature is powered by a third-party NEAR API. Zodl needs to make networking calls to fetch rates, quotes, execute transactions and check their status in the transaction history which can leak your IP address. We recommend you to allow Tor connection to protect your IP address at all times."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta función es provista por una API de terceros de NEAR. Zodl necesita hacer llamadas de red para obtener tasas, cotizaciones, ejecutar transacciones y revisar su estado en el historial de transacciones, lo cual puede exponer tu dirección IP. Te recomendamos permitir la conexión por Tor para proteger tu dirección IP en todo momento."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta función es provista por una API de terceros de NEAR. Zodl necesita hacer llamadas de red para obtener tasas, cotizaciones, ejecutar transacciones y revisar su estado en el historial de transacciones, lo cual puede exponer tu dirección IP. Te recomendamos permitir la conexión por Tor para proteger tu dirección IP en todo momento."
           }
         }
       }
     },
-    "swapAndPay.optIn.optionOneSubtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable API calls to the NEAR API."
+    "swapAndPay.optIn.optionOneSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable API calls to the NEAR API."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Habilitar llamadas API a la API de NEAR."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitar llamadas API a la API de NEAR."
           }
         }
       }
     },
-    "swapAndPay.optIn.optionOneTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allow Third-Party Requests"
+    "swapAndPay.optIn.optionOneTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow Third-Party Requests"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir solicitudes de terceros"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir solicitudes de terceros"
           }
         }
       }
     },
-    "swapAndPay.optIn.optionTwoSubtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protect IP address with Tor connection."
+    "swapAndPay.optIn.optionTwoSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protect IP address with Tor connection."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protege tu dirección IP con conexión Tor."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protege tu dirección IP con conexión Tor."
           }
         }
       }
     },
-    "swapAndPay.optIn.optionTwoTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Turn on IP Address Protection"
+    "swapAndPay.optIn.optionTwoTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Turn on IP Address Protection"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar protección de dirección IP"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar protección de dirección IP"
           }
         }
       }
     },
-    "swapAndPay.optIn.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap or Pay with"
+    "swapAndPay.optIn.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap or Pay with"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap o Pagar con"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap o Pagar con"
           }
         }
       }
     },
-    "swapAndPay.optIn.warn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note for the super privacy-conscious: Transactions executed via the NEAR API are transparent which means all transaction information is public."
+    "swapAndPay.optIn.warn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note for the super privacy-conscious: Transactions executed via the NEAR API are transparent which means all transaction information is public."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nota para los más conscientes de la privacidad: Las transacciones ejecutadas a través de la API de NEAR son transparentes, lo que significa que toda la información de la transacción es pública."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota para los más conscientes de la privacidad: Las transacciones ejecutadas a través de la API de NEAR son transparentes, lo que significa que toda la información de la transacción es pública."
           }
         }
       }
     },
-    "swapAndPay.pay": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay"
+    "swapAndPay.pay" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar"
           }
         }
       }
     },
-    "swapAndPay.payFrom": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay from"
+    "swapAndPay.payFrom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay from"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagar desde"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar desde"
           }
         }
       }
     },
-    "swapAndPay.payNow": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay Now"
+    "swapAndPay.payNow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay Now"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagar Ahora"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar Ahora"
           }
         }
       }
     },
-    "swapAndPay.payTo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay to"
+    "swapAndPay.payTo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagar a"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar a"
           }
         }
       }
     },
-    "swapAndPay.pendingPayInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your cross-chain payment is being processed. Follow its status on the transaction screen."
+    "swapAndPay.pendingPayInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your cross-chain payment is being processed. Follow its status on the transaction screen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu cross-chain pago se está procesando. Siga el estado en la pantalla de transacción."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu cross-chain pago se está procesando. Siga el estado en la pantalla de transacción."
           }
         }
       }
     },
-    "swapAndPay.pendingPayTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Pending"
+    "swapAndPay.pendingPayTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pago Pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pago Pendiente"
           }
         }
       }
     },
-    "swapAndPay.pendingSwapInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your swap is being processed. Follow its status on the transaction screen."
+    "swapAndPay.pendingSwapInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your swap is being processed. Follow its status on the transaction screen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu swap se está procesando. Siga el estado en la pantalla de transacción."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu swap se está procesando. Siga el estado en la pantalla de transacción."
           }
         }
       }
     },
-    "swapAndPay.pendingSwapTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Pending"
+    "swapAndPay.pendingSwapTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Pendiente"
           }
         }
       }
     },
-    "swapAndPay.processingMsg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your swap has been delayed. Swaps typically complete in minutes but may take longer depending on market conditions."
+    "swapAndPay.processingMsg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your swap has been delayed. Swaps typically complete in minutes but may take longer depending on market conditions."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu intercambio se ha demorado. Los intercambios generalmente se completan en minutos, pero pueden tardar más según las condiciones del mercado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu intercambio se ha demorado. Los intercambios generalmente se completan en minutos, pero pueden tardar más según las condiciones del mercado."
           }
         }
       }
     },
-    "swapAndPay.processingTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Processing"
+    "swapAndPay.processingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Processing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intercambio en proceso"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intercambio en proceso"
           }
         }
       }
     },
-    "swapAndPay.quote.zashi": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl"
+    "swapAndPay.quote.zashi" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl"
           }
         }
       }
     },
-    "swapAndPay.quoteUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quote Unavailable"
+    "swapAndPay.quoteUnavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quote Unavailable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cotización no disponible"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cotización no disponible"
           }
         }
       }
     },
-    "swapAndPay.rate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rate"
+    "swapAndPay.rate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rate"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tasa"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tasa"
           }
         }
       }
     },
-    "swapAndPay.recipient": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipient"
+    "swapAndPay.recipient" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recipient"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Destinatario"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destinatario"
           }
         }
       }
     },
-    "swapAndPay.refundedAmount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refunded amount"
+    "swapAndPay.refundedAmount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refunded amount"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monto reembolsado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto reembolsado"
           }
         }
       }
     },
-    "swapAndPay.refundInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your deposit was detected but the swap could not be completed. Your funds have been returned, minus transaction fees. If you haven't received them, contact the Zodl support team."
+    "swapAndPay.refundInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your deposit was detected but the swap could not be completed. Your funds have been returned, minus transaction fees. If you haven't received them, contact the Zodl support team."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu depósito fue detectado pero el intercambio no pudo completarse. Tus fondos han sido devueltos, descontando las tarifas de transacción. Si aún no los recibiste, contacta al equipo de soporte de Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu depósito fue detectado pero el intercambio no pudo completarse. Tus fondos han sido devueltos, descontando las tarifas de transacción. Si aún no los recibiste, contacta al equipo de soporte de Zodl."
           }
         }
       }
     },
-    "swapAndPay.refundTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funds Returned"
+    "swapAndPay.refundTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funds Returned"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fondos devueltos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondos devueltos"
           }
         }
       }
     },
-    "swapAndPay.search": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search by name or ticker..."
+    "swapAndPay.search" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search by name or ticker..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar por nombre o ticker..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar por nombre o ticker..."
           }
         }
       }
     },
-    "swapAndPay.selectToken": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select asset"
+    "swapAndPay.selectToken" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select asset"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar activo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar activo"
           }
         }
       }
     },
-    "swapAndPay.sendingInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your coins are being sent to the deposit address..."
+    "swapAndPay.sendingInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your coins are being sent to the deposit address..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus monedas están siendo enviadas a la dirección de depósito..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus monedas están siendo enviadas a la dirección de depósito..."
           }
         }
       }
     },
-    "swapAndPay.slippage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Slippage"
+    "swapAndPay.slippage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slippage"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deslizamiento"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deslizamiento"
           }
         }
       }
     },
-    "swapAndPay.slippageDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This setting determines the maximum allowable difference between the expected price of a swap and the actual price you pay, which is outside of Zodl's control."
+    "swapAndPay.slippageDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This setting determines the maximum allowable difference between the expected price of a swap and the actual price you pay, which is outside of Zodl's control."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta configuración determina la diferencia máxima permitida entre el precio esperado de un intercambio y el precio real que pagas, lo cual está fuera del control de Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta configuración determina la diferencia máxima permitida entre el precio esperado de un intercambio y el precio real que pagas, lo cual está fuera del control de Zodl."
           }
         }
       }
     },
-    "swapAndPay.slippageSet1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You may receive up to "
+    "swapAndPay.slippageSet1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You may receive up to "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Podrías recibir hasta "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podrías recibir hasta "
           }
         }
       }
     },
-    "swapAndPay.slippageSet2a": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@% (%@)"
+    "swapAndPay.slippageSet2a" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@% (%@)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@% (%@)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@% (%@)"
           }
         }
       }
     },
-    "swapAndPay.slippageSet2b": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@%"
+    "swapAndPay.slippageSet2b" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@%"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%"
           }
         }
       }
     },
-    "swapAndPay.slippageSet3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " less than quoted."
+    "swapAndPay.slippageSet3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " less than quoted."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " menos de lo cotizado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " menos de lo cotizado."
           }
         }
       }
     },
-    "swapAndPay.slippageTolerance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Slippage tolerance"
+    "swapAndPay.slippageTolerance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slippage tolerance"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tolerancia de deslizamiento"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tolerancia de deslizamiento"
           }
         }
       }
     },
-    "swapAndPay.slippageWarn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Any unused portion of the slippage fee will be refunded if the swap executes with lower slippage than expected."
+    "swapAndPay.slippageWarn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Any unused portion of the slippage fee will be refunded if the swap executes with lower slippage than expected."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cualquier parte no utilizada de la comisión de deslizamiento será reembolsada si el intercambio se ejecuta con menos deslizamiento del esperado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cualquier parte no utilizada de la comisión de deslizamiento será reembolsada si el intercambio se ejecuta con menos deslizamiento del esperado."
           }
         }
       }
     },
-    "swapAndPay.smallSlippageWarn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[Warning:](style: 'boldPrimary') Slippage ^[under %@%%](style: 'boldPrimary') increases the chance your swap will be unsuccessful and refunded. Consider using ^[%@%% or higher](style: 'boldPrimary'), especially for larger amounts."
+    "swapAndPay.smallSlippageWarn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Warning:](style: 'boldPrimary') Slippage ^[under %@%%](style: 'boldPrimary') increases the chance your swap will be unsuccessful and refunded. Consider using ^[%@%% or higher](style: 'boldPrimary'), especially for larger amounts."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[Advertencia:](style: 'boldPrimary') Un deslizamiento menor ^[al %@%%](style: 'boldPrimary') aumenta la probabilidad de que tu intercambio no se complete y sea reembolsado. Considera usar ^[%@%% o más](style: 'boldPrimary'), especialmente para montos mayores."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Advertencia:](style: 'boldPrimary') Un deslizamiento menor ^[al %@%%](style: 'boldPrimary') aumenta la probabilidad de que tu intercambio no se complete y sea reembolsado. Considera usar ^[%@%% o más](style: 'boldPrimary'), especialmente para montos mayores."
           }
         }
       }
     },
-    "swapAndPay.status": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status"
+    "swapAndPay.status" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado"
           }
         }
       }
     },
-    "swapAndPay.status.expired": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expired"
+    "swapAndPay.status.expired" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expired"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expirado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expirado"
           }
         }
       }
     },
-    "swapAndPay.status.failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed"
+    "swapAndPay.status.failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fallido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fallido"
           }
         }
       }
     },
-    "swapAndPay.status.incompleteDeposit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incomplete Deposit"
+    "swapAndPay.status.incompleteDeposit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incomplete Deposit"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depósito incompleto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depósito incompleto"
           }
         }
       }
     },
-    "swapAndPay.status.pending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
+    "swapAndPay.status.pending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendiente"
           }
         }
       }
     },
-    "swapAndPay.status.pendingDeposit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending Deposit"
+    "swapAndPay.status.pendingDeposit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending Deposit"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depósito pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depósito pendiente"
           }
         }
       }
     },
-    "swapAndPay.status.processing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processing"
+    "swapAndPay.status.processing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Procesando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Procesando"
           }
         }
       }
     },
-    "swapAndPay.status.refunded": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refunded"
+    "swapAndPay.status.refunded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refunded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reembolsado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reembolsado"
           }
         }
       }
     },
-    "swapAndPay.status.success": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Completed"
+    "swapAndPay.status.success" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Completado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completado"
           }
         }
       }
     },
-    "swapAndPay.successPayInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You successfully initiated a cross-chain payment. Follow its status on the transaction screen."
+    "swapAndPay.successPayInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You successfully initiated a cross-chain payment. Follow its status on the transaction screen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Has iniciado un pago entre cadenas exitosamente. Sigue su estado en la pantalla de transacciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Has iniciado un pago entre cadenas exitosamente. Sigue su estado en la pantalla de transacciones."
           }
         }
       }
     },
-    "swapAndPay.successSwapInfo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You successfully initiated a swap. Follow its status on the transaction screen."
+    "swapAndPay.successSwapInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You successfully initiated a swap. Follow its status on the transaction screen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Has iniciado un intercambio exitosamente. Sigue su estado en la pantalla de transacciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Has iniciado un intercambio exitosamente. Sigue su estado en la pantalla de transacciones."
           }
         }
       }
     },
-    "swapAndPay.swap": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap"
+    "swapAndPay.swap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap"
           }
         }
       }
     },
-    "swapAndPay.swapFrom": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap from"
+    "swapAndPay.swapFrom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap from"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap de"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap de"
           }
         }
       }
     },
-    "swapAndPay.swapNow": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Now"
+    "swapAndPay.swapNow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Now"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Ahora"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Ahora"
           }
         }
       }
     },
-    "swapAndPay.swapQuoteSlippageWarn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You could receive up to %@ less based on the %@ slippage you set."
+    "swapAndPay.swapQuoteSlippageWarn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You could receive up to %@ less based on the %@ slippage you set."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Podrías recibir hasta %@ menos según el deslizamiento %@ que configuraste."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podrías recibir hasta %@ menos según el deslizamiento %@ que configuraste."
           }
         }
       }
     },
-    "swapAndPay.swapTo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap to"
+    "swapAndPay.swapTo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap a"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap a"
           }
         }
       }
     },
-    "swapAndPay.to": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To"
+    "swapAndPay.to" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A"
           }
         }
       }
     },
-    "swapAndPay.totalAmount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total Amount"
+    "swapAndPay.totalAmount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total Amount"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monto total"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto total"
           }
         }
       }
     },
-    "swapAndPay.totalFees": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total fees"
+    "swapAndPay.totalFees" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total fees"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Comisiones totales"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comisiones totales"
           }
         }
       }
     },
-    "swapStatus.paid": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paid"
+    "swapStatus.paid" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paid"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagado"
           }
         }
       }
     },
-    "swapStatus.paying": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paying"
+    "swapStatus.paying" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paying"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagando"
           }
         }
       }
     },
-    "swapStatus.paymentExpired": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Expired"
+    "swapStatus.paymentExpired" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Expired"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pago expirado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pago expirado"
           }
         }
       }
     },
-    "swapStatus.paymentFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Failed"
+    "swapStatus.paymentFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pago fallido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pago fallido"
           }
         }
       }
     },
-    "swapStatus.paymentIncomplete": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Incomplete"
+    "swapStatus.paymentIncomplete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Incomplete"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pago incompleto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pago incompleto"
           }
         }
       }
     },
-    "swapStatus.paymentRefunded": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Refunded"
+    "swapStatus.paymentRefunded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Refunded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pago reembolsado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pago reembolsado"
           }
         }
       }
     },
-    "swapStatus.swapExpired": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Expired"
+    "swapStatus.swapExpired" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Expired"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap expirado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap expirado"
           }
         }
       }
     },
-    "swapStatus.swapFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Failed"
+    "swapStatus.swapFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap fallido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap fallido"
           }
         }
       }
     },
-    "swapStatus.swapIncomplete": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Incomplete"
+    "swapStatus.swapIncomplete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Incomplete"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intercambio incompleto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intercambio incompleto"
           }
         }
       }
     },
-    "swapStatus.swapped": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swapped"
+    "swapStatus.swapped" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swapped"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap realizado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap realizado"
           }
         }
       }
     },
-    "swapStatus.swapping": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swapping"
+    "swapStatus.swapping" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swapping"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haciendo swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haciendo swap"
           }
         }
       }
     },
-    "swapStatus.swapRefunded": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Refunded"
+    "swapStatus.swapRefunded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Refunded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap reembolsado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap reembolsado"
           }
         }
       }
     },
-    "swapToZec.address": {
-      "comment": "MARK: - Swap to ZEC",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ address..."
+    "swapToZec.address" : {
+      "comment" : "MARK: - Swap to ZEC",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ address..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección %@..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección %@..."
           }
         }
       }
     },
-    "swapToZec.deposit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deposit Amount"
+    "swapToZec.deposit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deposit Amount"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monto a depositar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto a depositar"
           }
         }
       }
     },
-    "swapToZec.depositTo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deposit to"
+    "swapToZec.depositTo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deposit to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depositar en"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depositar en"
           }
         }
       }
     },
-    "swapToZec.info1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use your "
+    "swapToZec.info1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use your "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usa tu "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa tu "
           }
         }
       }
     },
-    "swapToZec.info2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ on %@"
+    "swapToZec.info2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ on %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ en %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ en %@"
           }
         }
       }
     },
-    "swapToZec.info3": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " wallet to deposit funds. Depositing other assets may result in loss of funds."
+    "swapToZec.info3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " wallet to deposit funds. Depositing other assets may result in loss of funds."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " wallet para depositar fondos. Depositar otros activos puede resultar en la pérdida de fondos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " wallet para depositar fondos. Depositar otros activos puede resultar en la pérdida de fondos."
           }
         }
       }
     },
-    "swapToZec.refundAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refund Address"
+    "swapToZec.refundAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refund Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección de reembolso"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de reembolso"
           }
         }
       }
     },
-    "swapToZec.refundAddress.msg1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If the swap fails or market conditions change, your transaction may be refunded minus the transaction fees."
+    "swapToZec.refundAddress.msg1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If the swap fails or market conditions change, your transaction may be refunded minus the transaction fees."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si el swap falla o cambian las condiciones del mercado, tu transacción puede ser reembolsada menos las comisiones de transacción."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si el swap falla o cambian las condiciones del mercado, tu transacción puede ser reembolsada menos las comisiones de transacción."
           }
         }
       }
     },
-    "swapToZec.refundAddress.msg2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The refunded amount will be returned to your wallet in the source currency - USDC on NEAR. Please enter a valid address to avoid loss of funds."
+    "swapToZec.refundAddress.msg2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The refunded amount will be returned to your wallet in the source currency - USDC on NEAR. Please enter a valid address to avoid loss of funds."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El monto reembolsado será devuelto a tu wallet en la moneda de origen - USDC en NEAR. Ingresa una dirección válida para evitar la pérdida de fondos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El monto reembolsado será devuelto a tu wallet en la moneda de origen - USDC en NEAR. Ingresa una dirección válida para evitar la pérdida de fondos."
           }
         }
       }
     },
-    "swapToZec.refundAddress.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refund Address"
+    "swapToZec.refundAddress.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refund Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección de reembolso"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de reembolso"
           }
         }
       }
     },
-    "swapToZec.review": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review Quote"
+    "swapToZec.review" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review Quote"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Revisar cotización"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisar cotización"
           }
         }
       }
     },
-    "swapToZec.sentTheFunds": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I’ve sent the funds"
+    "swapToZec.sentTheFunds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I’ve sent the funds"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ya envié los fondos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya envié los fondos"
           }
         }
       }
     },
-    "swapToZec.share.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deposit address for %@ %@ on Near swap to ZEC in Zodl."
+    "swapToZec.share.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deposit address for %@ %@ on Near swap to ZEC in Zodl."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección de depósito para %@ %@ en Near swap a ZEC en Zodl."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de depósito para %@ %@ en Near swap a ZEC en Zodl."
           }
         }
       }
     },
-    "swapToZec.share.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Deposit Address"
+    "swapToZec.share.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Deposit Address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección de depósito para swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de depósito para swap"
           }
         }
       }
     },
-    "swapToZec.shareQR": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share QR"
+    "swapToZec.shareQR" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share QR"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartir QR"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir QR"
           }
         }
       }
     },
-    "swapToZec.swapCompleted": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Completed"
+    "swapToZec.swapCompleted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Completed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap completado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap completado"
           }
         }
       }
     },
-    "swapToZec.swapDetails": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Details"
+    "swapToZec.swapDetails" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Details"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detalles del swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles del swap"
           }
         }
       }
     },
-    "swapToZec.swapExpired": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Expired"
+    "swapToZec.swapExpired" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Expired"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap expirado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap expirado"
           }
         }
       }
     },
-    "swapToZec.swapFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Failed"
+    "swapToZec.swapFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap fallido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap fallido"
           }
         }
       }
     },
-    "swapToZec.swapIncomplete": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Incomplete"
+    "swapToZec.swapIncomplete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Incomplete"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intercambio incompleto"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intercambio incompleto"
           }
         }
       }
     },
-    "swapToZec.swapPending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Pending"
+    "swapToZec.swapPending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap pendiente"
           }
         }
       }
     },
-    "swapToZec.swapProcessing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Processing"
+    "swapToZec.swapProcessing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Processing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Procesando swap"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Procesando swap"
           }
         }
       }
     },
-    "swapToZec.swapRefunded": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap Refunded"
+    "swapToZec.swapRefunded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap Refunded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swap reembolsado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap reembolsado"
           }
         }
       }
     },
-    "sync.message.error": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+    "sync.message.error" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %@"
           }
         }
       }
     },
-    "sync.message.stopped": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stopped"
+    "sync.message.stopped" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stopped"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detenido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detenido"
           }
         }
       }
     },
-    "sync.message.sync": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@%% Synced"
+    "sync.message.sync" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%% Synced"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@%% Sincronizado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%% Sincronizado"
           }
         }
       }
     },
-    "sync.message.unprepared": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unprepared"
+    "sync.message.unprepared" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unprepared"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No preparado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No preparado"
           }
         }
       }
     },
-    "sync.message.uptodate": {
-      "comment": "MARK: - Sync message",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Up-To-Date"
+    "sync.message.uptodate" : {
+      "comment" : "MARK: - Sync message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Up-To-Date"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizado"
           }
         }
       }
     },
-    "tabs.account": {
-      "comment": "MARK: - Tabs",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Account"
+    "tabs.account" : {
+      "comment" : "MARK: - Tabs",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cuenta"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuenta"
           }
         }
       }
     },
-    "tabs.balances": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Balances"
+    "tabs.balances" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balances"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saldos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saldos"
           }
         }
       }
     },
-    "tabs.receive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receive"
+    "tabs.receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recibir"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recibir"
           }
         }
       }
     },
-    "tabs.receiveZec": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receive ZEC"
+    "tabs.receiveZec" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive ZEC"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recibir ZEC"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recibir ZEC"
           }
         }
       }
     },
-    "tabs.send": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send"
+    "tabs.send" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar"
           }
         }
       }
     },
-    "taxExport.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download your %@ transaction history from the previous calendar year in a .csv format."
+    "taxExport.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download your %@ transaction history from the previous calendar year in a .csv format."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descarga el historial de transacciones de %@ del año calendario anterior en formato .csv."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga el historial de transacciones de %@ del año calendario anterior en formato .csv."
           }
         }
       }
     },
-    "taxExport.download": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download"
+    "taxExport.download" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar"
           }
         }
       }
     },
-    "taxExport.fileName": {
-      "comment": "Transaction History Tax Export",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@_transaction_history_%@.csv"
+    "taxExport.fileName" : {
+      "comment" : "Transaction History Tax Export",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@_transaction_history_%@.csv"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@_historial_de_transacciones_%@.csv"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@_historial_de_transacciones_%@.csv"
           }
         }
       }
     },
-    "taxExport.shareDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ transaction history"
+    "taxExport.shareDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ transaction history"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ historial de transacciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ historial de transacciones"
           }
         }
       }
     },
-    "taxExport.taxFile": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export Tax File"
+    "taxExport.taxFile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export Tax File"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exportar Archivo de Impuestos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar Archivo de Impuestos"
           }
         }
       }
     },
-    "taxExport.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data Export"
+    "taxExport.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Export"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exportación de Datos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportación de Datos"
           }
         }
       }
     },
-    "texKeystone.gotIt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Got it"
+    "texKeystone.gotIt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got it"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entendido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entendido"
           }
         }
       }
     },
-    "texKeystone.step": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Step %@"
+    "texKeystone.step" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Step %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paso %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paso %@"
           }
         }
       }
     },
-    "texKeystone.step1.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transfer ZEC to your Zodl shielded address"
+    "texKeystone.step1.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer ZEC to your Zodl shielded address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transfiere ZEC a tu dirección protegida de Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfiere ZEC a tu dirección protegida de Zodl"
           }
         }
       }
     },
-    "texKeystone.step1.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send to Zodl first"
+    "texKeystone.step1.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send to Zodl first"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envía primero a Zodl"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envía primero a Zodl"
           }
         }
       }
     },
-    "texKeystone.step2.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Once received in Zodl, send the tokens to your final TEX destination address"
+    "texKeystone.step2.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Once received in Zodl, send the tokens to your final TEX destination address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Una vez recibido en Zodl, envía los tokens a tu dirección TEX de destino final"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una vez recibido en Zodl, envía los tokens a tu dirección TEX de destino final"
           }
         }
       }
     },
-    "texKeystone.step2.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send from Zodl to TEX address"
+    "texKeystone.step2.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send from Zodl to TEX address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envía desde Zodl a la dirección TEX"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envía desde Zodl a la dirección TEX"
           }
         }
       }
     },
-    "texKeystone.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unsupported Address Type"
+    "texKeystone.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unsupported Address Type"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipo de dirección no compatible"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de dirección no compatible"
           }
         }
       }
     },
-    "texKeystone.warn1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keystone doesn't currently support transfers to Binance TEX addresses. "
+    "texKeystone.warn1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone doesn't currently support transfers to Binance TEX addresses. "
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualmente, Keystone no es compatible con transferencias a direcciones Binance TEX."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualmente, Keystone no es compatible con transferencias a direcciones Binance TEX."
           }
         }
       }
     },
-    "texKeystone.warn2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please use the steps below to complete your transaction."
+    "texKeystone.warn2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please use the steps below to complete your transaction."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Por favor, utiliza los pasos a continuación para completar tu transacción."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por favor, utiliza los pasos a continuación para completar tu transacción."
           }
         }
       }
     },
-    "texKeystone.workaround": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Workaround Steps"
+    "texKeystone.workaround" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Workaround Steps"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pasos alternativos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pasos alternativos"
           }
         }
       }
     },
-    "tokenOnChain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "on"
+    "tokenOnChain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "on"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "en"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "en"
           }
         }
       }
     },
-    "tooltip.exchangeRate.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "We tried but we couldn’t refresh the exchange rate for you. Check your connection, relaunch the app, and we’ll try again."
+    "tooltip.exchangeRate.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We tried but we couldn’t refresh the exchange rate for you. Check your connection, relaunch the app, and we’ll try again."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lo intentamos pero no pudimos actualizar la tasa de cambio para ti. Verifica tu conexión, reinicia la aplicación e intentaremos de nuevo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo intentamos pero no pudimos actualizar la tasa de cambio para ti. Verifica tu conexión, reinicia la aplicación e intentaremos de nuevo."
           }
         }
       }
     },
-    "tooltip.exchangeRate.title": {
-      "comment": "MARK: - Tooltips",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exchange rate unavailable"
+    "tooltip.exchangeRate.title" : {
+      "comment" : "MARK: - Tooltips",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exchange rate unavailable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tasa de cambio no disponible"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tasa de cambio no disponible"
           }
         }
       }
     },
-    "torSettingsSheet.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Routes your connection through the Tor network for enhanced anonymity and privacy protection."
+    "torSettingsSheet.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Routes your connection through the Tor network for enhanced anonymity and privacy protection."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redirige tu conexión a través de la red Tor para mayor anonimato y protección de privacidad."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redirige tu conexión a través de la red Tor para mayor anonimato y protección de privacidad."
           }
         }
       }
     },
-    "torSettingsSheet.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If Tor is available in your region, we recommend enabling it for enhanced privacy during wallet restoration. This step is completely optional."
+    "torSettingsSheet.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If Tor is available in your region, we recommend enabling it for enhanced privacy during wallet restoration. This step is completely optional."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si Tor está disponible en tu región, recomendamos habilitarlo para una mayor privacidad durante la restauración de la billetera. Este paso es completamente opcional."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si Tor está disponible en tu región, recomendamos habilitarlo para una mayor privacidad durante la restauración de la billetera. Este paso es completamente opcional."
           }
         }
       }
     },
-    "torSettingsSheet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Tor Protection"
+    "torSettingsSheet.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Tor Protection"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Habilitar Protección Tor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitar Protección Tor"
           }
         }
       }
     },
-    "torSetup.alert.disable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disable"
+    "torSetup.alert.disable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desactivar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar"
           }
         }
       }
     },
-    "torSetup.alert.dontDisable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Don’t disable"
+    "torSetup.alert.dontDisable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don’t disable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No desactivar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No desactivar"
           }
         }
       }
     },
-    "torSetup.alert.msg": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tor connection issues detected. To improve performance, try disabling Tor. This will stop exchange rate updates. You can re-enable it later in Advanced Settings."
+    "torSetup.alert.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor connection issues detected. To improve performance, try disabling Tor. This will stop exchange rate updates. You can re-enable it later in Advanced Settings."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se detectaron problemas de conexión con Tor. Para mejorar el rendimiento, intenta desactivarlo. Esto detendrá la actualización de tasas de cambio. Puedes volver a activarlo más adelante en Configuración avanzada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se detectaron problemas de conexión con Tor. Para mejorar el rendimiento, intenta desactivarlo. Esto detendrá la actualización de tasas de cambio. Puedes volver a activarlo más adelante en Configuración avanzada."
           }
         }
       }
     },
-    "torSetup.alert.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disable Tor?"
+    "torSetup.alert.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable Tor?"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Desactivar Tor?"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Desactivar Tor?"
           }
         }
       }
     },
-    "torSetup.ccSheet.desc1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tor Protection is a beta feature that provides additional protections for your IP address. USD exchange rates are only available when it is enabled."
+    "torSetup.ccSheet.desc1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor Protection is a beta feature that provides additional protections for your IP address. USD exchange rates are only available when it is enabled."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La protección Tor es una función beta que brinda protección adicional a tu dirección IP. Las tasas de cambio en USD solo están disponibles cuando está activada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La protección Tor es una función beta que brinda protección adicional a tu dirección IP. Las tasas de cambio en USD solo están disponibles cuando está activada."
           }
         }
       }
     },
-    "torSetup.ccSheet.desc2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If Tor is permitted in your region, we recommend enabling it. You can manage it in Advanced Settings."
+    "torSetup.ccSheet.desc2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If Tor is permitted in your region, we recommend enabling it. You can manage it in Advanced Settings."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si el uso de Tor está permitido en tu región, te recomendamos activarla. Puedes gestionarlo en Configuración avanzada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si el uso de Tor está permitido en tu región, te recomendamos activarla. Puedes gestionarlo en Configuración avanzada."
           }
         }
       }
     },
-    "torSetup.ccSheet.enable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable"
+    "torSetup.ccSheet.enable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar"
           }
         }
       }
     },
-    "torSetup.ccSheet.later": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Do it later"
+    "torSetup.ccSheet.later" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Do it later"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hacerlo después"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hacerlo después"
           }
         }
       }
     },
-    "torSetup.ccSheet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tor Required for Currency Conversion"
+    "torSetup.ccSheet.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor Required for Currency Conversion"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se requiere Tor para la conversión de moneda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se requiere Tor para la conversión de moneda"
           }
         }
       }
     },
-    "torSetup.disableDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Don’t connect over Tor."
+    "torSetup.disableDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don’t connect over Tor."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No conectarse mediante Tor."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No conectarse mediante Tor."
           }
         }
       }
     },
-    "torSetup.enableDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect over Tor."
+    "torSetup.enableDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect over Tor."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectarse mediante Tor."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectarse mediante Tor."
           }
         }
       }
     },
-    "torSetup.learn.btnIn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opt in"
+    "torSetup.learn.btnIn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opt in"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar"
           }
         }
       }
     },
-    "torSetup.learn.btnOut": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opt out"
+    "torSetup.learn.btnOut" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opt out"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desactivar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar"
           }
         }
       }
     },
-    "torSetup.learn.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature provides additional protections for your IP address. If Tor is permitted in your region, we recommend enabling it. You can manage this in Advanced Settings."
+    "torSetup.learn.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This feature provides additional protections for your IP address. If Tor is permitted in your region, we recommend enabling it. You can manage this in Advanced Settings."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta función brinda protección adicional a tu dirección IP. Si el uso de Tor está permitido en tu región, te recomendamos activarla. Puedes gestionarlo en Configuración avanzada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta función brinda protección adicional a tu dirección IP. Si el uso de Tor está permitido en tu región, te recomendamos activarla. Puedes gestionarlo en Configuración avanzada."
           }
         }
       }
     },
-    "torSetup.option1.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetch exchange rates from third-party servers without revealing your IP address. (Only available with Tor enabled.)"
+    "torSetup.option1.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetch exchange rates from third-party servers without revealing your IP address. (Only available with Tor enabled.)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obtén tasas de cambio desde servidores de terceros sin revelar tu dirección IP. (Disponible solo con Tor activado.)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtén tasas de cambio desde servidores de terceros sin revelar tu dirección IP. (Disponible solo con Tor activado.)"
           }
         }
       }
     },
-    "torSetup.option1.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currency Conversion"
+    "torSetup.option1.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currency Conversion"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conversión de moneda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conversión de moneda"
           }
         }
       }
     },
-    "torSetup.option2.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send and retrieve transaction data over Tor for added privacy."
+    "torSetup.option2.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send and retrieve transaction data over Tor for added privacy."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envía y recupera datos de transacciones a través de Tor para mayor privacidad."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envía y recupera datos de transacciones a través de Tor para mayor privacidad."
           }
         }
       }
     },
-    "torSetup.option2.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transactions"
+    "torSetup.option2.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transactions"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transacciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transacciones"
           }
         }
       }
     },
-    "torSetup.option3.desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Access third-party APIs (e.g. NEAR) over Tor for added privacy."
+    "torSetup.option3.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Access third-party APIs (e.g. NEAR) over Tor for added privacy."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accede a APIs de terceros (por ejemplo, NEAR) a través de Tor para mayor privacidad."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accede a APIs de terceros (por ejemplo, NEAR) a través de Tor para mayor privacidad."
           }
         }
       }
     },
-    "torSetup.option3.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Integrations"
+    "torSetup.option3.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Integrations"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Integraciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Integraciones"
           }
         }
       }
     },
-    "torSetup.settings.desc1": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tor provides additional protections for your IP address. This feature uses Tor network to fetch exchange rates, send transactions, retrieve transaction data, and connect to third party APIs."
+    "torSetup.settings.desc1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor provides additional protections for your IP address. This feature uses Tor network to fetch exchange rates, send transactions, retrieve transaction data, and connect to third party APIs."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta función beta brinda protección adicional para tu dirección IP. Utiliza Tor para obtener tasas de cambio, enviar transacciones, recuperar datos de transacciones y conectarse a APIs de terceros."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta función beta brinda protección adicional para tu dirección IP. Utiliza Tor para obtener tasas de cambio, enviar transacciones, recuperar datos de transacciones y conectarse a APIs de terceros."
           }
         }
       }
     },
-    "torSetup.settings.desc2": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If Tor is permitted in your region, we recommend enabling it."
+    "torSetup.settings.desc2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If Tor is permitted in your region, we recommend enabling it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si el uso de Tor está permitido en tu región, te recomendamos habilitarlo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si el uso de Tor está permitido en tu región, te recomendamos habilitarlo."
           }
         }
       }
     },
-    "torSetup.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tor Protection"
+    "torSetup.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor Protection"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protección Tor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protección Tor"
           }
         }
       }
     },
-    "transaction.failedReceive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receive failed"
+    "transaction.failedReceive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recepción fallida"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recepción fallida"
           }
         }
       }
     },
-    "transaction.failedSend": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send failed"
+    "transaction.failedSend" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Envío fallido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envío fallido"
           }
         }
       }
     },
-    "transaction.failedShieldedFunds": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shielding Failed"
+    "transaction.failedShieldedFunds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shielding Failed"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fondos Protegidos Fallidos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondos Protegidos Fallidos"
           }
         }
       }
     },
-    "transaction.received": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Received"
+    "transaction.received" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Received"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recibido"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recibido"
           }
         }
       }
     },
-    "transaction.receiving": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receiving"
+    "transaction.receiving" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receiving"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recibiendo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recibiendo"
           }
         }
       }
     },
-    "transaction.sending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending"
+    "transaction.sending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviando"
           }
         }
       }
     },
-    "transaction.sent": {
-      "comment": "MARK: - Transactions",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sent"
+    "transaction.sent" : {
+      "comment" : "MARK: - Transactions",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviado"
           }
         }
       }
     },
-    "transaction.shieldedFunds": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shielded"
+    "transaction.shieldedFunds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shielded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protegidos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protegidos"
           }
         }
       }
     },
-    "transaction.shieldingFunds": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shielding"
+    "transaction.shieldingFunds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shielding"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Protegiendo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protegiendo"
           }
         }
       }
     },
-    "transactionDetail.feeSummary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee"
+    "transactionDetail.feeSummary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Comisión"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comisión"
           }
         }
       }
     },
-    "transactionHistory.defaultFee": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0.001"
+    "transactionHistory.defaultFee" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.001"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0.001"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.001"
           }
         }
       }
     },
-    "transactionHistory.details": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transaction Details"
+    "transactionHistory.details" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transaction Details"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detalles de la transacción"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles de la transacción"
           }
         }
       }
     },
-    "transactionHistory.noMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Message"
+    "transactionHistory.noMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Message"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin mensaje"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin mensaje"
           }
         }
       }
     },
-    "transactionHistory.nothingHere": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There’s nothing here, yet."
+    "transactionHistory.nothingHere" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There’s nothing here, yet."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aún no hay nada aquí."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay nada aquí."
           }
         }
       }
     },
-    "transactionHistory.pending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
+    "transactionHistory.pending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendiente"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendiente"
           }
         }
       }
     },
-    "transactionHistory.saveAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save address"
+    "transactionHistory.saveAddress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save address"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardar dirección"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar dirección"
           }
         }
       }
     },
-    "transactionHistory.seeAll": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "See all"
+    "transactionHistory.seeAll" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "See all"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver todo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver todo"
           }
         }
       }
     },
-    "transactionHistory.sendAgain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send again"
+    "transactionHistory.sendAgain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send again"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviar de nuevo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar de nuevo"
           }
         }
       }
     },
-    "transactionHistory.sentTo": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sent to"
+    "transactionHistory.sentTo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent to"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviado a"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviado a"
           }
         }
       }
     },
-    "transactionHistory.threeDots": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@..."
+    "transactionHistory.threeDots" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@..."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@..."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@..."
           }
         }
       }
     },
-    "transactionHistory.timestamp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timestamp"
+    "transactionHistory.timestamp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timestamp"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Marca de tiempo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marca de tiempo"
           }
         }
       }
     },
-    "transactionHistory.viewLess": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View less"
+    "transactionHistory.viewLess" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View less"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver menos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver menos"
           }
         }
       }
     },
-    "transactionHistory.viewMore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View more"
+    "transactionHistory.viewMore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View more"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ver más"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver más"
           }
         }
       }
     },
-    "transactionList.transactionId": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transaction ID"
+    "transactionList.transactionId" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transaction ID"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID de Transacción"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de Transacción"
           }
         }
       }
     },
-    "walletBirthdayHeightSubtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entering your Wallet Birthday Height ensures we can display all your funds and transaction history correctly."
+    "walletBirthdayHeightSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entering your Wallet Birthday Height ensures we can display all your funds and transaction history correctly."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Al introducir la Altura de Creación de tu Billetera, nos aseguramos de poder mostrar correctamente todos tus fondos y el historial de transacciones."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al introducir la Altura de Creación de tu Billetera, nos aseguramos de poder mostrar correctamente todos tus fondos y el historial de transacciones."
           }
         }
       }
     },
-    "walletBirthdayHelpDesc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. It is important to provide the correct height because that determines the range of blocks we will scan to display your transaction history and wallet balance. If you have recovered a seed from a different hardware device, make sure to enter the block height of your original hardware device."
+    "walletBirthdayHelpDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. It is important to provide the correct height because that determines the range of blocks we will scan to display your transaction history and wallet balance. If you have recovered a seed from a different hardware device, make sure to enter the block height of your original hardware device."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[La Altura de Creación de la Billetera (Wallet Birthday Height)](style: 'boldPrimary') corresponde a la altura del bloque (número de bloque en la cadena de bloques) en la que se creó tu billetera. Es importante proporcionar la altura correcta, ya que determina el rango de bloques que analizaremos para mostrar tu historial de transacciones y el saldo de tu billetera. Si recuperaste una semilla de otro dispositivo, asegúrate de ingresar la altura del bloque de tu dispositivo original."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[La Altura de Creación de la Billetera (Wallet Birthday Height)](style: 'boldPrimary') corresponde a la altura del bloque (número de bloque en la cadena de bloques) en la que se creó tu billetera. Es importante proporcionar la altura correcta, ya que determina el rango de bloques que analizaremos para mostrar tu historial de transacciones y el saldo de tu billetera. Si recuperaste una semilla de otro dispositivo, asegúrate de ingresar la altura del bloque de tu dispositivo original."
           }
         }
       }
     },
-    "walletBirthdayHelpDescRecovery": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. If you ever lose access to your Zodl app and need to recover your funds, providing the block height along with your recovery phrase can significantly speed up the process."
+    "walletBirthdayHelpDescRecovery" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. If you ever lose access to your Zodl app and need to recover your funds, providing the block height along with your recovery phrase can significantly speed up the process."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "^[La Altura de Cumpleaños de la Billetera](style: 'boldPrimary') es la altura del bloque (número de bloque en la blockchain) en el que tu billetera fue creada. Si alguna vez pierdes acceso a tu aplicación Zodl y necesitas recuperar tus fondos, proporcionar la altura del bloque junto con tu frase de recuperación puede acelerar significativamente el proceso."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[La Altura de Cumpleaños de la Billetera](style: 'boldPrimary') es la altura del bloque (número de bloque en la blockchain) en el que tu billetera fue creada. Si alguna vez pierdes acceso a tu aplicación Zodl y necesitas recuperar tus fondos, proporcionar la altura del bloque junto con tu frase de recuperación puede acelerar significativamente el proceso."
           }
         }
       }
     },
-    "walletStatus.disconnected": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "DISCONNECTED…"
+    "walletStatus.disconnected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DISCONNECTED…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "DESCONECTADO…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DESCONECTADO…"
           }
         }
       }
     },
-    "walletStatus.restoringWallet": {
-      "comment": "MARK: - Wallet Status",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "RESTORING YOUR WALLET…"
+    "walletStatus.restoringWallet" : {
+      "comment" : "MARK: - Wallet Status",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RESTORING YOUR WALLET…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "RESTAURANDO TU BILLETERA…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RESTAURANDO TU BILLETERA…"
           }
         }
       }
     },
-    "whatsNew.version": {
-      "comment": "MARK: - What's new",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zodl Version %@"
+    "whatsNew.version" : {
+      "comment" : "MARK: - What's new",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zodl Version %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión de Zodl %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión de Zodl %@"
           }
         }
       }
     },
-    "Zcash": {
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zcash"
+    "Zcash" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash"
           }
         }
       }
     },
-    "zecKeyboard.invalid": {
-      "comment": "MARK: - ZEC Keyboard",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This transaction amount is invalid."
+    "zecKeyboard.invalid" : {
+      "comment" : "MARK: - ZEC Keyboard",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This transaction amount is invalid."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este monto de transacción no es válido."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este monto de transacción no es válido."
           }
         }
       }
     }
   },
-  "version": "1.1"
+  "version" : "1.1"
 }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -1,18759 +1,18722 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "keystone.addHWWallet.contactSupport" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact Support"
+  "sourceLanguage": "en",
+  "strings": {
+    "keystone.addHWWallet.contactSupport": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact Support"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contactar Soporte"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contactar Soporte"
           }
         }
       }
     },
-    "keystone.addHWWallet.failureDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could not connect your Keystone wallet. Your funds are safe. Please check that you are running the latest firmware."
+    "keystone.addHWWallet.failureDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not connect your Keystone wallet. Your funds are safe. Please check that you are running the latest firmware."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo conectar tu wallet Keystone. Tus fondos están seguros. Verifica que tengas el firmware más reciente instalado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo conectar tu wallet Keystone. Tus fondos están seguros. Verifica que tengas el firmware más reciente instalado."
           }
         }
       }
     },
-    "keystone.addHWWallet.failureTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connection Failed"
+    "keystone.addHWWallet.failureTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de Conexión"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de Conexión"
           }
         }
       }
     },
-    "keystone.addHWWallet.tryAgain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try again"
+    " %@": {},
+    "#%@": {},
+    "%": {},
+    "%@": {},
+    "%@ · ": {},
+    "%@ / %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ / %2$@"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intentar de nuevo"
-          }
-        }
-      }
-    },
-    " %@" : {
-
-    },
-    "#%@" : {
-
-    },
-    "%" : {
-
-    },
-    "%@" : {
-
-    },
-    "%@ · " : {
-
-    },
-    "%@ / %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ / %2$@"
-          }
         }
       }
     },
-    "%@ %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ %2$@"
+    "%@ %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ %2$@"
           }
         }
       }
-    },
-    "%@ ZEC" : {
-
     },
-    "%@..." : {
-
-    },
-    "%@%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@%2$@"
+    "%@ ZEC": {},
+    "%@...": {},
+    "%@%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@%2$@"
           }
         }
       }
-    },
-    "%@%%" : {
-
     },
-    "~%@ %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "~%1$@ %2$@"
+    "%@%%": {},
+    "~%@ %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "~%1$@ %2$@"
           }
         }
       }
     },
-    "about.additionalInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Developed by the team that set the industry standard for onchain privacy, the original developers of the Zcash protocol."
+    "about.additionalInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Developed by the team that set the industry standard for onchain privacy, the original developers of the Zcash protocol."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desarrollada por el equipo que estableció el estándar de la industria en privacidad en cadena (on-chain), los desarrolladores originales del protocolo Zcash."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desarrollada por el equipo que estableció el estándar de la industria en privacidad en cadena (on-chain), los desarrolladores originales del protocolo Zcash."
           }
         }
       }
     },
-    "about.info" : {
-      "comment" : "MARK: - About",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl is a Zcash-powered mobile wallet, built for unstoppable private payments. It’s optimized for storage and real-world use of shielded $ZEC—the truly private cryptocurrency."
+    "about.info": {
+      "comment": "MARK: - About",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl is a Zcash-powered mobile wallet, built for unstoppable private payments. It’s optimized for storage and real-world use of shielded $ZEC—the truly private cryptocurrency."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl es una wallet móvil impulsada por Zcash, creada para pagos privados imparables. Está optimizada para almacenar y usar en el mundo real $ZEC protegido: la criptomoneda verdaderamente privada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl es una wallet móvil impulsada por Zcash, creada para pagos privados imparables. Está optimizada para almacenar y usar en el mundo real $ZEC protegido: la criptomoneda verdaderamente privada."
           }
         }
       }
     },
-    "about.privacyPolicy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy Policy"
+    "about.privacyPolicy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy Policy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Política de privacidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Política de privacidad"
           }
         }
       }
     },
-    "about.termsOfUse" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terms of Service"
+    "about.termsOfUse": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terms of Service"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Términos del Servicio"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Términos del Servicio"
           }
         }
       }
     },
-    "about.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introducing Zodl"
+    "about.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introducing Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Presentando Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Presentando Zodl"
           }
         }
       }
     },
-    "accounts.addressBook.contacts" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address Book Contacts"
+    "accounts.addressBook.contacts": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address Book Contacts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contactos del Libro de Direcciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contactos del Libro de Direcciones"
           }
         }
       }
     },
-    "accounts.addressBook.your" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Wallets"
+    "accounts.addressBook.your": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Wallets"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus Billeteras"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus Billeteras"
           }
         }
       }
     },
-    "accounts.keystone" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone"
+    "accounts.keystone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone"
           }
         }
       }
     },
-    "accounts.keystone.shieldedAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash Shielded Address"
+    "accounts.keystone.shieldedAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash Shielded Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección Protegida de Zcash"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección Protegida de Zcash"
           }
         }
       }
     },
-    "accounts.keystone.transparentAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash Transparent Address"
+    "accounts.keystone.transparentAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash Transparent Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección Transparente de Zcash"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección Transparente de Zcash"
           }
         }
       }
     },
-    "accounts.sendingFrom" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send from"
+    "accounts.sendingFrom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send from"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviando desde"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando desde"
           }
         }
       }
     },
-    "accounts.zashi" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl"
+    "accounts.zashi": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl"
           }
         }
       }
     },
-    "accounts.zashi.shieldedAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash Shielded Address"
+    "accounts.zashi.shieldedAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash Shielded Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección Protegida de Zcash"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección Protegida de Zcash"
           }
         }
       }
     },
-    "accounts.zashi.transparentAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash Transparent Address"
+    "accounts.zashi.transparentAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash Transparent Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección Transparente de Zcash"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección Transparente de Zcash"
           }
         }
       }
     },
-    "addressBook.addNewContact" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add New Contact"
+    "addressBook.addNewContact": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add New Contact"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar nuevo contacto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar nuevo contacto"
           }
         }
       }
     },
-    "addressBook.alert.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You are about to delete this contact. This cannot be undone."
+    "addressBook.alert.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You are about to delete this contact. This cannot be undone."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estás a punto de eliminar este contacto. Esto no se puede deshacer."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estás a punto de eliminar este contacto. Esto no se puede deshacer."
           }
         }
       }
     },
-    "addressBook.alert.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure?"
+    "addressBook.alert.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Estás seguro?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Estás seguro?"
           }
         }
       }
     },
-    "addressBook.empty" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your address book is empty"
+    "addressBook.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your address book is empty"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu libreta de direcciones está vacía"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu libreta de direcciones está vacía"
           }
         }
       }
     },
-    "addressBook.error.addressExists" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An address with this chain is already in your Address Book."
+    "addressBook.error.addressExists": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An address with this chain is already in your Address Book."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ya existe una dirección con esta cadena en tu libreta de direcciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya existe una dirección con esta cadena en tu libreta de direcciones."
           }
         }
       }
     },
-    "addressBook.error.invalidAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid address."
+    "addressBook.error.invalidAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid address."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección no válida."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección no válida."
           }
         }
       }
     },
-    "addressBook.error.nameExists" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This contact name is already in use. Please choose a different name."
+    "addressBook.error.nameExists": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This contact name is already in use. Please choose a different name."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este nombre de contacto ya está en uso. Por favor, elige un nombre diferente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este nombre de contacto ya está en uso. Por favor, elige un nombre diferente."
           }
         }
       }
     },
-    "addressBook.error.nameLength" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This contact name exceeds the 32-character limit. Please shorten the name."
+    "addressBook.error.nameLength": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This contact name exceeds the 32-character limit. Please shorten the name."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este nombre de contacto supera el límite de 32 caracteres. Por favor, acorta el nombre."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este nombre de contacto supera el límite de 32 caracteres. Por favor, acorta el nombre."
           }
         }
       }
     },
-    "addressBook.manualEntry" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manual Entry"
+    "addressBook.manualEntry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual Entry"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrada manual"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrada manual"
           }
         }
       }
     },
-    "addressBook.newContact.address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Address"
+    "addressBook.newContact.address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección de la billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección de la billetera"
           }
         }
       }
     },
-    "addressBook.newContact.addressPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter wallet address..."
+    "addressBook.newContact.addressPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter wallet address..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresa la dirección de la billetera..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa la dirección de la billetera..."
           }
         }
       }
     },
-    "addressBook.newContact.name" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact Name"
+    "addressBook.newContact.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact Name"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre del contacto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del contacto"
           }
         }
       }
     },
-    "addressBook.newContact.namePlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter contact name..."
+    "addressBook.newContact.namePlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter contact name..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresa el nombre del contacto..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa el nombre del contacto..."
           }
         }
       }
     },
-    "addressBook.savedAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saved Address"
+    "addressBook.savedAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección guardada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección guardada"
           }
         }
       }
     },
-    "addressBook.scanAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan QR code"
+    "addressBook.scanAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan QR code"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escanear código QR"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanear código QR"
           }
         }
       }
     },
-    "addressBook.selectRecipient" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select recipient"
+    "addressBook.selectRecipient": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select recipient"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar destinatario"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar destinatario"
           }
         }
       }
     },
-    "addressBook.title" : {
-      "comment" : "MARK: - Address Book",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address Book"
+    "addressBook.title": {
+      "comment": "MARK: - Address Book",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address Book"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Libreta de Direcciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Libreta de Direcciones"
           }
         }
       }
     },
-    "addressDetails.copyAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Address"
+    "addressDetails.copyAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar Dirección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar Dirección"
           }
         }
       }
     },
-    "addressDetails.shareDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hi, scan this QR code to send me a ZEC payment!"
+    "addressDetails.shareDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hi, scan this QR code to send me a ZEC payment!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hola, ¡escanea este código QR para enviarme un pago en ZEC!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hola, ¡escanea este código QR para enviarme un pago en ZEC!"
           }
         }
       }
     },
-    "addressDetails.shareQR" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share QR Code"
+    "addressDetails.shareQR": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share QR Code"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir Código QR"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir Código QR"
           }
         }
       }
     },
-    "addressDetails.shareTitle" : {
-      "comment" : "MARK: - Address Details",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "My Zodl ZEC Address"
+    "addressDetails.shareTitle": {
+      "comment": "MARK: - Address Details",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "My Zodl ZEC Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mi Dirección ZEC de Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mi Dirección ZEC de Zodl"
           }
         }
       }
     },
-    "annotation.add" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add note"
+    "annotation.add": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add note"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar nota"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar nota"
           }
         }
       }
     },
-    "annotation.addArticle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a note"
+    "annotation.addArticle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a note"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar nota"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar nota"
           }
         }
       }
     },
-    "annotation.chars" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@/%@ characters"
+    "annotation.chars": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@/%@ characters"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@/%@ caracteres"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@/%@ caracteres"
           }
         }
       }
     },
-    "annotation.delete" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete note"
+    "annotation.delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete note"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar nota"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar nota"
           }
         }
       }
     },
-    "annotation.edit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit a note"
+    "annotation.edit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit a note"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editar nota"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar nota"
           }
         }
       }
     },
-    "annotation.placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Write an optional note to describe this transaction..."
+    "annotation.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Write an optional note to describe this transaction..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribe una nota opcional para describir esta transacción..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribe una nota opcional para describir esta transacción..."
           }
         }
       }
     },
-    "annotation.save" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save note"
+    "annotation.save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save note"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar nota"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar nota"
           }
         }
       }
     },
-    "annotation.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note"
+    "annotation.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nota"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota"
           }
         }
       }
     },
-    "autoShieldingHelpContent" : {
-
-    },
-    "balance.availableTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spendable:"
+    "autoShieldingHelpContent": {},
+    "balance.availableTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spendable:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gastable:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gastable:"
           }
         }
       }
     },
-    "balances.dismiss" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dismiss"
+    "balances.dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descartar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar"
           }
         }
       }
     },
-    "balances.everythingDone" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All your funds are shielded and spendable."
+    "balances.everythingDone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All your funds are shielded and spendable."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos tus fondos están protegidos y son gastables."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos tus fondos están protegidos y son gastables."
           }
         }
       }
     },
-    "balances.infoPending" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pending receipt of change from a prior transaction."
+    "balances.infoPending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending receipt of change from a prior transaction."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pendiente de recibir el cambio de una transacción anterior."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendiente de recibir el cambio de una transacción anterior."
           }
         }
       }
     },
-    "balances.infoShielding" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shield your transparent ZEC to make it spendable and private. Doing so will create a shielding in-wallet transaction, consolidating your transparent and shielded funds. (Typical fee: %@)"
+    "balances.infoShielding": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shield your transparent ZEC to make it spendable and private. Doing so will create a shielding in-wallet transaction, consolidating your transparent and shielded funds. (Typical fee: %@)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protege tus ZEC transparentes para hacerlos gastables y privados. Esto creará una transacción de protección en la billetera, consolidando tus fondos transparentes y protegidos. (Tarifa típica: %@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protege tus ZEC transparentes para hacerlos gastables y privados. Esto creará una transacción de protección en la billetera, consolidando tus fondos transparentes y protegidos. (Tarifa típica: %@)"
           }
         }
       }
     },
-    "balances.infoSyncing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl is scanning the blockchain to make sure your balances are displayed correctly."
+    "balances.infoSyncing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl is scanning the blockchain to make sure your balances are displayed correctly."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl está escaneando la blockchain para asegurarse de que tus balances se muestren correctamente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl está escaneando la blockchain para asegurarse de que tus balances se muestren correctamente."
           }
         }
       }
     },
-    "balances.pending" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pending"
+    "balances.pending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendiente"
           }
         }
       }
     },
-    "balances.spendableBalance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shielded (Spendable)"
+    "balances.spendableBalance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shielded (Spendable)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protegido (Gastable)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protegido (Gastable)"
           }
         }
       }
     },
-    "balances.spendableBalance.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spendable Balance"
+    "balances.spendableBalance.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spendable Balance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Balance Gastable"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balance Gastable"
           }
         }
       }
     },
-    "balances.synced" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synced"
+    "balances.synced": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synced"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizado"
           }
         }
       }
     },
-    "balances.syncing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing"
+    "balances.syncing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizando"
           }
         }
       }
     },
-    "coinVote.common.abstain" : {
-      "comment" : "MARK: - Coin Vote",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abstain"
+    "coinVote.common.abstain": {
+      "comment": "MARK: - Coin Vote",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abstain"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abstain"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abstain"
           }
         }
       }
     },
-    "coinVote.common.back" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+    "coinVote.common.back": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
         }
       }
     },
-    "coinVote.common.blockNumber" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Block #%@"
+    "coinVote.common.blockNumber": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block #%@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Block #%@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block #%@"
           }
         }
       }
     },
-    "coinVote.common.cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "coinVote.common.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         }
       }
     },
-    "coinVote.common.close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+    "coinVote.common.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         }
       }
     },
-    "coinVote.common.confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm"
+    "coinVote.common.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm"
           }
         }
       }
     },
-    "coinVote.common.confirmation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmation"
+    "coinVote.common.confirmation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmation"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmation"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmation"
           }
         }
       }
     },
-    "coinVote.common.continue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+    "coinVote.common.continue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
           }
         }
       }
     },
-    "coinVote.common.dismiss" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dismiss"
+    "coinVote.common.dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dismiss"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
           }
         }
       }
     },
-    "coinVote.common.done" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+    "coinVote.common.done": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
           }
         }
       }
     },
-    "coinVote.common.endsDate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ends %@"
+    "coinVote.common.endsDate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ends %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ends %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ends %@"
           }
         }
       }
     },
-    "coinVote.common.goBack" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go back"
+    "coinVote.common.goBack": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go back"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go back"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go back"
           }
         }
       }
     },
-    "coinVote.common.gotIt" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Got it"
+    "coinVote.common.gotIt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Got it"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it"
           }
         }
       }
     },
-    "coinVote.common.governanceTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Governance"
+    "coinVote.common.governanceTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Governance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Governance"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Governance"
           }
         }
       }
     },
-    "coinVote.common.next" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next"
+    "coinVote.common.next": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
           }
         }
       }
     },
-    "coinVote.common.oppose" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oppose"
+    "coinVote.common.oppose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oppose"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oppose"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oppose"
           }
         }
       }
     },
-    "coinVote.common.pollDescription" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll Description"
+    "coinVote.common.pollDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll Description"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll Description"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll Description"
           }
         }
       }
     },
-    "coinVote.common.refresh" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refresh"
+    "coinVote.common.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refresh"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
           }
         }
       }
     },
-    "coinVote.common.retry" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+    "coinVote.common.retry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
           }
         }
       }
     },
-    "coinVote.common.save" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "coinVote.common.save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         }
       }
     },
-    "coinVote.common.screenTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coinholder Polling"
+    "coinVote.common.screenTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coinholder Polling"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coinholder Polling"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coinholder Polling"
           }
         }
       }
     },
-    "coinVote.common.submission" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submission"
+    "coinVote.common.submission": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submission"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submission"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submission"
           }
         }
       }
     },
-    "coinVote.common.support" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support"
+    "coinVote.common.support": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support"
           }
         }
       }
     },
-    "coinVote.common.tryAgain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try again"
+    "coinVote.common.tryAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try again"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try again"
           }
         }
       }
     },
-    "coinVote.common.viewLess" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View less"
+    "coinVote.common.viewLess": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View less"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View less"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View less"
           }
         }
       }
     },
-    "coinVote.common.viewMore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View more"
+    "coinVote.common.viewMore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View more"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View more"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View more"
           }
         }
       }
     },
-    "coinVote.common.viewResults" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View results"
+    "coinVote.common.viewResults": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View results"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View results"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View results"
           }
         }
       }
     },
-    "coinVote.common.voted" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voted"
+    "coinVote.common.voted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voted"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voted"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voted"
           }
         }
       }
     },
-    "coinVote.common.votedDate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voted %@"
+    "coinVote.common.votedDate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voted %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voted %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voted %@"
           }
         }
       }
     },
-    "coinVote.common.votingPower" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting Power %@ ZEC"
+    "coinVote.common.votingPower": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting Power %@ ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting Power %@ ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting Power %@ ZEC"
           }
         }
       }
     },
-    "coinVote.common.zecValue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC"
+    "coinVote.common.zecValue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ZEC"
           }
         }
       }
     },
-    "coinVote.common.zipPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ZIP-TBD"
+    "coinVote.common.zipPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ZIP-TBD"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ZIP-TBD"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ZIP-TBD"
           }
         }
       }
     },
-    "coinVote.components.commitment" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "commitment: %@"
+    "coinVote.components.commitment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "commitment: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "commitment: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "commitment: %@"
           }
         }
       }
     },
-    "coinVote.components.expectedBy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expected by %@"
+    "coinVote.components.expectedBy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expected by %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expected by %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expected by %@"
           }
         }
       }
     },
-    "coinVote.components.finishingUp" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finishing up…"
+    "coinVote.components.finishingUp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finishing up…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finishing up…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finishing up…"
           }
         }
       }
     },
-    "coinVote.components.notVoted" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not voted"
+    "coinVote.components.notVoted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not voted"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not voted"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not voted"
           }
         }
       }
     },
-    "coinVote.components.preparingNoteWitnesses" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing note witnesses..."
+    "coinVote.components.preparingNoteWitnesses": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing note witnesses..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing note witnesses..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing note witnesses..."
           }
         }
       }
     },
-    "coinVote.components.preparingVotingAuthorization" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing voting authorization... %@%%"
+    "coinVote.components.preparingVotingAuthorization": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing voting authorization... %@%%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing voting authorization... %@%%"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing voting authorization... %@%%"
           }
         }
       }
     },
-    "coinVote.components.privacyExplanation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Each share is sent at different times across various servers throughout the vote period to further protect your privacy. Each value is encrypted, and only the total amount across all voters will be revealed at the end of the vote period."
+    "coinVote.components.privacyExplanation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Each share is sent at different times across various servers throughout the vote period to further protect your privacy. Each value is encrypted, and only the total amount across all voters will be revealed at the end of the vote period."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Each share is sent at different times across various servers throughout the vote period to further protect your privacy. Each value is encrypted, and only the total amount across all voters will be revealed at the end of the vote period."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Each share is sent at different times across various servers throughout the vote period to further protect your privacy. Each value is encrypted, and only the total amount across all voters will be revealed at the end of the vote period."
           }
         }
       }
     },
-    "coinVote.components.prototypeBanner" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prototype — some features are mocked"
+    "coinVote.components.prototypeBanner": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prototype — some features are mocked"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prototype — some features are mocked"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prototype — some features are mocked"
           }
         }
       }
     },
-    "coinVote.components.prototypeVcStub" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prototype VC Stub"
+    "coinVote.components.prototypeVcStub": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prototype VC Stub"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prototype VC Stub"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prototype VC Stub"
           }
         }
       }
     },
-    "coinVote.components.readyToVote" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ready to vote"
+    "coinVote.components.readyToVote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready to vote"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ready to vote"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready to vote"
           }
         }
       }
     },
-    "coinVote.components.shareInfoSubtitleConfirmed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All shares have been confirmed on-chain."
+    "coinVote.components.shareInfoSubtitleConfirmed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All shares have been confirmed on-chain."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All shares have been confirmed on-chain."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All shares have been confirmed on-chain."
           }
         }
       }
     },
-    "coinVote.components.shareInfoSubtitleSubmitting" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your vote is being submitted in multiple shares to protect your privacy."
+    "coinVote.components.shareInfoSubtitleSubmitting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your vote is being submitted in multiple shares to protect your privacy."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your vote is being submitted in multiple shares to protect your privacy."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your vote is being submitted in multiple shares to protect your privacy."
           }
         }
       }
     },
-    "coinVote.components.shareInfoTitleConfirmed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote Confirmed"
+    "coinVote.components.shareInfoTitleConfirmed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote Confirmed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote Confirmed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote Confirmed"
           }
         }
       }
     },
-    "coinVote.components.shareInfoTitleSubmitting" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting Vote"
+    "coinVote.components.shareInfoTitleSubmitting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting Vote"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting Vote"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting Vote"
           }
         }
       }
     },
-    "coinVote.components.submittingVote" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting vote"
+    "coinVote.components.submittingVote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting vote"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting vote"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting vote"
           }
         }
       }
     },
-    "coinVote.components.transaction" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tx: %@"
+    "coinVote.components.transaction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tx: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tx: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tx: %@"
           }
         }
       }
     },
-    "coinVote.components.vanNullifier" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "van nullifier: %@"
+    "coinVote.components.vanNullifier": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "van nullifier: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "van nullifier: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "van nullifier: %@"
           }
         }
       }
     },
-    "coinVote.components.voteConfirmed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote confirmed"
+    "coinVote.components.voteConfirmed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote confirmed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote confirmed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote confirmed"
           }
         }
       }
     },
-    "coinVote.configError.decodeFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting config decode failed: %@"
+    "coinVote.configError.decodeFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting config decode failed: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting config decode failed: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting config decode failed: %@"
           }
         }
       }
     },
-    "coinVote.configError.invalidConfig" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting config is invalid."
+    "coinVote.configError.invalidConfig": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting config is invalid."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting config is invalid."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting config is invalid."
           }
         }
       }
     },
-    "coinVote.configError.proposalsHashMismatch" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting config proposals don't match the active round. Please update the wallet."
+    "coinVote.configError.proposalsHashMismatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting config proposals don't match the active round. Please update the wallet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting config proposals don't match the active round. Please update the wallet."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting config proposals don't match the active round. Please update the wallet."
           }
         }
       }
     },
-    "coinVote.configError.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Update Required"
+    "coinVote.configError.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Update Required"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Update Required"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Update Required"
           }
         }
       }
     },
-    "coinVote.configError.unsupportedVersion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet does not support %@ version \"%@\". Please update the wallet."
+    "coinVote.configError.unsupportedVersion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet does not support %@ version \"%@\". Please update the wallet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet does not support %@ version \"%@\". Please update the wallet."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet does not support %@ version \"%@\". Please update the wallet."
           }
         }
       }
     },
-    "coinVote.configSettings.accessibilityActions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source actions"
+    "coinVote.configSettings.accessibilityActions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source actions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source actions"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source actions"
           }
         }
       }
     },
-    "coinVote.configSettings.accessibilityClose" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+    "coinVote.configSettings.accessibilityClose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         }
       }
     },
-    "coinVote.configSettings.accessibilityDefault" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default data source"
+    "coinVote.configSettings.accessibilityDefault": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default data source"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default data source"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default data source"
           }
         }
       }
     },
-    "coinVote.configSettings.accessibilitySelectChain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select %@"
+    "coinVote.configSettings.accessibilitySelectChain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select %@"
           }
         }
       }
     },
-    "coinVote.configSettings.addCustomSource" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add custom source"
+    "coinVote.configSettings.addCustomSource": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add custom source"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add custom source"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add custom source"
           }
         }
       }
     },
-    "coinVote.configSettings.bundledName" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coinholder Poll"
+    "coinVote.configSettings.bundledName": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coinholder Poll"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coinholder Poll"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coinholder Poll"
           }
         }
       }
     },
-    "coinVote.configSettings.customChainFallbackName" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custom chain"
+    "coinVote.configSettings.customChainFallbackName": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom chain"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custom chain"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom chain"
           }
         }
       }
     },
-    "coinVote.configSettings.defaultBadge" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default"
+    "coinVote.configSettings.defaultBadge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
           }
         }
       }
     },
-    "coinVote.configSettings.delete" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete"
+    "coinVote.configSettings.delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
           }
         }
       }
     },
-    "coinVote.configSettings.edit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit"
+    "coinVote.configSettings.edit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit"
           }
         }
       }
     },
-    "coinVote.configSettings.errorDuplicateUrl" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This source URL is already added."
+    "coinVote.configSettings.errorDuplicateUrl": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This source URL is already added."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This source URL is already added."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This source URL is already added."
           }
         }
       }
     },
-    "coinVote.configSettings.errorInvalidUrl" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please enter a valid URL (e.g. https://zodl.com/polls)"
+    "coinVote.configSettings.errorInvalidUrl": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please enter a valid URL (e.g. https://zodl.com/polls)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please enter a valid URL (e.g. https://zodl.com/polls)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please enter a valid URL (e.g. https://zodl.com/polls)"
           }
         }
       }
     },
-    "coinVote.configSettings.errorTitleTooLong" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Title must be 15 characters or less, including spaces."
+    "coinVote.configSettings.errorTitleTooLong": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title must be 15 characters or less, including spaces."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Title must be 15 characters or less, including spaces."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title must be 15 characters or less, including spaces."
           }
         }
       }
     },
-    "coinVote.configSettings.headerAddBody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a poll source that isn't listed by default. You'll need a valid chain URL from the provider hosting the poll."
+    "coinVote.configSettings.headerAddBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a poll source that isn't listed by default. You'll need a valid chain URL from the provider hosting the poll."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add a poll source that isn't listed by default. You'll need a valid chain URL from the provider hosting the poll."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a poll source that isn't listed by default. You'll need a valid chain URL from the provider hosting the poll."
           }
         }
       }
     },
-    "coinVote.configSettings.headerAddTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Custom Source"
+    "coinVote.configSettings.headerAddTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Custom Source"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Custom Source"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Custom Source"
           }
         }
       }
     },
-    "coinVote.configSettings.headerEditBody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update the title or URL for this custom poll source. You'll need a valid chain URL from the provider hosting the poll."
+    "coinVote.configSettings.headerEditBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update the title or URL for this custom poll source. You'll need a valid chain URL from the provider hosting the poll."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update the title or URL for this custom poll source. You'll need a valid chain URL from the provider hosting the poll."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update the title or URL for this custom poll source. You'll need a valid chain URL from the provider hosting the poll."
           }
         }
       }
     },
-    "coinVote.configSettings.headerEditTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Custom Source"
+    "coinVote.configSettings.headerEditTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Custom Source"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Custom Source"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Custom Source"
           }
         }
       }
     },
-    "coinVote.configSettings.menuCopyUrl" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Data Source URL"
+    "coinVote.configSettings.menuCopyUrl": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Data Source URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Data Source URL"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Data Source URL"
           }
         }
       }
     },
-    "coinVote.configSettings.save" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "coinVote.configSettings.save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         }
       }
     },
-    "coinVote.configSettings.saveChanges" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save changes"
+    "coinVote.configSettings.saveChanges": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save changes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save changes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save changes"
           }
         }
       }
     },
-    "coinVote.configSettings.screenTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Data Source"
+    "coinVote.configSettings.screenTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Data Source"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Data Source"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Data Source"
           }
         }
       }
     },
-    "coinVote.configSettings.sectionSubtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pick a poll source, or add your own."
+    "coinVote.configSettings.sectionSubtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick a poll source, or add your own."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pick a poll source, or add your own."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick a poll source, or add your own."
           }
         }
       }
     },
-    "coinVote.configSettings.sectionTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll Data Source"
+    "coinVote.configSettings.sectionTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll Data Source"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll Data Source"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll Data Source"
           }
         }
       }
     },
-    "coinVote.configSettings.titleField" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Title"
+    "coinVote.configSettings.titleField": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Title"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title"
           }
         }
       }
     },
-    "coinVote.configSettings.toolbarAdd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ADD SOURCE"
+    "coinVote.configSettings.toolbarAdd": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ADD SOURCE"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ADD SOURCE"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ADD SOURCE"
           }
         }
       }
     },
-    "coinVote.configSettings.toolbarEdit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "EDIT SOURCE"
+    "coinVote.configSettings.toolbarEdit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EDIT SOURCE"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "EDIT SOURCE"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EDIT SOURCE"
           }
         }
       }
     },
-    "coinVote.configSettings.urlField" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+    "coinVote.configSettings.urlField": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         }
       }
     },
-    "coinVote.configSettings.urlPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter..."
+    "coinVote.configSettings.urlPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter..."
           }
         }
       }
     },
-    "coinVote.configSettings.validating" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Validating..."
+    "coinVote.configSettings.validating": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validating..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Validating..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validating..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.authorizationFailedMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We couldn't authorize your vote.\nCheck your connection and try again."
+    "coinVote.confirmSubmission.authorizationFailedMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We couldn't authorize your vote.\nCheck your connection and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We couldn't authorize your vote.\nCheck your connection and try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We couldn't authorize your vote.\nCheck your connection and try again."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.authorizationFailedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization Failed"
+    "coinVote.confirmSubmission.authorizationFailedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization Failed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization Failed"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.bundleProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bundle %@ of %@"
+    "coinVote.confirmSubmission.bundleProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bundle %@ of %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bundle %@ of %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bundle %@ of %@"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.confirmWithKeystone" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm with Keystone"
+    "coinVote.confirmSubmission.confirmWithKeystone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm with Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm with Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm with Keystone"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailAmount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amount"
+    "coinVote.confirmSubmission.detailAmount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amount"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailAmountValue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0.00000001 ZEC"
+    "coinVote.confirmSubmission.detailAmountValue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.00000001 ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0.00000001 ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.00000001 ZEC"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailFee" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee"
+    "coinVote.confirmSubmission.detailFee": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailFeeValue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0 ZEC"
+    "coinVote.confirmSubmission.detailFeeValue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0 ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0 ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0 ZEC"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailMemo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memo"
+    "coinVote.confirmSubmission.detailMemo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memo"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memo"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailPoll" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll"
+    "coinVote.confirmSubmission.detailPoll": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailVotingHotkey" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting hotkey"
+    "coinVote.confirmSubmission.detailVotingHotkey": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting hotkey"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting hotkey"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting hotkey"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailVotingPower" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting power"
+    "coinVote.confirmSubmission.detailVotingPower": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting power"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting power"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting power"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.detailVotingPowerValue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC"
+    "coinVote.confirmSubmission.detailVotingPowerValue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ZEC"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubmittedCountMultiple" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitted %@ votes with voting power %@."
+    "coinVote.confirmSubmission.headerSubmittedCountMultiple": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitted %@ votes with voting power %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitted %@ votes with voting power %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitted %@ votes with voting power %@."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubmittedCountSingle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitted %@ vote with voting power %@."
+    "coinVote.confirmSubmission.headerSubmittedCountSingle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitted %@ vote with voting power %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitted %@ vote with voting power %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitted %@ vote with voting power %@."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubmittingCountMultiple" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting %@ votes with voting power %@."
+    "coinVote.confirmSubmission.headerSubmittingCountMultiple": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting %@ votes with voting power %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting %@ votes with voting power %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting %@ votes with voting power %@."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubmittingCountSingle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting %@ vote with voting power %@."
+    "coinVote.confirmSubmission.headerSubmittingCountSingle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting %@ vote with voting power %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting %@ vote with voting power %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting %@ vote with voting power %@."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubtitleCompleted" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your vote was successfully published and cannot be changed."
+    "coinVote.confirmSubmission.headerSubtitleCompleted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your vote was successfully published and cannot be changed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your vote was successfully published and cannot be changed."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your vote was successfully published and cannot be changed."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubtitleIdle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review before confirming the voting authorization. This is final. Your vote will be published and cannot be changed."
+    "coinVote.confirmSubmission.headerSubtitleIdle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review before confirming the voting authorization. This is final. Your vote will be published and cannot be changed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review before confirming the voting authorization. This is final. Your vote will be published and cannot be changed."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review before confirming the voting authorization. This is final. Your vote will be published and cannot be changed."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubtitleIdleKeystone" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review before signing the voting authorization with your Keystone. This is final. Your vote will be published and cannot be changed."
+    "coinVote.confirmSubmission.headerSubtitleIdleKeystone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review before signing the voting authorization with your Keystone. This is final. Your vote will be published and cannot be changed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review before signing the voting authorization with your Keystone. This is final. Your vote will be published and cannot be changed."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review before signing the voting authorization with your Keystone. This is final. Your vote will be published and cannot be changed."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerSubtitleSubmitting" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote submission is in progress, please don’t leave this screen until it is finished."
+    "coinVote.confirmSubmission.headerSubtitleSubmitting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote submission is in progress, please don’t leave this screen until it is finished."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote submission is in progress, please don’t leave this screen until it is finished."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote submission is in progress, please don’t leave this screen until it is finished."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerTitleCompleted" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submission Confirmed!"
+    "coinVote.confirmSubmission.headerTitleCompleted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submission Confirmed!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submission Confirmed!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submission Confirmed!"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerTitleIdle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm & Submit"
+    "coinVote.confirmSubmission.headerTitleIdle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm & Submit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm & Submit"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm & Submit"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.headerTitleSubmitting" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting vote..."
+    "coinVote.confirmSubmission.headerTitleSubmitting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting vote..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting vote..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting vote..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.memoMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
+    "coinVote.confirmSubmission.memoMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.progressAuthorizing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorizing..."
+    "coinVote.confirmSubmission.progressAuthorizing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorizing..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorizing..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorizing..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.progressSubmittingVoteCount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting vote %@ of %@..."
+    "coinVote.confirmSubmission.progressSubmittingVoteCount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting vote %@ of %@..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting vote %@ of %@..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting vote %@ of %@..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.progressTimeRemainingMany" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About %@ minutes left..."
+    "coinVote.confirmSubmission.progressTimeRemainingMany": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About %@ minutes left..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About %@ minutes left..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About %@ minutes left..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.progressTimeRemainingOne" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About 1 minute left..."
+    "coinVote.confirmSubmission.progressTimeRemainingOne": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About 1 minute left..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About 1 minute left..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About 1 minute left..."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.submissionFailedMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your vote couldn't be submitted\nCheck your connection and try again."
+    "coinVote.confirmSubmission.submissionFailedMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your vote couldn't be submitted\nCheck your connection and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your vote couldn't be submitted\nCheck your connection and try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your vote couldn't be submitted\nCheck your connection and try again."
           }
         }
       }
     },
-    "coinVote.confirmSubmission.submissionFailedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submission Failed"
+    "coinVote.confirmSubmission.submissionFailedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submission Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submission Failed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submission Failed"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.submitCTA" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submit"
+    "coinVote.confirmSubmission.submitCTA": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submit"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submit"
           }
         }
       }
     },
-    "coinVote.confirmSubmission.voteProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote %@ of %@"
+    "coinVote.confirmSubmission.voteProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote %@ of %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote %@ of %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote %@ of %@"
           }
         }
       }
     },
-    "coinVote.delegation.insufficientSnapshotBalance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your shielded balance at the snapshot (%@ ZEC) is below the minimum required to vote (%@ ZEC)."
+    "coinVote.delegation.insufficientSnapshotBalance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your shielded balance at the snapshot (%@ ZEC) is below the minimum required to vote (%@ ZEC)."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your shielded balance at the snapshot (%@ ZEC) is below the minimum required to vote (%@ ZEC)."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your shielded balance at the snapshot (%@ ZEC) is below the minimum required to vote (%@ ZEC)."
           }
         }
       }
     },
-    "coinVote.delegation.restoreVotingStateFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to restore voting state: %@"
+    "coinVote.delegation.restoreVotingStateFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to restore voting state: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to restore voting state: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to restore voting state: %@"
           }
         }
       }
     },
-    "coinVote.delegationSigning.awaitingWeightSummary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC signed · %@ ZEC awaiting"
+    "coinVote.delegationSigning.awaitingWeightSummary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ZEC signed · %@ ZEC awaiting"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC signed · %@ ZEC awaiting"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ZEC signed · %@ ZEC awaiting"
           }
         }
       }
     },
-    "coinVote.delegationSigning.buildingBundleRequest" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Building bundle %@ of %@..."
+    "coinVote.delegationSigning.buildingBundleRequest": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building bundle %@ of %@..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Building bundle %@ of %@..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building bundle %@ of %@..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.buildingRequest" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Building delegation request..."
+    "coinVote.delegationSigning.buildingRequest": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building delegation request..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Building delegation request..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building delegation request..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.bundleProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign bundle %@ of %@"
+    "coinVote.delegationSigning.bundleProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign bundle %@ of %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign bundle %@ of %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign bundle %@ of %@"
           }
         }
       }
     },
-    "coinVote.delegationSigning.currentBundleProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signature %@ of %@"
+    "coinVote.delegationSigning.currentBundleProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signature %@ of %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signature %@ of %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signature %@ of %@"
           }
         }
       }
     },
-    "coinVote.delegationSigning.currentBundleWeight" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This bundle adds %@ ZEC of voting weight."
+    "coinVote.delegationSigning.currentBundleWeight": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This bundle adds %@ ZEC of voting weight."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This bundle adds %@ ZEC of voting weight."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This bundle adds %@ ZEC of voting weight."
           }
         }
       }
     },
-    "coinVote.delegationSigning.duplicateSignature" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That Keystone signature was already scanned for bundle %@ of %@. Sign the current bundle on Keystone, then scan the new QR."
+    "coinVote.delegationSigning.duplicateSignature": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That Keystone signature was already scanned for bundle %@ of %@. Sign the current bundle on Keystone, then scan the new QR."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That Keystone signature was already scanned for bundle %@ of %@. Sign the current bundle on Keystone, then scan the new QR."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That Keystone signature was already scanned for bundle %@ of %@. Sign the current bundle on Keystone, then scan the new QR."
           }
         }
       }
     },
-    "coinVote.delegationSigning.finalizingAuthorizationEllipsis" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizing voting authorization…"
+    "coinVote.delegationSigning.finalizingAuthorizationEllipsis": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizing voting authorization…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizing voting authorization…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizing voting authorization…"
           }
         }
       }
     },
-    "coinVote.delegationSigning.instruction" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "After you have signed with Keystone, tap on the Scan Signature button below."
+    "coinVote.delegationSigning.instruction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After you have signed with Keystone, tap on the Scan Signature button below."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "After you have signed with Keystone, tap on the Scan Signature button below."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After you have signed with Keystone, tap on the Scan Signature button below."
           }
         }
       }
     },
-    "coinVote.delegationSigning.memo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memo"
+    "coinVote.delegationSigning.memo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memo"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memo"
           }
         }
       }
     },
-    "coinVote.delegationSigning.memoMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
+    "coinVote.delegationSigning.memoMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I am authorizing this hotkey managed by my wallet to vote on %@ with %@ ZEC."
           }
         }
       }
     },
-    "coinVote.delegationSigning.multiBundleInstruction" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your voting weight is split into %@ Keystone signatures. After each signature, we'll prepare the next one."
+    "coinVote.delegationSigning.multiBundleInstruction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your voting weight is split into %@ Keystone signatures. After each signature, we'll prepare the next one."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your voting weight is split into %@ Keystone signatures. After each signature, we'll prepare the next one."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your voting weight is split into %@ Keystone signatures. After each signature, we'll prepare the next one."
           }
         }
       }
     },
-    "coinVote.delegationSigning.parsingSignatureEllipsis" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parsing signature…"
+    "coinVote.delegationSigning.parsingSignatureEllipsis": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parsing signature…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parsing signature…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parsing signature…"
           }
         }
       }
     },
-    "coinVote.delegationSigning.preparingNextBundle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bundle %@ signed. Preparing bundle %@ of %@..."
+    "coinVote.delegationSigning.preparingNextBundle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bundle %@ signed. Preparing bundle %@ of %@..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bundle %@ signed. Preparing bundle %@ of %@..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bundle %@ signed. Preparing bundle %@ of %@..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.preparingRequestEllipsis" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing signing request…"
+    "coinVote.delegationSigning.preparingRequestEllipsis": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing signing request…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing signing request…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing signing request…"
           }
         }
       }
     },
-    "coinVote.delegationSigning.processing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processing..."
+    "coinVote.delegationSigning.processing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processing..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processing..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processing..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.processingSignature" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processing signature..."
+    "coinVote.delegationSigning.processingSignature": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processing signature..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processing signature..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processing signature..."
           }
         }
       }
     },
-    "coinVote.delegationSigning.qrEncodingFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QR encoding failed. Tap Cancel and try again."
+    "coinVote.delegationSigning.qrEncodingFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR encoding failed. Tap Cancel and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QR encoding failed. Tap Cancel and try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR encoding failed. Tap Cancel and try again."
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanInstructions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan Keystone QR code\nto sign the transaction"
+    "coinVote.delegationSigning.scanInstructions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan Keystone QR code\nto sign the transaction"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan Keystone QR code\nto sign the transaction"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan Keystone QR code\nto sign the transaction"
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanSignature" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan signature"
+    "coinVote.delegationSigning.scanSignature": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan signature"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan signature"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan signature"
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanSignedBundle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan Signed Bundle %@"
+    "coinVote.delegationSigning.scanSignedBundle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan Signed Bundle %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan Signed Bundle %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan Signed Bundle %@"
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanSignedPCZTCTA" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan signed PCZT"
+    "coinVote.delegationSigning.scanSignedPCZTCTA": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan signed PCZT"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan signed PCZT"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan signed PCZT"
           }
         }
       }
     },
-    "coinVote.delegationSigning.scanSignedPCZTInstruction" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open your Keystone device and scan the signed PCZT back to continue."
+    "coinVote.delegationSigning.scanSignedPCZTInstruction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open your Keystone device and scan the signed PCZT back to continue."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open your Keystone device and scan the signed PCZT back to continue."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open your Keystone device and scan the signed PCZT back to continue."
           }
         }
       }
     },
-    "coinVote.delegationSigning.signatureRejectedOk" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "coinVote.delegationSigning.signatureRejectedOk": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         }
       }
     },
-    "coinVote.delegationSigning.signatureRejectedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something Went Wrong"
+    "coinVote.delegationSigning.signatureRejectedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something Went Wrong"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something Went Wrong"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something Went Wrong"
           }
         }
       }
     },
-    "coinVote.delegationSigning.signedProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ of %@ signed"
+    "coinVote.delegationSigning.signedProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ of %@ signed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ of %@ signed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ of %@ signed"
           }
         }
       }
     },
-    "coinVote.delegationSigning.signedWeightSummary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC Signed · %@ ZEC Pending"
+    "coinVote.delegationSigning.signedWeightSummary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ZEC Signed · %@ ZEC Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ZEC Signed · %@ ZEC Pending"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ZEC Signed · %@ ZEC Pending"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipAlertCancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep Signing"
+    "coinVote.delegationSigning.skipAlertCancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Signing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep Signing"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Signing"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipAlertMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You will vote with %@ ZEC from your signed bundles. The remaining %@ ZEC in unsigned bundles will not be included. This cannot be changed for this round."
+    "coinVote.delegationSigning.skipAlertMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You will vote with %@ ZEC from your signed bundles. The remaining %@ ZEC in unsigned bundles will not be included. This cannot be changed for this round."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You will vote with %@ ZEC from your signed bundles. The remaining %@ ZEC in unsigned bundles will not be included. This cannot be changed for this round."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You will vote with %@ ZEC from your signed bundles. The remaining %@ ZEC in unsigned bundles will not be included. This cannot be changed for this round."
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipAlertPrimary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote with signed bundles only"
+    "coinVote.delegationSigning.skipAlertPrimary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote with signed bundles only"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote with signed bundles only"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote with signed bundles only"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipAlertTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Signed Bundles Only?"
+    "coinVote.delegationSigning.skipAlertTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Signed Bundles Only?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Signed Bundles Only?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Signed Bundles Only?"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipRemainingBundle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip Remaining %@ Bundle"
+    "coinVote.delegationSigning.skipRemainingBundle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip Remaining %@ Bundle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip Remaining %@ Bundle"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip Remaining %@ Bundle"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipRemainingBundles" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip Remaining %@ Bundles"
+    "coinVote.delegationSigning.skipRemainingBundles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip Remaining %@ Bundles"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip Remaining %@ Bundles"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip Remaining %@ Bundles"
           }
         }
       }
     },
-    "coinVote.delegationSigning.skipRemainingBundlesCTA" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip remaining bundles"
+    "coinVote.delegationSigning.skipRemainingBundlesCTA": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip remaining bundles"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip remaining bundles"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip remaining bundles"
           }
         }
       }
     },
-    "coinVote.delegationSigning.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorize Vote"
+    "coinVote.delegationSigning.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorize Vote"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorize Vote"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorize Vote"
           }
         }
       }
     },
-    "coinVote.delegationSigning.useSignedBundlesOnly" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use signed bundles only"
+    "coinVote.delegationSigning.useSignedBundlesOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use signed bundles only"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use signed bundles only"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use signed bundles only"
           }
         }
       }
     },
-    "coinVote.delegationSigning.useSignedBundlesOnlySubtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue without the remaining %@ ZEC."
+    "coinVote.delegationSigning.useSignedBundlesOnlySubtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue without the remaining %@ ZEC."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue without the remaining %@ ZEC."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue without the remaining %@ ZEC."
           }
         }
       }
     },
-    "coinVote.delegationSigning.wrongSignature" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That signature is for a different bundle. Sign bundle %@ of %@ on Keystone, then scan the new QR."
+    "coinVote.delegationSigning.wrongSignature": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That signature is for a different bundle. Sign bundle %@ of %@ on Keystone, then scan the new QR."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That signature is for a different bundle. Sign bundle %@ of %@ on Keystone, then scan the new QR."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That signature is for a different bundle. Sign bundle %@ of %@ on Keystone, then scan the new QR."
           }
         }
       }
     },
-    "coinVote.error.changeDataSource" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change data source"
+    "coinVote.error.changeDataSource": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change data source"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change data source"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change data source"
           }
         }
       }
     },
-    "coinVote.error.configUnavailableTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting unavailable"
+    "coinVote.error.configUnavailableTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting unavailable"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting unavailable"
           }
         }
       }
     },
-    "coinVote.error.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something Went Wrong"
+    "coinVote.error.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something Went Wrong"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something Went Wrong"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something Went Wrong"
           }
         }
       }
     },
-    "coinVote.howToVote.infoCard" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your balance at the snapshot time determines your voting weight. You don't need to move your funds anywhere."
+    "coinVote.howToVote.infoCard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your balance at the snapshot time determines your voting weight. You don't need to move your funds anywhere."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your balance at the snapshot time determines your voting weight. You don't need to move your funds anywhere."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your balance at the snapshot time determines your voting weight. You don't need to move your funds anywhere."
           }
         }
       }
     },
-    "coinVote.howToVote.stepAuthorizeBody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When you're ready, you'll confirm a small authorization transaction and submit your vote in one step. After submission, your vote cannot be changed."
+    "coinVote.howToVote.stepAuthorizeBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When you're ready, you'll confirm a small authorization transaction and submit your vote in one step. After submission, your vote cannot be changed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When you're ready, you'll confirm a small authorization transaction and submit your vote in one step. After submission, your vote cannot be changed."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When you're ready, you'll confirm a small authorization transaction and submit your vote in one step. After submission, your vote cannot be changed."
           }
         }
       }
     },
-    "coinVote.howToVote.stepAuthorizeTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorize and Submit"
+    "coinVote.howToVote.stepAuthorizeTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorize and Submit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorize and Submit"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorize and Submit"
           }
         }
       }
     },
-    "coinVote.howToVote.stepVotingBody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
+    "coinVote.howToVote.stepVotingBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vote on each question by selecting an answer. You can skip questions and update your choices anytime before submitting."
           }
         }
       }
     },
-    "coinVote.howToVote.stepVotingTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting on Proposals"
+    "coinVote.howToVote.stepVotingTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting on Proposals"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting on Proposals"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting on Proposals"
           }
         }
       }
     },
-    "coinVote.howToVote.subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your ZEC gives you a voice. Shape the future of the Zcash network by voting on active proposals."
+    "coinVote.howToVote.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your ZEC gives you a voice. Shape the future of the Zcash network by voting on active proposals."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your ZEC gives you a voice. Shape the future of the Zcash network by voting on active proposals."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your ZEC gives you a voice. Shape the future of the Zcash network by voting on active proposals."
           }
         }
       }
     },
-    "coinVote.howToVote.titleKeystone" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "How to vote with Keystone"
+    "coinVote.howToVote.titleKeystone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How to vote with Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "How to vote with Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How to vote with Keystone"
           }
         }
       }
     },
-    "coinVote.howToVote.titleZodl" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "How to vote with Zodl"
+    "coinVote.howToVote.titleZodl": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How to vote with Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "How to vote with Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How to vote with Zodl"
           }
         }
       }
     },
-    "coinVote.ineligible.balanceTooLowMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your shielded balance at the snapshot block was %@, which is below the 0.125 ZEC minimum required to vote."
+    "coinVote.ineligible.balanceTooLowMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your shielded balance at the snapshot block was %@, which is below the 0.125 ZEC minimum required to vote."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your shielded balance at the snapshot block was %@, which is below the 0.125 ZEC minimum required to vote."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your shielded balance at the snapshot block was %@, which is below the 0.125 ZEC minimum required to vote."
           }
         }
       }
     },
-    "coinVote.ineligible.detailBallots" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ballots"
+    "coinVote.ineligible.detailBallots": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ballots"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ballots"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ballots"
           }
         }
       }
     },
-    "coinVote.ineligible.detailMinimum" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minimum"
+    "coinVote.ineligible.detailMinimum": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimum"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minimum"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimum"
           }
         }
       }
     },
-    "coinVote.ineligible.detailMinimumValue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0.125 ZEC"
+    "coinVote.ineligible.detailMinimumValue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.125 ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0.125 ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.125 ZEC"
           }
         }
       }
     },
-    "coinVote.ineligible.detailNotesFound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notes found"
+    "coinVote.ineligible.detailNotesFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes found"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notes found"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes found"
           }
         }
       }
     },
-    "coinVote.ineligible.detailSnapshot" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapshot"
+    "coinVote.ineligible.detailSnapshot": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapshot"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapshot"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapshot"
           }
         }
       }
     },
-    "coinVote.ineligible.detailYourBalance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your balance"
+    "coinVote.ineligible.detailYourBalance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your balance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your balance"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your balance"
           }
         }
       }
     },
-    "coinVote.ineligible.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To participate in future voting rounds, ensure you have at least 0.125 ZEC in shielded funds before the snapshot block."
+    "coinVote.ineligible.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To participate in future voting rounds, ensure you have at least 0.125 ZEC in shielded funds before the snapshot block."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To participate in future voting rounds, ensure you have at least 0.125 ZEC in shielded funds before the snapshot block."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To participate in future voting rounds, ensure you have at least 0.125 ZEC in shielded funds before the snapshot block."
           }
         }
       }
     },
-    "coinVote.ineligible.noNotesMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet has no shielded notes from before the snapshot block. Only funds that existed at block #%@ are eligible for this voting round."
+    "coinVote.ineligible.noNotesMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet has no shielded notes from before the snapshot block. Only funds that existed at block #%@ are eligible for this voting round."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet has no shielded notes from before the snapshot block. Only funds that existed at block #%@ are eligible for this voting round."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet has no shielded notes from before the snapshot block. Only funds that existed at block #%@ are eligible for this voting round."
           }
         }
       }
     },
-    "coinVote.ineligible.snapshotBody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
+    "coinVote.ineligible.snapshotBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting power is derived from your shielded ZEC at the round's snapshot height. This wallet had no eligible notes at that moment."
           }
         }
       }
     },
-    "coinVote.ineligible.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Eligible for This Round"
+    "coinVote.ineligible.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Eligible for This Round"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Eligible for This Round"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Eligible for This Round"
           }
         }
       }
     },
-    "coinVote.ineligible.titleNoVote" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can't vote in this round"
+    "coinVote.ineligible.titleNoVote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can't vote in this round"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can't vote in this round"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can't vote in this round"
           }
         }
       }
     },
-    "coinVote.pollClosedSheet.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting period has ended.\nYour vote can no longer be submitted."
+    "coinVote.pollClosedSheet.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting period has ended.\nYour vote can no longer be submitted."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting period has ended.\nYour vote can no longer be submitted."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting period has ended.\nYour vote can no longer be submitted."
           }
         }
       }
     },
-    "coinVote.pollClosedSheet.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll Closed"
+    "coinVote.pollClosedSheet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll Closed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll Closed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll Closed"
           }
         }
       }
     },
-    "coinVote.pollClosedSheet.viewStatus" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View status"
+    "coinVote.pollClosedSheet.viewStatus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View status"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View status"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View status"
           }
         }
       }
     },
-    "coinVote.pollsList.approvedByZodl" : {
-      "comment" : "Accessibility label and badge text indicating that a poll is endorsed by Zodl.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Approved by Zodl"
+    "coinVote.pollsList.approvedByZodl": {
+      "comment": "Accessibility label and badge text indicating that a poll is endorsed by Zodl.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Approved by Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Approved by Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Approved by Zodl"
           }
         }
       }
     },
-    "coinVote.pollsList.chainConfigAccessibility" : {
-      "comment" : "Accessibility label for the voting chain config button on the polls list.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting chain config"
+    "coinVote.pollsList.chainConfigAccessibility": {
+      "comment": "Accessibility label for the voting chain config button on the polls list.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting chain config"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting chain config"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting chain config"
           }
         }
       }
     },
-    "coinVote.pollsList.dateClosed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Closed %@"
+    "coinVote.pollsList.dateClosed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closed %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Closed %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closed %@"
           }
         }
       }
     },
-    "coinVote.pollsList.dateCloses" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Closes %@"
+    "coinVote.pollsList.dateCloses": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closes %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Closes %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closes %@"
           }
         }
       }
     },
-    "coinVote.pollsList.emptyMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There aren’t any active polls at the moment.\nCheck back later."
+    "coinVote.pollsList.emptyMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There aren’t any active polls at the moment.\nCheck back later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There aren’t any active polls at the moment.\nCheck back later."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There aren’t any active polls at the moment.\nCheck back later."
           }
         }
       }
     },
-    "coinVote.pollsList.emptyTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No polls right now"
+    "coinVote.pollsList.emptyTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No polls right now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No polls right now"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No polls right now"
           }
         }
       }
     },
-    "coinVote.pollsList.enterPoll" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter Poll"
+    "coinVote.pollsList.enterPoll": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter Poll"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter Poll"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter Poll"
           }
         }
       }
     },
-    "coinVote.pollsList.insufficientBalanceMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
+    "coinVote.pollsList.insufficientBalanceMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet is not eligible for this voting round because it held %1$@ ZEC at snapshot block height #%2$@. A minimum balance of %3$@ ZEC was required to participate."
           }
         }
       }
     },
-    "coinVote.pollsList.insufficientBalanceTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insufficient Balance"
+    "coinVote.pollsList.insufficientBalanceTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insufficient Balance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insufficient Balance"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insufficient Balance"
           }
         }
       }
     },
-    "coinVote.pollsList.loadErrorMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check your connection and try again. If the problem persists, come back later."
+    "coinVote.pollsList.loadErrorMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your connection and try again. If the problem persists, come back later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check your connection and try again. If the problem persists, come back later."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your connection and try again. If the problem persists, come back later."
           }
         }
       }
     },
-    "coinVote.pollsList.loadErrorTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load polls"
+    "coinVote.pollsList.loadErrorTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load polls"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load polls"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load polls"
           }
         }
       }
     },
-    "coinVote.pollsList.review" : {
-      "comment" : "Poll card action label for a round the user has already voted in.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review"
+    "coinVote.pollsList.review": {
+      "comment": "Poll card action label for a round the user has already voted in.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review"
           }
         }
       }
     },
-    "coinVote.pollsList.statusActive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Active"
+    "coinVote.pollsList.statusActive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Active"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active"
           }
         }
       }
     },
-    "coinVote.pollsList.statusClosed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Closed"
+    "coinVote.pollsList.statusClosed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Closed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closed"
           }
         }
       }
     },
-    "coinVote.pollsList.unverifiedSheetMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
+    "coinVote.pollsList.unverifiedSheetMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This poll hasn't been verified.\nWe can't confirm its legitimacy or how results will be used."
           }
         }
       }
     },
-    "coinVote.pollsList.unverifiedSheetProceed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proceed anyway"
+    "coinVote.pollsList.unverifiedSheetProceed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proceed anyway"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proceed anyway"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proceed anyway"
           }
         }
       }
     },
-    "coinVote.pollsList.unverifiedSheetTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unverified Poll"
+    "coinVote.pollsList.unverifiedSheetTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unverified Poll"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unverified Poll"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unverified Poll"
           }
         }
       }
     },
-    "coinVote.pollsList.viewMyVotes" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View My Votes"
+    "coinVote.pollsList.viewMyVotes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View My Votes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View My Votes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View My Votes"
           }
         }
       }
     },
-    "coinVote.proposalDetail.notFound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proposal not found"
+    "coinVote.proposalDetail.notFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proposal not found"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proposal not found"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proposal not found"
           }
         }
       }
     },
-    "coinVote.proposalDetail.position" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ OF %@"
+    "coinVote.proposalDetail.position": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ OF %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ OF %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ OF %@"
           }
         }
       }
     },
-    "coinVote.proposalDetail.skippedMessageMultiple" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You have not responded to %@ questions. Confirm to skip these questions or go back to respond."
+    "coinVote.proposalDetail.skippedMessageMultiple": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have not responded to %@ questions. Confirm to skip these questions or go back to respond."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You have not responded to %@ questions. Confirm to skip these questions or go back to respond."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have not responded to %@ questions. Confirm to skip these questions or go back to respond."
           }
         }
       }
     },
-    "coinVote.proposalDetail.skippedMessageSingle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You have not responded to %@ question. Confirm to skip this question or go back to respond."
+    "coinVote.proposalDetail.skippedMessageSingle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have not responded to %@ question. Confirm to skip this question or go back to respond."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You have not responded to %@ question. Confirm to skip this question or go back to respond."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have not responded to %@ question. Confirm to skip this question or go back to respond."
           }
         }
       }
     },
-    "coinVote.proposalDetail.unansweredMessageMultiple" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You have not responded to %@ questions. Confirm to abstain from these questions or go back to respond."
+    "coinVote.proposalDetail.unansweredMessageMultiple": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have not responded to %@ questions. Confirm to abstain from these questions or go back to respond."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You have not responded to %@ questions. Confirm to abstain from these questions or go back to respond."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have not responded to %@ questions. Confirm to abstain from these questions or go back to respond."
           }
         }
       }
     },
-    "coinVote.proposalDetail.unansweredMessageSingle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You have not responded to %@ question. Confirm to abstain from this question or go back to respond."
+    "coinVote.proposalDetail.unansweredMessageSingle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have not responded to %@ question. Confirm to abstain from this question or go back to respond."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You have not responded to %@ question. Confirm to abstain from this question or go back to respond."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You have not responded to %@ question. Confirm to abstain from this question or go back to respond."
           }
         }
       }
     },
-    "coinVote.proposalDetail.unansweredTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unanswered Questions"
+    "coinVote.proposalDetail.unansweredTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unanswered Questions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unanswered Questions"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unanswered Questions"
           }
         }
       }
     },
-    "coinVote.proposalDetail.viewForumDiscussion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View Forum Discussion"
+    "coinVote.proposalDetail.viewForumDiscussion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Forum Discussion"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View Forum Discussion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Forum Discussion"
           }
         }
       }
     },
-    "coinVote.proposalList.ctaConfirmSubmit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm & Submit"
+    "coinVote.proposalList.ctaConfirmSubmit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm & Submit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm & Submit"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm & Submit"
           }
         }
       }
     },
-    "coinVote.proposalList.ctaContinueVoting" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue Voting"
+    "coinVote.proposalList.ctaContinueVoting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue Voting"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue Voting"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue Voting"
           }
         }
       }
     },
-    "coinVote.proposalList.ctaReviewAnswers" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review Answers"
+    "coinVote.proposalList.ctaReviewAnswers": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review Answers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review Answers"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review Answers"
           }
         }
       }
     },
-    "coinVote.proposalList.ctaStartVoting" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start Voting"
+    "coinVote.proposalList.ctaStartVoting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Voting"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start Voting"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Voting"
           }
         }
       }
     },
-    "coinVote.proposalList.headerEndsAt" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ends %@"
+    "coinVote.proposalList.headerEndsAt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ends %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ends %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ends %@"
           }
         }
       }
     },
-    "coinVote.proposalList.noActiveRoundMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There are no voting rounds in progress. Rounds are created by governance administrators — check back later."
+    "coinVote.proposalList.noActiveRoundMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There are no voting rounds in progress. Rounds are created by governance administrators — check back later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There are no voting rounds in progress. Rounds are created by governance administrators — check back later."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There are no voting rounds in progress. Rounds are created by governance administrators — check back later."
           }
         }
       }
     },
-    "coinVote.proposalList.noActiveRoundTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Active Voting Round"
+    "coinVote.proposalList.noActiveRoundTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Active Voting Round"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Active Voting Round"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Active Voting Round"
           }
         }
       }
     },
-    "coinVote.proposalList.preparingVotingPower" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing your voting power…"
+    "coinVote.proposalList.preparingVotingPower": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing your voting power…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing your voting power…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing your voting power…"
           }
         }
       }
     },
-    "coinVote.proposalList.reviewSubtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap on the question to edit any of your answers. After you review your answers, tap on Confirm & Submit."
+    "coinVote.proposalList.reviewSubtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap on the question to edit any of your answers. After you review your answers, tap on Confirm & Submit."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap on the question to edit any of your answers. After you review your answers, tap on Confirm & Submit."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap on the question to edit any of your answers. After you review your answers, tap on Confirm & Submit."
           }
         }
       }
     },
-    "coinVote.proposalList.reviewTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review and submit vote"
+    "coinVote.proposalList.reviewTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review and submit vote"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review and submit vote"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review and submit vote"
           }
         }
       }
     },
-    "coinVote.proposalList.submitVotesCount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submit votes (%@)"
+    "coinVote.proposalList.submitVotesCount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submit votes (%@)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submit votes (%@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submit votes (%@)"
           }
         }
       }
     },
-    "coinVote.proposalList.viewForumDiscussions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View Forum Discussions"
+    "coinVote.proposalList.viewForumDiscussions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Forum Discussions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View Forum Discussions"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Forum Discussions"
           }
         }
       }
     },
-    "coinVote.proposalList.viewMore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View more"
+    "coinVote.proposalList.viewMore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View more"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View more"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View more"
           }
         }
       }
     },
-    "coinVote.proposalList.votingPower" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting power: %@"
+    "coinVote.proposalList.votingPower": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting power: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting power: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting power: %@"
           }
         }
       }
     },
-    "coinVote.proposalList.yourVote" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your vote:"
+    "coinVote.proposalList.yourVote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your vote:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your vote:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your vote:"
           }
         }
       }
     },
-    "coinVote.results.approvedByZodl" : {
-      "comment" : "Accessibility label for the Zodl badge on the results header indicating an approved poll.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Approved by Zodl"
+    "coinVote.results.approvedByZodl": {
+      "comment": "Accessibility label for the Zodl badge on the results header indicating an approved poll.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Approved by Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Approved by Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Approved by Zodl"
           }
         }
       }
     },
-    "coinVote.results.loadErrorMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check your connection and try again. If the problem persists, come back later."
+    "coinVote.results.loadErrorMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your connection and try again. If the problem persists, come back later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check your connection and try again. If the problem persists, come back later."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your connection and try again. If the problem persists, come back later."
           }
         }
       }
     },
-    "coinVote.results.loadErrorTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load results"
+    "coinVote.results.loadErrorTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load results"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load results"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load results"
           }
         }
       }
     },
-    "coinVote.results.loading" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading results..."
+    "coinVote.results.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading results..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading results..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading results..."
           }
         }
       }
     },
-    "coinVote.results.metaLine" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voted %@  ·  Voting Power %@ ZEC"
+    "coinVote.results.metaLine": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voted %@  ·  Voting Power %@ ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voted %@  ·  Voting Power %@ ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voted %@  ·  Voting Power %@ ZEC"
           }
         }
       }
     },
-    "coinVote.results.noProposalsInRound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No proposals in this round"
+    "coinVote.results.noProposalsInRound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No proposals in this round"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No proposals in this round"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No proposals in this round"
           }
         }
       }
     },
-    "coinVote.results.noVotesRecorded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No votes recorded"
+    "coinVote.results.noVotesRecorded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No votes recorded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No votes recorded"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No votes recorded"
           }
         }
       }
     },
-    "coinVote.results.option" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Option %@"
+    "coinVote.results.option": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Option %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Option %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Option %@"
           }
         }
       }
     },
-    "coinVote.results.percentValue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%%"
+    "coinVote.results.percentValue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%%"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%%"
           }
         }
       }
     },
-    "coinVote.results.tie" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tie"
+    "coinVote.results.tie": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tie"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tie"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tie"
           }
         }
       }
     },
-    "coinVote.results.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Results"
+    "coinVote.results.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Results"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Results"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Results"
           }
         }
       }
     },
-    "coinVote.results.total" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total: %@"
+    "coinVote.results.total": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total: %@"
           }
         }
       }
     },
-    "coinVote.results.votedLine" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voted: %@"
+    "coinVote.results.votedLine": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voted: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voted: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voted: %@"
           }
         }
       }
     },
-    "coinVote.results.winnerLabel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winner:"
+    "coinVote.results.winnerLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winner:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winner:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winner:"
           }
         }
       }
     },
-    "coinVote.store.error.delegationTxFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "delegation TX failed on-chain (code %@) or missing delegate_vote event%@"
+    "coinVote.store.error.delegationTxFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "delegation TX failed on-chain (code %@) or missing delegate_vote event%@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "delegation TX failed on-chain (code %@) or missing delegate_vote event%@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "delegation TX failed on-chain (code %@) or missing delegate_vote event%@"
           }
         }
       }
     },
-    "coinVote.store.error.invalidDelegationSignature" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone delegation signature tuple (rk, sighash, sig) is inconsistent with the payload being submitted."
+    "coinVote.store.error.invalidDelegationSignature": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone delegation signature tuple (rk, sighash, sig) is inconsistent with the payload being submitted."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone delegation signature tuple (rk, sighash, sig) is inconsistent with the payload being submitted."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone delegation signature tuple (rk, sighash, sig) is inconsistent with the payload being submitted."
           }
         }
       }
     },
-    "coinVote.store.error.missingActiveSession" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "missing active voting session"
+    "coinVote.store.error.missingActiveSession": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "missing active voting session"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "missing active voting session"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "missing active voting session"
           }
         }
       }
     },
-    "coinVote.store.error.missingHotkeyAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "missing hotkey address for delegation PCZT"
+    "coinVote.store.error.missingHotkeyAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "missing hotkey address for delegation PCZT"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "missing hotkey address for delegation PCZT"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "missing hotkey address for delegation PCZT"
           }
         }
       }
     },
-    "coinVote.store.error.missingKeystoneBundleSignature" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Missing Keystone signature for one or more delegation bundles."
+    "coinVote.store.error.missingKeystoneBundleSignature": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing Keystone signature for one or more delegation bundles."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Missing Keystone signature for one or more delegation bundles."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing Keystone signature for one or more delegation bundles."
           }
         }
       }
     },
-    "coinVote.store.error.missingPendingUnsignedPczt" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "missing pending unsigned delegation PCZT"
+    "coinVote.store.error.missingPendingUnsignedPczt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "missing pending unsigned delegation PCZT"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "missing pending unsigned delegation PCZT"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "missing pending unsigned delegation PCZT"
           }
         }
       }
     },
-    "coinVote.store.error.missingSigningAccount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "missing signing account for delegation PCZT"
+    "coinVote.store.error.missingSigningAccount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "missing signing account for delegation PCZT"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "missing signing account for delegation PCZT"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "missing signing account for delegation PCZT"
           }
         }
       }
     },
-    "coinVote.store.error.missingVoteCommitmentBundle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vote commitment build completed without a commitment bundle"
+    "coinVote.store.error.missingVoteCommitmentBundle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vote commitment build completed without a commitment bundle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vote commitment build completed without a commitment bundle"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vote commitment build completed without a commitment bundle"
           }
         }
       }
     },
-    "coinVote.store.error.voteCommitmentTxFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vote commitment TX failed on-chain (code %@)%@"
+    "coinVote.store.error.voteCommitmentTxFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vote commitment TX failed on-chain (code %@)%@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vote commitment TX failed on-chain (code %@)%@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vote commitment TX failed on-chain (code %@)%@"
           }
         }
       }
     },
-    "coinVote.store.roundTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Round %@"
+    "coinVote.store.roundTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Round %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Round %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Round %@"
           }
         }
       }
     },
-    "coinVote.store.submissionAuthorizingVote" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorizing vote..."
+    "coinVote.store.submissionAuthorizingVote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorizing vote..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorizing vote..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorizing vote..."
           }
         }
       }
     },
-    "coinVote.store.submissionAuthorizingVoteProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorizing vote... %@%%"
+    "coinVote.store.submissionAuthorizingVoteProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorizing vote... %@%%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorizing vote... %@%%"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorizing vote... %@%%"
           }
         }
       }
     },
-    "coinVote.store.submissionPreparingProof" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Building vote proof..."
+    "coinVote.store.submissionPreparingProof": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building vote proof..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Building vote proof..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building vote proof..."
           }
         }
       }
     },
-    "coinVote.store.submissionPreparingProofProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Building vote proof (%@/%@)..."
+    "coinVote.store.submissionPreparingProofProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building vote proof (%@/%@)..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Building vote proof (%@/%@)..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building vote proof (%@/%@)..."
           }
         }
       }
     },
-    "coinVote.store.submissionSendingShares" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending to vote servers..."
+    "coinVote.store.submissionSendingShares": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending to vote servers..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending to vote servers..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending to vote servers..."
           }
         }
       }
     },
-    "coinVote.store.submissionSendingSharesProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending to vote servers (%@/%@)..."
+    "coinVote.store.submissionSendingSharesProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending to vote servers (%@/%@)..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending to vote servers (%@/%@)..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending to vote servers (%@/%@)..."
           }
         }
       }
     },
-    "coinVote.store.submissionWaitingForConfirmation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for confirmation..."
+    "coinVote.store.submissionWaitingForConfirmation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for confirmation..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for confirmation..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for confirmation..."
           }
         }
       }
     },
-    "coinVote.store.submissionWaitingForConfirmationProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for confirmation (%@/%@)..."
+    "coinVote.store.submissionWaitingForConfirmationProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for confirmation (%@/%@)..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for confirmation (%@/%@)..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for confirmation (%@/%@)..."
           }
         }
       }
     },
-    "coinVote.store.userError.commitmentTreeNotGrown" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your transaction hasn't been confirmed yet. The network may be congested — please wait a moment and try again."
+    "coinVote.store.userError.commitmentTreeNotGrown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your transaction hasn't been confirmed yet. The network may be congested — please wait a moment and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your transaction hasn't been confirmed yet. The network may be congested — please wait a moment and try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your transaction hasn't been confirmed yet. The network may be congested — please wait a moment and try again."
           }
         }
       }
     },
-    "coinVote.store.userError.http5" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting server is temporarily unavailable. Please try again shortly."
+    "coinVote.store.userError.http5": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting server is temporarily unavailable. Please try again shortly."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting server is temporarily unavailable. Please try again shortly."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting server is temporarily unavailable. Please try again shortly."
           }
         }
       }
     },
-    "coinVote.store.userError.invalidAnchorHeight" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting state is out of sync. Please retry to use the latest data."
+    "coinVote.store.userError.invalidAnchorHeight": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting state is out of sync. Please retry to use the latest data."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting state is out of sync. Please retry to use the latest data."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting state is out of sync. Please retry to use the latest data."
           }
         }
       }
     },
-    "coinVote.store.userError.invalidProof" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your proof was rejected by the network. Please try again."
+    "coinVote.store.userError.invalidProof": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your proof was rejected by the network. Please try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your proof was rejected by the network. Please try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your proof was rejected by the network. Please try again."
           }
         }
       }
     },
-    "coinVote.store.userError.lightwalletdUnavailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to reach the Zcash lightwalletd server. Please check your internet connection or try switching to a different server in Settings."
+    "coinVote.store.userError.lightwalletdUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to reach the Zcash lightwalletd server. Please check your internet connection or try switching to a different server in Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to reach the Zcash lightwalletd server. Please check your internet connection or try switching to a different server in Settings."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to reach the Zcash lightwalletd server. Please check your internet connection or try switching to a different server in Settings."
           }
         }
       }
     },
-    "coinVote.store.userError.noReachableVoteServers" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to reach any vote server. Please check your internet connection and try again."
+    "coinVote.store.userError.noReachableVoteServers": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to reach any vote server. Please check your internet connection and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to reach any vote server. Please check your internet connection and try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to reach any vote server. Please check your internet connection and try again."
           }
         }
       }
     },
-    "coinVote.store.userError.noTreeState" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting commitment tree is not available yet. The voting round may not have started or the chain has not processed any commitments."
+    "coinVote.store.userError.noTreeState": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting commitment tree is not available yet. The voting round may not have started or the chain has not processed any commitments."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting commitment tree is not available yet. The voting round may not have started or the chain has not processed any commitments."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting commitment tree is not available yet. The voting round may not have started or the chain has not processed any commitments."
           }
         }
       }
     },
-    "coinVote.store.userError.nullifierAlreadySpent" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This wallet has already been registered for this voting round. If you have this wallet on multiple devices, please use the device where you originally started the voting process."
+    "coinVote.store.userError.nullifierAlreadySpent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This wallet has already been registered for this voting round. If you have this wallet on multiple devices, please use the device where you originally started the voting process."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This wallet has already been registered for this voting round. If you have this wallet on multiple devices, please use the device where you originally started the voting process."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This wallet has already been registered for this voting round. If you have this wallet on multiple devices, please use the device where you originally started the voting process."
           }
         }
       }
     },
-    "coinVote.store.userError.pirEndpointsMissing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting configuration is missing nullifier-service endpoints. Please update the app and try again."
+    "coinVote.store.userError.pirEndpointsMissing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting configuration is missing nullifier-service endpoints. Please update the app and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting configuration is missing nullifier-service endpoints. Please update the app and try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting configuration is missing nullifier-service endpoints. Please update the app and try again."
           }
         }
       }
     },
-    "coinVote.store.userError.pirInvalidProofData" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The nullifier service returned invalid proof data. Please try again in a few minutes."
+    "coinVote.store.userError.pirInvalidProofData": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The nullifier service returned invalid proof data. Please try again in a few minutes."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The nullifier service returned invalid proof data. Please try again in a few minutes."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The nullifier service returned invalid proof data. Please try again in a few minutes."
           }
         }
       }
     },
-    "coinVote.store.userError.pirSnapshotMismatch" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The nullifier service is out of sync with the round's snapshot. Voting cannot proceed until a PIR server reports the matching snapshot. Please try again in a few minutes."
+    "coinVote.store.userError.pirSnapshotMismatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The nullifier service is out of sync with the round's snapshot. Voting cannot proceed until a PIR server reports the matching snapshot. Please try again in a few minutes."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The nullifier service is out of sync with the round's snapshot. Voting cannot proceed until a PIR server reports the matching snapshot. Please try again in a few minutes."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The nullifier service is out of sync with the round's snapshot. Voting cannot proceed until a PIR server reports the matching snapshot. Please try again in a few minutes."
           }
         }
       }
     },
-    "coinVote.store.userError.pirUnavailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to reach the nullifier service. Please check your internet connection and try again."
+    "coinVote.store.userError.pirUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to reach the nullifier service. Please check your internet connection and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to reach the nullifier service. Please check your internet connection and try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to reach the nullifier service. Please check your internet connection and try again."
           }
         }
       }
     },
-    "coinVote.store.userError.proofGenerationFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proof generation failed. Please try again."
+    "coinVote.store.userError.proofGenerationFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proof generation failed. Please try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proof generation failed. Please try again."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proof generation failed. Please try again."
           }
         }
       }
     },
-    "coinVote.store.userError.roundNotActive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This voting round is no longer accepting votes. It may have ended or is not yet open."
+    "coinVote.store.userError.roundNotActive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This voting round is no longer accepting votes. It may have ended or is not yet open."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This voting round is no longer accepting votes. It may have ended or is not yet open."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This voting round is no longer accepting votes. It may have ended or is not yet open."
           }
         }
       }
     },
-    "coinVote.store.userError.roundNotFound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This voting round could not be found on the network."
+    "coinVote.store.userError.roundNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This voting round could not be found on the network."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This voting round could not be found on the network."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This voting round could not be found on the network."
           }
         }
       }
     },
-    "coinVote.submission.continuedProcessingMessageMultiple" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending %@ votes to the network"
+    "coinVote.submission.continuedProcessingMessageMultiple": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending %@ votes to the network"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending %@ votes to the network"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending %@ votes to the network"
           }
         }
       }
     },
-    "coinVote.submission.continuedProcessingMessageSingle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending %@ vote to the network"
+    "coinVote.submission.continuedProcessingMessageSingle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending %@ vote to the network"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending %@ vote to the network"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending %@ vote to the network"
           }
         }
       }
     },
-    "coinVote.submission.continuedProcessingTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting votes"
+    "coinVote.submission.continuedProcessingTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting votes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submitting votes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting votes"
           }
         }
       }
     },
-    "coinVote.submission.genericBatchFailure" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Some votes could not be submitted."
+    "coinVote.submission.genericBatchFailure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some votes could not be submitted."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Some votes could not be submitted."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some votes could not be submitted."
           }
         }
       }
     },
-    "coinVote.tallying.bodyInProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting has closed. Final results will appear here once the helpers finish tallying."
+    "coinVote.tallying.bodyInProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting has closed. Final results will appear here once the helpers finish tallying."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voting has closed. Final results will appear here once the helpers finish tallying."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voting has closed. Final results will appear here once the helpers finish tallying."
           }
         }
       }
     },
-    "coinVote.tallying.detailEnded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ended"
+    "coinVote.tallying.detailEnded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ended"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ended"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ended"
           }
         }
       }
     },
-    "coinVote.tallying.detailProposals" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proposals"
+    "coinVote.tallying.detailProposals": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proposals"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proposals"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proposals"
           }
         }
       }
     },
-    "coinVote.tallying.detailRound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Round"
+    "coinVote.tallying.detailRound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Round"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Round"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Round"
           }
         }
       }
     },
-    "coinVote.tallying.status" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tallying"
+    "coinVote.tallying.status": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tallying"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tallying"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tallying"
           }
         }
       }
     },
-    "coinVote.tallying.subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Results are being tallied. The election authority is decrypting the aggregate vote totals."
+    "coinVote.tallying.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Results are being tallied. The election authority is decrypting the aggregate vote totals."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Results are being tallied. The election authority is decrypting the aggregate vote totals."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Results are being tallied. The election authority is decrypting the aggregate vote totals."
           }
         }
       }
     },
-    "coinVote.tallying.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Votes Closed"
+    "coinVote.tallying.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Votes Closed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Votes Closed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Votes Closed"
           }
         }
       }
     },
-    "coinVote.tallying.titleInProgress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tallying in progress"
+    "coinVote.tallying.titleInProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tallying in progress"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tallying in progress"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tallying in progress"
           }
         }
       }
     },
-    "coinVote.votingView.noRoundsMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There are no voting rounds available right now."
+    "coinVote.votingView.noRoundsMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There are no voting rounds available right now."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There are no voting rounds available right now."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There are no voting rounds available right now."
           }
         }
       }
     },
-    "coinVote.votingView.noRoundsTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Voting Rounds"
+    "coinVote.votingView.noRoundsTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Voting Rounds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Voting Rounds"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Voting Rounds"
           }
         }
       }
     },
-    "coinVote.votingView.pollClosedMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting period has ended.\nYour vote can no longer be submitted."
+    "coinVote.votingView.pollClosedMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting period has ended.\nYour vote can no longer be submitted."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The voting period has ended.\nYour vote can no longer be submitted."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The voting period has ended.\nYour vote can no longer be submitted."
           }
         }
       }
     },
-    "coinVote.votingView.pollClosedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll Closed"
+    "coinVote.votingView.pollClosedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll Closed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poll Closed"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poll Closed"
           }
         }
       }
     },
-    "coinVote.votingView.unverifiedPollMessage" : {
-      "comment" : "Body shown when the user is about to open a poll that is not Zodl-endorsed.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This poll hasn't been verified. We can't confirm its legitimacy or how results will be used."
+    "coinVote.votingView.unverifiedPollMessage": {
+      "comment": "Body shown when the user is about to open a poll that is not Zodl-endorsed.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This poll hasn't been verified. We can't confirm its legitimacy or how results will be used."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This poll hasn't been verified. We can't confirm its legitimacy or how results will be used."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This poll hasn't been verified. We can't confirm its legitimacy or how results will be used."
           }
         }
       }
     },
-    "coinVote.votingView.unverifiedPollProceedAnyway" : {
-      "comment" : "Action label on the unverified-poll sheet that opens the poll despite the warning.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proceed anyway"
+    "coinVote.votingView.unverifiedPollProceedAnyway": {
+      "comment": "Action label on the unverified-poll sheet that opens the poll despite the warning.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proceed anyway"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proceed anyway"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proceed anyway"
           }
         }
       }
     },
-    "coinVote.votingView.unverifiedPollTitle" : {
-      "comment" : "Title of the sheet shown when the user is about to open a poll that is not Zodl-endorsed.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unverified Poll"
+    "coinVote.votingView.unverifiedPollTitle": {
+      "comment": "Title of the sheet shown when the user is about to open a poll that is not Zodl-endorsed.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unverified Poll"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unverified Poll"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unverified Poll"
           }
         }
       }
     },
-    "coinVote.walletSyncing.catchingUp" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Catching up to round snapshot"
+    "coinVote.walletSyncing.catchingUp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catching up to round snapshot"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Catching up to round snapshot"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catching up to round snapshot"
           }
         }
       }
     },
-    "coinVote.walletSyncing.detailBlocksRemaining" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blocks remaining"
+    "coinVote.walletSyncing.detailBlocksRemaining": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocks remaining"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blocks remaining"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocks remaining"
           }
         }
       }
     },
-    "coinVote.walletSyncing.detailSnapshotBlock" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapshot block"
+    "coinVote.walletSyncing.detailSnapshotBlock": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapshot block"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapshot block"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapshot block"
           }
         }
       }
     },
-    "coinVote.walletSyncing.detailSyncedTo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet synced to"
+    "coinVote.walletSyncing.detailSyncedTo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet synced to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet synced to"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet synced to"
           }
         }
       }
     },
-    "coinVote.walletSyncing.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please wait for your wallet to finish syncing, then come back to vote."
+    "coinVote.walletSyncing.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please wait for your wallet to finish syncing, then come back to vote."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please wait for your wallet to finish syncing, then come back to vote."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please wait for your wallet to finish syncing, then come back to vote."
           }
         }
       }
     },
-    "coinVote.walletSyncing.subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet needs to sync to the snapshot block height before you can participate in voting."
+    "coinVote.walletSyncing.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet needs to sync to the snapshot block height before you can participate in voting."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet needs to sync to the snapshot block height before you can participate in voting."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet needs to sync to the snapshot block height before you can participate in voting."
           }
         }
       }
     },
-    "coinVote.walletSyncing.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Syncing"
+    "coinVote.walletSyncing.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Syncing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Syncing"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Syncing"
           }
         }
       }
     },
-    "component.lowPrivacy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Private"
+    "component.lowPrivacy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Private"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Público"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Público"
           }
         }
       }
     },
-    "component.maxPrivacy" : {
-      "comment" : "MARK: - UI Components",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Private"
+    "component.maxPrivacy": {
+      "comment": "MARK: - UI Components",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privado"
           }
         }
       }
     },
-    "connectedHWInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you disconnect now, your Keystone will no longer be paired with your Zodl wallet."
+    "connectedHWInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you disconnect now, your Keystone will no longer be paired with your Zodl wallet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si desconectas ahora, tu Keystone dejará de estar vinculado con tu billetera Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si desconectas ahora, tu Keystone dejará de estar vinculado con tu billetera Zodl."
           }
         }
       }
     },
-    "crosspay.help.desc1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Make cross-chain payments in any NEAR-supported coin or token."
+    "crosspay.help.desc1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Make cross-chain payments in any NEAR-supported coin or token."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haz pagos entre cadenas en cualquier moneda o token compatible con NEAR."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haz pagos entre cadenas en cualquier moneda o token compatible con NEAR."
           }
         }
       }
     },
-    "crosspay.help.desc2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If the actual slippage and network conditions result in your recipient receiving less than the promised amount, your transaction will be reversed. You will receive a full refund minus network fees."
+    "crosspay.help.desc2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If the actual slippage and network conditions result in your recipient receiving less than the promised amount, your transaction will be reversed. You will receive a full refund minus network fees."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si el deslizamiento real y las condiciones de la red resultan en que tu destinatario reciba menos de la cantidad prometida, tu transacción será revertida. Recibirás un reembolso completo menos las comisiones de red."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si el deslizamiento real y las condiciones de la red resultan en que tu destinatario reciba menos de la cantidad prometida, tu transacción será revertida. Recibirás un reembolso completo menos las comisiones de red."
           }
         }
       }
     },
-    "crosspay.help.payWith" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CrossPay with"
+    "crosspay.help.payWith": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CrossPay with"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CrossPay con"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CrossPay con"
           }
         }
       }
     },
-    "crosspay.pay" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay"
+    "crosspay.pay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagar"
           }
         }
       }
     },
-    "crosspay.slippageSet1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You may pay up to "
+    "crosspay.slippageSet1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You may pay up to "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podrías pagar hasta "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podrías pagar hasta "
           }
         }
       }
     },
-    "crosspay.slippageSet2a" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@% (%@)"
+    "crosspay.slippageSet2a": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@% (%@)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@% (%@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@% (%@)"
           }
         }
       }
     },
-    "crosspay.slippageSet2b" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%"
+    "crosspay.slippageSet2b": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%"
           }
         }
       }
     },
-    "crosspay.slippageSet3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " more, in addition to transaction fees."
+    "crosspay.slippageSet3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " more, in addition to transaction fees."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " más, además de las comisiones de transacción."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " más, además de las comisiones de transacción."
           }
         }
       }
     },
-    "crosspay.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CrossPay"
+    "crosspay.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CrossPay"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CrossPay"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CrossPay"
           }
         }
       }
     },
-    "crosspay.total" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total"
+    "crosspay.total": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total"
           }
         }
       }
     },
-    "currencyConversion.currencyLabel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currency"
+    "currencyConversion.currencyLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currency"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moneda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moneda"
           }
         }
       }
     },
-    "currencyConversion.enable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable"
+    "currencyConversion.enable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Habilitar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Habilitar"
           }
         }
       }
     },
-    "currencyConversion.ipDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl's currency conversion feature doesn't compromise your IP address."
+    "currencyConversion.ipDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl's currency conversion feature doesn't compromise your IP address."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La función de conversión de moneda de Zodl no compromete tu dirección IP."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La función de conversión de moneda de Zodl no compromete tu dirección IP."
           }
         }
       }
     },
-    "currencyConversion.ipTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IP Address Protection"
+    "currencyConversion.ipTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IP Address Protection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protección de Dirección IP"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protección de Dirección IP"
           }
         }
       }
     },
-    "currencyConversion.learnMoreDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Display your balance and payment amounts in selected currency. For Swap and Pay, exchange rates will continue to be shown in USD. You can manage this feature in Advanced Settings."
+    "currencyConversion.learnMoreDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display your balance and payment amounts in selected currency. For Swap and Pay, exchange rates will continue to be shown in USD. You can manage this feature in Advanced Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra tu saldo y montos de pago en tu moneda seleccionada. Para Swap y Pay, los tipos de cambio se seguirán mostrando en USD. Puedes administrar esta función en Configuración avanzada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra tu saldo y montos de pago en tu moneda seleccionada. Para Swap y Pay, los tipos de cambio se seguirán mostrando en USD. Puedes administrar esta función en Configuración avanzada."
           }
         }
       }
     },
-    "currencyConversion.learnMoreOptionDisable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable"
+    "currencyConversion.learnMoreOptionDisable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deshabilitar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deshabilitar"
           }
         }
       }
     },
-    "currencyConversion.learnMoreOptionDisableDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Don't show currency conversion."
+    "currencyConversion.learnMoreOptionDisableDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don't show currency conversion."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No mostrar la conversión de moneda."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No mostrar la conversión de moneda."
           }
         }
       }
     },
-    "currencyConversion.learnMoreOptionEnableDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show currency conversion."
+    "currencyConversion.learnMoreOptionEnableDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show currency conversion."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar la conversión de moneda."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar la conversión de moneda."
           }
         }
       }
     },
-    "currencyConversion.note" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note for the super privacy-conscious: Because we pull the conversion rate from exchanges, an exchange might be able to see that the exchange rate was queried before a transaction occurred."
+    "currencyConversion.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the super privacy-conscious: Because we pull the conversion rate from exchanges, an exchange might be able to see that the exchange rate was queried before a transaction occurred."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nota para los más conscientes de la privacidad: Debido a que obtenemos la tasa de conversión de los intercambios, un intercambio podría ver que la tasa de cambio fue consultada antes de que ocurriera una transacción."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota para los más conscientes de la privacidad: Debido a que obtenemos la tasa de conversión de los intercambios, un intercambio podría ver que la tasa de cambio fue consultada antes de que ocurriera una transacción."
           }
         }
       }
     },
-    "currencyConversion.refresh" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rate Refresh"
+    "currencyConversion.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rate Refresh"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizar tasa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar tasa"
           }
         }
       }
     },
-    "currencyConversion.refreshDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The rate is refreshed automatically and can also be refreshed manually."
+    "currencyConversion.refreshDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The rate is refreshed automatically and can also be refreshed manually."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La tasa se actualiza automáticamente y también se puede actualizar manualmente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La tasa se actualiza automáticamente y también se puede actualizar manualmente."
           }
         }
       }
     },
-    "currencyConversion.saveBtn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save changes"
+    "currencyConversion.saveBtn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save changes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar cambios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar cambios"
           }
         }
       }
     },
-    "currencyConversion.selectCurrencyTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select currency"
+    "currencyConversion.selectCurrencyTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select currency"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar moneda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar moneda"
           }
         }
       }
     },
-    "currencyConversion.settingsDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Display your balance and payment amounts in your selected currency. For Swap and Pay, exchange rates will continue to be shown in USD."
+    "currencyConversion.settingsDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display your balance and payment amounts in your selected currency. For Swap and Pay, exchange rates will continue to be shown in USD."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra tu saldo y montos de pago en tu moneda seleccionada. Para Swap y Pay, los tipos de cambio se seguirán mostrando en USD."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra tu saldo y montos de pago en tu moneda seleccionada. Para Swap y Pay, los tipos de cambio se seguirán mostrando en USD."
           }
         }
       }
     },
-    "currencyConversion.skipBtn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip for now"
+    "currencyConversion.skipBtn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip for now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omitir por ahora"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir por ahora"
           }
         }
       }
     },
-    "currencyConversion.title" : {
-      "comment" : "MARK: Currency Conversion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currency Conversion"
+    "currencyConversion.title": {
+      "comment": "MARK: Currency Conversion",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currency Conversion"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conversión de Moneda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conversión de Moneda"
           }
         }
       }
     },
-    "currencyConversion.torOffInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you would like to protect your IP address, enable Tor Protection in Advanced Settings."
+    "currencyConversion.torOffInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you would like to protect your IP address, enable Tor Protection in Advanced Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si deseas proteger tu dirección IP, activa la Protección Tor en la Configuración Avanzada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si deseas proteger tu dirección IP, activa la Protección Tor en la Configuración Avanzada."
           }
         }
       }
     },
-    "currencyConversion.torOnInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disabling Tor Protection will also disable the Currency Conversion feature until re-enabled."
+    "currencyConversion.torOnInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disabling Tor Protection will also disable the Currency Conversion feature until re-enabled."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar la Protección Tor también desactivará la función de Conversión de Moneda hasta que se vuelva a activar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar la Protección Tor también desactivará la función de Conversión de Moneda hasta que se vuelva a activar."
           }
         }
       }
     },
-    "currentlyConnected" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currently connected"
+    "currentlyConnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currently connected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectado actualmente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado actualmente"
           }
         }
       }
     },
-    "deeplinkWarning.cta" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rescan in Zodl"
+    "deeplinkWarning.cta": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rescan in Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reescanear en Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reescanear en Zodl"
           }
         }
       }
     },
-    "deeplinkWarning.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For better safety and security, rescan the QR code with Zodl."
+    "deeplinkWarning.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For better safety and security, rescan the QR code with Zodl."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para mayor seguridad y protección, vuelve a escanear el código QR con Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para mayor seguridad y protección, vuelve a escanear el código QR con Zodl."
           }
         }
       }
     },
-    "deeplinkWarning.screenTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hello!"
+    "deeplinkWarning.screenTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hello!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Hola!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Hola!"
           }
         }
       }
     },
-    "deeplinkWarning.title" : {
-      "comment" : "MARK: - Deeplink Warning",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Looks like you used a third-party app to scan for payment."
+    "deeplinkWarning.title": {
+      "comment": "MARK: - Deeplink Warning",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Looks like you used a third-party app to scan for payment."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parece que utilizaste una aplicación de terceros para escanear un pago."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parece que utilizaste una aplicación de terceros para escanear un pago."
           }
         }
       }
     },
-    "deleteKeystoneDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnecting your hardware wallet will permanently delete some local data that can’t be recovered from the blockchain."
+    "deleteKeystoneDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnecting your hardware wallet will permanently delete some local data that can’t be recovered from the blockchain."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectar tu hardware wallet eliminará permanentemente algunos datos locales que no pueden recuperarse de la blockchain."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar tu hardware wallet eliminará permanentemente algunos datos locales que no pueden recuperarse de la blockchain."
           }
         }
       }
     },
-    "deleteKeystoneTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect Keystone"
+    "deleteKeystoneTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectar Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar Keystone"
           }
         }
       }
     },
-    "deleteWallet.actionButtonTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Zodl"
+    "deleteWallet.actionButtonTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer Zodl"
           }
         }
       }
     },
-    "deleteWallet.message2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Make sure you have both your secret recovery phrase and wallet birthday height saved before you proceed."
+    "deleteWallet.message2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Make sure you have both your secret recovery phrase and wallet birthday height saved before you proceed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asegúrate de haber guardado tanto tu frase de recuperación secreta como la altura de cumpleaños de la billetera antes de continuar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asegúrate de haber guardado tanto tu frase de recuperación secreta como la altura de cumpleaños de la billetera antes de continuar."
           }
         }
       }
     },
-    "deleteWallet.message3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resetting the Zodl app will delete the app database and cached app data, and disconnect all connected hardware wallets."
+    "deleteWallet.message3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetting the Zodl app will delete the app database and cached app data, and disconnect all connected hardware wallets."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer la aplicación Zodl eliminará la base de datos y los datos en caché de la aplicación, además de desconectar todas las billeteras de hardware conectadas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer la aplicación Zodl eliminará la base de datos y los datos en caché de la aplicación, además de desconectar todas las billeteras de hardware conectadas."
           }
         }
       }
     },
-    "deleteWallet.message4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Once you Reset Zodl, the only way to access your funds is through a wallet restore process that requires your Zodl Recovery Phrase and Wallet Birthday Height."
+    "deleteWallet.message4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Once you Reset Zodl, the only way to access your funds is through a wallet restore process that requires your Zodl Recovery Phrase and Wallet Birthday Height."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Una vez que restablezcas Zodl, la única forma de acceder a tus fondos será mediante un proceso de restauración de billetera que requiere tu Frase de Recuperación de Zodl y la Altura de Cumpleaños de la Billetera."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una vez que restablezcas Zodl, la única forma de acceder a tus fondos será mediante un proceso de restauración de billetera que requiere tu Frase de Recuperación de Zodl y la Altura de Cumpleaños de la Billetera."
           }
         }
       }
     },
-    "deleteWallet.metadataWarn1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep encrypted metadata backup - which includes contacts, notes, bookmarks, and swap/payment details."
+    "deleteWallet.metadataWarn1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep encrypted metadata backup - which includes contacts, notes, bookmarks, and swap/payment details."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conserva la copia de seguridad cifrada de los metadatos, que incluye contactos, notas, marcadores y detalles de intercambios/pagos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conserva la copia de seguridad cifrada de los metadatos, que incluye contactos, notas, marcadores y detalles de intercambios/pagos."
           }
         }
       }
     },
-    "deleteWallet.metadataWarn2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This data cannot be recovered during Restore."
+    "deleteWallet.metadataWarn2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This data cannot be recovered during Restore."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estos datos no se podrán recuperar durante la restauración."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estos datos no se podrán recuperar durante la restauración."
           }
         }
       }
     },
-    "deleteWallet.screenTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset"
+    "deleteWallet.screenTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer"
           }
         }
       }
     },
-    "deleteWallet.sheet.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resetting the app cannot be undone. You will need to restore your wallet using your secret recovery phrase."
+    "deleteWallet.sheet.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetting the app cannot be undone. You will need to restore your wallet using your secret recovery phrase."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer la app no se puede deshacer. Necesitarás restaurar tu billetera usando tu frase secreta de recuperación."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer la app no se puede deshacer. Necesitarás restaurar tu billetera usando tu frase secreta de recuperación."
           }
         }
       }
     },
-    "deleteWallet.sheet.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure?"
+    "deleteWallet.sheet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Estás seguro?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Estás seguro?"
           }
         }
       }
     },
-    "deleteWallet.title" : {
-      "comment" : "MARK: - Delete Wallet",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Zodl"
+    "deleteWallet.title": {
+      "comment": "MARK: - Delete Wallet",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer Zodl"
           }
         }
       }
     },
-    "depositFunds.alert.cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel swap"
+    "depositFunds.alert.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel swap"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar swap"
           }
         }
       }
     },
-    "depositFunds.alert.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you've sent or intend to send the funds, tap 'I've sent the funds.' Or cancel the swap to return to the previous screen."
+    "depositFunds.alert.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you've sent or intend to send the funds, tap 'I've sent the funds.' Or cancel the swap to return to the previous screen."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si ya enviaste los fondos o tienes intención de hacerlo, toca ’Ya envié los fondos.’ O cancela el swap para volver a la pantalla anterior."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si ya enviaste los fondos o tienes intención de hacerlo, toca ’Ya envié los fondos.’ O cancela el swap para volver a la pantalla anterior."
           }
         }
       }
     },
-    "depositFunds.alert.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure you want to exit?"
+    "depositFunds.alert.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to exit?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Estás seguro de que deseas salir?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Estás seguro de que deseas salir?"
           }
         }
       }
     },
-    "depositFunds.bulletPoint1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send the exact amount of the asset displayed. Sending less will result in a refund."
+    "depositFunds.bulletPoint1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send the exact amount of the asset displayed. Sending less will result in a refund."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envía el monto exacto del activo que se muestra. Enviar menos resultará en un reembolso."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envía el monto exacto del activo que se muestra. Enviar menos resultará en un reembolso."
           }
         }
       }
     },
-    "depositFunds.bulletPoint2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Double-check that you are sending the correct asset on the correct network (e.g., USDC on Solana)."
+    "depositFunds.bulletPoint2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Double-check that you are sending the correct asset on the correct network (e.g., USDC on Solana)."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifica que estás enviando el activo correcto en la red correcta (por ej., USDC en Solana)."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica que estás enviando el activo correcto en la red correcta (por ej., USDC en Solana)."
           }
         }
       }
     },
-    "depositFunds.bulletPoint3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "It’s best to send from a wallet you own. Sending from an exchange may result in delays or refunds."
+    "depositFunds.bulletPoint3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It’s best to send from a wallet you own. Sending from an exchange may result in delays or refunds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es mejor enviar desde una wallet que sea tuya. Enviar desde un exchange puede causar demoras o reembolsos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es mejor enviar desde una wallet que sea tuya. Enviar desde un exchange puede causar demoras o reembolsos."
           }
         }
       }
     },
-    "depositFunds.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap into ZEC with any NEAR-supported asset."
+    "depositFunds.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap into ZEC with any NEAR-supported asset."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haz swap a ZEC con cualquier activo compatible con NEAR."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haz swap a ZEC con cualquier activo compatible con NEAR."
           }
         }
       }
     },
-    "depositFunds.title" : {
-      "comment" : "MARK: Deposit funds",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deposit Funds"
+    "depositFunds.title": {
+      "comment": "MARK: Deposit funds",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deposit Funds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depositar fondos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depositar fondos"
           }
         }
       }
     },
-    "deposits.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deposits may take several minutes to confirm."
+    "deposits.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deposits may take several minutes to confirm."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los depósitos pueden tardar varios minutos en confirmarse."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los depósitos pueden tardar varios minutos en confirmarse."
           }
         }
       }
     },
-    "disconnectHWWallet.bullet1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed or expired sends"
+    "disconnectHWWallet.bullet1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed or expired sends"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envíos fallidos o vencidos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envíos fallidos o vencidos"
           }
         }
       }
     },
-    "disconnectHWWallet.bullet2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mempool transactions that never confirmed"
+    "disconnectHWWallet.bullet2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mempool transactions that never confirmed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transacciones en el mempool que nunca se confirmaron"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transacciones en el mempool que nunca se confirmaron"
           }
         }
       }
     },
-    "disconnectHWWallet.bullet3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transactions later reversed in a chain reorg"
+    "disconnectHWWallet.bullet3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transactions later reversed in a chain reorg"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transacciones revertidas posteriormente en una reorganización de cadena"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transacciones revertidas posteriormente en una reorganización de cadena"
           }
         }
       }
     },
-    "disconnectHWWallet.contactSupport" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact Support"
+    "disconnectHWWallet.contactSupport": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact Support"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contactar Soporte"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contactar Soporte"
           }
         }
       }
     },
-    "disconnectHWWallet.cta" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect Hardware"
+    "disconnectHWWallet.cta": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect Hardware"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectar Hardware"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar Hardware"
           }
         }
       }
     },
-    "disconnectHWWallet.failureDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnecting the hardware wallet couldn't be finalized."
+    "disconnectHWWallet.failureDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnecting the hardware wallet couldn't be finalized."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo finalizar la desconexión del hardware wallet. "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo finalizar la desconexión del hardware wallet. "
           }
         }
       }
     },
-    "disconnectHWWallet.failureTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect Failed"
+    "disconnectHWWallet.failureTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al Desconectar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al Desconectar"
           }
         }
       }
     },
-    "disconnectHWWallet.mayInclude" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This may include:"
+    "disconnectHWWallet.mayInclude": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This may include:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envíos fallidos o vencidos:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envíos fallidos o vencidos:"
           }
         }
       }
     },
-    "disconnectHWWallet.sheetDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnecting the hardware wallet cannot be undone."
+    "disconnectHWWallet.sheetDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnecting the hardware wallet cannot be undone."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectar el hardware wallet no se puede deshacer."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar el hardware wallet no se puede deshacer."
           }
         }
       }
     },
-    "disconnectHWWallet.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnect"
+    "disconnectHWWallet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar"
           }
         }
       }
     },
-    "disconnectHWWallet.tryAgain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try again"
+    "disconnectHWWallet.tryAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intentar de nuevo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentar de nuevo"
           }
         }
       }
     },
-    "enhanceTransaction.btn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetch data"
+    "enhanceTransaction.btn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetch data"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtener datos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtener datos"
           }
         }
       }
     },
-    "enhanceTransaction.fieldTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transaction ID"
+    "enhanceTransaction.fieldTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transaction ID"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID de transacción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID de transacción"
           }
         }
       }
     },
-    "enhanceTransaction.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you confirm, Zodl will fetch transaction data for a transaction ID you provide."
+    "enhanceTransaction.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you confirm, Zodl will fetch transaction data for a transaction ID you provide."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si confirmas, Zodl obtendrá datos de una transacción usando el ID que proporciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si confirmas, Zodl obtendrá datos de una transacción usando el ID que proporciones."
           }
         }
       }
     },
-    "enhanceTransaction.placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter or paste..."
+    "enhanceTransaction.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter or paste..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresa o pega..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa o pega..."
           }
         }
       }
     },
-    "enhanceTransaction.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refresh Transaction Data"
+    "enhanceTransaction.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh Transaction Data"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizar datos de la transacción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar datos de la transacción"
           }
         }
       }
-    },
-    "Error: %@" : {
-
     },
-    "errorPage.action.contactSupport" : {
-      "comment" : "MARK: - Error Pages",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact Support"
+    "Error: %@": {},
+    "errorPage.action.contactSupport": {
+      "comment": "MARK: - Error Pages",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact Support"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contactar Soporte"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contactar Soporte"
           }
         }
       }
     },
-    "exportLogs.alert.failed.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+    "exportLogs.alert.failed.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         }
       }
     },
-    "exportLogs.alert.failed.title" : {
-      "comment" : "MARK: - Export logs",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error when exporting logs"
+    "exportLogs.alert.failed.title": {
+      "comment": "MARK: - Export logs",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error when exporting logs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al exportar registros"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al exportar registros"
           }
         }
       }
     },
-    "filter.apply" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apply"
+    "filter.apply": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar"
           }
         }
       }
     },
-    "filter.at" : {
-      "comment" : "example: Nov 29 at 4:15pm",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "at"
+    "filter.at": {
+      "comment": "example: Nov 29 at 4:15pm",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "at"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "a las"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a las"
           }
         }
       }
     },
-    "filter.bookmarked" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bookmarked"
+    "filter.bookmarked": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bookmarked"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Marcado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcado"
           }
         }
       }
     },
-    "filter.daysAgo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ days ago"
+    "filter.daysAgo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ days ago"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hace %@ días"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hace %@ días"
           }
         }
       }
     },
-    "filter.memos" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memos"
+    "filter.memos": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memos"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memorandos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memorandos"
           }
         }
       }
     },
-    "filter.noResults" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No results"
+    "filter.noResults": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No results"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin resultados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin resultados"
           }
         }
       }
     },
-    "filter.notes" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notes"
+    "filter.notes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notas"
           }
         }
       }
     },
-    "filter.previous7days" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous 7 days"
+    "filter.previous7days": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous 7 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Últimos 7 días"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Últimos 7 días"
           }
         }
       }
     },
-    "filter.previous30days" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous 30 days"
+    "filter.previous30days": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous 30 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Últimos 30 días"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Últimos 30 días"
           }
         }
       }
     },
-    "filter.received" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Received"
+    "filter.received": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Received"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recibido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recibido"
           }
         }
       }
     },
-    "filter.reset" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset"
+    "filter.reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer"
           }
         }
       }
     },
-    "filter.search" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search"
+    "filter.search": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
           }
         }
       }
     },
-    "filter.sent" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent"
+    "filter.sent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado"
           }
         }
       }
     },
-    "filter.swap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swaps"
+    "filter.swap": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swaps"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swaps"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swaps"
           }
         }
       }
     },
-    "filter.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filter"
+    "filter.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filtrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar"
           }
         }
       }
     },
-    "filter.today" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Today"
+    "filter.today": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Today"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hoy"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoy"
           }
         }
       }
     },
-    "filter.weTried" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We tried but couldn’t find anything."
+    "filter.weTried": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We tried but couldn’t find anything."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lo intentamos, pero no pudimos encontrar nada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo intentamos, pero no pudimos encontrar nada."
           }
         }
       }
     },
-    "filter.yesterday" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yesterday"
+    "filter.yesterday": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yesterday"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayer"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayer"
           }
         }
       }
     },
-    "firstWalletTransactionSubtitleHWWallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entering the block height at which your wallet was created ensures that correct number of blocks will be scanned. If you're not sure, choose an earlier date."
+    "firstWalletTransactionSubtitleHWWallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entering the block height at which your wallet was created ensures that correct number of blocks will be scanned. If you're not sure, choose an earlier date."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresar la altura del bloque en que se creó tu billetera garantiza que se escanee el número correcto de bloques. Si no estás seguro, elige una fecha anterior."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresar la altura del bloque en que se creó tu billetera garantiza que se escanee el número correcto de bloques. Si no estás seguro, elige una fecha anterior."
           }
         }
       }
     },
-    "firstWalletTransactionSubtitleRestore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Decide how far Zodl should scan. Enter a date before your first received transaction. If you’re not sure, choose an earlier date."
+    "firstWalletTransactionSubtitleRestore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decide how far Zodl should scan. Enter a date before your first received transaction. If you’re not sure, choose an earlier date."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Decide hasta dónde debe escanear Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decide hasta dónde debe escanear Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior."
           }
         }
       }
     },
-    "firstWalletTransactionSubtitleResync" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Decide how far Zodl should resync. Enter a date before your first received transaction. If you’re not sure, choose an earlier date."
+    "firstWalletTransactionSubtitleResync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decide how far Zodl should resync. Enter a date before your first received transaction. If you’re not sure, choose an earlier date."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Decide hasta dónde debe resincronizarse Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decide hasta dónde debe resincronizarse Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior."
           }
         }
       }
     },
-    "general.activity" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activity"
+    "general.activity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activity"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actividad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actividad"
           }
         }
       }
     },
-    "general.alert.caution" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heads up"
+    "general.alert.caution": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heads up"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aviso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso"
           }
         }
       }
     },
-    "general.alert.continue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+    "general.alert.continue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         }
       }
     },
-    "general.alert.ignore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignore"
+    "general.alert.ignore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorar"
           }
         }
       }
     },
-    "general.alert.warning" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warning"
+    "general.alert.warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advertencia"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencia"
           }
         }
       }
     },
-    "general.back" : {
-      "comment" : "MARK: - Common & Shared",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+    "general.back": {
+      "comment": "MARK: - Common & Shared",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atrás"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrás"
           }
         }
       }
     },
-    "general.cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "general.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         }
       }
     },
-    "general.close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+    "general.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
           }
         }
       }
     },
-    "general.confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm"
+    "general.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar"
           }
         }
       }
     },
-    "general.copiedAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copied %@"
+    "general.copiedAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección %@ copiada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección %@ copiada"
           }
         }
       }
     },
-    "general.copiedAmount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copied amount"
+    "general.copiedAmount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied amount"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto copiado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monto copiado"
           }
         }
       }
     },
-    "general.copiedToTheClipboard" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copied to the clipboard!"
+    "general.copiedToTheClipboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied to the clipboard!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Copiado al portapapeles!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Copiado al portapapeles!"
           }
         }
       }
     },
-    "general.delete" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete"
+    "general.delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         }
       }
     },
-    "general.done" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+    "general.done": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hecho"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hecho"
           }
         }
       }
     },
-    "general.fee" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Typical Fee < %@"
+    "general.fee": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Typical Fee < %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tarifa Típica < %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarifa Típica < %@"
           }
         }
       }
     },
-    "general.feeShort" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "< %@"
+    "general.feeShort": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "< %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "< %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "< %@"
           }
         }
       }
     },
-    "general.hide" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hide"
+    "general.hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocultar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar"
           }
         }
       }
     },
-    "general.hideBalancesLeast" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+    "general.hideBalancesLeast": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         }
       }
     },
-    "general.hideBalancesMost" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "-----"
+    "general.hideBalancesMost": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-----"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "-----"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-----"
           }
         }
       }
     },
-    "general.hideBalancesMostStandalone" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "-----"
+    "general.hideBalancesMostStandalone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-----"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "-----"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-----"
           }
         }
       }
     },
-    "general.less" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Less"
+    "general.less": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Less"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menos"
           }
         }
       }
     },
-    "general.loading" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading"
+    "general.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando"
           }
         }
       }
     },
-    "general.more" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More"
+    "general.more": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Más"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más"
           }
         }
       }
     },
-    "general.next" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next"
+    "general.next": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siguiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siguiente"
           }
         }
       }
     },
-    "general.no" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+    "general.no": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
           }
         }
       }
     },
-    "general.ok" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ok"
+    "general.ok": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ok"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ok"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ok"
           }
         }
       }
     },
-    "general.request" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Request"
+    "general.request": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solicitar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitar"
           }
         }
       }
     },
-    "general.save" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "general.save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
           }
         }
       }
     },
-    "general.send" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send"
+    "general.send": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar"
           }
         }
       }
     },
-    "general.share" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share"
+    "general.share": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir"
           }
         }
       }
     },
-    "general.show" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show"
+    "general.show": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar"
           }
         }
       }
     },
-    "general.unknown" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unknown"
+    "general.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconocido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconocido"
           }
         }
       }
     },
-    "general.yes" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yes"
+    "general.yes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sí"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sí"
           }
         }
       }
     },
-    "hardwareWalletExplainer.cta" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Got It"
+    "hardwareWalletExplainer.cta": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got It"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entendido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entendido"
           }
         }
       }
     },
-    "hardwareWalletExplainer.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A hardware wallet (HW wallet) is a physical device that stores your cryptocurrency private keys offline, keeping them safe from online hackers and malware."
+    "hardwareWalletExplainer.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A hardware wallet (HW wallet) is a physical device that stores your cryptocurrency private keys offline, keeping them safe from online hackers and malware."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Un hardware wallet es un dispositivo físico que almacena tus claves privadas de criptomonedas sin conexión a internet, manteniéndolas a salvo de hackers y malware."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un hardware wallet es un dispositivo físico que almacena tus claves privadas de criptomonedas sin conexión a internet, manteniéndolas a salvo de hackers y malware."
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureDescription1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your keys never leave the device, even when signing transactions"
+    "hardwareWalletExplainer.featureDescription1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your keys never leave the device, even when signing transactions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus claves nunca salen del dispositivo, incluso al firmar transacciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus claves nunca salen del dispositivo, incluso al firmar transacciones"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureDescription2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Immune to computer viruses and phishing attacks"
+    "hardwareWalletExplainer.featureDescription2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Immune to computer viruses and phishing attacks"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inmune a virus informáticos y ataques de phishing"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inmune a virus informáticos y ataques de phishing"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureDescription3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You own your keys, you own your crypto"
+    "hardwareWalletExplainer.featureDescription3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You own your keys, you own your crypto"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus claves son tuyas, tu cripto es tuya"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus claves son tuyas, tu cripto es tuya"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureTitle1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximum Security"
+    "hardwareWalletExplainer.featureTitle1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximum Security"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seguridad Máxima"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seguridad Máxima"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureTitle2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protection from Malware"
+    "hardwareWalletExplainer.featureTitle2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protection from Malware"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protección contra Malware"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protección contra Malware"
           }
         }
       }
     },
-    "hardwareWalletExplainer.featureTitle3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Full Control"
+    "hardwareWalletExplainer.featureTitle3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Control"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Control Total"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control Total"
           }
         }
       }
     },
-    "hardwareWalletExplainer.infoBoxDescription" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone is a popular hardware wallet brand that offers air-gapped security with QR code signing. It's one of many trusted hardware wallet options, alongside Ledger and others."
+    "hardwareWalletExplainer.infoBoxDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone is a popular hardware wallet brand that offers air-gapped security with QR code signing. It's one of many trusted hardware wallet options, alongside Ledger and others."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone es una marca popular de hardware wallet que ofrece seguridad air-gapped con firma mediante códigos QR. Es una de las muchas opciones confiables de hardware wallet, junto con Ledger y otros."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone es una marca popular de hardware wallet que ofrece seguridad air-gapped con firma mediante códigos QR. Es una de las muchas opciones confiables de hardware wallet, junto con Ledger y otros."
           }
         }
       }
     },
-    "hardwareWalletExplainer.infoBoxTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About Keystone"
+    "hardwareWalletExplainer.infoBoxTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sobre Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sobre Keystone"
           }
         }
       }
     },
-    "hardwareWalletExplainer.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "What's a Hardware Wallet?"
+    "hardwareWalletExplainer.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What's a Hardware Wallet?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Qué es un Hardware Wallet?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Qué es un Hardware Wallet?"
           }
         }
       }
     },
-    "home.migratingDatabases" : {
-      "comment" : "MARK: - Home Screen",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Upgrading databases…"
+    "home.migratingDatabases": {
+      "comment": "MARK: - Home Screen",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrading databases…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizando bases de datos…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando bases de datos…"
           }
         }
       }
     },
-    "homeScreen.moreDotted" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More..."
+    "homeScreen.moreDotted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Más..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más..."
           }
         }
       }
     },
-    "homeScreen.moreWarning" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Information you share with Zodl integration partners is subject to their privacy policies."
+    "homeScreen.moreWarning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Information you share with Zodl integration partners is subject to their privacy policies."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La información que compartas con los socios de integración de Zodl está sujeta a sus políticas de privacidad."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La información que compartas con los socios de integración de Zodl está sujeta a sus políticas de privacidad."
           }
         }
       }
     },
-    "importWallet.birthday.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet birthday height"
+    "importWallet.birthday.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet birthday height"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altura de cumpleaños de la billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altura de cumpleaños de la billetera"
           }
         }
       }
     },
-    "importWallet.button.restoreWallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore"
+    "importWallet.button.restoreWallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar"
           }
         }
       }
     },
-    "keepScreenOnRestoring" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep screen on while restoring"
+    "keepScreenOnRestoring": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep screen on while restoring"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantener la pantalla encendida mientras se restaura."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantener la pantalla encendida mientras se restaura."
           }
         }
       }
     },
-    "keepScreenOnResyncing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep screen on while resyncing"
+    "keepScreenOnResyncing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep screen on while resyncing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantener la pantalla encendida mientras se resincroniza"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantener la pantalla encendida mientras se resincroniza"
           }
         }
       }
     },
-    "keepScreenOnSyncing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep screen on while syncing"
+    "keepScreenOnSyncing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep screen on while syncing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantener la pantalla encendida mientras se sincroniza"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantener la pantalla encendida mientras se sincroniza"
           }
         }
       }
     },
-    "keepZodlOpenInstructionsHWWallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to complete syncing. Follow these steps to prevent interruption:"
+    "keepZodlOpenInstructionsHWWallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to complete syncing. Follow these steps to prevent interruption:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en sincronizarse. Sigue estos pasos para evitar interrupciones:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en sincronizarse. Sigue estos pasos para evitar interrupciones:"
           }
         }
       }
     },
-    "keepZodlOpenInstructionsRestoring" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to restore. Follow these steps to prevent interruption:"
+    "keepZodlOpenInstructionsRestoring": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to restore. Follow these steps to prevent interruption:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en restaurarse. Sigue estos pasos para evitar interrupciones:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en restaurarse. Sigue estos pasos para evitar interrupciones:"
           }
         }
       }
     },
-    "keepZodlOpenInstructionsResyncing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to resync. Follow these steps to prevent interruption:"
+    "keepZodlOpenInstructionsResyncing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to resync. Follow these steps to prevent interruption:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en resincronizarse. Sigue estos pasos para evitar interrupciones:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl está escaneando la cadena de bloques para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en resincronizarse. Sigue estos pasos para evitar interrupciones:"
           }
         }
       }
     },
-    "keepZodlOpenSubtitleHWWallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet is being synced."
+    "keepZodlOpenSubtitleHWWallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet is being synced."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu billetera se está sincronizando."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu billetera se está sincronizando."
           }
         }
       }
     },
-    "keepZodlOpenSubtitleRestore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet is being restored."
+    "keepZodlOpenSubtitleRestore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet is being restored."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu billetera se está restaurando."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu billetera se está restaurando."
           }
         }
       }
     },
-    "keepZodlOpenSubtitleResync" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet is being resynced."
+    "keepZodlOpenSubtitleResync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet is being resynced."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu billetera se está resincronizando."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu billetera se está resincronizando."
           }
         }
       }
     },
-    "keepZodlOpenWarningHWWallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[Warning:](style: 'boldPrimary') Your Zodl funds cannot be spent until your Keystone wallet is synced."
+    "keepZodlOpenWarningHWWallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[Warning:](style: 'boldPrimary') Your Zodl funds cannot be spent until your Keystone wallet is synced."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos de Zodl hasta que tu billetera Keystone esté sincronizada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos de Zodl hasta que tu billetera Keystone esté sincronizada."
           }
         }
       }
     },
-    "keepZodlOpenWarningRestore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is restored."
+    "keepZodlOpenWarningRestore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is restored."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera esté completamente restaurada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera esté completamente restaurada."
           }
         }
       }
     },
-    "keepZodlOpenWarningResync" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is resynced."
+    "keepZodlOpenWarningResync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[Warning:](style: 'boldPrimary') Your funds cannot be spent until your wallet is resynced."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera se haya resincronizado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[Advertencia:](style: 'boldPrimary') No podrás usar tus fondos hasta que tu billetera se haya resincronizado."
           }
         }
       }
     },
-    "keystone.addHWWallet.close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+    "keystone.addHWWallet.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
           }
         }
       }
     },
-    "keystone.addHWWallet.connect" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect"
+    "keystone.addHWWallet.connect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar"
           }
         }
       }
     },
-    "keystone.addHWWallet.connectActive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect active device"
+    "keystone.addHWWallet.connectActive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect active device"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectar dispositivo activo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar dispositivo activo"
           }
         }
       }
     },
-    "keystone.addHWWallet.connected" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connected!"
+    "keystone.addHWWallet.connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Keystone Conectado"
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Keystone Conectado"
           }
         }
       }
     },
-    "keystone.addHWWallet.connectedDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Keystone hardware wallet has been successfully connected."
+    "keystone.addHWWallet.connectedDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Keystone hardware wallet has been successfully connected."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Tu billetera de hardware Keystone se ha conectado correctamente. Ahora puedes firmar transacciones de forma inalámbrica."
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Tu billetera de hardware Keystone se ha conectado correctamente. Ahora puedes firmar transacciones de forma inalámbrica."
           }
         }
       }
     },
-    "keystone.addHWWallet.connectNew" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect new device"
+    "keystone.addHWWallet.connectNew": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect new device"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectar nuevo dispositivo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar nuevo dispositivo"
           }
         }
       }
     },
-    "keystone.addHWWallet.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select the wallet you'd like to connect to proceed. Once connected, you’ll be able to wirelessly sign transactions with your hardware wallet."
+    "keystone.addHWWallet.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select the wallet you'd like to connect to proceed. Once connected, you’ll be able to wirelessly sign transactions with your hardware wallet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciona la billetera que deseas conectar para continuar. Una vez conectada, podrás firmar transacciones de manera inalámbrica con tu billetera de hardware."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona la billetera que deseas conectar para continuar. Una vez conectada, podrás firmar transacciones de manera inalámbrica con tu billetera de hardware."
           }
         }
       }
     },
-    "keystone.addHWWallet.deviceDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to a hardware wallet that was previously connected to Zashi will require synchronization to discover your transaction history. We'll guide you through it."
+    "keystone.addHWWallet.deviceDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to a hardware wallet that was previously connected to Zashi will require synchronization to discover your transaction history. We'll guide you through it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectarse a una billetera de hardware que ya estaba conectada a Zashi requerirá sincronización para descubrir tu historial de transacciones. Te guiaremos en el proceso."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectarse a una billetera de hardware que ya estaba conectada a Zashi requerirá sincronización para descubrir tu historial de transacciones. Te guiaremos en el proceso."
           }
         }
       }
     },
-    "keystone.addHWWallet.deviceQuestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New or Active Device?"
+    "keystone.addHWWallet.deviceQuestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New or Active Device?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Dispositivo nuevo o activo?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Dispositivo nuevo o activo?"
           }
         }
       }
     },
-    "keystone.addHWWallet.enterManually" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter block height"
+    "keystone.addHWWallet.enterManually": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter block height"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresar altura de bloque"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresar altura de bloque"
           }
         }
       }
     },
-    "keystone.addHWWallet.howTo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instructions:"
+    "keystone.addHWWallet.howTo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instructions:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instrucciones:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instrucciones:"
           }
         }
       }
     },
-    "keystone.addHWWallet.readyToScan" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ready to Scan"
+    "keystone.addHWWallet.readyToScan": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready to Scan"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listo para Escanear"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo para Escanear"
           }
         }
       }
     },
-    "keystone.addHWWallet.scan" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan your device’s QR code to connect."
+    "keystone.addHWWallet.scan": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan your device’s QR code to connect."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escanea el código QR de tu dispositivo para conectarte."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanea el código QR de tu dispositivo para conectarte."
           }
         }
       }
     },
-    "keystone.addHWWallet.step1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unlock your Keystone"
+    "keystone.addHWWallet.step1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock your Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desbloquea tu Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desbloquea tu Keystone"
           }
         }
       }
     },
-    "keystone.addHWWallet.step2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap the menu icon"
+    "keystone.addHWWallet.step2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap the menu icon"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toca el ícono del menú"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca el ícono del menú"
           }
         }
       }
     },
-    "keystone.addHWWallet.step3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap on Connect Software Wallet"
+    "keystone.addHWWallet.step3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap on Connect Software Wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciona 'Conectar Billetera de Software'"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona 'Conectar Billetera de Software'"
           }
         }
       }
     },
-    "keystone.addHWWallet.step4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Zodl app and scan QR code"
+    "keystone.addHWWallet.step4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Zodl app and scan QR code"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Selecciona la app Zodl y escanea el código QR"
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Selecciona la app Zodl y escanea el código QR"
           }
         }
       }
     },
-    "keystone.addHWWallet.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm Account to Access"
+    "keystone.addHWWallet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm Account to Access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmar Cuenta para Acceder"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar Cuenta para Acceder"
           }
         }
       }
     },
-    "keystone.addHWWallet.tutorial" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View Keystone tutorial"
+    "keystone.addHWWallet.tutorial": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Keystone tutorial"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver tutorial de Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver tutorial de Keystone"
           }
         }
       }
     },
-    "keystone.confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm with Keystone"
+    "keystone.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm with Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirma con Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirma con Keystone"
           }
         }
       }
     },
-    "keystone.confirmPay" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay with Keystone"
+    "keystone.confirmPay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay with Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagar with Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagar with Keystone"
           }
         }
       }
     },
-    "keystone.confirmSwap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap with Keystone"
+    "keystone.confirmSwap": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap with Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap con Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap con Keystone"
           }
         }
       }
     },
-    "keystone.connect" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect Hardware Wallet"
+    "keystone.connect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect Hardware Wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectar Billetera de Hardware"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar Billetera de Hardware"
           }
         }
       }
     },
-    "keystone.drawer.banner.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Get 5%% off airgapped hardware wallet. Promo code \"Zodl\"."
+    "keystone.drawer.banner.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get 5%% off airgapped hardware wallet. Promo code \"Zodl\"."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtén un 5%% de descuento en una billetera de hardware aislada. Código promocional: 'Zodl'."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtén un 5%% de descuento en una billetera de hardware aislada. Código promocional: 'Zodl'."
           }
         }
       }
     },
-    "keystone.drawer.banner.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone Hardware Wallet"
+    "keystone.drawer.banner.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone Hardware Wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Billetera de Hardware Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billetera de Hardware Keystone"
           }
         }
       }
     },
-    "keystone.drawer.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallets & Hardware"
+    "keystone.drawer.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallets & Hardware"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Billeteras y Dispositivos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billeteras y Dispositivos"
           }
         }
       }
     },
-    "keystone.scanInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan Keystone wallet QR code"
+    "keystone.scanInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan Keystone wallet QR code"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escanea el código QR de tu billetera Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanea el código QR de tu billetera Keystone"
           }
         }
       }
     },
-    "keystone.signWith.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "After you have signed with Keystone, tap on the Get Signature button below."
+    "keystone.signWith.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After you have signed with Keystone, tap on the Get Signature button below."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Después de firmar con Keystone, toca el botón 'Obtener Firma' abajo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Después de firmar con Keystone, toca el botón 'Obtener Firma' abajo."
           }
         }
       }
     },
-    "keystone.signWith.getSignature" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Get Signature"
+    "keystone.signWith.getSignature": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get Signature"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtener Firma"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtener Firma"
           }
         }
       }
     },
-    "keystone.signWith.hardware" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hardware"
+    "keystone.signWith.hardware": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hardware"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hardware"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hardware"
           }
         }
       }
     },
-    "keystone.signWith.reject" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reject"
+    "keystone.signWith.reject": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reject"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechazar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechazar"
           }
         }
       }
     },
-    "keystone.signWith.signTransaction" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign Transaction"
+    "keystone.signWith.signTransaction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign Transaction"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Firmar Transacción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Firmar Transacción"
           }
         }
       }
     },
-    "keystone.signWith.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan with your Keystone wallet"
+    "keystone.signWith.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan with your Keystone wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escanea con tu billetera Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanea con tu billetera Keystone"
           }
         }
       }
     },
-    "keystone.wallet" : {
-      "comment" : "MARK: Keystone integration",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone Wallet"
+    "keystone.wallet": {
+      "comment": "MARK: Keystone integration",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone Wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Billetera Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billetera Keystone"
           }
         }
       }
     },
-    "keystoneHW" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone Hardware"
+    "keystoneHW": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone Hardware"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hardware Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hardware Keystone"
           }
         }
       }
     },
-    "keystoneTransactionReject.goBack" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go back"
+    "keystoneTransactionReject.goBack": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go back"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volver"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver"
           }
         }
       }
     },
-    "keystoneTransactionReject.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rejecting the signature will cancel the transaction, and you’ll need to start over if you want to proceed."
+    "keystoneTransactionReject.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rejecting the signature will cancel the transaction, and you’ll need to start over if you want to proceed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechazar la firma cancelará la transacción y tendrás que empezar de nuevo si deseas continuar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechazar la firma cancelará la transacción y tendrás que empezar de nuevo si deseas continuar."
           }
         }
       }
     },
-    "keystoneTransactionReject.rejectSig" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reject Signature"
+    "keystoneTransactionReject.rejectSig": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reject Signature"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechazar firma"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechazar firma"
           }
         }
       }
     },
-    "keystoneTransactionReject.title" : {
-      "comment" : "Keystone iteration 1",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure?"
+    "keystoneTransactionReject.title": {
+      "comment": "Keystone iteration 1",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Estás seguro?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Estás seguro?"
           }
         }
       }
     },
-    "localAuthentication.reason" : {
-      "comment" : "MARK: - Local authentication",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The Following content requires authentication."
+    "localAuthentication.reason": {
+      "comment": "MARK: - Local authentication",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Following content requires authentication."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El siguiente contenido requiere autenticación."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El siguiente contenido requiere autenticación."
           }
         }
       }
     },
-    "messageEditor.addUA" : {
-      "comment" : "MARK: - Message Editor",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reply-to: Include my address in the memo"
+    "messageEditor.addUA": {
+      "comment": "MARK: - Message Editor",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reply-to: Include my address in the memo"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Responder a: Incluir mi dirección en el memo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responder a: Incluir mi dirección en el memo"
           }
         }
       }
     },
-    "messageEditor.addUAformat" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\n>>> reply-to: %@"
+    "messageEditor.addUAformat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\n>>> reply-to: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\n>>> responder a: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\n>>> responder a: %@"
           }
         }
       }
     },
-    "messageEditor.removeUA" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your address is included in the memo"
+    "messageEditor.removeUA": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your address is included in the memo"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu dirección está incluida en el memo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu dirección está incluida en el memo"
           }
         }
       }
     },
-    "notEnoughFreeSpace.dataAvailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ MB available. "
+    "notEnoughFreeSpace.dataAvailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ MB available. "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ MB disponibles. "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ MB disponibles. "
           }
         }
       }
     },
-    "notEnoughFreeSpace.messagePost" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing will stay paused until more space is available."
+    "notEnoughFreeSpace.messagePost": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing will stay paused until more space is available."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La sincronización permanecerá pausada hasta que haya más espacio disponible."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sincronización permanecerá pausada hasta que haya más espacio disponible."
           }
         }
       }
     },
-    "notEnoughFreeSpace.messagePre" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl requires %@ GB of space to synchronize the Zcash blockchain but there is only "
+    "notEnoughFreeSpace.messagePre": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl requires %@ GB of space to synchronize the Zcash blockchain but there is only "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl requiere %@ GB de espacio para sincronizar la blockchain de Zcash, pero solo hay "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl requiere %@ GB de espacio para sincronizar la blockchain de Zcash, pero solo hay "
           }
         }
       }
     },
-    "notEnoughFreeSpace.requiredSpace" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "~%@ MB of additional space required to continue"
+    "notEnoughFreeSpace.requiredSpace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "~%@ MB of additional space required to continue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se requieren ~%@ MB de espacio adicional para continuar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requieren ~%@ MB de espacio adicional para continuar."
           }
         }
       }
     },
-    "notEnoughFreeSpace.title" : {
-      "comment" : "MARK: - Not Enogh Free Space",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not enough free space"
+    "notEnoughFreeSpace.title": {
+      "comment": "MARK: - Not Enogh Free Space",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not enough free space"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay suficiente espacio libre"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay suficiente espacio libre"
           }
         }
       }
     },
-    "osStatusError.error" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error code: %@"
+    "osStatusError.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error code: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código de error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Código de error: %@"
           }
         }
       }
     },
-    "osStatusError.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your funds are safe but something happened while we were trying to retrieve the Keychain data. Close the Zodl app, and give it a fresh launch, we will try again."
+    "osStatusError.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your funds are safe but something happened while we were trying to retrieve the Keychain data. Close the Zodl app, and give it a fresh launch, we will try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus fondos están seguros, pero algo ocurrió mientras intentábamos recuperar los datos del llavero. Cierra la aplicación de Zodl y ábrela de nuevo; lo intentaremos otra vez."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus fondos están seguros, pero algo ocurrió mientras intentábamos recuperar los datos del llavero. Cierra la aplicación de Zodl y ábrela de nuevo; lo intentaremos otra vez."
           }
         }
       }
     },
-    "osStatusError.title" : {
-      "comment" : "MARK: OSStatusError",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "It’s not you, it’s us."
+    "osStatusError.title": {
+      "comment": "MARK: OSStatusError",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It’s not you, it’s us."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No eres tú, somos nosotros."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No eres tú, somos nosotros."
           }
         }
       }
     },
-    "partners.flexa.keystoneNotSupportedMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flexa payments require a ZODL account. Switch to a ZODL account to pay with Flexa."
+    "partners.flexa.keystoneNotSupportedMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flexa payments require a ZODL account. Switch to a ZODL account to pay with Flexa."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Los pagos con Flexa requieren una cuenta ZODL. Cambia a una cuenta ZODL para pagar con Flexa."
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Los pagos con Flexa requieren una cuenta ZODL. Cambia a una cuenta ZODL para pagar con Flexa."
           }
         }
       }
     },
-    "partners.flexa.transactionFailedMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We're sorry but something has failed. Please try again."
+    "partners.flexa.transactionFailedMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We're sorry but something has failed. Please try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lo sentimos, pero algo falló. Por favor, inténtalo de nuevo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo sentimos, pero algo falló. Por favor, inténtalo de nuevo."
           }
         }
       }
     },
-    "partners.flexa.transactionFailedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transaction Failed"
+    "partners.flexa.transactionFailedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transaction Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transacción Fallida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transacción Fallida"
           }
         }
       }
     },
-    "plainOnboarding.button.createNewWallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create new wallet"
+    "plainOnboarding.button.createNewWallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create new wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear nueva billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear nueva billetera"
           }
         }
       }
     },
-    "plainOnboarding.button.restoreWallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore existing wallet"
+    "plainOnboarding.button.restoreWallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore existing wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurar billetera existente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar billetera existente"
           }
         }
       }
     },
-    "plainOnboarding.title" : {
-      "comment" : "MARK: - Plain Onboarding Flow",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash-powered mobile wallet built for financial sovereignty."
+    "plainOnboarding.title": {
+      "comment": "MARK: - Plain Onboarding Flow",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash-powered mobile wallet built for financial sovereignty."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Billetera móvil impulsada por Zcash, diseñada para la soberanía financiera."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billetera móvil impulsada por Zcash, diseñada para la soberanía financiera."
           }
         }
       }
     },
-    "privateDataConsent.confirmation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I agree to Zodl's Export Private Data Policies and Privacy Policy"
+    "privateDataConsent.confirmation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I agree to Zodl's Export Private Data Policies and Privacy Policy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acepto las Políticas de Exportación de Datos Privados y la Política de Privacidad de Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acepto las Políticas de Exportación de Datos Privados y la Política de Privacidad de Zodl"
           }
         }
       }
     },
-    "privateDataConsent.message1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "By clicking \"I Agree\" below, you give your consent to export all of your wallets’ private data such as the entire history of your wallet(s), including any connected hardware wallets. All private information, memos, amounts, and recipient addresses, even for your shielded activity will be exported.*"
+    "privateDataConsent.message1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "By clicking \"I Agree\" below, you give your consent to export all of your wallets’ private data such as the entire history of your wallet(s), including any connected hardware wallets. All private information, memos, amounts, and recipient addresses, even for your shielded activity will be exported.*"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Al hacer clic en 'Estoy de Acuerdo', das tu consentimiento para exportar todos los datos privados de tus billeteras, como el historial completo de tus billeteras, incluyendo cualquier billetera de hardware conectada. Toda información privada, notas, montos y direcciones de destinatarios, incluso para tus actividades protegidas, serán exportadas.*"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al hacer clic en 'Estoy de Acuerdo', das tu consentimiento para exportar todos los datos privados de tus billeteras, como el historial completo de tus billeteras, incluyendo cualquier billetera de hardware conectada. Toda información privada, notas, montos y direcciones de destinatarios, incluso para tus actividades protegidas, serán exportadas.*"
           }
         }
       }
     },
-    "privateDataConsent.message2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The private data also gives the ability to see certain future actions you take with Zodl."
+    "privateDataConsent.message2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The private data also gives the ability to see certain future actions you take with Zodl."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los datos privados también permiten ver ciertas acciones futuras que realices con Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los datos privados también permiten ver ciertas acciones futuras que realices con Zodl."
           }
         }
       }
     },
-    "privateDataConsent.message3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sharing this private data is irrevocable - once you have shared this private data with someone, there is no way to revoke their access."
+    "privateDataConsent.message3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sharing this private data is irrevocable - once you have shared this private data with someone, there is no way to revoke their access."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir estos datos privados es irrevocable: una vez que hayas compartido estos datos privados con alguien, no hay forma de revocar su acceso."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir estos datos privados es irrevocable: una vez que hayas compartido estos datos privados con alguien, no hay forma de revocar su acceso."
           }
         }
       }
     },
-    "privateDataConsent.message4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "*Note that this private data does not give them the ability to spend your funds, only the ability to see what you do with your funds."
+    "privateDataConsent.message4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "*Note that this private data does not give them the ability to spend your funds, only the ability to see what you do with your funds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "*Ten en cuenta que estos datos privados no les dan la capacidad de gastar tus fondos, solo la capacidad de ver lo que haces con tus fondos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "*Ten en cuenta que estos datos privados no les dan la capacidad de gastar tus fondos, solo la capacidad de ver lo que haces con tus fondos."
           }
         }
       }
     },
-    "privateDataConsent.screenTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Data Export"
+    "privateDataConsent.screenTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data Export"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportación de Datos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportación de Datos"
           }
         }
       }
     },
-    "privateDataConsent.title" : {
-      "comment" : "MARK: - Private Data Consent",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consent for Exporting Private Data"
+    "privateDataConsent.title": {
+      "comment": "MARK: - Private Data Consent",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consent for Exporting Private Data"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consentimiento para Exportar Datos Privados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consentimiento para Exportar Datos Privados"
           }
         }
       }
     },
-    "proposalPartial.mailSubject" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TEX Transaction Error"
+    "proposalPartial.mailSubject": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TEX Transaction Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de transacción TEX"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de transacción TEX"
           }
         }
       }
     },
-    "qrCodeFor" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QR Code for %@"
+    "qrCodeFor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR Code for %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código QR para %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Código QR para %@"
           }
         }
       }
     },
-    "receive.copy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy"
+    "receive.copy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
           }
         }
       }
     },
-    "receive.error.cantExtractSaplingAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "could not extract sapling receiver from UA"
+    "receive.error.cantExtractSaplingAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "could not extract sapling receiver from UA"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "no se pudo extraer el receptor Sapling de la Dirección Unificada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "no se pudo extraer el receptor Sapling de la Dirección Unificada"
           }
         }
       }
     },
-    "receive.error.cantExtractTransparentAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "could not extract transparent receiver from UA"
+    "receive.error.cantExtractTransparentAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "could not extract transparent receiver from UA"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "no se pudo extraer el receptor transparente de la Dirección Unificada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "no se pudo extraer el receptor transparente de la Dirección Unificada"
           }
         }
       }
     },
-    "receive.error.cantExtractUnifiedAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "could not extract UA"
+    "receive.error.cantExtractUnifiedAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "could not extract UA"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "no se pudo extraer la Dirección Unificada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "no se pudo extraer la Dirección Unificada"
           }
         }
       }
     },
-    "receive.help.shielded.desc1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use this address to receive and store your ZEC privately. Transparent and shielded ZEC sent to this address will be received and stored as shielded ZEC."
+    "receive.help.shielded.desc1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use this address to receive and store your ZEC privately. Transparent and shielded ZEC sent to this address will be received and stored as shielded ZEC."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa esta dirección para recibir y almacenar tus ZEC de forma privada. Los ZEC transparentes y protegidos enviados a esta dirección se recibirán y almacenarán como ZEC protegidos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa esta dirección para recibir y almacenar tus ZEC de forma privada. Los ZEC transparentes y protegidos enviados a esta dirección se recibirán y almacenarán como ZEC protegidos."
           }
         }
       }
     },
-    "receive.help.shielded.desc2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A new Zcash Shielded Address is generated each time you open the Receive screen."
+    "receive.help.shielded.desc2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A new Zcash Shielded Address is generated each time you open the Receive screen."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se genera una nueva dirección protegida de Zcash cada vez que abres la pantalla de \"Recibir\"."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se genera una nueva dirección protegida de Zcash cada vez que abres la pantalla de \"Recibir\"."
           }
         }
       }
     },
-    "receive.help.shielded.desc3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All transactions sent to your different rotating Shielded Addresses will remain part of one wallet balance under the same seed phrase."
+    "receive.help.shielded.desc3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All transactions sent to your different rotating Shielded Addresses will remain part of one wallet balance under the same seed phrase."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todas las transacciones enviadas a tus diferentes direcciones protegidas rotativas formarán parte de un mismo saldo de billetera vinculado a tu frase semilla."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las transacciones enviadas a tus diferentes direcciones protegidas rotativas formarán parte de un mismo saldo de billetera vinculado a tu frase semilla."
           }
         }
       }
     },
-    "receive.help.shielded.desc4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "While we recommend using a new address every time, each unique address can be reused."
+    "receive.help.shielded.desc4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "While we recommend using a new address every time, each unique address can be reused."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aunque recomendamos usar una nueva dirección cada vez, cada dirección única se puede reutilizar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aunque recomendamos usar una nueva dirección cada vez, cada dirección única se puede reutilizar."
           }
         }
       }
     },
-    "receive.help.shielded.title" : {
-      "comment" : "Receive help",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash Shielded Address (Rotating)"
+    "receive.help.shielded.title": {
+      "comment": "Receive help",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash Shielded Address (Rotating)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección protegida de Zcash (rotativa)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección protegida de Zcash (rotativa)"
           }
         }
       }
     },
-    "receive.help.transparent.desc1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This addresses type works just like Bitcoin addresses and offers NO PRIVACY. The details of transactions sent to this address will be public and visible on the blockchain."
+    "receive.help.transparent.desc1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This addresses type works just like Bitcoin addresses and offers NO PRIVACY. The details of transactions sent to this address will be public and visible on the blockchain."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este tipo de dirección funciona como una dirección de Bitcoin y NO OFRECE PRIVACIDAD. Los detalles de las transacciones enviadas a esta dirección serán públicos y visibles en la blockchain."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este tipo de dirección funciona como una dirección de Bitcoin y NO OFRECE PRIVACIDAD. Los detalles de las transacciones enviadas a esta dirección serán públicos y visibles en la blockchain."
           }
         }
       }
     },
-    "receive.help.transparent.desc2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We don't recommend using this address type unless the wallet or exchange from which ZEC is being sent doesn’t support sending funds to shielded Zcash addresses."
+    "receive.help.transparent.desc2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We don't recommend using this address type unless the wallet or exchange from which ZEC is being sent doesn’t support sending funds to shielded Zcash addresses."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No recomendamos usar este tipo de dirección a menos que la billetera o casa de cambio desde donde se envían los ZEC no admita direcciones protegidas de Zcash."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No recomendamos usar este tipo de dirección a menos que la billetera o casa de cambio desde donde se envían los ZEC no admita direcciones protegidas de Zcash."
           }
         }
       }
     },
-    "receive.help.transparent.desc3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To protect your privacy, Zodl will guide you to shield any transparent ZEC you receive with just one click."
+    "receive.help.transparent.desc3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To protect your privacy, Zodl will guide you to shield any transparent ZEC you receive with just one click."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para proteger tu privacidad, Zodl te guiará para proteger cualquier ZEC transparente que recibas con un solo clic."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para proteger tu privacidad, Zodl te guiará para proteger cualquier ZEC transparente que recibas con un solo clic."
           }
         }
       }
     },
-    "receive.help.transparent.desc4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You won't be able to spend your transparent ZEC until you shield it."
+    "receive.help.transparent.desc4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You won't be able to spend your transparent ZEC until you shield it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No podrás gastar tus ZEC transparentes hasta que los protejas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No podrás gastar tus ZEC transparentes hasta que los protejas."
           }
         }
       }
     },
-    "receive.help.transparent.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash Transparent Address (Static)"
+    "receive.help.transparent.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash Transparent Address (Static)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección transparente de Zcash (estática)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección transparente de Zcash (estática)"
           }
         }
       }
     },
-    "receive.qrCode" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QR Code"
+    "receive.qrCode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR Code"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código QR"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Código QR"
           }
         }
       }
     },
-    "receive.request" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Request"
+    "receive.request": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solicitar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitar"
           }
         }
       }
     },
-    "receive.saplingAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash Sapling Address"
+    "receive.saplingAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash Sapling Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección Sapling de Zcash"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección Sapling de Zcash"
           }
         }
       }
     },
-    "receive.warning" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For privacy, always use shielded address."
+    "receive.warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For privacy, always use shielded address."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para privacidad, utilice siempre una dirección protegida."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para privacidad, utilice siempre una dirección protegida."
           }
         }
       }
     },
-    "recoverFunds.btn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan address"
+    "recoverFunds.btn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escanear dirección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanear dirección"
           }
         }
       }
     },
-    "recoverFunds.fieldTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transparent Address"
+    "recoverFunds.fieldTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparent Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección transparente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección transparente"
           }
         }
       }
     },
-    "recoverFunds.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you confirm, Zodl will scan the transparent address you provide and discover its funds. This may take a few minutes."
+    "recoverFunds.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you confirm, Zodl will scan the transparent address you provide and discover its funds. This may take a few minutes."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si confirmas, Zodl escaneará la dirección transparente que proporciones y descubrirá sus fondos. Esto puede tardar unos minutos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si confirmas, Zodl escaneará la dirección transparente que proporciones y descubrirá sus fondos. Esto puede tardar unos minutos."
           }
         }
       }
     },
-    "recoverFunds.placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter or paste..."
+    "recoverFunds.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter or paste..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresa o pega..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa o pega..."
           }
         }
       }
     },
-    "recoverFunds.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discover Funds"
+    "recoverFunds.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discover Funds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descubrir fondos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descubrir fondos"
           }
         }
       }
     },
-    "recoverFunds.tor" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This operation requires Tor Protection. Please enable it in the Advanced Settings. "
+    "recoverFunds.tor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This operation requires Tor Protection. Please enable it in the Advanced Settings. "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta operación requiere Protección Tor. Por favor, habilítala en la Configuración Avanzada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta operación requiere Protección Tor. Por favor, habilítala en la Configuración Avanzada."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.alert.failed.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attempt to load the stored wallet from the keychain failed. Error: %@"
+    "recoveryPhraseDisplay.alert.failed.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attempt to load the stored wallet from the keychain failed. Error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El intento de cargar la billetera almacenada desde el llavero falló. Error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El intento de cargar la billetera almacenada desde el llavero falló. Error: %@"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.alert.failed.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to load stored wallet"
+    "recoveryPhraseDisplay.alert.failed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to load stored wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo cargar la billetera almacenada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo cargar la billetera almacenada"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.birthdayTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Birthday Height"
+    "recoveryPhraseDisplay.birthdayTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Birthday Height"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altura de Cumpleaños de la Billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altura de Cumpleaños de la Billetera"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.button.remindMeLater" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remind me later"
+    "recoveryPhraseDisplay.button.remindMeLater": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remind me later"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recuérdame más tarde"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuérdame más tarde"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.button.wroteItDown" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I've saved it"
+    "recoveryPhraseDisplay.button.wroteItDown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I've saved it"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lo he guardado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo he guardado"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "These words are the only way to recover your funds! Make sure to save them in the correct order."
+    "recoveryPhraseDisplay.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These words are the only way to recover your funds! Make sure to save them in the correct order."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Estas palabras son la única manera de recuperar tus fondos! Asegúrate de guardarlas en el orden correcto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Estas palabras son la única manera de recuperar tus fondos! Asegúrate de guardarlas en el orden correcto."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.hide" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hide security details"
+    "recoveryPhraseDisplay.hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide security details"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocultar detalles de seguridad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar detalles de seguridad"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.noWords" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The keys are missing. No backup phrase is stored in the keychain."
+    "recoveryPhraseDisplay.noWords": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The keys are missing. No backup phrase is stored in the keychain."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Faltan las claves. No hay ninguna frase de respaldo almacenada en el llavero."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faltan las claves. No hay ninguna frase de respaldo almacenada en el llavero."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.proceedWarning" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep this phrase securely hidden. Don’t take screenshots of it or store it on your phone!"
+    "recoveryPhraseDisplay.proceedWarning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep this phrase securely hidden. Don’t take screenshots of it or store it on your phone!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantén esta frase de manera segura oculta. ¡No tomes capturas de pantalla ni la guardes en tu teléfono!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén esta frase de manera segura oculta. ¡No tomes capturas de pantalla ni la guardes en tu teléfono!"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.reveal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reveal security details"
+    "recoveryPhraseDisplay.reveal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal security details"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar detalles de seguridad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar detalles de seguridad"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.screenTitle" : {
-      "comment" : "MARK: - Secret Recovery Phrase Display",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recovery Phrase"
+    "recoveryPhraseDisplay.screenTitle": {
+      "comment": "MARK: - Secret Recovery Phrase Display",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recovery Phrase"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frase de Recuperación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frase de Recuperación"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Secret Recovery Phrase"
+    "recoveryPhraseDisplay.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secret Recovery Phrase"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frase de Recuperación Secreta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frase de Recuperación Secreta"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningControl.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use it to access your funds from other devices and Zcash wallets."
+    "recoveryPhraseDisplay.warningControl.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use it to access your funds from other devices and Zcash wallets."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Úsala para acceder a tus fondos desde otros dispositivos y billeteras Zcash."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Úsala para acceder a tus fondos desde otros dispositivos y billeteras Zcash."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningControl.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Control your wallet"
+    "recoveryPhraseDisplay.warningControl.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control your wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controla tu billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controla tu billetera"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningHeight.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The block height at which your wallet was created can significantly speed up the wallet recovery process."
+    "recoveryPhraseDisplay.warningHeight.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The block height at which your wallet was created can significantly speed up the wallet recovery process."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La altura del bloque en el que se creó tu billetera puede acelerar significativamente el proceso de recuperación de la billetera."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La altura del bloque en el que se creó tu billetera puede acelerar significativamente el proceso de recuperación de la billetera."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningHeight.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet birthday height"
+    "recoveryPhraseDisplay.warningHeight.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet birthday height"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altura de cumpleaños de la billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altura de cumpleaños de la billetera"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your secret recovery phrase is a unique set of 24 words, appearing in a precise order. It protects access to your funds."
+    "recoveryPhraseDisplay.warningInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your secret recovery phrase is a unique set of 24 words, appearing in a precise order. It protects access to your funds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu frase de recuperación secreta es un conjunto único de 24 palabras, que aparecen en un orden preciso. Protege el acceso a tus fondos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu frase de recuperación secreta es un conjunto único de 24 palabras, que aparecen en un orden preciso. Protege el acceso a tus fondos."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningKeep.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Don't share it with anyone! It can be used to gain full control of your funds."
+    "recoveryPhraseDisplay.warningKeep.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don't share it with anyone! It can be used to gain full control of your funds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡No la compartas con nadie! Puede usarse para obtener control total de tus fondos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡No la compartas con nadie! Puede usarse para obtener control total de tus fondos."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningKeep.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep it private"
+    "recoveryPhraseDisplay.warningKeep.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep it private"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manténla privada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manténla privada"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningStore.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We don’t have access to it and will never ask for it. If you lose it, it cannot be recovered."
+    "recoveryPhraseDisplay.warningStore.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We don’t have access to it and will never ask for it. If you lose it, it cannot be recovered."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No tenemos acceso a ella y nunca te pediremos que la compartas. Si la pierdes, no puede ser recuperada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tenemos acceso a ella y nunca te pediremos que la compartas. Si la pierdes, no puede ser recuperada."
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningStore.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Store it securely"
+    "recoveryPhraseDisplay.warningStore.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Store it securely"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guárdala de manera segura"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guárdala de manera segura"
           }
         }
       }
     },
-    "recoveryPhraseDisplay.warningTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Secret Recovery Phrase"
+    "recoveryPhraseDisplay.warningTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Secret Recovery Phrase"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu Frase de Recuperación Secreta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu Frase de Recuperación Secreta"
           }
         }
       }
     },
-    "reportSwap.contact" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact Support"
+    "reportSwap.contact": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact Support"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contactar soporte"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contactar soporte"
           }
         }
       }
     },
-    "reportSwap.depositAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deposit Address: "
+    "reportSwap.depositAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deposit Address: "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección de depósito: "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección de depósito: "
           }
         }
       }
     },
-    "reportSwap.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tapping the button below will send details about this swap (like the deposit address and target asset) to the Zodl support team so they can help resolve your issue. The transaction info is included automatically."
+    "reportSwap.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapping the button below will send details about this swap (like the deposit address and target asset) to the Zodl support team so they can help resolve your issue. The transaction info is included automatically."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Al tocar el botón de abajo, se enviarán detalles de este swap (como la dirección de depósito y el activo destino) al equipo de soporte de Zodl para que puedan ayudarte a resolver tu problema. La información de la transacción se incluye automáticamente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al tocar el botón de abajo, se enviarán detalles de este swap (como la dirección de depósito y el activo destino) al equipo de soporte de Zodl para que puedan ayudarte a resolver tu problema. La información de la transacción se incluye automáticamente."
           }
         }
       }
     },
-    "reportSwap.please" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please describe your issue here: "
+    "reportSwap.please": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please describe your issue here: "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor describe tu problema aquí: "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor describe tu problema aquí: "
           }
         }
       }
     },
-    "reportSwap.report" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report Issue"
+    "reportSwap.report": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report Issue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reportar problema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reportar problema"
           }
         }
       }
     },
-    "reportSwap.sourceAsset" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source Asset: %@ on %@\n"
+    "reportSwap.sourceAsset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source Asset: %@ on %@\n"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activo de origen: %@ en %@\n"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activo de origen: %@ en %@\n"
           }
         }
       }
     },
-    "reportSwap.swapDetails" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Details:"
+    "reportSwap.swapDetails": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Details:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalles del swap:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles del swap:"
           }
         }
       }
     },
-    "reportSwap.targetAsset" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Target Asset: %@ on %@\n"
+    "reportSwap.targetAsset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Target Asset: %@ on %@\n"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activo destino: %@ en %@\n"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activo destino: %@ en %@\n"
           }
         }
       }
     },
-    "reportSwap.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report Swap Issue"
+    "reportSwap.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report Swap Issue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reportar problema con swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reportar problema con swap"
           }
         }
       }
     },
-    "requestZec.summary.shareDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hi, I have generated a ZEC payment request for you using the Zodl app!"
+    "requestZec.summary.shareDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hi, I have generated a ZEC payment request for you using the Zodl app!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hola, he generado una solicitud de pago en ZEC para ti utilizando la aplicación Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hola, he generado una solicitud de pago en ZEC para ti utilizando la aplicación Zodl."
           }
         }
       }
     },
-    "requestZec.summary.shareMsg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(download link: https://apps.apple.com/app/zashi-zcash-wallet/id1672392439)"
+    "requestZec.summary.shareMsg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(download link: https://apps.apple.com/app/zashi-zcash-wallet/id1672392439)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(enlace de descarga: https://apps.apple.com/app/zashi-zcash-wallet/id1672392439)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(enlace de descarga: https://apps.apple.com/app/zashi-zcash-wallet/id1672392439)"
           }
         }
       }
     },
-    "requestZec.summary.shareQR" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share QR Code"
+    "requestZec.summary.shareQR": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share QR Code"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir Código QR"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir Código QR"
           }
         }
       }
     },
-    "requestZec.summary.shareTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Request ZEC"
+    "requestZec.summary.shareTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solicitar ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitar ZEC"
           }
         }
       }
     },
-    "requestZec.title" : {
-      "comment" : "MARK: - Request ZEC",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Request"
+    "requestZec.title": {
+      "comment": "MARK: - Request ZEC",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Request"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solicitud de Pago"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitud de Pago"
           }
         }
       }
     },
-    "requestZec.whatFor" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "What’s this for?"
+    "requestZec.whatFor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What’s this for?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Para qué es esto?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Para qué es esto?"
           }
         }
       }
     },
-    "restoreInfo.gotIt" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Got it!"
+    "restoreInfo.gotIt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Entendido!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Entendido!"
           }
         }
       }
     },
-    "restoreInfo.tip1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep the Zodl app open on an active phone screen."
+    "restoreInfo.tip1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep the Zodl app open on an active phone screen."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantén la app de Zodl abierta con la pantalla del teléfono activa."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén la app de Zodl abierta con la pantalla del teléfono activa."
           }
         }
       }
     },
-    "restoreInfo.tip2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To prevent your phone screen from going dark, turn off power-saving mode and keep your phone plugged in."
+    "restoreInfo.tip2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To prevent your phone screen from going dark, turn off power-saving mode and keep your phone plugged in."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para evitar que la pantalla se apague, desactiva el modo de ahorro de energía y mantén el teléfono conectado a la corriente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para evitar que la pantalla se apague, desactiva el modo de ahorro de energía y mantén el teléfono conectado a la corriente."
           }
         }
       }
     },
-    "restoreInfo.title" : {
-      "comment" : "MARK: - Restore Info",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep Zodl open!"
+    "restoreInfo.title": {
+      "comment": "MARK: - Restore Info",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Zodl open!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Mantén Zodl abierto!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Mantén Zodl abierto!"
           }
         }
       }
     },
-    "restoreWallet.birthday.estimate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estimate my block height"
+    "restoreWallet.birthday.estimate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estimate my block height"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estimar mi altura de bloque"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estimar mi altura de bloque"
           }
         }
       }
     },
-    "restoreWallet.birthday.estimated.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl will scan and recover all transactions made after the following block number."
+    "restoreWallet.birthday.estimated.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl will scan and recover all transactions made after the following block number."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
           }
         }
       }
     },
-    "restoreWallet.birthday.estimated.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estimated Block Height"
+    "restoreWallet.birthday.estimated.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estimated Block Height"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altura de Bloque Estimada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altura de Bloque Estimada"
           }
         }
       }
     },
-    "restoreWallet.birthday.estimateDate.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "First Wallet Transaction"
+    "restoreWallet.birthday.estimateDate.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "First Wallet Transaction"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Primera Transacción de la Billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primera Transacción de la Billetera"
           }
         }
       }
     },
-    "restoreWallet.birthday.fieldInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Birthday Height is the point in time when your wallet was created."
+    "restoreWallet.birthday.fieldInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Birthday Height is the point in time when your wallet was created."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La Altura de Cumpleaños de la Billetera es el momento en que se creó tu billetera."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La Altura de Cumpleaños de la Billetera es el momento en que se creó tu billetera."
           }
         }
       }
     },
-    "restoreWallet.birthday.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entering your Wallet Birthday Height helps speed up the restore process."
+    "restoreWallet.birthday.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entering your Wallet Birthday Height helps speed up the restore process."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresar la Altura de Cumpleaños de tu Billetera ayuda a acelerar el proceso de restauración."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresar la Altura de Cumpleaños de tu Billetera ayuda a acelerar el proceso de restauración."
           }
         }
       }
     },
-    "restoreWallet.birthday.placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter number"
+    "restoreWallet.birthday.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter number"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresa el número"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa el número"
           }
         }
       }
     },
-    "restoreWallet.birthday.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Block Height"
+    "restoreWallet.birthday.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block Height"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altura de Bloque"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altura de Bloque"
           }
         }
       }
     },
-    "restoreWallet.help.phrase" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[The Secret Recovery Phrase](style: 'boldPrimary') is a unique set of 24 words, appearing in a precise order. It can be used to gain full control of your funds from any device via any Zcash wallet app. Think of it as the master key to your wallet. It is stored in Zodl’s Advanced Settings."
+    "restoreWallet.help.phrase": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[The Secret Recovery Phrase](style: 'boldPrimary') is a unique set of 24 words, appearing in a precise order. It can be used to gain full control of your funds from any device via any Zcash wallet app. Think of it as the master key to your wallet. It is stored in Zodl’s Advanced Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[La Frase de Recuperación Secreta](style: 'boldPrimary') es un conjunto único de 24 palabras, que aparecen en un orden preciso. Se puede usar para obtener control total de tus fondos desde cualquier dispositivo a través de cualquier aplicación de billetera Zcash. Piensa en ella como la llave maestra de tu billetera. Se guarda en la Configuración Avanzada de Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[La Frase de Recuperación Secreta](style: 'boldPrimary') es un conjunto único de 24 palabras, que aparecen en un orden preciso. Se puede usar para obtener control total de tus fondos desde cualquier dispositivo a través de cualquier aplicación de billetera Zcash. Piensa en ella como la llave maestra de tu billetera. Se guarda en la Configuración Avanzada de Zodl."
           }
         }
       }
     },
-    "restoreWallet.help.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Need to know more?"
+    "restoreWallet.help.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Need to know more?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Necesitas saber más?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Necesitas saber más?"
           }
         }
       }
     },
-    "restoreWallet.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please type in your 24-word secret recovery phrase in the correct order."
+    "restoreWallet.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please type in your 24-word secret recovery phrase in the correct order."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, ingresa tu frase secreta de recuperación de 24 palabras en el orden correcto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor, ingresa tu frase secreta de recuperación de 24 palabras en el orden correcto."
           }
         }
       }
     },
-    "restoreWallet.title" : {
-      "comment" : "Onboarding: Restore Wallet",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Secret Recovery Phrase"
+    "restoreWallet.title": {
+      "comment": "Onboarding: Restore Wallet",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secret Recovery Phrase"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frase de Recuperación Secreta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frase de Recuperación Secreta"
           }
         }
       }
     },
-    "resyncEstimatedBlockHeightInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Zodl will scan and recover all transactions made after the following block number."
+    "resyncEstimatedBlockHeightInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Zodl will scan and recover all transactions made after the following block number."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque."
           }
         }
       }
     },
-    "resyncWallet.change" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change"
+    "resyncWallet.change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar"
           }
         }
       }
     },
-    "resyncWallet.confirmTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm Resync"
+    "resyncWallet.confirmTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm Resync"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmar Resincronización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar Resincronización"
           }
         }
       }
     },
-    "resyncWallet.dateInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unless you specify otherwise below, Zodl will resync from the date displayed."
+    "resyncWallet.dateInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unless you specify otherwise below, Zodl will resync from the date displayed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A menos que especifiques lo contrario a continuación, Zodl se resincronizará desde la fecha mostrada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A menos que especifiques lo contrario a continuación, Zodl se resincronizará desde la fecha mostrada."
           }
         }
       }
     },
-    "resyncWallet.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resync the current wallet without resetting the app. This can be used to troubleshoot issues that would normally require restoring your wallet like fixing your Keystone balance."
+    "resyncWallet.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resync the current wallet without resetting the app. This can be used to troubleshoot issues that would normally require restoring your wallet like fixing your Keystone balance."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resincroniza la billetera actual sin restablecer la app. Esto puede usarse para solucionar problemas que normalmente requerirían restaurar tu billetera como corregir tu balance de Keystone."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resincroniza la billetera actual sin restablecer la app. Esto puede usarse para solucionar problemas que normalmente requerirían restaurar tu billetera como corregir tu balance de Keystone."
           }
         }
       }
     },
-    "resyncWallet.failedDescription" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resync of the wallet couldn’t be finalized. Please try again or report an issue."
+    "resyncWallet.failedDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resync of the wallet couldn’t be finalized. Please try again or report an issue."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo completar la resincronización de la billetera. Inténtalo de nuevo o informa del problema."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo completar la resincronización de la billetera. Inténtalo de nuevo o informa del problema."
           }
         }
       }
     },
-    "resyncWallet.failedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resync Failed"
+    "resyncWallet.failedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resync Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de resincronización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de resincronización"
           }
         }
       }
     },
-    "resyncWallet.start" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start Resync"
+    "resyncWallet.start": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Resync"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar resincronización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar resincronización"
           }
         }
       }
     },
-    "resyncWallet.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resync Wallet"
+    "resyncWallet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resync Wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resincronizar Billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resincronizar Billetera"
           }
         }
       }
     },
-    "resyncWalletCurrentHeightInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Use the button below if you wish to change it."
+    "resyncWalletCurrentHeightInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet will be resynced from ^[%@](style: 'boldPrimary') (%@ blocks). Use the button below if you wish to change it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Usa el botón de abajo si deseas cambiarlo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu billetera se resincronizará desde ^[%@](style: 'boldPrimary') (%@ bloques).. Usa el botón de abajo si deseas cambiarlo."
           }
         }
       }
     },
-    "root.destination.alert.failedToProcessDeeplink.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deeplink: (%@))\nError: (%@) (code: %@)"
+    "root.destination.alert.failedToProcessDeeplink.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deeplink: (%@))\nError: (%@) (code: %@)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enlace profundo: (%@))\nError: (%@) (código: %@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enlace profundo: (%@))\nError: (%@) (código: %@)"
           }
         }
       }
     },
-    "root.destination.alert.failedToProcessDeeplink.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to process deeplink."
+    "root.destination.alert.failedToProcessDeeplink.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to process deeplink."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo procesar el enlace profundo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo procesar el enlace profundo."
           }
         }
       }
     },
-    "root.existingWallet.Message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We identified a Zodl database backup on this device. If you create a new wallet, you will lose access to this database backup and if you try to restore later, some information may be lost."
+    "root.existingWallet.Message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We identified a Zodl database backup on this device. If you create a new wallet, you will lose access to this database backup and if you try to restore later, some information may be lost."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Identificamos una copia de seguridad de la base de datos de Zodl en este dispositivo. Si creas una nueva billetera, perderás acceso a esta copia de seguridad de la base de datos y si intentas restaurarla más tarde, se podría perder información."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identificamos una copia de seguridad de la base de datos de Zodl en este dispositivo. Si creas una nueva billetera, perderás acceso a esta copia de seguridad de la base de datos y si intentas restaurarla más tarde, se podría perder información."
           }
         }
       }
     },
-    "root.existingWallet.restore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore"
+    "root.existingWallet.restore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar"
           }
         }
       }
     },
-    "root.initialization.alert.cantCreateNewWallet.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Can't create new wallet. Error: %@"
+    "root.initialization.alert.cantCreateNewWallet.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Can't create new wallet. Error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede crear una nueva billetera. Error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede crear una nueva billetera. Error: %@"
           }
         }
       }
     },
-    "root.initialization.alert.cantLoadSeedPhrase.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Can't load seed phrase from local storage."
+    "root.initialization.alert.cantLoadSeedPhrase.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Can't load seed phrase from local storage."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede cargar la frase semilla desde el almacenamiento local."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede cargar la frase semilla desde el almacenamiento local."
           }
         }
       }
     },
-    "root.initialization.alert.cantStoreThatUserPassedPhraseBackupTest.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Can't store information that user passed phrase backup test. Error: %@"
+    "root.initialization.alert.cantStoreThatUserPassedPhraseBackupTest.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Can't store information that user passed phrase backup test. Error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede almacenar la información de que el usuario pasó la prueba de respaldo de frase. Error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede almacenar la información de que el usuario pasó la prueba de respaldo de frase. Error: %@"
           }
         }
       }
     },
-    "root.initialization.alert.error.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+    "root.initialization.alert.error.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         }
       }
     },
-    "root.initialization.alert.failed.title" : {
-      "comment" : "MARK: - Root",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet initialisation failed."
+    "root.initialization.alert.failed.title": {
+      "comment": "MARK: - Root",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet initialisation failed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falló la inicialización de la billetera."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falló la inicialización de la billetera."
           }
         }
       }
     },
-    "root.initialization.alert.sdkInitFailed.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to initialize the SDK"
+    "root.initialization.alert.sdkInitFailed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to initialize the SDK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo inicializar el SDK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo inicializar el SDK"
           }
         }
       }
     },
-    "root.initialization.alert.walletStateFailed.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App initialisation state: %@."
+    "root.initialization.alert.walletStateFailed.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App initialisation state: %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado de inicialización de la aplicación: %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de inicialización de la aplicación: %@."
           }
         }
       }
     },
-    "root.initialization.alert.wipe.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure?"
+    "root.initialization.alert.wipe.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Estás seguro?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Estás seguro?"
           }
         }
       }
     },
-    "root.initialization.alert.wipe.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wipe of the wallet"
+    "root.initialization.alert.wipe.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wipe of the wallet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrado de la billetera"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrado de la billetera"
           }
         }
       }
     },
-    "root.initialization.alert.wipeFailed.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet deletion only partially succeeded. Please retry to finish the resetting process."
+    "root.initialization.alert.wipeFailed.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet deletion only partially succeeded. Please retry to finish the resetting process."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La eliminación de la billetera solo tuvo éxito parcialmente. Por favor, intenta de nuevo para completar el proceso de restablecimiento."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La eliminación de la billetera solo tuvo éxito parcialmente. Por favor, intenta de nuevo para completar el proceso de restablecimiento."
           }
         }
       }
     },
-    "root.initialization.alert.wipeFailed.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet deletion failed."
+    "root.initialization.alert.wipeFailed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet deletion failed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La eliminación de la billetera falló"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La eliminación de la billetera falló"
           }
         }
       }
     },
-    "root.seedPhrase.differentSeed.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This recovery phrase doesn't match the Zodl database backup saved on this device. If you proceed, you will lose access to this database backup and if you try to restore later, some information may be lost."
+    "root.seedPhrase.differentSeed.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This recovery phrase doesn't match the Zodl database backup saved on this device. If you proceed, you will lose access to this database backup and if you try to restore later, some information may be lost."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta frase de recuperación no coincide con la copia de seguridad de la base de datos de Zodl guardada en este dispositivo. Si continúas, perderás acceso a esta copia de seguridad de la base de datos y si intentas restaurarla más tarde, se podría perder información."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta frase de recuperación no coincide con la copia de seguridad de la base de datos de Zodl guardada en este dispositivo. Si continúas, perderás acceso a esta copia de seguridad de la base de datos y si intentas restaurarla más tarde, se podría perder información."
           }
         }
       }
     },
-    "root.seedPhrase.differentSeed.tryAgain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try Again"
+    "root.seedPhrase.differentSeed.tryAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intentar de nuevo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentar de nuevo"
           }
         }
       }
     },
-    "root.serviceUnavailable.Message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your current server is experiencing difficulties. Check your device connection, and/or navigate to Advanced Settings to choose a different server."
+    "root.serviceUnavailable.Message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your current server is experiencing difficulties. Check your device connection, and/or navigate to Advanced Settings to choose a different server."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu servidor actual está experimentando dificultades. Verifica la conexión de tu dispositivo y/o navega a Configuración Avanzada para elegir un servidor diferente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu servidor actual está experimentando dificultades. Verifica la conexión de tu dispositivo y/o navega a Configuración Avanzada para elegir un servidor diferente."
           }
         }
       }
     },
-    "root.serviceUnavailable.switchServer" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch server"
+    "root.serviceUnavailable.switchServer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch server"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar servidor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar servidor"
           }
         }
       }
     },
-    "scan.cameraSettings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The camera is not authorized. Please go to the system settings of Zodl and turn it on."
+    "scan.cameraSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The camera is not authorized. Please go to the system settings of Zodl and turn it on."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La cámara no está autorizada. Por favor, ve a la configuración del sistema de Zodl y actívala."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cámara no está autorizada. Por favor, ve a la configuración del sistema de Zodl y actívala."
           }
         }
       }
     },
-    "scan.invalidImage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This image doesn't contain a valid Zcash address."
+    "scan.invalidImage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This image doesn't contain a valid Zcash address."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta imagen no contiene una dirección Zcash válida."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta imagen no contiene una dirección Zcash válida."
           }
         }
       }
     },
-    "scan.invalidQR" : {
-      "comment" : "MARK: - Scan",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This QR code doesn't contain a valid Zcash address."
+    "scan.invalidQR": {
+      "comment": "MARK: - Scan",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This QR code doesn't contain a valid Zcash address."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este código QR no contiene una dirección Zcash válida."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este código QR no contiene una dirección Zcash válida."
           }
         }
       }
     },
-    "scan.openSettings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open settings"
+    "scan.openSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir configuración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir configuración"
           }
         }
       }
     },
-    "scan.severalCodesFound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This image contains several valid Zcash addresses."
+    "scan.severalCodesFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This image contains several valid Zcash addresses."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta imagen contiene varias direcciones Zcash válidas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta imagen contiene varias direcciones Zcash válidas."
           }
         }
       }
     },
-    "send.addressNotInBook" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add contact by tapping on Address Book icon."
+    "send.addressNotInBook": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add contact by tapping on Address Book icon."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agrega un contacto tocando el ícono de la libreta de direcciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agrega un contacto tocando el ícono de la libreta de direcciones."
           }
         }
       }
     },
-    "send.addressPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash Address"
+    "send.addressPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección de Zcash"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección de Zcash"
           }
         }
       }
     },
-    "send.alert.failure.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+    "send.alert.failure.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         }
       }
     },
-    "send.alert.failure.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to send funds"
+    "send.alert.failure.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to send funds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo enviar fondos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo enviar fondos"
           }
         }
       }
     },
-    "send.amount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amount"
+    "send.amount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monto"
           }
         }
       }
     },
-    "send.amountSummary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total Amount"
+    "send.amountSummary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total Amount"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto Total"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monto Total"
           }
         }
       }
     },
-    "send.confirmationTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmation"
+    "send.confirmationTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmation"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmación"
           }
         }
       }
     },
-    "send.currencyPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USD"
+    "send.currencyPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USD"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USD"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USD"
           }
         }
       }
     },
-    "send.currencyUnavailable.continueInZEC" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue in ZEC"
+    "send.currencyUnavailable.continueInZEC": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue in ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar en ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar en ZEC"
           }
         }
       }
     },
-    "send.currencyUnavailable.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Live rates for %@ can't be fetched right now. You can use USD as a fallback, or keep entering amounts in ZEC only."
+    "send.currencyUnavailable.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live rates for %@ can't be fetched right now. You can use USD as a fallback, or keep entering amounts in ZEC only."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pueden obtener las tasas en tiempo real de %@ en este momento. Puedes usar USD como alternativa o seguir ingresando montos solo en ZEC."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pueden obtener las tasas en tiempo real de %@ en este momento. Puedes usar USD como alternativa o seguir ingresando montos solo en ZEC."
           }
         }
       }
     },
-    "send.currencyUnavailable.switchToUSD" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch to USD"
+    "send.currencyUnavailable.switchToUSD": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch to USD"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar a USD"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar a USD"
           }
         }
       }
     },
-    "send.currencyUnavailable.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ conversion unavailable"
+    "send.currencyUnavailable.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ conversion unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conversión de %@ no disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conversión de %@ no disponible"
           }
         }
       }
     },
-    "send.error.insufficientFunds" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insufficient funds"
+    "send.error.insufficientFunds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insufficient funds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fondos insuficientes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondos insuficientes"
           }
         }
       }
     },
-    "send.error.invalidAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid address"
+    "send.error.invalidAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección no válida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección no válida"
           }
         }
       }
     },
-    "send.error.invalidAmount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid amount"
+    "send.error.invalidAmount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid amount"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto no válido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monto no válido"
           }
         }
       }
     },
-    "send.failure" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to send"
+    "send.failure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to send"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo enviar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo enviar"
           }
         }
       }
     },
-    "send.failureAnchorInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet's chain state changed while preparing this transaction. Please wait for sync to complete and try again."
+    "send.failureAnchorInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet's chain state changed while preparing this transaction. Please wait for sync to complete and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El estado de la cadena cambió mientras se preparaba la transacción. Por favor, espera a que la sincronización termine e intenta de nuevo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estado de la cadena cambió mientras se preparaba la transacción. Por favor, espera a que la sincronización termine e intenta de nuevo."
           }
         }
       }
     },
-    "send.failureInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There was an error attempting to send coins. Try it again, please."
+    "send.failureInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There was an error attempting to send coins. Try it again, please."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hubo un error al intentar enviar monedas. Por favor, inténtalo de nuevo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hubo un error al intentar enviar monedas. Por favor, inténtalo de nuevo."
           }
         }
       }
     },
-    "send.failureShielding" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to shield"
+    "send.failureShielding": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to shield"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo proteger"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo proteger"
           }
         }
       }
     },
-    "send.failureShieldingInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There was an error attempting to shield your coins. Try it again, please."
+    "send.failureShieldingInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There was an error attempting to shield your coins. Try it again, please."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hubo un error al intentar proteger tus monedas. Por favor, inténtalo de nuevo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hubo un error al intentar proteger tus monedas. Por favor, inténtalo de nuevo."
           }
         }
       }
     },
-    "send.feeSummary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee"
+    "send.feeSummary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tarifa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarifa"
           }
         }
       }
     },
-    "send.info.memo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transparent transactions can’t have memos"
+    "send.info.memo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparent transactions can’t have memos"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las transacciones transparentes no pueden tener mensajes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las transacciones transparentes no pueden tener mensajes"
           }
         }
       }
     },
-    "send.memoPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Write encrypted message here..."
+    "send.memoPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Write encrypted message here..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escribe un mensaje que será enviado cifrado..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribe un mensaje que será enviado cifrado..."
           }
         }
       }
     },
-    "send.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Message"
+    "send.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensaje"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensaje"
           }
         }
       }
     },
-    "send.partialFailureInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Only some of the transactions were accepted. Please contact support so we can help verify and recover the remaining funds."
+    "send.partialFailureInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only some of the transactions were accepted. Please contact support so we can help verify and recover the remaining funds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solo se aceptaron algunas de las transacciones. Contacta a soporte para que podamos ayudar a verificar y recuperar los fondos restantes."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo se aceptaron algunas de las transacciones. Contacta a soporte para que podamos ayudar a verificar y recuperar los fondos restantes."
           }
         }
       }
     },
-    "send.pendingInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your transaction is being processed."
+    "send.pendingInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your transaction is being processed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu transacción se está procesando."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu transacción se está procesando."
           }
         }
       }
     },
-    "send.pendingShieldingInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your shielding transaction is being processed."
+    "send.pendingShieldingInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your shielding transaction is being processed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus Fondos Protegidos se están procesando."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus Fondos Protegidos se están procesando."
           }
         }
       }
     },
-    "send.pendingShieldingTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shielding Pending"
+    "send.pendingShieldingTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shielding Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fondos Protegidos Pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondos Protegidos Pendiente"
           }
         }
       }
     },
-    "send.pendingTimeoutInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timed out waiting for a server response. Your transaction may still have been broadcast."
+    "send.pendingTimeoutInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timed out waiting for a server response. Your transaction may still have been broadcast."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se agotó el tiempo de espera de la respuesta del servidor. Es posible que tu transacción aún se haya transmitido."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se agotó el tiempo de espera de la respuesta del servidor. Es posible que tu transacción aún se haya transmitido."
           }
         }
       }
     },
-    "send.pendingTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transaction Pending"
+    "send.pendingTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transaction Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transacción Pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transacción Pendiente"
           }
         }
       }
     },
-    "send.report" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report"
+    "send.report": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reportar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reportar"
           }
         }
       }
     },
-    "send.requestPayment.for" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For:"
+    "send.requestPayment.for": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para:"
           }
         }
       }
     },
-    "send.requestPayment.requestedBy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requested By"
+    "send.requestPayment.requestedBy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requested By"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solicitado por"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitado por"
           }
         }
       }
     },
-    "send.requestPayment.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Request"
+    "send.requestPayment.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Request"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solicitud de Pago"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitud de Pago"
           }
         }
       }
     },
-    "send.requestPayment.total" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total"
+    "send.requestPayment.total": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total"
           }
         }
       }
     },
-    "send.review" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review"
+    "send.review": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revisar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar"
           }
         }
       }
     },
-    "send.sending" : {
-      "comment" : "MARK: - Send",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending..."
+    "send.sending": {
+      "comment": "MARK: - Send",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviando..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando..."
           }
         }
       }
     },
-    "send.sendingInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your coins are being sent to"
+    "send.sendingInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your coins are being sent to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus monedas están siendo enviados a"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus monedas están siendo enviados a"
           }
         }
       }
     },
-    "send.shielding" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shielding"
+    "send.shielding": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shielding"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protegiendo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protegiendo"
           }
         }
       }
     },
-    "send.shieldingInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your coins are getting shielded"
+    "send.shieldingInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your coins are getting shielded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus monedas están siendo protegidos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus monedas están siendo protegidos"
           }
         }
       }
     },
-    "send.success" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent!"
+    "send.success": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Enviado!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Enviado!"
           }
         }
       }
     },
-    "send.successInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your coins were successfully sent to"
+    "send.successInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your coins were successfully sent to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus monedas fueron enviados exitosamente a"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus monedas fueron enviados exitosamente a"
           }
         }
       }
     },
-    "send.successShielding" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shielded!"
+    "send.successShielding": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shielded!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Protegidos!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Protegidos!"
           }
         }
       }
     },
-    "send.successShieldingInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your coins have been successfully shielded"
+    "send.successShieldingInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your coins have been successfully shielded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus monedas han sido protegidos con éxito"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus monedas han sido protegidos con éxito"
           }
         }
       }
     },
-    "send.to" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send to"
+    "send.to": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar a"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar a"
           }
         }
       }
     },
-    "send.toSummary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send to"
+    "send.toSummary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviando a"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando a"
           }
         }
       }
     },
-    "send.viewTransaction" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View Transaction"
+    "send.viewTransaction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Transaction"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver Transacción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver Transacción"
           }
         }
       }
     },
-    "sendFeedback.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please let us know about any problems you have had, or features you want to see in the future."
+    "sendFeedback.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please let us know about any problems you have had, or features you want to see in the future."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, háznos saber sobre cualquier problema que hayas tenido, o funciones que te gustaría ver en el futuro."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor, háznos saber sobre cualquier problema que hayas tenido, o funciones que te gustaría ver en el futuro."
           }
         }
       }
     },
-    "sendFeedback.hcwhPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I would like to ask about..."
+    "sendFeedback.hcwhPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I would like to ask about..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Me gustaría preguntar sobre..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Me gustaría preguntar sobre..."
           }
         }
       }
     },
-    "sendFeedback.howCanWeHelp" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "How can we help you?"
+    "sendFeedback.howCanWeHelp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How can we help you?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Cómo podemos ayudarte?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Cómo podemos ayudarte?"
           }
         }
       }
     },
-    "sendFeedback.ratingQuestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "How is your Zodl experience?"
+    "sendFeedback.ratingQuestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How is your Zodl experience?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Cómo ha sido tu experiencia con Zodl?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Cómo ha sido tu experiencia con Zodl?"
           }
         }
       }
     },
-    "sendFeedback.screenTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support"
+    "sendFeedback.screenTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soporte"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soporte"
           }
         }
       }
     },
-    "sendFeedback.share.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl"
+    "sendFeedback.share.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl"
           }
         }
       }
     },
-    "sendFeedback.share.notAppleMailInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your device doesn’t have an Apple email set up, so we prepared this message for you to send using your preferred email client. Please send this message to:"
+    "sendFeedback.share.notAppleMailInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your device doesn’t have an Apple email set up, so we prepared this message for you to send using your preferred email client. Please send this message to:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu dispositivo no tiene configurado un correo de Apple, así que preparamos este mensaje para que lo envíes usando tu cliente de correo preferido. Por favor, envía este mensaje a:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu dispositivo no tiene configurado un correo de Apple, así que preparamos este mensaje para que lo envíes usando tu cliente de correo preferido. Por favor, envía este mensaje a:"
           }
         }
       }
     },
-    "sendFeedback.share.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support message"
+    "sendFeedback.share.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensaje de soporte"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensaje de soporte"
           }
         }
       }
     },
-    "sendFeedback.title" : {
-      "comment" : "MARK: - Send Feedback",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send Us Feedback"
+    "sendFeedback.title": {
+      "comment": "MARK: - Send Feedback",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Us Feedback"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envíanos tus Comentarios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envíanos tus Comentarios"
           }
         }
       }
     },
-    "sendSelect.payWithNear" : {
-      "comment" : "CrossPay",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CrossPay with Near"
+    "sendSelect.payWithNear": {
+      "comment": "CrossPay",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CrossPay with Near"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CrossPay con Near"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CrossPay con Near"
           }
         }
       }
     },
-    "sendSelect.payWithNear.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use shielded ZEC to send private cross-chain payments."
+    "sendSelect.payWithNear.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use shielded ZEC to send private cross-chain payments."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use shielded ZEC to send private cross-chain payments."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use shielded ZEC to send private cross-chain payments."
           }
         }
       }
     },
-    "sendSelect.swapWithNear" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap ZEC with NEAR Intents"
+    "sendSelect.swapWithNear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap ZEC with NEAR Intents"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap ZEC con NEAR Intents"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap ZEC con NEAR Intents"
           }
         }
       }
     },
-    "sendSelect.swapWithNear.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap ZEC with other cryptocurrencies."
+    "sendSelect.swapWithNear.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap ZEC with other cryptocurrencies."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haz swap de ZEC con otras criptomonedas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haz swap de ZEC con otras criptomonedas."
           }
         }
       }
     },
-    "sendSelect.zashi.send" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay in ZEC"
+    "sendSelect.zashi.send": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay in ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagar en ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagar en ZEC"
           }
         }
       }
     },
-    "sendSelect.zashi.send.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay anyone by sending them ZEC."
+    "sendSelect.zashi.send.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay anyone by sending them ZEC."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paga a cualquiera enviándole ZEC."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paga a cualquiera enviándole ZEC."
           }
         }
       }
     },
-    "serverSetup.active" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Active"
+    "serverSetup.active": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activo"
           }
         }
       }
     },
-    "serverSetup.alert.failed.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+    "serverSetup.alert.failed.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         }
       }
     },
-    "serverSetup.alert.failed.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid endpoint"
+    "serverSetup.alert.failed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid endpoint"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Punto final no válido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto final no válido"
           }
         }
       }
     },
-    "serverSetup.allServers" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browse all servers"
+    "serverSetup.allServers": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse all servers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Explorar todos los servidores"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explorar todos los servidores"
           }
         }
       }
     },
-    "serverSetup.automatic" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatic"
+    "serverSetup.automatic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automático"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automático"
           }
         }
       }
     },
-    "serverSetup.connectionMode" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connection mode"
+    "serverSetup.connectionMode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de conexión"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de conexión"
           }
         }
       }
     },
-    "serverSetup.couldTakeTime" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This may take a moment..."
+    "serverSetup.couldTakeTime": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This may take a moment..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto puede tardar un momento..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto puede tardar un momento..."
           }
         }
       }
     },
-    "serverSetup.custom" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "custom"
+    "serverSetup.custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "custom"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "personalizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "personalizado"
           }
         }
       }
     },
-    "serverSetup.default" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default"
+    "serverSetup.default": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Predeterminado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
           }
         }
       }
     },
-    "serverSetup.fastestServers" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fastest servers"
+    "serverSetup.fastestServers": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fastest servers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Servidores más rápidos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidores más rápidos"
           }
         }
       }
     },
-    "serverSetup.manual" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manual"
+    "serverSetup.manual": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manual"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual"
           }
         }
       }
     },
-    "serverSetup.multiServerInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We may use multiple servers to optimize performance. To reduce metadata exposure, choose Manual connection mode to select your single server of choice, and ensure Tor is enabled in Advanced Settings."
+    "serverSetup.multiServerInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We may use multiple servers to optimize performance. To reduce metadata exposure, choose Manual connection mode to select your single server of choice, and ensure Tor is enabled in Advanced Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Podemos usar varios servidores para optimizar el rendimiento. Para reducir la exposición de metadatos, selecciona el modo de conexión Manual para elegir un único servidor de tu preferencia y asegúrate de que Tor esté habilitado en Configuración Avanzada."
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Podemos usar varios servidores para optimizar el rendimiento. Para reducir la exposición de metadatos, selecciona el modo de conexión Manual para elegir un único servidor de tu preferencia y asegúrate de que Tor esté habilitado en Configuración Avanzada."
           }
         }
       }
     },
-    "serverSetup.otherServers" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Other servers"
+    "serverSetup.otherServers": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other servers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otros servidores"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otros servidores"
           }
         }
       }
     },
-    "serverSetup.performingTest" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Performing Server Test"
+    "serverSetup.performingTest": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Performing Server Test"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Realizando prueba de servidor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Realizando prueba de servidor"
           }
         }
       }
     },
-    "serverSetup.placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "<hostname>:<port>"
+    "serverSetup.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<hostname>:<port>"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "<nombre del host>:<puerto>"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<nombre del host>:<puerto>"
           }
         }
       }
     },
-    "serverSetup.refresh" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refresh"
+    "serverSetup.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
           }
         }
       }
     },
-    "serverSetup.save" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save selection"
+    "serverSetup.save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save selection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar selección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar selección"
           }
         }
       }
     },
-    "serverSetup.testing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testing"
+    "serverSetup.testing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Probando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Probando"
           }
         }
       }
     },
-    "serverSetup.title" : {
-      "comment" : "MARK: - Server Setup",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server"
+    "serverSetup.title": {
+      "comment": "MARK: - Server Setup",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Servidor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidor"
           }
         }
       }
     },
-    "settings.about" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+    "settings.about": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acerca de"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de"
           }
         }
       }
     },
-    "settings.addressBook" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address Book"
+    "settings.addressBook": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address Book"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Libreta de Direcciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Libreta de Direcciones"
           }
         }
       }
     },
-    "settings.advanced" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advanced Settings"
+    "settings.advanced": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advanced Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración Avanzada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración Avanzada"
           }
         }
       }
     },
-    "settings.chooseServer" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose a Server"
+    "settings.chooseServer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a Server"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elegir un Servidor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegir un Servidor"
           }
         }
       }
     },
-    "settings.coinholderPolling" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beta: Coinholder Polling"
+    "settings.coinholderPolling": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beta: Coinholder Polling"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beta: Coinholder Polling"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beta: Coinholder Polling"
           }
         }
       }
     },
-    "settings.deleteZashi" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Zodl"
+    "settings.deleteZashi": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer Zodl"
           }
         }
       }
     },
-    "settings.deleteZashiWarning" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You will be asked to confirm on the next screen"
+    "settings.deleteZashiWarning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You will be asked to confirm on the next screen"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se te pedirá que confirmes en la siguiente pantalla"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se te pedirá que confirmes en la siguiente pantalla"
           }
         }
       }
     },
-    "settings.exportLogsOnly" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export logs only"
+    "settings.exportLogsOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export logs only"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar solo registros"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar solo registros"
           }
         }
       }
     },
-    "settings.exportPrivateData" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export Private Data"
+    "settings.exportPrivateData": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Private Data"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar Datos Privados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar Datos Privados"
           }
         }
       }
     },
-    "settings.feedback" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send Us Feedback"
+    "settings.feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Us Feedback"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envíanos tus Comentarios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envíanos tus Comentarios"
           }
         }
       }
     },
-    "settings.flexa" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay with Flexa"
+    "settings.flexa": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay with Flexa"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagar con Flexa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagar con Flexa"
           }
         }
       }
     },
-    "settings.flexaDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spend ZEC at thousands of retail locations."
+    "settings.flexaDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spend ZEC at thousands of retail locations."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gasta ZEC en miles de establecimientos comerciales."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gasta ZEC en miles de establecimientos comerciales."
           }
         }
       }
     },
-    "settings.keystone" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect Keystone"
+    "settings.keystone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect Keystone"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectar Keystone"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar Keystone"
           }
         }
       }
     },
-    "settings.keystoneDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect airgapped hardware wallet to store shielded ZEC."
+    "settings.keystoneDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect airgapped hardware wallet to store shielded ZEC."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conecta una billetera de hardware aislada (air-gapped) para almacenar ZEC protegidos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecta una billetera de hardware aislada (air-gapped) para almacenar ZEC protegidos."
           }
         }
       }
     },
-    "settings.private" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor Protection"
+    "settings.private": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor Protection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protección Tor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protección Tor"
           }
         }
       }
     },
-    "settings.recoveryPhrase" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl Recovery Phrase"
+    "settings.recoveryPhrase": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl Recovery Phrase"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frase de Recuperación de Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frase de Recuperación de Zodl"
           }
         }
       }
     },
-    "settings.title" : {
-      "comment" : "MARK: - Settings",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More"
+    "settings.title": {
+      "comment": "MARK: - Settings",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Más"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más"
           }
         }
       }
     },
-    "settings.version" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %@ (%@)"
+    "settings.version": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ (%@)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión %@ (%@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión %@ (%@)"
           }
         }
       }
     },
-    "settings.whatsNew" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "What’s New"
+    "settings.whatsNew": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What’s New"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Novedades"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novedades"
           }
         }
       }
     },
-    "sheet.insufficientBalance.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We couldn’t create this transaction for you. Your wallet doesn’t have enough balance to cover both the transaction amount and transaction fees. Please lower the transaction amount to account for the fees. "
+    "sheet.insufficientBalance.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We couldn’t create this transaction for you. Your wallet doesn’t have enough balance to cover both the transaction amount and transaction fees. Please lower the transaction amount to account for the fees. "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No pudimos crear esta transacción. Tu billetera no tiene suficiente saldo para cubrir tanto el monto de la transacción como las comisiones. Por favor, reduce el monto para considerar las comisiones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No pudimos crear esta transacción. Tu billetera no tiene suficiente saldo para cubrir tanto el monto de la transacción como las comisiones. Por favor, reduce el monto para considerar las comisiones."
           }
         }
       }
     },
-    "sheet.insufficientBalance.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insufficient Funds"
+    "sheet.insufficientBalance.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insufficient Funds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fondos insuficientes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondos insuficientes"
           }
         }
       }
     },
-    "sheet.syncTimeout.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There was an error trying to execute the last operation. Check your connection, VPN setting, restart the app, or try one of the following:"
+    "sheet.syncTimeout.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There was an error trying to execute the last operation. Check your connection, VPN setting, restart the app, or try one of the following:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocurrió un error al intentar ejecutar la última operación. Revisa tu conexión, la configuración de VPN, reinicia la app o prueba una de las siguientes opciones:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocurrió un error al intentar ejecutar la última operación. Revisa tu conexión, la configuración de VPN, reinicia la app o prueba una de las siguientes opciones:"
           }
         }
       }
     },
-    "sheet.syncTimeout.server" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch server"
+    "sheet.syncTimeout.server": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch server"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar servidor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar servidor"
           }
         }
       }
     },
-    "sheet.syncTimeout.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something went wrong"
+    "sheet.syncTimeout.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something went wrong"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algo salió mal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algo salió mal"
           }
         }
       }
     },
-    "sheet.syncTimeout.tor" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Tor protection"
+    "sheet.syncTimeout.tor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Tor protection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deshabilitar protección Tor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deshabilitar protección Tor"
           }
         }
       }
     },
-    "shieldFunds.error.failure.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An error happened during the last shielding transaction. You can try again later or report this issue if the problem persists. \n\n %@"
+    "shieldFunds.error.failure.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An error happened during the last shielding transaction. You can try again later or report this issue if the problem persists. \n\n %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocurrió un error durante la última transacción de protección. Puedes intentarlo nuevamente más tarde o reportar este problema si persiste. \n\n %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocurrió un error durante la última transacción de protección. Puedes intentarlo nuevamente más tarde o reportar este problema si persiste. \n\n %@"
           }
         }
       }
     },
-    "shieldFunds.error.gprc.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An error happened during the last shielding transaction. We will try to resubmit the transaction later. If it fails, you may need to repeat the shielding attempt at a later time."
+    "shieldFunds.error.gprc.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An error happened during the last shielding transaction. We will try to resubmit the transaction later. If it fails, you may need to repeat the shielding attempt at a later time."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocurrió un error durante la última transacción de protección. Intentaremos reenviar la transacción más tarde. Si falla, es posible que debas repetir el intento de protección más tarde."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocurrió un error durante la última transacción de protección. Intentaremos reenviar la transacción más tarde. Si falla, es posible que debas repetir el intento de protección más tarde."
           }
         }
       }
     },
-    "shieldFunds.error.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shielding Error"
+    "shieldFunds.error.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shielding Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de Protección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de Protección"
           }
         }
       }
     },
-    "smartBanner.content.autoShielding.button" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+    "smartBanner.content.autoShielding.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar"
           }
         }
       }
     },
-    "smartBanner.content.autoShielding.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable automatic shielding"
+    "smartBanner.content.autoShielding.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable automatic shielding"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activa la protección automática"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa la protección automática"
           }
         }
       }
     },
-    "smartBanner.content.autoShielding.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-Shielding"
+    "smartBanner.content.autoShielding.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Shielding"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-Protección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Protección"
           }
         }
       }
     },
-    "smartBanner.content.backup.button" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+    "smartBanner.content.backup.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar"
           }
         }
       }
     },
-    "smartBanner.content.backup.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prevent potential loss of funds"
+    "smartBanner.content.backup.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prevent potential loss of funds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Evita la pérdida potencial de fondos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evita la pérdida potencial de fondos"
           }
         }
       }
     },
-    "smartBanner.content.backup.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Backup Required"
+    "smartBanner.content.backup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Backup Required"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Respaldo de Billetera Requerido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respaldo de Billetera Requerido"
           }
         }
       }
     },
-    "smartBanner.content.currencyConversion.button" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+    "smartBanner.content.currencyConversion.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar"
           }
         }
       }
     },
-    "smartBanner.content.currencyConversion.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable to display fiat values"
+    "smartBanner.content.currencyConversion.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable to display fiat values"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activa para mostrar valores fiat"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa para mostrar valores fiat"
           }
         }
       }
     },
-    "smartBanner.content.currencyConversion.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currency Conversion"
+    "smartBanner.content.currencyConversion.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currency Conversion"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conversión de Moneda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conversión de Moneda"
           }
         }
       }
     },
-    "smartBanner.content.disconnected.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check your connection and reload Zodl"
+    "smartBanner.content.disconnected.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your connection and reload Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifica tu conexión y recarga Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica tu conexión y recarga Zodl"
           }
         }
       }
     },
-    "smartBanner.content.disconnected.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Disconnected"
+    "smartBanner.content.disconnected.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Disconnected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Billetera Desconectada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billetera Desconectada"
           }
         }
       }
     },
-    "smartBanner.content.restore.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep Zodl open on active phone screen"
+    "smartBanner.content.restore.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Zodl open on active phone screen"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantén Zodl abierta en una pantalla activa del teléfono"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén Zodl abierta en una pantalla activa del teléfono"
           }
         }
       }
     },
-    "smartBanner.content.restore.infoSpendable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your funds are ready to be used now"
+    "smartBanner.content.restore.infoSpendable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your funds are ready to be used now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus fondos están listos para ser utilizados ahora"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus fondos están listos para ser utilizados ahora"
           }
         }
       }
     },
-    "smartBanner.content.restore.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restoring Wallet • %@ Complete"
+    "smartBanner.content.restore.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restoring Wallet • %@ Complete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurando Billetera • %@ Completo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurando Billetera • %@ Completo"
           }
         }
       }
     },
-    "smartBanner.content.shield.button" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shield"
+    "smartBanner.content.shield.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shield"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proteger"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proteger"
           }
         }
       }
     },
-    "smartBanner.content.shield.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unshielded Balance"
+    "smartBanner.content.shield.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unshielded Balance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saldo No Protegido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saldo No Protegido"
           }
         }
       }
     },
-    "smartBanner.content.sync.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your wallet is updating"
+    "smartBanner.content.sync.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your wallet is updating"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu billetera se está actualizando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu billetera se está actualizando"
           }
         }
       }
     },
-    "smartBanner.content.sync.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing • %@ Complete"
+    "smartBanner.content.sync.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing • %@ Complete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizando • %@ Completo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizando • %@ Completo"
           }
         }
       }
     },
-    "smartBanner.content.syncingError.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attempting to resolve"
+    "smartBanner.content.syncingError.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attempting to resolve"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intentando resolver"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentando resolver"
           }
         }
       }
     },
-    "smartBanner.content.syncingError.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error encountered while syncing"
+    "smartBanner.content.syncingError.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error encountered while syncing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al sincronizar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al sincronizar"
           }
         }
       }
     },
-    "smartBanner.content.tor.button" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review"
+    "smartBanner.content.tor.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revisar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar"
           }
         }
       }
     },
-    "smartBanner.content.tor.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protect your IP address"
+    "smartBanner.content.tor.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protect your IP address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protege tu dirección IP"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protege tu dirección IP"
           }
         }
       }
     },
-    "smartBanner.content.tor.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Tor Protection"
+    "smartBanner.content.tor.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Tor Protection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar protección Tor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar protección Tor"
           }
         }
       }
     },
-    "smartBanner.content.updatingBalance.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for last transaction to process"
+    "smartBanner.content.updatingBalance.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for last transaction to process"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esperando a que la última transacción se procese"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando a que la última transacción se procese"
           }
         }
       }
     },
-    "smartBanner.content.updatingBalance.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updating Balance..."
+    "smartBanner.content.updatingBalance.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updating Balance..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizando Balance..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando Balance..."
           }
         }
       }
     },
-    "smartBanner.help.backup.acknowledge" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I read and understand the risks of not backing up my wallet."
+    "smartBanner.help.backup.acknowledge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I read and understand the risks of not backing up my wallet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "He leído y entiendo los riesgos de no respaldar mi billetera."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "He leído y entiendo los riesgos de no respaldar mi billetera."
           }
         }
       }
     },
-    "smartBanner.help.backup.info1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prevent potential loss of funds by securely backing up your wallet."
+    "smartBanner.help.backup.info1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prevent potential loss of funds by securely backing up your wallet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Evita la pérdida potencial de fondos respaldando tu billetera de forma segura."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evita la pérdida potencial de fondos respaldando tu billetera de forma segura."
           }
         }
       }
     },
-    "smartBanner.help.backup.info2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back up access to your funds by backing up:"
+    "smartBanner.help.backup.info2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back up access to your funds by backing up:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Respalda el acceso a tus fondos realizando un respaldo de:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respalda el acceso a tus fondos realizando un respaldo de:"
           }
         }
       }
     },
-    "smartBanner.help.backup.info3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In case you lose access to the app or to your device, knowing the Secret Recovery Phrase is the only way to recover your funds. We cannot see it and cannot help you recover it."
+    "smartBanner.help.backup.info3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In case you lose access to the app or to your device, knowing the Secret Recovery Phrase is the only way to recover your funds. We cannot see it and cannot help you recover it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En caso de que pierdas acceso a la aplicación o a tu dispositivo, conocer la Frase de Recuperación Secreta es la única forma de recuperar tus fondos. No podemos verla ni podemos ayudarte a recuperarla."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En caso de que pierdas acceso a la aplicación o a tu dispositivo, conocer la Frase de Recuperación Secreta es la única forma de recuperar tus fondos. No podemos verla ni podemos ayudarte a recuperarla."
           }
         }
       }
     },
-    "smartBanner.help.backup.info4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anyone with access to your Secret Recovery Phrase will have full control of your wallet, so keep it secure and never show it to anyone."
+    "smartBanner.help.backup.info4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anyone with access to your Secret Recovery Phrase will have full control of your wallet, so keep it secure and never show it to anyone."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cualquiera que tenga acceso a tu Frase de Recuperación Secreta tendrá control total de tu billetera, así que mantenla segura y nunca la muestres a nadie."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cualquiera que tenga acceso a tu Frase de Recuperación Secreta tendrá control total de tu billetera, así que mantenla segura y nunca la muestres a nadie."
           }
         }
       }
     },
-    "smartBanner.help.backup.point1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Secret Recovery Phrase (a unique set of 24 words in a precise order) "
+    "smartBanner.help.backup.point1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secret Recovery Phrase (a unique set of 24 words in a precise order) "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frase de Recuperación Secreta (un conjunto único de 24 palabras en un orden preciso)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frase de Recuperación Secreta (un conjunto único de 24 palabras en un orden preciso)"
           }
         }
       }
     },
-    "smartBanner.help.backup.point2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Birthday Height (block height at which your wallet was created)"
+    "smartBanner.help.backup.point2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Birthday Height (block height at which your wallet was created)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altura de Cumpleaños de la Billetera (altura de bloque en la que se creó tu billetera)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altura de Cumpleaños de la Billetera (altura de bloque en la que se creó tu billetera)"
           }
         }
       }
     },
-    "smartBanner.help.backup.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Backup Required"
+    "smartBanner.help.backup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup Required"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Respaldo Requerido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respaldo Requerido"
           }
         }
       }
     },
-    "smartBanner.help.diconnected.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You appear to be offline. Please restore your internet connection to use Zodl wallet."
+    "smartBanner.help.diconnected.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You appear to be offline. Please restore your internet connection to use Zodl wallet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parece que estás offline. Por favor, restaura tu conexión a internet para usar la billetera Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parece que estás offline. Por favor, restaura tu conexión a internet para usar la billetera Zodl."
           }
         }
       }
     },
-    "smartBanner.help.diconnected.title" : {
-      "comment" : "Smart Banner",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Disconnected"
+    "smartBanner.help.diconnected.title": {
+      "comment": "Smart Banner",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Disconnected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Billetera Desconectada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billetera Desconectada"
           }
         }
       }
     },
-    "smartBanner.help.remindMePhase1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remind me in 2 days"
+    "smartBanner.help.remindMePhase1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remind me in 2 days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recuérdame en 2 días"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuérdame en 2 días"
           }
         }
       }
     },
-    "smartBanner.help.remindMePhase2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remind me in 2 weeks"
+    "smartBanner.help.remindMePhase2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remind me in 2 weeks"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recuérdame en 2 semanas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuérdame en 2 semanas"
           }
         }
       }
     },
-    "smartBanner.help.remindMePhase3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remind me next month"
+    "smartBanner.help.remindMePhase3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remind me next month"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recuérdame el próximo mes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuérdame el próximo mes"
           }
         }
       }
     },
-    "smartBanner.help.restore.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to restore. Follow these steps to prevent interruption:"
+    "smartBanner.help.restore.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl is scanning the blockchain to retrieve your transactions. Older wallets can take hours to restore. Follow these steps to prevent interruption:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl está escaneando la blockchain para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en restaurarse. Sigue estos pasos para evitar interrupciones:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl está escaneando la blockchain para recuperar tus transacciones. Las billeteras más antiguas pueden tardar horas en restaurarse. Sigue estos pasos para evitar interrupciones:"
           }
         }
       }
     },
-    "smartBanner.help.restore.point1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep the Zodl app open on an active phone screen."
+    "smartBanner.help.restore.point1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep the Zodl app open on an active phone screen."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantén la aplicación Zodl abierta en una pantalla activa del teléfono."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén la aplicación Zodl abierta en una pantalla activa del teléfono."
           }
         }
       }
     },
-    "smartBanner.help.restore.point2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To prevent your phone screen from going dark, turn off power-saving mode and keep your phone plugged in."
+    "smartBanner.help.restore.point2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To prevent your phone screen from going dark, turn off power-saving mode and keep your phone plugged in."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para evitar que la pantalla de tu teléfono se apague, desactiva el modo de ahorro de energía y mantén tu teléfono conectado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para evitar que la pantalla de tu teléfono se apague, desactiva el modo de ahorro de energía y mantén tu teléfono conectado."
           }
         }
       }
     },
-    "smartBanner.help.restore.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Restore in Progress"
+    "smartBanner.help.restore.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Restore in Progress"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restauración de Billetera en Progreso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restauración de Billetera en Progreso"
           }
         }
       }
     },
-    "smartBanner.help.restore.warning" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funds cannot be spent until your wallet is restored."
+    "smartBanner.help.restore.warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funds cannot be spent until your wallet is restored."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los fondos no pueden ser gastados hasta que tu billetera esté restaurada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los fondos no pueden ser gastados hasta que tu billetera esté restaurada."
           }
         }
       }
     },
-    "smartBanner.help.resync.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Resync in Progress"
+    "smartBanner.help.resync.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Resync in Progress"
           }
         }
       }
     },
-    "smartBanner.help.shield.doNotShowAgain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do not show this message again"
+    "smartBanner.help.shield.doNotShowAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not show this message again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No mostrar este mensaje de nuevo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No mostrar este mensaje de nuevo"
           }
         }
       }
     },
-    "smartBanner.help.shield.info1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To protect user privacy, Zodl doesn't support spending transparent ZEC. Tap the \"Shield\" button below to make your transparent funds spendable and your total Zodl balance private. "
+    "smartBanner.help.shield.info1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To protect user privacy, Zodl doesn't support spending transparent ZEC. Tap the \"Shield\" button below to make your transparent funds spendable and your total Zodl balance private. "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para proteger la privacidad del usuario, Zodl no admite el gasto de ZEC transparente. Toca el botón \"Proteger\" abajo para hacer que tus fondos transparentes sean gastables y tu saldo total en Zodl sea privado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para proteger la privacidad del usuario, Zodl no admite el gasto de ZEC transparente. Toca el botón \"Proteger\" abajo para hacer que tus fondos transparentes sean gastables y tu saldo total en Zodl sea privado."
           }
         }
       }
     },
-    "smartBanner.help.shield.info2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This will create a shielding in-wallet transaction, consolidating your transparent and shielded funds. (Typical fee: %@)"
+    "smartBanner.help.shield.info2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will create a shielding in-wallet transaction, consolidating your transparent and shielded funds. (Typical fee: %@)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto creará una transacción de protección en la billetera, consolidando tus fondos transparentes y protegidos. (Tarifa típica: %@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto creará una transacción de protección en la billetera, consolidando tus fondos transparentes y protegidos. (Tarifa típica: %@)"
           }
         }
       }
     },
-    "smartBanner.help.shield.notNow" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not now"
+    "smartBanner.help.shield.notNow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ahora no"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ahora no"
           }
         }
       }
     },
-    "smartBanner.help.shield.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Shield Transparent Funds"
+    "smartBanner.help.shield.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always Shield Transparent Funds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protege Siempre los Fondos Transparentes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protege Siempre los Fondos Transparentes"
           }
         }
       }
     },
-    "smartBanner.help.shield.transparent" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transparent"
+    "smartBanner.help.shield.transparent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparent"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transparente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparente"
           }
         }
       }
     },
-    "smartBanner.help.sync.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl is scanning the blockchain for your latest transactions to make sure your balances are displayed correctly. Keep the Zodl app open on an active phone screen to avoid interruptions."
+    "smartBanner.help.sync.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl is scanning the blockchain for your latest transactions to make sure your balances are displayed correctly. Keep the Zodl app open on an active phone screen to avoid interruptions."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl está escaneando la blockchain para tus últimas transacciones para asegurarse de que tus balances se muestren correctamente. Mantén la aplicación Zodl abierta en una pantalla activa del teléfono para evitar interrupciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl está escaneando la blockchain para tus últimas transacciones para asegurarse de que tus balances se muestren correctamente. Mantén la aplicación Zodl abierta en una pantalla activa del teléfono para evitar interrupciones."
           }
         }
       }
     },
-    "smartBanner.help.sync.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Sync in Progress"
+    "smartBanner.help.sync.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Sync in Progress"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronización de Billetera en Progreso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización de Billetera en Progreso"
           }
         }
       }
     },
-    "smartBanner.help.syncError.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing Error"
+    "smartBanner.help.syncError.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de Sincronización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de Sincronización"
           }
         }
       }
     },
-    "smartBanner.help.updatingBalance.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your last transaction is getting mined and confirmed."
+    "smartBanner.help.updatingBalance.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your last transaction is getting mined and confirmed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu última transacción está siendo minada y confirmada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu última transacción está siendo minada y confirmada."
           }
         }
       }
     },
-    "smartBanner.help.updatingBalance.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updating Balance"
+    "smartBanner.help.updatingBalance.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updating Balance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizando Balance"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando Balance"
           }
         }
       }
     },
-    "smartBannerContentResyncing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resyncing"
+    "smartBannerContentResyncing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resyncing"
           }
         }
       }
     },
-    "splash.authFaceID" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap the face icon to use Face ID and unlock it."
+    "splash.authFaceID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap the face icon to use Face ID and unlock it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toca el ícono de la cara para usar Face ID y desbloquear."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca el ícono de la cara para usar Face ID y desbloquear."
           }
         }
       }
     },
-    "splash.authPasscode" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap the key icon to enter your passcode and unlock it."
+    "splash.authPasscode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap the key icon to enter your passcode and unlock it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toca el ícono de la llave para ingresar tu código y desbloquear."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca el ícono de la llave para ingresar tu código y desbloquear."
           }
         }
       }
     },
-    "splash.authTitle" : {
-      "comment" : "MARK: - Splash Screen",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Zodl account is secured."
+    "splash.authTitle": {
+      "comment": "MARK: - Splash Screen",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Zodl account is secured."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu cuenta Zodl está protegida."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu cuenta Zodl está protegida."
           }
         }
       }
     },
-    "splash.authTouchID" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap the print icon to use Touch ID and unlock it."
+    "splash.authTouchID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap the print icon to use Touch ID and unlock it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toca el ícono de la huella para usar Touch ID y desbloquear."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca el ícono de la huella para usar Touch ID y desbloquear."
           }
         }
       }
     },
-    "supportData.appVersionItem.bundleIdentifier" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App identifier"
+    "supportData.appVersionItem.bundleIdentifier": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App identifier"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Identificador de la aplicación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identificador de la aplicación"
           }
         }
       }
     },
-    "supportData.appVersionItem.version" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App version"
+    "supportData.appVersionItem.version": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de la aplicación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de la aplicación"
           }
         }
       }
     },
-    "supportData.deviceModelItem.device" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Device"
+    "supportData.deviceModelItem.device": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Device"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dispositivo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dispositivo"
           }
         }
       }
     },
-    "supportData.freeDiskSpaceItem.freeDiskSpace" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usable storage"
+    "supportData.freeDiskSpaceItem.freeDiskSpace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usable storage"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Almacenamiento disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento disponible"
           }
         }
       }
     },
-    "supportData.localeItem.decimalSeparator" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currency decimal separator"
+    "supportData.localeItem.decimalSeparator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currency decimal separator"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Separador decimal de moneda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separador decimal de moneda"
           }
         }
       }
     },
-    "supportData.localeItem.groupingSeparator" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currency grouping separator"
+    "supportData.localeItem.groupingSeparator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currency grouping separator"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Separador de agrupación de moneda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separador de agrupación de moneda"
           }
         }
       }
     },
-    "supportData.localeItem.locale" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locale"
+    "supportData.localeItem.locale": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locale"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Región"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Región"
           }
         }
       }
     },
-    "supportData.permissionItem.camera" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Camera access"
+    "supportData.permissionItem.camera": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Camera access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso a la cámara"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso a la cámara"
           }
         }
       }
     },
-    "supportData.permissionItem.faceID" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FaceID available"
+    "supportData.permissionItem.faceID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FaceID available"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FaceID disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FaceID disponible"
           }
         }
       }
     },
-    "supportData.permissionItem.permissions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permissions"
+    "supportData.permissionItem.permissions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permisos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permisos"
           }
         }
       }
     },
-    "supportData.permissionItem.touchID" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TouchID available"
+    "supportData.permissionItem.touchID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TouchID available"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TouchID disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TouchID disponible"
           }
         }
       }
     },
-    "supportData.systemVersionItem.version" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "iOS version"
+    "supportData.systemVersionItem.version": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de iOS"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de iOS"
           }
         }
       }
     },
-    "supportData.timeItem.time" : {
-      "comment" : "MARK: - Support Data",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Current time"
+    "supportData.timeItem.time": {
+      "comment": "MARK: - Support Data",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current time"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hora actual"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hora actual"
           }
         }
       }
     },
-    "swap.nearProvider" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "near"
+    "swap.nearProvider": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "near"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "near"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "near"
           }
         }
       }
     },
-    "swap.quoteUnavailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We tried but couldn’t get a quote for a payment with your parameters. You can try to adjust the slippage or try again later."
+    "swap.quoteUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We tried but couldn’t get a quote for a payment with your parameters. You can try to adjust the slippage or try again later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intentamos, pero no pudimos obtener una cotización para un pago con tus parámetros. Puedes ajustar el slippage o intentar más tarde."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentamos, pero no pudimos obtener una cotización para un pago con tus parámetros. Puedes ajustar el slippage o intentar más tarde."
           }
         }
       }
     },
-    "swap.quoteUnavailableSwap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We tried but couldn’t get a quote for a swap with your parameters. You can try to adjust the slippage or try again later."
+    "swap.quoteUnavailableSwap": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We tried but couldn’t get a quote for a swap with your parameters. You can try to adjust the slippage or try again later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intentamos, pero no pudimos obtener una cotización para un swap con tus parámetros. Puedes ajustar el slippage o intentar más tarde."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentamos, pero no pudimos obtener una cotización para un swap con tus parámetros. Puedes ajustar el slippage o intentar más tarde."
           }
         }
       }
     },
-    "swapAndPay.address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address"
+    "swapAndPay.address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección"
           }
         }
       }
     },
-    "swapAndPay.addressBookNewContact" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add new contact"
+    "swapAndPay.addressBookNewContact": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add new contact"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar nuevo contacto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar nuevo contacto"
           }
         }
       }
     },
-    "swapAndPay.addressBookSelect" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select..."
+    "swapAndPay.addressBookSelect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar..."
           }
         }
       }
     },
-    "swapAndPay.addressBookSelectChain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Chain"
+    "swapAndPay.addressBookSelectChain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Chain"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar cadena"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar cadena"
           }
         }
       }
     },
-    "swapAndPay.addressBookZcash" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash address is not allowed"
+    "swapAndPay.addressBookZcash": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash address is not allowed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección de Zcash no permitida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección de Zcash no permitida"
           }
         }
       }
     },
-    "swapAndPay.cancelDont" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Don’t cancel"
+    "swapAndPay.cancelDont": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don’t cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No cancelar"
           }
         }
       }
     },
-    "swapAndPay.cancelMsg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you leave this screen, all the information you entered will be lost."
+    "swapAndPay.cancelMsg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you leave this screen, all the information you entered will be lost."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si sales de esta pantalla, toda la información ingresada se perderá."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si sales de esta pantalla, toda la información ingresada se perderá."
           }
         }
       }
     },
-    "swapAndPay.cancelPayment" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel payment"
+    "swapAndPay.cancelPayment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel payment"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar pago"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar pago"
           }
         }
       }
     },
-    "swapAndPay.cancelSwap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel swap"
+    "swapAndPay.cancelSwap": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel swap"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar swap"
           }
         }
       }
     },
-    "swapAndPay.canceltitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure?"
+    "swapAndPay.canceltitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Estás seguro?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Estás seguro?"
           }
         }
       }
     },
-    "swapAndPay.checkStatus" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check status"
+    "swapAndPay.checkStatus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check status"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver estado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver estado"
           }
         }
       }
     },
-    "swapAndPay.custom" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custom"
+    "swapAndPay.custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otro"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otro"
           }
         }
       }
     },
-    "swapAndPay.editPayment" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit payment"
+    "swapAndPay.editPayment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit payment"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editar pago"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar pago"
           }
         }
       }
     },
-    "swapAndPay.editSwap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit swap"
+    "swapAndPay.editSwap": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit swap"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editar swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar swap"
           }
         }
       }
     },
-    "swapAndPay.emptyAssets.subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We tried but couldn’t find anything."
+    "swapAndPay.emptyAssets.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We tried but couldn’t find anything."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lo intentamos pero no encontramos nada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo intentamos pero no encontramos nada."
           }
         }
       }
     },
-    "swapAndPay.emptyAssets.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No results"
+    "swapAndPay.emptyAssets.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No results"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin resultados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin resultados"
           }
         }
       }
     },
-    "swapAndPay.executedSlippage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Realized slippage"
+    "swapAndPay.executedSlippage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Realized slippage"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deslizamiento realizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deslizamiento realizado"
           }
         }
       }
     },
-    "swapAndPay.expiredMsg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This swap expired after its 24-hour validity window. If you didn't send funds, no action is needed. If you did send funds, contact support so we can help."
+    "swapAndPay.expiredMsg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This swap expired after its 24-hour validity window. If you didn't send funds, no action is needed. If you did send funds, contact support so we can help."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este intercambio venció tras su ventana de validez de 24 horas. Si no enviaste fondos, no es necesario hacer nada. Si enviaste fondos, contacta a soporte para que podamos ayudarte."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este intercambio venció tras su ventana de validez de 24 horas. Si no enviaste fondos, no es necesario hacer nada. Si enviaste fondos, contacta a soporte para que podamos ayudarte."
           }
         }
       }
     },
-    "swapAndPay.expiredTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Expired"
+    "swapAndPay.expiredTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Expired"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intercambio vencido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intercambio vencido"
           }
         }
       }
     },
-    "swapAndPay.failedMsg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This swap could not be completed. If you deposited funds and didn't receive your swap, contact support so we can help resolve it."
+    "swapAndPay.failedMsg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This swap could not be completed. If you deposited funds and didn't receive your swap, contact support so we can help resolve it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este intercambio no pudo completarse. Si depositaste fondos y no recibiste tu intercambio, contacta a soporte para que podamos resolverlo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este intercambio no pudo completarse. Si depositaste fondos y no recibiste tu intercambio, contacta a soporte para que podamos resolverlo."
           }
         }
       }
     },
-    "swapAndPay.failedTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Failed"
+    "swapAndPay.failedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intercambio fallido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intercambio fallido"
           }
         }
       }
     },
-    "swapAndPay.failure.laterDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please try again later."
+    "swapAndPay.failure.laterDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please try again later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor inténtalo más tarde."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor inténtalo más tarde."
           }
         }
       }
     },
-    "swapAndPay.failure.laterTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The service is unavailable"
+    "swapAndPay.failure.laterTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The service is unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El servicio no está disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El servicio no está disponible"
           }
         }
       }
     },
-    "swapAndPay.failure.retryDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please check your connection and try again."
+    "swapAndPay.failure.retryDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please check your connection and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor revisa tu conexión e inténtalo de nuevo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor revisa tu conexión e inténtalo de nuevo."
           }
         }
       }
     },
-    "swapAndPay.failure.retryTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unexpected error"
+    "swapAndPay.failure.retryTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unexpected error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error inesperado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error inesperado"
           }
         }
       }
     },
-    "swapAndPay.failure.tryAgain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try again"
+    "swapAndPay.failure.tryAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intentar de nuevo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentar de nuevo"
           }
         }
       }
     },
-    "swapAndPay.failure.wrong" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Something went wrong"
+    "swapAndPay.failure.wrong": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something went wrong"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algo salió mal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algo salió mal"
           }
         }
       }
     },
-    "swapAndPay.failure.wrongDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We couldn’t load the assets. Please check your connection and try again."
+    "swapAndPay.failure.wrongDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We couldn’t load the assets. Please check your connection and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No pudimos cargar los activos. Por favor revisa tu conexión e inténtalo de nuevo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No pudimos cargar los activos. Por favor revisa tu conexión e inténtalo de nuevo."
           }
         }
       }
     },
-    "swapAndPay.failurePayInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There was an error initiating a cross-chain payment. Try it again, please."
+    "swapAndPay.failurePayInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There was an error initiating a cross-chain payment. Try it again, please."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hubo un error al iniciar el pago entre cadenas. Inténtalo de nuevo, por favor."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hubo un error al iniciar el pago entre cadenas. Inténtalo de nuevo, por favor."
           }
         }
       }
     },
-    "swapAndPay.failureSwapInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There was an error initiating a swap. Try it again, please."
+    "swapAndPay.failureSwapInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There was an error initiating a swap. Try it again, please."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hubo un error al iniciar el intercambio. Inténtalo de nuevo, por favor."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hubo un error al iniciar el intercambio. Inténtalo de nuevo, por favor."
           }
         }
       }
     },
-    "swapAndPay.forcedOptIn.optionOne" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I understand that Zodl makes API requests to the NEAR API every time I interact with a Swap/Pay transaction."
+    "swapAndPay.forcedOptIn.optionOne": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I understand that Zodl makes API requests to the NEAR API every time I interact with a Swap/Pay transaction."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entiendo que Zodl realiza solicitudes a la API de NEAR cada vez que interactúo con una transacción de Intercambio/Pago."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entiendo que Zodl realiza solicitudes a la API de NEAR cada vez que interactúo con una transacción de Intercambio/Pago."
           }
         }
       }
     },
-    "swapAndPay.forcedOptIn.optionTwo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I understand that by not enabling Tor, my IP address will be leaked by the NEAR API."
+    "swapAndPay.forcedOptIn.optionTwo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I understand that by not enabling Tor, my IP address will be leaked by the NEAR API."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entiendo que al no habilitar Tor, mi dirección IP será expuesta por la API de NEAR."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entiendo que al no habilitar Tor, mi dirección IP será expuesta por la API de NEAR."
           }
         }
       }
     },
-    "swapAndPay.from" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "From"
+    "swapAndPay.from": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "From"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De"
           }
         }
       }
     },
-    "swapAndPay.getQuote" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Get a quote"
+    "swapAndPay.getQuote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get a quote"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtener cotización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtener cotización"
           }
         }
       }
     },
-    "swapAndPay.help.swapDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap ZEC with any NEAR-supported token. "
+    "swapAndPay.help.swapDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap ZEC with any NEAR-supported token. "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haz swap de ZEC con cualquier token compatible con NEAR."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haz swap de ZEC con cualquier token compatible con NEAR."
           }
         }
       }
     },
-    "swapAndPay.help.swapDesc1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If swapping TO ZEC, you will send funds from a 3rd party wallet and provide an address where change can be refunded."
+    "swapAndPay.help.swapDesc1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If swapping TO ZEC, you will send funds from a 3rd party wallet and provide an address where change can be refunded."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si haces swap HACIA ZEC, enviarás fondos desde una wallet de terceros y deberás proporcionar una dirección donde se pueda reembolsar el cambio."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si haces swap HACIA ZEC, enviarás fondos desde una wallet de terceros y deberás proporcionar una dirección donde se pueda reembolsar el cambio."
           }
         }
       }
     },
-    "swapAndPay.help.swapDesc2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If swapping FROM ZEC, you must provide a valid address for the asset you are swapping to."
+    "swapAndPay.help.swapDesc2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If swapping FROM ZEC, you must provide a valid address for the asset you are swapping to."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si haces swap DESDE ZEC, debes proporcionar una dirección válida para el activo al que haces swap."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si haces swap DESDE ZEC, debes proporcionar una dirección válida para el activo al que haces swap."
           }
         }
       }
     },
-    "swapAndPay.help.swapWith" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap with"
+    "swapAndPay.help.swapWith": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap with"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap con"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap con"
           }
         }
       }
     },
-    "swapAndPay.incompleteInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deposit an additional ^[%@ %@](style: 'boldPrimary') to complete this swap before ^[%@](style: 'boldPrimary'), or your deposit will be refunded."
+    "swapAndPay.incompleteInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deposit an additional ^[%@ %@](style: 'boldPrimary') to complete this swap before ^[%@](style: 'boldPrimary'), or your deposit will be refunded."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deposita ^[%@ %@](style: 'boldPrimary') adicionales para completar este intercambio antes del ^[%@](style: 'boldPrimary'), o tu depósito será reembolsado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deposita ^[%@ %@](style: 'boldPrimary') adicionales para completar este intercambio antes del ^[%@](style: 'boldPrimary'), o tu depósito será reembolsado."
           }
         }
       }
     },
-    "swapAndPay.max" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spendable: %@"
+    "swapAndPay.max": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spendable: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gastable: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gastable: %@"
           }
         }
       }
     },
-    "swapAndPay.maxAllowedSlippage1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please enter maximum slippage of"
+    "swapAndPay.maxAllowedSlippage1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please enter maximum slippage of"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor ingresa un deslizamiento máximo de"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor ingresa un deslizamiento máximo de"
           }
         }
       }
     },
-    "swapAndPay.maxAllowedSlippage2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " %@."
+    "swapAndPay.maxAllowedSlippage2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " %@."
           }
         }
       }
     },
-    "swapAndPay.maxSlippage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Max slippage %@%"
+    "swapAndPay.maxSlippage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max slippage %@%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Máx. deslizamiento %@%"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máx. deslizamiento %@%"
           }
         }
       }
     },
-    "swapAndPay.maxSlippageTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Max slippage"
+    "swapAndPay.maxSlippageTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max slippage"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Máx. deslizamiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máx. deslizamiento"
           }
         }
       }
     },
-    "swapAndPay.oneZecRate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 ZEC = %@ %@"
+    "swapAndPay.oneZecRate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 ZEC = %@ %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 ZEC = %@ %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 ZEC = %@ %@"
           }
         }
       }
     },
-    "swapAndPay.optIn.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This feature is powered by a third-party NEAR API. Zodl needs to make networking calls to fetch rates, quotes, execute transactions and check their status in the transaction history which can leak your IP address. We recommend you to allow Tor connection to protect your IP address at all times."
+    "swapAndPay.optIn.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This feature is powered by a third-party NEAR API. Zodl needs to make networking calls to fetch rates, quotes, execute transactions and check their status in the transaction history which can leak your IP address. We recommend you to allow Tor connection to protect your IP address at all times."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta función es provista por una API de terceros de NEAR. Zodl necesita hacer llamadas de red para obtener tasas, cotizaciones, ejecutar transacciones y revisar su estado en el historial de transacciones, lo cual puede exponer tu dirección IP. Te recomendamos permitir la conexión por Tor para proteger tu dirección IP en todo momento."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta función es provista por una API de terceros de NEAR. Zodl necesita hacer llamadas de red para obtener tasas, cotizaciones, ejecutar transacciones y revisar su estado en el historial de transacciones, lo cual puede exponer tu dirección IP. Te recomendamos permitir la conexión por Tor para proteger tu dirección IP en todo momento."
           }
         }
       }
     },
-    "swapAndPay.optIn.optionOneSubtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable API calls to the NEAR API."
+    "swapAndPay.optIn.optionOneSubtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable API calls to the NEAR API."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Habilitar llamadas API a la API de NEAR."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Habilitar llamadas API a la API de NEAR."
           }
         }
       }
     },
-    "swapAndPay.optIn.optionOneTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow Third-Party Requests"
+    "swapAndPay.optIn.optionOneTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow Third-Party Requests"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir solicitudes de terceros"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir solicitudes de terceros"
           }
         }
       }
     },
-    "swapAndPay.optIn.optionTwoSubtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protect IP address with Tor connection."
+    "swapAndPay.optIn.optionTwoSubtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protect IP address with Tor connection."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protege tu dirección IP con conexión Tor."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protege tu dirección IP con conexión Tor."
           }
         }
       }
     },
-    "swapAndPay.optIn.optionTwoTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Turn on IP Address Protection"
+    "swapAndPay.optIn.optionTwoTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn on IP Address Protection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar protección de dirección IP"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar protección de dirección IP"
           }
         }
       }
     },
-    "swapAndPay.optIn.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap or Pay with"
+    "swapAndPay.optIn.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap or Pay with"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap o Pagar con"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap o Pagar con"
           }
         }
       }
     },
-    "swapAndPay.optIn.warn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note for the super privacy-conscious: Transactions executed via the NEAR API are transparent which means all transaction information is public."
+    "swapAndPay.optIn.warn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the super privacy-conscious: Transactions executed via the NEAR API are transparent which means all transaction information is public."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nota para los más conscientes de la privacidad: Las transacciones ejecutadas a través de la API de NEAR son transparentes, lo que significa que toda la información de la transacción es pública."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota para los más conscientes de la privacidad: Las transacciones ejecutadas a través de la API de NEAR son transparentes, lo que significa que toda la información de la transacción es pública."
           }
         }
       }
     },
-    "swapAndPay.pay" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay"
+    "swapAndPay.pay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagar"
           }
         }
       }
     },
-    "swapAndPay.payFrom" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay from"
+    "swapAndPay.payFrom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay from"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagar desde"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagar desde"
           }
         }
       }
     },
-    "swapAndPay.payNow" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay Now"
+    "swapAndPay.payNow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay Now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagar Ahora"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagar Ahora"
           }
         }
       }
     },
-    "swapAndPay.payTo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pay to"
+    "swapAndPay.payTo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagar a"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagar a"
           }
         }
       }
     },
-    "swapAndPay.pendingPayInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your cross-chain payment is being processed. Follow its status on the transaction screen."
+    "swapAndPay.pendingPayInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your cross-chain payment is being processed. Follow its status on the transaction screen."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu cross-chain pago se está procesando. Siga el estado en la pantalla de transacción."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu cross-chain pago se está procesando. Siga el estado en la pantalla de transacción."
           }
         }
       }
     },
-    "swapAndPay.pendingPayTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Pending"
+    "swapAndPay.pendingPayTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pago Pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pago Pendiente"
           }
         }
       }
     },
-    "swapAndPay.pendingSwapInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your swap is being processed. Follow its status on the transaction screen."
+    "swapAndPay.pendingSwapInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your swap is being processed. Follow its status on the transaction screen."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu swap se está procesando. Siga el estado en la pantalla de transacción."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu swap se está procesando. Siga el estado en la pantalla de transacción."
           }
         }
       }
     },
-    "swapAndPay.pendingSwapTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Pending"
+    "swapAndPay.pendingSwapTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Pendiente"
           }
         }
       }
     },
-    "swapAndPay.processingMsg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your swap has been delayed. Swaps typically complete in minutes but may take longer depending on market conditions."
+    "swapAndPay.processingMsg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your swap has been delayed. Swaps typically complete in minutes but may take longer depending on market conditions."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu intercambio se ha demorado. Los intercambios generalmente se completan en minutos, pero pueden tardar más según las condiciones del mercado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu intercambio se ha demorado. Los intercambios generalmente se completan en minutos, pero pueden tardar más según las condiciones del mercado."
           }
         }
       }
     },
-    "swapAndPay.processingTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Processing"
+    "swapAndPay.processingTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Processing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intercambio en proceso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intercambio en proceso"
           }
         }
       }
     },
-    "swapAndPay.quote.zashi" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl"
+    "swapAndPay.quote.zashi": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl"
           }
         }
       }
     },
-    "swapAndPay.quoteUnavailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quote Unavailable"
+    "swapAndPay.quoteUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quote Unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cotización no disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cotización no disponible"
           }
         }
       }
     },
-    "swapAndPay.rate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rate"
+    "swapAndPay.rate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rate"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tasa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasa"
           }
         }
       }
     },
-    "swapAndPay.recipient" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recipient"
+    "swapAndPay.recipient": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recipient"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Destinatario"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destinatario"
           }
         }
       }
     },
-    "swapAndPay.refundedAmount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refunded amount"
+    "swapAndPay.refundedAmount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refunded amount"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto reembolsado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monto reembolsado"
           }
         }
       }
     },
-    "swapAndPay.refundInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your deposit was detected but the swap could not be completed. Your funds have been returned, minus transaction fees. If you haven't received them, contact the Zodl support team."
+    "swapAndPay.refundInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your deposit was detected but the swap could not be completed. Your funds have been returned, minus transaction fees. If you haven't received them, contact the Zodl support team."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu depósito fue detectado pero el intercambio no pudo completarse. Tus fondos han sido devueltos, descontando las tarifas de transacción. Si aún no los recibiste, contacta al equipo de soporte de Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu depósito fue detectado pero el intercambio no pudo completarse. Tus fondos han sido devueltos, descontando las tarifas de transacción. Si aún no los recibiste, contacta al equipo de soporte de Zodl."
           }
         }
       }
     },
-    "swapAndPay.refundTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funds Returned"
+    "swapAndPay.refundTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funds Returned"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fondos devueltos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondos devueltos"
           }
         }
       }
     },
-    "swapAndPay.search" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search by name or ticker..."
+    "swapAndPay.search": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search by name or ticker..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar por nombre o ticker..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar por nombre o ticker..."
           }
         }
       }
     },
-    "swapAndPay.selectToken" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select asset"
+    "swapAndPay.selectToken": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select asset"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar activo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar activo"
           }
         }
       }
     },
-    "swapAndPay.sendingInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your coins are being sent to the deposit address..."
+    "swapAndPay.sendingInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your coins are being sent to the deposit address..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus monedas están siendo enviadas a la dirección de depósito..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus monedas están siendo enviadas a la dirección de depósito..."
           }
         }
       }
     },
-    "swapAndPay.slippage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slippage"
+    "swapAndPay.slippage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slippage"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deslizamiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deslizamiento"
           }
         }
       }
     },
-    "swapAndPay.slippageDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This setting determines the maximum allowable difference between the expected price of a swap and the actual price you pay, which is outside of Zodl's control."
+    "swapAndPay.slippageDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This setting determines the maximum allowable difference between the expected price of a swap and the actual price you pay, which is outside of Zodl's control."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta configuración determina la diferencia máxima permitida entre el precio esperado de un intercambio y el precio real que pagas, lo cual está fuera del control de Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta configuración determina la diferencia máxima permitida entre el precio esperado de un intercambio y el precio real que pagas, lo cual está fuera del control de Zodl."
           }
         }
       }
     },
-    "swapAndPay.slippageSet1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You may receive up to "
+    "swapAndPay.slippageSet1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You may receive up to "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podrías recibir hasta "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podrías recibir hasta "
           }
         }
       }
     },
-    "swapAndPay.slippageSet2a" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@% (%@)"
+    "swapAndPay.slippageSet2a": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@% (%@)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@% (%@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@% (%@)"
           }
         }
       }
     },
-    "swapAndPay.slippageSet2b" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%"
+    "swapAndPay.slippageSet2b": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%"
           }
         }
       }
     },
-    "swapAndPay.slippageSet3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " less than quoted."
+    "swapAndPay.slippageSet3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " less than quoted."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " menos de lo cotizado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " menos de lo cotizado."
           }
         }
       }
     },
-    "swapAndPay.slippageTolerance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slippage tolerance"
+    "swapAndPay.slippageTolerance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slippage tolerance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tolerancia de deslizamiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tolerancia de deslizamiento"
           }
         }
       }
     },
-    "swapAndPay.slippageWarn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Any unused portion of the slippage fee will be refunded if the swap executes with lower slippage than expected."
+    "swapAndPay.slippageWarn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Any unused portion of the slippage fee will be refunded if the swap executes with lower slippage than expected."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cualquier parte no utilizada de la comisión de deslizamiento será reembolsada si el intercambio se ejecuta con menos deslizamiento del esperado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cualquier parte no utilizada de la comisión de deslizamiento será reembolsada si el intercambio se ejecuta con menos deslizamiento del esperado."
           }
         }
       }
     },
-    "swapAndPay.smallSlippageWarn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[Warning:](style: 'boldPrimary') Slippage ^[under %@%%](style: 'boldPrimary') increases the chance your swap will be unsuccessful and refunded. Consider using ^[%@%% or higher](style: 'boldPrimary'), especially for larger amounts."
+    "swapAndPay.smallSlippageWarn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[Warning:](style: 'boldPrimary') Slippage ^[under %@%%](style: 'boldPrimary') increases the chance your swap will be unsuccessful and refunded. Consider using ^[%@%% or higher](style: 'boldPrimary'), especially for larger amounts."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[Advertencia:](style: 'boldPrimary') Un deslizamiento menor ^[al %@%%](style: 'boldPrimary') aumenta la probabilidad de que tu intercambio no se complete y sea reembolsado. Considera usar ^[%@%% o más](style: 'boldPrimary'), especialmente para montos mayores."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[Advertencia:](style: 'boldPrimary') Un deslizamiento menor ^[al %@%%](style: 'boldPrimary') aumenta la probabilidad de que tu intercambio no se complete y sea reembolsado. Considera usar ^[%@%% o más](style: 'boldPrimary'), especialmente para montos mayores."
           }
         }
       }
     },
-    "swapAndPay.status" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status"
+    "swapAndPay.status": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado"
           }
         }
       }
     },
-    "swapAndPay.status.expired" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expired"
+    "swapAndPay.status.expired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expired"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expirado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expirado"
           }
         }
       }
     },
-    "swapAndPay.status.failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed"
+    "swapAndPay.status.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fallido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fallido"
           }
         }
       }
     },
-    "swapAndPay.status.incompleteDeposit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incomplete Deposit"
+    "swapAndPay.status.incompleteDeposit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incomplete Deposit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depósito incompleto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depósito incompleto"
           }
         }
       }
     },
-    "swapAndPay.status.pending" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pending"
+    "swapAndPay.status.pending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendiente"
           }
         }
       }
     },
-    "swapAndPay.status.pendingDeposit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pending Deposit"
+    "swapAndPay.status.pendingDeposit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending Deposit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depósito pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depósito pendiente"
           }
         }
       }
     },
-    "swapAndPay.status.processing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processing"
+    "swapAndPay.status.processing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procesando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procesando"
           }
         }
       }
     },
-    "swapAndPay.status.refunded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refunded"
+    "swapAndPay.status.refunded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refunded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reembolsado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reembolsado"
           }
         }
       }
     },
-    "swapAndPay.status.success" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completed"
+    "swapAndPay.status.success": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completado"
           }
         }
       }
     },
-    "swapAndPay.successPayInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You successfully initiated a cross-chain payment. Follow its status on the transaction screen."
+    "swapAndPay.successPayInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You successfully initiated a cross-chain payment. Follow its status on the transaction screen."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Has iniciado un pago entre cadenas exitosamente. Sigue su estado en la pantalla de transacciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Has iniciado un pago entre cadenas exitosamente. Sigue su estado en la pantalla de transacciones."
           }
         }
       }
     },
-    "swapAndPay.successSwapInfo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You successfully initiated a swap. Follow its status on the transaction screen."
+    "swapAndPay.successSwapInfo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You successfully initiated a swap. Follow its status on the transaction screen."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Has iniciado un intercambio exitosamente. Sigue su estado en la pantalla de transacciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Has iniciado un intercambio exitosamente. Sigue su estado en la pantalla de transacciones."
           }
         }
       }
     },
-    "swapAndPay.swap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap"
+    "swapAndPay.swap": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap"
           }
         }
       }
     },
-    "swapAndPay.swapFrom" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap from"
+    "swapAndPay.swapFrom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap from"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap de"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap de"
           }
         }
       }
     },
-    "swapAndPay.swapNow" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Now"
+    "swapAndPay.swapNow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Now"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Ahora"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Ahora"
           }
         }
       }
     },
-    "swapAndPay.swapQuoteSlippageWarn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You could receive up to %@ less based on the %@ slippage you set."
+    "swapAndPay.swapQuoteSlippageWarn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You could receive up to %@ less based on the %@ slippage you set."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podrías recibir hasta %@ menos según el deslizamiento %@ que configuraste."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podrías recibir hasta %@ menos según el deslizamiento %@ que configuraste."
           }
         }
       }
     },
-    "swapAndPay.swapTo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap to"
+    "swapAndPay.swapTo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap a"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap a"
           }
         }
       }
     },
-    "swapAndPay.to" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To"
+    "swapAndPay.to": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A"
           }
         }
       }
     },
-    "swapAndPay.totalAmount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total Amount"
+    "swapAndPay.totalAmount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total Amount"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto total"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monto total"
           }
         }
       }
     },
-    "swapAndPay.totalFees" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total fees"
+    "swapAndPay.totalFees": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total fees"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comisiones totales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comisiones totales"
           }
         }
       }
     },
-    "swapStatus.paid" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paid"
+    "swapStatus.paid": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paid"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagado"
           }
         }
       }
     },
-    "swapStatus.paying" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paying"
+    "swapStatus.paying": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paying"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagando"
           }
         }
       }
     },
-    "swapStatus.paymentExpired" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Expired"
+    "swapStatus.paymentExpired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Expired"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pago expirado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pago expirado"
           }
         }
       }
     },
-    "swapStatus.paymentFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Failed"
+    "swapStatus.paymentFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pago fallido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pago fallido"
           }
         }
       }
     },
-    "swapStatus.paymentIncomplete" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Incomplete"
+    "swapStatus.paymentIncomplete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Incomplete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pago incompleto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pago incompleto"
           }
         }
       }
     },
-    "swapStatus.paymentRefunded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Refunded"
+    "swapStatus.paymentRefunded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Refunded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pago reembolsado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pago reembolsado"
           }
         }
       }
     },
-    "swapStatus.swapExpired" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Expired"
+    "swapStatus.swapExpired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Expired"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap expirado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap expirado"
           }
         }
       }
     },
-    "swapStatus.swapFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Failed"
+    "swapStatus.swapFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap fallido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap fallido"
           }
         }
       }
     },
-    "swapStatus.swapIncomplete" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Incomplete"
+    "swapStatus.swapIncomplete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Incomplete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intercambio incompleto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intercambio incompleto"
           }
         }
       }
     },
-    "swapStatus.swapped" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swapped"
+    "swapStatus.swapped": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swapped"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap realizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap realizado"
           }
         }
       }
     },
-    "swapStatus.swapping" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swapping"
+    "swapStatus.swapping": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swapping"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haciendo swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haciendo swap"
           }
         }
       }
     },
-    "swapStatus.swapRefunded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Refunded"
+    "swapStatus.swapRefunded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Refunded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap reembolsado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap reembolsado"
           }
         }
       }
     },
-    "swapToZec.address" : {
-      "comment" : "MARK: - Swap to ZEC",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ address..."
+    "swapToZec.address": {
+      "comment": "MARK: - Swap to ZEC",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ address..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección %@..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección %@..."
           }
         }
       }
     },
-    "swapToZec.deposit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deposit Amount"
+    "swapToZec.deposit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deposit Amount"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto a depositar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monto a depositar"
           }
         }
       }
     },
-    "swapToZec.depositTo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deposit to"
+    "swapToZec.depositTo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deposit to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depositar en"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depositar en"
           }
         }
       }
     },
-    "swapToZec.info1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use your "
+    "swapToZec.info1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use your "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa tu "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa tu "
           }
         }
       }
     },
-    "swapToZec.info2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ on %@"
+    "swapToZec.info2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ on %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ en %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ en %@"
           }
         }
       }
     },
-    "swapToZec.info3" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " wallet to deposit funds. Depositing other assets may result in loss of funds."
+    "swapToZec.info3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " wallet to deposit funds. Depositing other assets may result in loss of funds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " wallet para depositar fondos. Depositar otros activos puede resultar en la pérdida de fondos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " wallet para depositar fondos. Depositar otros activos puede resultar en la pérdida de fondos."
           }
         }
       }
     },
-    "swapToZec.refundAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refund Address"
+    "swapToZec.refundAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refund Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección de reembolso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección de reembolso"
           }
         }
       }
     },
-    "swapToZec.refundAddress.msg1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If the swap fails or market conditions change, your transaction may be refunded minus the transaction fees."
+    "swapToZec.refundAddress.msg1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If the swap fails or market conditions change, your transaction may be refunded minus the transaction fees."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si el swap falla o cambian las condiciones del mercado, tu transacción puede ser reembolsada menos las comisiones de transacción."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si el swap falla o cambian las condiciones del mercado, tu transacción puede ser reembolsada menos las comisiones de transacción."
           }
         }
       }
     },
-    "swapToZec.refundAddress.msg2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The refunded amount will be returned to your wallet in the source currency - USDC on NEAR. Please enter a valid address to avoid loss of funds."
+    "swapToZec.refundAddress.msg2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The refunded amount will be returned to your wallet in the source currency - USDC on NEAR. Please enter a valid address to avoid loss of funds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El monto reembolsado será devuelto a tu wallet en la moneda de origen - USDC en NEAR. Ingresa una dirección válida para evitar la pérdida de fondos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El monto reembolsado será devuelto a tu wallet en la moneda de origen - USDC en NEAR. Ingresa una dirección válida para evitar la pérdida de fondos."
           }
         }
       }
     },
-    "swapToZec.refundAddress.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refund Address"
+    "swapToZec.refundAddress.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refund Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección de reembolso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección de reembolso"
           }
         }
       }
     },
-    "swapToZec.review" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review Quote"
+    "swapToZec.review": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review Quote"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revisar cotización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar cotización"
           }
         }
       }
     },
-    "swapToZec.sentTheFunds" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I’ve sent the funds"
+    "swapToZec.sentTheFunds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I’ve sent the funds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ya envié los fondos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya envié los fondos"
           }
         }
       }
     },
-    "swapToZec.share.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deposit address for %@ %@ on Near swap to ZEC in Zodl."
+    "swapToZec.share.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deposit address for %@ %@ on Near swap to ZEC in Zodl."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección de depósito para %@ %@ en Near swap a ZEC en Zodl."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección de depósito para %@ %@ en Near swap a ZEC en Zodl."
           }
         }
       }
     },
-    "swapToZec.share.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Deposit Address"
+    "swapToZec.share.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Deposit Address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dirección de depósito para swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección de depósito para swap"
           }
         }
       }
     },
-    "swapToZec.shareQR" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share QR"
+    "swapToZec.shareQR": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share QR"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir QR"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir QR"
           }
         }
       }
     },
-    "swapToZec.swapCompleted" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Completed"
+    "swapToZec.swapCompleted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Completed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap completado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap completado"
           }
         }
       }
     },
-    "swapToZec.swapDetails" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Details"
+    "swapToZec.swapDetails": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Details"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalles del swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles del swap"
           }
         }
       }
     },
-    "swapToZec.swapExpired" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Expired"
+    "swapToZec.swapExpired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Expired"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap expirado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap expirado"
           }
         }
       }
     },
-    "swapToZec.swapFailed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Failed"
+    "swapToZec.swapFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap fallido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap fallido"
           }
         }
       }
     },
-    "swapToZec.swapIncomplete" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Incomplete"
+    "swapToZec.swapIncomplete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Incomplete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intercambio incompleto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intercambio incompleto"
           }
         }
       }
     },
-    "swapToZec.swapPending" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Pending"
+    "swapToZec.swapPending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap pendiente"
           }
         }
       }
     },
-    "swapToZec.swapProcessing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Processing"
+    "swapToZec.swapProcessing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Processing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procesando swap"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procesando swap"
           }
         }
       }
     },
-    "swapToZec.swapRefunded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap Refunded"
+    "swapToZec.swapRefunded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Refunded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Swap reembolsado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap reembolsado"
           }
         }
       }
     },
-    "sync.message.error" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+    "sync.message.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %@"
           }
         }
       }
     },
-    "sync.message.stopped" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stopped"
+    "sync.message.stopped": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopped"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detenido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detenido"
           }
         }
       }
     },
-    "sync.message.sync" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%% Synced"
+    "sync.message.sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%% Synced"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%% Sincronizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%% Sincronizado"
           }
         }
       }
     },
-    "sync.message.unprepared" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unprepared"
+    "sync.message.unprepared": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unprepared"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No preparado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No preparado"
           }
         }
       }
     },
-    "sync.message.uptodate" : {
-      "comment" : "MARK: - Sync message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Up-To-Date"
+    "sync.message.uptodate": {
+      "comment": "MARK: - Sync message",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Up-To-Date"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizado"
           }
         }
       }
     },
-    "tabs.account" : {
-      "comment" : "MARK: - Tabs",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Account"
+    "tabs.account": {
+      "comment": "MARK: - Tabs",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cuenta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuenta"
           }
         }
       }
     },
-    "tabs.balances" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Balances"
+    "tabs.balances": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balances"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saldos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saldos"
           }
         }
       }
     },
-    "tabs.receive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive"
+    "tabs.receive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receive"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recibir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recibir"
           }
         }
       }
     },
-    "tabs.receiveZec" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive ZEC"
+    "tabs.receiveZec": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receive ZEC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recibir ZEC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recibir ZEC"
           }
         }
       }
     },
-    "tabs.send" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send"
+    "tabs.send": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar"
           }
         }
       }
     },
-    "taxExport.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download your %@ transaction history from the previous calendar year in a .csv format."
+    "taxExport.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download your %@ transaction history from the previous calendar year in a .csv format."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descarga el historial de transacciones de %@ del año calendario anterior en formato .csv."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga el historial de transacciones de %@ del año calendario anterior en formato .csv."
           }
         }
       }
     },
-    "taxExport.download" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download"
+    "taxExport.download": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar"
           }
         }
       }
     },
-    "taxExport.fileName" : {
-      "comment" : "Transaction History Tax Export",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@_transaction_history_%@.csv"
+    "taxExport.fileName": {
+      "comment": "Transaction History Tax Export",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@_transaction_history_%@.csv"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@_historial_de_transacciones_%@.csv"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@_historial_de_transacciones_%@.csv"
           }
         }
       }
     },
-    "taxExport.shareDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ transaction history"
+    "taxExport.shareDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ transaction history"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ historial de transacciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ historial de transacciones"
           }
         }
       }
     },
-    "taxExport.taxFile" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export Tax File"
+    "taxExport.taxFile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Tax File"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar Archivo de Impuestos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar Archivo de Impuestos"
           }
         }
       }
     },
-    "taxExport.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Data Export"
+    "taxExport.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data Export"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportación de Datos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportación de Datos"
           }
         }
       }
     },
-    "texKeystone.gotIt" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Got it"
+    "texKeystone.gotIt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entendido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entendido"
           }
         }
       }
     },
-    "texKeystone.step" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Step %@"
+    "texKeystone.step": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paso %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paso %@"
           }
         }
       }
     },
-    "texKeystone.step1.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transfer ZEC to your Zodl shielded address"
+    "texKeystone.step1.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer ZEC to your Zodl shielded address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transfiere ZEC a tu dirección protegida de Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfiere ZEC a tu dirección protegida de Zodl"
           }
         }
       }
     },
-    "texKeystone.step1.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send to Zodl first"
+    "texKeystone.step1.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send to Zodl first"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envía primero a Zodl"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envía primero a Zodl"
           }
         }
       }
     },
-    "texKeystone.step2.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Once received in Zodl, send the tokens to your final TEX destination address"
+    "texKeystone.step2.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Once received in Zodl, send the tokens to your final TEX destination address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Una vez recibido en Zodl, envía los tokens a tu dirección TEX de destino final"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una vez recibido en Zodl, envía los tokens a tu dirección TEX de destino final"
           }
         }
       }
     },
-    "texKeystone.step2.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send from Zodl to TEX address"
+    "texKeystone.step2.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send from Zodl to TEX address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envía desde Zodl a la dirección TEX"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envía desde Zodl a la dirección TEX"
           }
         }
       }
     },
-    "texKeystone.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unsupported Address Type"
+    "texKeystone.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsupported Address Type"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de dirección no compatible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de dirección no compatible"
           }
         }
       }
     },
-    "texKeystone.warn1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keystone doesn't currently support transfers to Binance TEX addresses. "
+    "texKeystone.warn1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keystone doesn't currently support transfers to Binance TEX addresses. "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualmente, Keystone no es compatible con transferencias a direcciones Binance TEX."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualmente, Keystone no es compatible con transferencias a direcciones Binance TEX."
           }
         }
       }
     },
-    "texKeystone.warn2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please use the steps below to complete your transaction."
+    "texKeystone.warn2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please use the steps below to complete your transaction."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, utiliza los pasos a continuación para completar tu transacción."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor, utiliza los pasos a continuación para completar tu transacción."
           }
         }
       }
     },
-    "texKeystone.workaround" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Workaround Steps"
+    "texKeystone.workaround": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workaround Steps"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pasos alternativos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pasos alternativos"
           }
         }
       }
     },
-    "tokenOnChain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "on"
+    "tokenOnChain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "on"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "en"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "en"
           }
         }
       }
     },
-    "tooltip.exchangeRate.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We tried but we couldn’t refresh the exchange rate for you. Check your connection, relaunch the app, and we’ll try again."
+    "tooltip.exchangeRate.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We tried but we couldn’t refresh the exchange rate for you. Check your connection, relaunch the app, and we’ll try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lo intentamos pero no pudimos actualizar la tasa de cambio para ti. Verifica tu conexión, reinicia la aplicación e intentaremos de nuevo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo intentamos pero no pudimos actualizar la tasa de cambio para ti. Verifica tu conexión, reinicia la aplicación e intentaremos de nuevo."
           }
         }
       }
     },
-    "tooltip.exchangeRate.title" : {
-      "comment" : "MARK: - Tooltips",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exchange rate unavailable"
+    "tooltip.exchangeRate.title": {
+      "comment": "MARK: - Tooltips",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exchange rate unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tasa de cambio no disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasa de cambio no disponible"
           }
         }
       }
     },
-    "torSettingsSheet.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Routes your connection through the Tor network for enhanced anonymity and privacy protection."
+    "torSettingsSheet.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routes your connection through the Tor network for enhanced anonymity and privacy protection."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redirige tu conexión a través de la red Tor para mayor anonimato y protección de privacidad."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redirige tu conexión a través de la red Tor para mayor anonimato y protección de privacidad."
           }
         }
       }
     },
-    "torSettingsSheet.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If Tor is available in your region, we recommend enabling it for enhanced privacy during wallet restoration. This step is completely optional."
+    "torSettingsSheet.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If Tor is available in your region, we recommend enabling it for enhanced privacy during wallet restoration. This step is completely optional."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si Tor está disponible en tu región, recomendamos habilitarlo para una mayor privacidad durante la restauración de la billetera. Este paso es completamente opcional."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si Tor está disponible en tu región, recomendamos habilitarlo para una mayor privacidad durante la restauración de la billetera. Este paso es completamente opcional."
           }
         }
       }
     },
-    "torSettingsSheet.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Tor Protection"
+    "torSettingsSheet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Tor Protection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Habilitar Protección Tor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Habilitar Protección Tor"
           }
         }
       }
     },
-    "torSetup.alert.disable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable"
+    "torSetup.alert.disable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar"
           }
         }
       }
     },
-    "torSetup.alert.dontDisable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Don’t disable"
+    "torSetup.alert.dontDisable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don’t disable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No desactivar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No desactivar"
           }
         }
       }
     },
-    "torSetup.alert.msg" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor connection issues detected. To improve performance, try disabling Tor. This will stop exchange rate updates. You can re-enable it later in Advanced Settings."
+    "torSetup.alert.msg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor connection issues detected. To improve performance, try disabling Tor. This will stop exchange rate updates. You can re-enable it later in Advanced Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se detectaron problemas de conexión con Tor. Para mejorar el rendimiento, intenta desactivarlo. Esto detendrá la actualización de tasas de cambio. Puedes volver a activarlo más adelante en Configuración avanzada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se detectaron problemas de conexión con Tor. Para mejorar el rendimiento, intenta desactivarlo. Esto detendrá la actualización de tasas de cambio. Puedes volver a activarlo más adelante en Configuración avanzada."
           }
         }
       }
     },
-    "torSetup.alert.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Tor?"
+    "torSetup.alert.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Tor?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Desactivar Tor?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Desactivar Tor?"
           }
         }
       }
     },
-    "torSetup.ccSheet.desc1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor Protection is a beta feature that provides additional protections for your IP address. USD exchange rates are only available when it is enabled."
+    "torSetup.ccSheet.desc1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor Protection is a beta feature that provides additional protections for your IP address. USD exchange rates are only available when it is enabled."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La protección Tor es una función beta que brinda protección adicional a tu dirección IP. Las tasas de cambio en USD solo están disponibles cuando está activada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La protección Tor es una función beta que brinda protección adicional a tu dirección IP. Las tasas de cambio en USD solo están disponibles cuando está activada."
           }
         }
       }
     },
-    "torSetup.ccSheet.desc2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If Tor is permitted in your region, we recommend enabling it. You can manage it in Advanced Settings."
+    "torSetup.ccSheet.desc2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If Tor is permitted in your region, we recommend enabling it. You can manage it in Advanced Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si el uso de Tor está permitido en tu región, te recomendamos activarla. Puedes gestionarlo en Configuración avanzada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si el uso de Tor está permitido en tu región, te recomendamos activarla. Puedes gestionarlo en Configuración avanzada."
           }
         }
       }
     },
-    "torSetup.ccSheet.enable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable"
+    "torSetup.ccSheet.enable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar"
           }
         }
       }
     },
-    "torSetup.ccSheet.later" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do it later"
+    "torSetup.ccSheet.later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do it later"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hacerlo después"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hacerlo después"
           }
         }
       }
     },
-    "torSetup.ccSheet.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor Required for Currency Conversion"
+    "torSetup.ccSheet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor Required for Currency Conversion"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se requiere Tor para la conversión de moneda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere Tor para la conversión de moneda"
           }
         }
       }
     },
-    "torSetup.disableDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Don’t connect over Tor."
+    "torSetup.disableDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don’t connect over Tor."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No conectarse mediante Tor."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No conectarse mediante Tor."
           }
         }
       }
     },
-    "torSetup.enableDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect over Tor."
+    "torSetup.enableDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect over Tor."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectarse mediante Tor."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectarse mediante Tor."
           }
         }
       }
     },
-    "torSetup.learn.btnIn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opt in"
+    "torSetup.learn.btnIn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opt in"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar"
           }
         }
       }
     },
-    "torSetup.learn.btnOut" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opt out"
+    "torSetup.learn.btnOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opt out"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar"
           }
         }
       }
     },
-    "torSetup.learn.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This feature provides additional protections for your IP address. If Tor is permitted in your region, we recommend enabling it. You can manage this in Advanced Settings."
+    "torSetup.learn.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This feature provides additional protections for your IP address. If Tor is permitted in your region, we recommend enabling it. You can manage this in Advanced Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta función brinda protección adicional a tu dirección IP. Si el uso de Tor está permitido en tu región, te recomendamos activarla. Puedes gestionarlo en Configuración avanzada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta función brinda protección adicional a tu dirección IP. Si el uso de Tor está permitido en tu región, te recomendamos activarla. Puedes gestionarlo en Configuración avanzada."
           }
         }
       }
     },
-    "torSetup.option1.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetch exchange rates from third-party servers without revealing your IP address. (Only available with Tor enabled.)"
+    "torSetup.option1.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetch exchange rates from third-party servers without revealing your IP address. (Only available with Tor enabled.)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtén tasas de cambio desde servidores de terceros sin revelar tu dirección IP. (Disponible solo con Tor activado.)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtén tasas de cambio desde servidores de terceros sin revelar tu dirección IP. (Disponible solo con Tor activado.)"
           }
         }
       }
     },
-    "torSetup.option1.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currency Conversion"
+    "torSetup.option1.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currency Conversion"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conversión de moneda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conversión de moneda"
           }
         }
       }
     },
-    "torSetup.option2.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send and retrieve transaction data over Tor for added privacy."
+    "torSetup.option2.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send and retrieve transaction data over Tor for added privacy."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envía y recupera datos de transacciones a través de Tor para mayor privacidad."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envía y recupera datos de transacciones a través de Tor para mayor privacidad."
           }
         }
       }
     },
-    "torSetup.option2.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transactions"
+    "torSetup.option2.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transactions"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transacciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transacciones"
           }
         }
       }
     },
-    "torSetup.option3.desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Access third-party APIs (e.g. NEAR) over Tor for added privacy."
+    "torSetup.option3.desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Access third-party APIs (e.g. NEAR) over Tor for added privacy."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accede a APIs de terceros (por ejemplo, NEAR) a través de Tor para mayor privacidad."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accede a APIs de terceros (por ejemplo, NEAR) a través de Tor para mayor privacidad."
           }
         }
       }
     },
-    "torSetup.option3.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Integrations"
+    "torSetup.option3.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integrations"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Integraciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integraciones"
           }
         }
       }
     },
-    "torSetup.settings.desc1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor provides additional protections for your IP address. This feature uses Tor network to fetch exchange rates, send transactions, retrieve transaction data, and connect to third party APIs."
+    "torSetup.settings.desc1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor provides additional protections for your IP address. This feature uses Tor network to fetch exchange rates, send transactions, retrieve transaction data, and connect to third party APIs."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta función beta brinda protección adicional para tu dirección IP. Utiliza Tor para obtener tasas de cambio, enviar transacciones, recuperar datos de transacciones y conectarse a APIs de terceros."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta función beta brinda protección adicional para tu dirección IP. Utiliza Tor para obtener tasas de cambio, enviar transacciones, recuperar datos de transacciones y conectarse a APIs de terceros."
           }
         }
       }
     },
-    "torSetup.settings.desc2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If Tor is permitted in your region, we recommend enabling it."
+    "torSetup.settings.desc2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If Tor is permitted in your region, we recommend enabling it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si el uso de Tor está permitido en tu región, te recomendamos habilitarlo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si el uso de Tor está permitido en tu región, te recomendamos habilitarlo."
           }
         }
       }
     },
-    "torSetup.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor Protection"
+    "torSetup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor Protection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protección Tor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protección Tor"
           }
         }
       }
     },
-    "transaction.failedReceive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive failed"
+    "transaction.failedReceive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receive failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recepción fallida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recepción fallida"
           }
         }
       }
     },
-    "transaction.failedSend" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send failed"
+    "transaction.failedSend": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envío fallido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envío fallido"
           }
         }
       }
     },
-    "transaction.failedShieldedFunds" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shielding Failed"
+    "transaction.failedShieldedFunds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shielding Failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fondos Protegidos Fallidos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondos Protegidos Fallidos"
           }
         }
       }
     },
-    "transaction.received" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Received"
+    "transaction.received": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Received"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recibido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recibido"
           }
         }
       }
     },
-    "transaction.receiving" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receiving"
+    "transaction.receiving": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receiving"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recibiendo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recibiendo"
           }
         }
       }
     },
-    "transaction.sending" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending"
+    "transaction.sending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando"
           }
         }
       }
     },
-    "transaction.sent" : {
-      "comment" : "MARK: - Transactions",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent"
+    "transaction.sent": {
+      "comment": "MARK: - Transactions",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado"
           }
         }
       }
     },
-    "transaction.shieldedFunds" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shielded"
+    "transaction.shieldedFunds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shielded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protegidos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protegidos"
           }
         }
       }
     },
-    "transaction.shieldingFunds" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shielding"
+    "transaction.shieldingFunds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shielding"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protegiendo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protegiendo"
           }
         }
       }
     },
-    "transactionDetail.feeSummary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee"
+    "transactionDetail.feeSummary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comisión"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comisión"
           }
         }
       }
     },
-    "transactionHistory.defaultFee" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0.001"
+    "transactionHistory.defaultFee": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.001"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0.001"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.001"
           }
         }
       }
     },
-    "transactionHistory.details" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transaction Details"
+    "transactionHistory.details": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transaction Details"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalles de la transacción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles de la transacción"
           }
         }
       }
     },
-    "transactionHistory.noMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Message"
+    "transactionHistory.noMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Message"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin mensaje"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin mensaje"
           }
         }
       }
     },
-    "transactionHistory.nothingHere" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There’s nothing here, yet."
+    "transactionHistory.nothingHere": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There’s nothing here, yet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aún no hay nada aquí."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay nada aquí."
           }
         }
       }
     },
-    "transactionHistory.pending" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pending"
+    "transactionHistory.pending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pendiente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendiente"
           }
         }
       }
     },
-    "transactionHistory.saveAddress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save address"
+    "transactionHistory.saveAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save address"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar dirección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar dirección"
           }
         }
       }
     },
-    "transactionHistory.seeAll" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "See all"
+    "transactionHistory.seeAll": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See all"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver todo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver todo"
           }
         }
       }
     },
-    "transactionHistory.sendAgain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send again"
+    "transactionHistory.sendAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar de nuevo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar de nuevo"
           }
         }
       }
     },
-    "transactionHistory.sentTo" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent to"
+    "transactionHistory.sentTo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent to"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviado a"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado a"
           }
         }
       }
     },
-    "transactionHistory.threeDots" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@..."
+    "transactionHistory.threeDots": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@..."
           }
         }
       }
     },
-    "transactionHistory.timestamp" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timestamp"
+    "transactionHistory.timestamp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timestamp"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Marca de tiempo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marca de tiempo"
           }
         }
       }
     },
-    "transactionHistory.viewLess" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View less"
+    "transactionHistory.viewLess": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View less"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver menos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver menos"
           }
         }
       }
     },
-    "transactionHistory.viewMore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View more"
+    "transactionHistory.viewMore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View more"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver más"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver más"
           }
         }
       }
     },
-    "transactionList.transactionId" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transaction ID"
+    "transactionList.transactionId": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transaction ID"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID de Transacción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID de Transacción"
           }
         }
       }
     },
-    "walletBirthdayHeightSubtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entering your Wallet Birthday Height ensures we can display all your funds and transaction history correctly."
+    "walletBirthdayHeightSubtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entering your Wallet Birthday Height ensures we can display all your funds and transaction history correctly."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Al introducir la Altura de Creación de tu Billetera, nos aseguramos de poder mostrar correctamente todos tus fondos y el historial de transacciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al introducir la Altura de Creación de tu Billetera, nos aseguramos de poder mostrar correctamente todos tus fondos y el historial de transacciones."
           }
         }
       }
     },
-    "walletBirthdayHelpDesc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. It is important to provide the correct height because that determines the range of blocks we will scan to display your transaction history and wallet balance. If you have recovered a seed from a different hardware device, make sure to enter the block height of your original hardware device."
+    "walletBirthdayHelpDesc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. It is important to provide the correct height because that determines the range of blocks we will scan to display your transaction history and wallet balance. If you have recovered a seed from a different hardware device, make sure to enter the block height of your original hardware device."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[La Altura de Creación de la Billetera (Wallet Birthday Height)](style: 'boldPrimary') corresponde a la altura del bloque (número de bloque en la cadena de bloques) en la que se creó tu billetera. Es importante proporcionar la altura correcta, ya que determina el rango de bloques que analizaremos para mostrar tu historial de transacciones y el saldo de tu billetera. Si recuperaste una semilla de otro dispositivo, asegúrate de ingresar la altura del bloque de tu dispositivo original."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[La Altura de Creación de la Billetera (Wallet Birthday Height)](style: 'boldPrimary') corresponde a la altura del bloque (número de bloque en la cadena de bloques) en la que se creó tu billetera. Es importante proporcionar la altura correcta, ya que determina el rango de bloques que analizaremos para mostrar tu historial de transacciones y el saldo de tu billetera. Si recuperaste una semilla de otro dispositivo, asegúrate de ingresar la altura del bloque de tu dispositivo original."
           }
         }
       }
     },
-    "walletBirthdayHelpDescRecovery" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. If you ever lose access to your Zodl app and need to recover your funds, providing the block height along with your recovery phrase can significantly speed up the process."
+    "walletBirthdayHelpDescRecovery": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[The Wallet Birthday Height](style: 'boldPrimary') is the block height (block # in the blockchain) at which your wallet was created. If you ever lose access to your Zodl app and need to recover your funds, providing the block height along with your recovery phrase can significantly speed up the process."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[La Altura de Cumpleaños de la Billetera](style: 'boldPrimary') es la altura del bloque (número de bloque en la blockchain) en el que tu billetera fue creada. Si alguna vez pierdes acceso a tu aplicación Zodl y necesitas recuperar tus fondos, proporcionar la altura del bloque junto con tu frase de recuperación puede acelerar significativamente el proceso."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "^[La Altura de Cumpleaños de la Billetera](style: 'boldPrimary') es la altura del bloque (número de bloque en la blockchain) en el que tu billetera fue creada. Si alguna vez pierdes acceso a tu aplicación Zodl y necesitas recuperar tus fondos, proporcionar la altura del bloque junto con tu frase de recuperación puede acelerar significativamente el proceso."
           }
         }
       }
     },
-    "walletStatus.disconnected" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DISCONNECTED…"
+    "walletStatus.disconnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DISCONNECTED…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DESCONECTADO…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DESCONECTADO…"
           }
         }
       }
     },
-    "walletStatus.restoringWallet" : {
-      "comment" : "MARK: - Wallet Status",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RESTORING YOUR WALLET…"
+    "walletStatus.restoringWallet": {
+      "comment": "MARK: - Wallet Status",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RESTORING YOUR WALLET…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RESTAURANDO TU BILLETERA…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RESTAURANDO TU BILLETERA…"
           }
         }
       }
     },
-    "whatsNew.version" : {
-      "comment" : "MARK: - What's new",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zodl Version %@"
+    "whatsNew.version": {
+      "comment": "MARK: - What's new",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zodl Version %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de Zodl %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de Zodl %@"
           }
         }
       }
     },
-    "Zcash" : {
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zcash"
+    "Zcash": {
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zcash"
           }
         }
       }
     },
-    "zecKeyboard.invalid" : {
-      "comment" : "MARK: - ZEC Keyboard",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This transaction amount is invalid."
+    "zecKeyboard.invalid": {
+      "comment": "MARK: - ZEC Keyboard",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This transaction amount is invalid."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este monto de transacción no es válido."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este monto de transacción no es válido."
           }
         }
       }
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -1,6 +1,74 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "keystone.addHWWallet.contactSupport" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact Support"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contactar Soporte"
+          }
+        }
+      }
+    },
+    "keystone.addHWWallet.failureDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not connect your Keystone wallet. Your funds are safe. Please check that you are running the latest firmware."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo conectar tu wallet Keystone. Tus fondos están seguros. Verifica que tengas el firmware más reciente instalado."
+          }
+        }
+      }
+    },
+    "keystone.addHWWallet.failureTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connection Failed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de Conexión"
+          }
+        }
+      }
+    },
+    "keystone.addHWWallet.tryAgain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentar de nuevo"
+          }
+        }
+      }
+    },
     " %@" : {
 
     },

--- a/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
+++ b/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
@@ -144,6 +144,11 @@ struct AddKeystoneHWWallet {
                         )
                         if let uuid {
                             await send(.accountImported(uuid))
+                        } else {
+                            // The live SDK never returns nil today, but the interface
+                            // permits it; treat it as a failure so isImportingAccount
+                            // can't be left stuck true.
+                            await send(.accountImportFailed("Keystone account import returned no account UUID"))
                         }
                     } catch {
                         // Surface only the SDK error's localizedDescription (a static

--- a/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
+++ b/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
@@ -65,7 +65,7 @@ struct AddKeystoneHWWallet {
 
     enum Action: BindableAction, Equatable {
         case accountImported(AccountUUID)
-        case accountImportFailed
+        case accountImportFailed(String)
         case accountImportSucceeded
         case accountTapped
         case backToHomeTapped
@@ -138,18 +138,24 @@ struct AddKeystoneHWWallet {
                             await send(.accountImported(uuid))
                         }
                     } catch {
-                        // TODO: error handling
-                        await send(.accountImportFailed)
+                        // Surface only the SDK error's localizedDescription (a static
+                        // code + message, e.g. "ZRUST0067: …"); the raw Rust error
+                        // string is never included, so no UFVK/seed data can leak.
+                        await send(.accountImportFailed(error.localizedDescription))
                     }
                 }
-                
+
             case .accountImported(let uuid):
                 return .run { send in
-                    let walletAccounts = try await sdkSynchronizer.walletAccounts()
-                    await send(.loadedWalletAccounts(walletAccounts, uuid))
-                    await send(.accountImportSucceeded)
+                    do {
+                        let walletAccounts = try await sdkSynchronizer.walletAccounts()
+                        await send(.loadedWalletAccounts(walletAccounts, uuid))
+                        await send(.accountImportSucceeded)
+                    } catch {
+                        await send(.accountImportFailed(error.localizedDescription))
+                    }
                 }
-                
+
             case .accountImportFailed:
                 return .none
                 

--- a/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
+++ b/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
@@ -15,6 +15,7 @@ struct AddKeystoneHWWallet {
     @ObservableState
     struct State: Equatable {
         var isHelpSheetPresented = false
+        var isImportingAccount = false
         var isInAppBrowserOn = false
         var isKSAccountSelected = false
         var randomSuccessIconIndex = 0
@@ -123,6 +124,13 @@ struct AddKeystoneHWWallet {
                 guard let account = state.zcashAccounts, let firstAccount = account.accounts.first else {
                     return .none
                 }
+                // Re-taps while an import is in flight would start a duplicate
+                // importAccount; the duplicate throws (the account already
+                // exists) and pops the failure sheet over the success screen.
+                guard !state.isImportingAccount else {
+                    return .none
+                }
+                state.isImportingAccount = true
                 return .run { send in
                     do {
                         let uuid = try await sdkSynchronizer.importAccount(
@@ -157,9 +165,11 @@ struct AddKeystoneHWWallet {
                 }
 
             case .accountImportFailed:
+                state.isImportingAccount = false
                 return .none
-                
+
             case .accountImportSucceeded:
+                state.isImportingAccount = false
                 return .none
 
             case let .loadedWalletAccounts(walletAccounts, uuid):

--- a/secant/Sources/Features/AddKeystoneHWWallet/KeystoneDeviceReadyView.swift
+++ b/secant/Sources/Features/AddKeystoneHWWallet/KeystoneDeviceReadyView.swift
@@ -40,14 +40,26 @@ struct KeystoneDeviceReadyView: View {
                 ) {
                     store.send(.setBirthdayTapped)
                 }
+                .disabled(store.isImportingAccount)
                 .padding(.bottom, 12)
 
-                ZashiButton(
-                    String(localizable: .keystoneAddHWWalletConnectNew)
-                ) {
-                    store.send(.unlockTapped(nil))
+                if store.isImportingAccount {
+                    ZashiButton(
+                        String(localizable: .keystoneAddHWWalletConnectNew),
+                        accessoryView: ProgressView()
+                    ) {
+                        store.send(.unlockTapped(nil))
+                    }
+                    .disabled(true)
+                    .padding(.bottom, 24)
+                } else {
+                    ZashiButton(
+                        String(localizable: .keystoneAddHWWalletConnectNew)
+                    ) {
+                        store.send(.unlockTapped(nil))
+                    }
+                    .padding(.bottom, 24)
                 }
-                .padding(.bottom, 24)
             }
             .screenHorizontalPadding()
             .zashiBackV2(background: false) {

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
@@ -49,7 +49,7 @@ extension AddKeystoneHWWalletCoordFlow {
                 state.isFailureSheetPresented = true
                 return .none
 
-case .path(.element(id: _, action: .keystoneDeviceReady(.setBirthdayTapped))):
+            case .path(.element(id: _, action: .keystoneDeviceReady(.setBirthdayTapped))):
                 var birthdayState = WalletBirthday.State.initial
                 birthdayState.isKeystoneFlow = true
                 state.path.append(.estimateBirthdaysDate(birthdayState))

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
@@ -43,6 +43,11 @@ extension AddKeystoneHWWalletCoordFlow {
                 return .none
 
             case .path(.element(id: _, action: .keystoneDeviceReady(.accountImportFailed(let errMsg)))):
+                for id in state.path.ids {
+                    if case .restoreInfo = state.path[id: id] {
+                        state.path[id: id, case: \.restoreInfo]?.isProcessing = false
+                    }
+                }
                 state.errMsg = errMsg
                 // TCA Store is @MainActor; reducer body always runs on main.
                 state.canSendMail = MainActor.assumeIsolated { MFMailComposeViewController.canSendMail() }
@@ -111,9 +116,10 @@ extension AddKeystoneHWWalletCoordFlow {
 
                 // MARK: - RestoreInfo
                 
-            case .path(.element(id: _, action: .restoreInfo(.gotItTapped))):
+            case .path(.element(id: let restoreInfoId, action: .restoreInfo(.gotItTapped))):
                 for id in state.path.ids {
                     if case .keystoneDeviceReady = state.path[id: id] {
+                        state.path[id: restoreInfoId, case: \.restoreInfo]?.isProcessing = true
                         return .send(.path(.element(id: id, action: .keystoneDeviceReady(.unlockTapped(state.birthday)))))
                     }
                 }

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
@@ -43,17 +43,18 @@ extension AddKeystoneHWWalletCoordFlow {
                 return .none
 
             case .path(.element(id: _, action: .keystoneDeviceReady(.accountImportFailed(let errMsg)))):
+                for id in state.path.ids {
+                    if case .restoreInfo = state.path[id: id] {
+                        state.path[id: id, case: \.restoreInfo]?.isProcessing = false
+                    }
+                }
                 // A failure arriving after the success screen is on the stack can
                 // only be a stray duplicate attempt — the account is imported, so
                 // don't cover the success screen with the failure sheet.
                 for element in state.path {
                     if case .keystoneConnected = element {
+                        LoggerProxy.warn("Keystone account import failure suppressed (success screen already on stack): \(errMsg)")
                         return .none
-                    }
-                }
-                for id in state.path.ids {
-                    if case .restoreInfo = state.path[id: id] {
-                        state.path[id: id, case: \.restoreInfo]?.isProcessing = false
                     }
                 }
                 state.errMsg = errMsg

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
@@ -49,20 +49,7 @@ extension AddKeystoneHWWalletCoordFlow {
                 state.isFailureSheetPresented = true
                 return .none
 
-            case .tryAgainTapped:
-                state.isFailureSheetPresented = false
-                for id in state.path.ids {
-                    if case .keystoneDeviceReady = state.path[id: id] {
-                        let birthday = state.birthday
-                        return .run { send in
-                            try? await Task.sleep(for: .seconds(0.3))
-                            await send(.path(.element(id: id, action: .keystoneDeviceReady(.unlockTapped(birthday)))))
-                        }
-                    }
-                }
-                return .none
-
-            case .path(.element(id: _, action: .keystoneDeviceReady(.setBirthdayTapped))):
+case .path(.element(id: _, action: .keystoneDeviceReady(.setBirthdayTapped))):
                 var birthdayState = WalletBirthday.State.initial
                 birthdayState.isKeystoneFlow = true
                 state.path.append(.estimateBirthdaysDate(birthdayState))

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
@@ -43,6 +43,14 @@ extension AddKeystoneHWWalletCoordFlow {
                 return .none
 
             case .path(.element(id: _, action: .keystoneDeviceReady(.accountImportFailed(let errMsg)))):
+                // A failure arriving after the success screen is on the stack can
+                // only be a stray duplicate attempt — the account is imported, so
+                // don't cover the success screen with the failure sheet.
+                for element in state.path {
+                    if case .keystoneConnected = element {
+                        return .none
+                    }
+                }
                 for id in state.path.ids {
                     if case .restoreInfo = state.path[id: id] {
                         state.path[id: id, case: \.restoreInfo]?.isProcessing = false

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import ComposableArchitecture
+@preconcurrency import MessageUI
 
 extension AddKeystoneHWWalletCoordFlow {
     func coordinatorReduce() -> Reduce<AddKeystoneHWWalletCoordFlow.State, AddKeystoneHWWalletCoordFlow.Action> {
@@ -39,6 +40,26 @@ extension AddKeystoneHWWalletCoordFlow {
 
             case .path(.element(id: _, action: .keystoneDeviceReady(.accountImportSucceeded))):
                 state.path.append(.keystoneConnected(AddKeystoneHWWallet.State.initial))
+                return .none
+
+            case .path(.element(id: _, action: .keystoneDeviceReady(.accountImportFailed(let errMsg)))):
+                state.errMsg = errMsg
+                // TCA Store is @MainActor; reducer body always runs on main.
+                state.canSendMail = MainActor.assumeIsolated { MFMailComposeViewController.canSendMail() }
+                state.isFailureSheetPresented = true
+                return .none
+
+            case .tryAgainTapped:
+                state.isFailureSheetPresented = false
+                for id in state.path.ids {
+                    if case .keystoneDeviceReady = state.path[id: id] {
+                        let birthday = state.birthday
+                        return .run { send in
+                            try? await Task.sleep(for: .seconds(0.3))
+                            await send(.path(.element(id: id, action: .keystoneDeviceReady(.unlockTapped(birthday)))))
+                        }
+                    }
+                }
                 return .none
 
             case .path(.element(id: _, action: .keystoneDeviceReady(.setBirthdayTapped))):

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
+@preconcurrency import MessageUI
 
 @Reducer
 struct AddKeystoneHWWalletCoordFlow {
@@ -27,8 +28,15 @@ struct AddKeystoneHWWalletCoordFlow {
     struct State {
         var addKeystoneHWWalletState = AddKeystoneHWWallet.State.initial
         var birthday: BlockHeight? = nil
+        var isFailureSheetPresented = false
         var isHelpSheetPresented = false
         var path = StackState<Path.State>()
+
+        // support
+        var canSendMail = false
+        var errMsg = ""
+        var messageToBeShared: String?
+        var supportData: SupportData?
 
         init() { }
     }
@@ -37,7 +45,12 @@ struct AddKeystoneHWWalletCoordFlow {
         case addKeystoneHWWallet(AddKeystoneHWWallet.Action)
         case binding(BindingAction<AddKeystoneHWWalletCoordFlow.State>)
         case closeHelpSheetTapped
+        case contactSupportTapped
+        case dismissFailureSheet
         case path(StackActionOf<Path>)
+        case sendSupportMailFinished
+        case shareFinished
+        case tryAgainTapped
     }
 
     @Dependency(\.audioServices) var audioServices
@@ -59,6 +72,39 @@ struct AddKeystoneHWWalletCoordFlow {
             case .closeHelpSheetTapped:
                 state.isHelpSheetPresented = false
                 return .none
+
+            case .dismissFailureSheet:
+                state.isFailureSheetPresented = false
+                return .none
+
+            case .contactSupportTapped:
+                state.isFailureSheetPresented = false
+                let prefixMessage = "\(state.errMsg)\n\n"
+                if state.canSendMail {
+                    state.supportData = SupportDataGenerator.generate(prefixMessage)
+                    return .none
+                } else {
+                    let sharePrefix =
+                    """
+                    ===
+                    \(String(localizable: .sendFeedbackShareNotAppleMailInfo)) \(SupportDataGenerator.Constants.email)
+                    ===
+
+                    \(prefixMessage)
+                    """
+                    let supportData = SupportDataGenerator.generate(sharePrefix)
+                    state.messageToBeShared = supportData.message
+                }
+                return .none
+
+            case .sendSupportMailFinished:
+                state.supportData = nil
+                return .none
+
+            case .shareFinished:
+                state.messageToBeShared = nil
+                return .none
+
             default: return .none
             }
         }

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
@@ -44,9 +44,9 @@ struct AddKeystoneHWWalletCoordFlow {
     enum Action: BindableAction {
         case addKeystoneHWWallet(AddKeystoneHWWallet.Action)
         case binding(BindingAction<AddKeystoneHWWalletCoordFlow.State>)
+        case cancelFailureTapped
         case closeHelpSheetTapped
         case contactSupportTapped
-        case dismissFailureSheet
         case path(StackActionOf<Path>)
         case sendSupportMailFinished
         case shareFinished
@@ -73,9 +73,12 @@ struct AddKeystoneHWWalletCoordFlow {
                 state.isHelpSheetPresented = false
                 return .none
 
-            case .dismissFailureSheet:
+            case .cancelFailureTapped:
+                // Close the sheet and leave the whole add-Keystone flow. Root
+                // observes `backToHomeTapped` and tears the flow down (path = nil),
+                // so the user is never stranded on the connection screen.
                 state.isFailureSheetPresented = false
-                return .none
+                return .send(.addKeystoneHWWallet(.backToHomeTapped))
 
             case .contactSupportTapped:
                 state.isFailureSheetPresented = false

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowStore.swift
@@ -50,7 +50,6 @@ struct AddKeystoneHWWalletCoordFlow {
         case path(StackActionOf<Path>)
         case sendSupportMailFinished
         case shareFinished
-        case tryAgainTapped
     }
 
     @Dependency(\.audioServices) var audioServices

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
@@ -142,8 +142,19 @@ struct AddKeystoneHWWalletCoordFlowView: View {
             }
             .padding(.bottom, 12)
 
-            ZashiButton(String(localizable: .keystoneAddHWWalletContactSupport)) {
+            ZashiButton(
+                String(localizable: .keystoneAddHWWalletContactSupport),
+                type: .secondary
+            ) {
                 store.send(.contactSupportTapped)
+            }
+            .padding(.bottom, 12)
+
+            ZashiButton(
+                String(localizable: .generalCancel),
+                type: .ghost
+            ) {
+                store.send(.cancelFailureTapped)
             }
             .padding(.bottom, Design.Spacing.sheetBottomSpace)
         }

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
@@ -135,16 +135,8 @@ struct AddKeystoneHWWalletCoordFlowView: View {
                 .padding(.bottom, 32)
 
             ZashiButton(
-                String(localizable: .keystoneAddHWWalletTryAgain),
-                type: .destructive2
-            ) {
-                store.send(.tryAgainTapped)
-            }
-            .padding(.bottom, 12)
-
-            ZashiButton(
                 String(localizable: .keystoneAddHWWalletContactSupport),
-                type: .secondary
+                type: .destructive2
             ) {
                 store.send(.contactSupportTapped)
             }

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
@@ -136,7 +136,7 @@ struct AddKeystoneHWWalletCoordFlowView: View {
 
             ZashiButton(
                 String(localizable: .keystoneAddHWWalletContactSupport),
-                type: .destructive2
+                type: .secondary
             ) {
                 store.send(.contactSupportTapped)
             }
@@ -144,7 +144,7 @@ struct AddKeystoneHWWalletCoordFlowView: View {
 
             ZashiButton(
                 String(localizable: .generalCancel),
-                type: .ghost
+                type: .primary
             ) {
                 store.send(.cancelFailureTapped)
             }

--- a/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/AddKeystoneHWWalletCoordFlowView.swift
@@ -32,6 +32,31 @@ struct AddKeystoneHWWalletCoordFlowView: View {
                 .zashiSheet(isPresented: $store.isHelpSheetPresented) {
                     helpSheetContent()
                 }
+                .zashiSheet(isPresented: $store.isFailureSheetPresented) {
+                    failureSheetContent()
+                }
+                .overlay {
+                    if let supportData = store.supportData {
+                        UIMailDialogView(
+                            supportData: supportData,
+                            completion: {
+                                store.send(.sendSupportMailFinished)
+                            }
+                        )
+                        // UIMailDialogView only wraps MFMailComposeViewController presentation
+                        // so frame is set to 0 to not break SwiftUI's layout
+                        .frame(width: 0, height: 0)
+                    }
+
+                    if let message = store.messageToBeShared {
+                        UIShareDialogView(activityItems: [message]) {
+                            store.send(.shareFinished)
+                        }
+                        // UIShareDialogView only wraps UIActivityViewController presentation
+                        // so frame is set to 0 to not break SwiftUI's layout
+                        .frame(width: 0, height: 0)
+                    }
+                }
             } destination: { store in
                 switch store.case {
                 case let .accountHWWalletSelection(store):
@@ -81,6 +106,44 @@ struct AddKeystoneHWWalletCoordFlowView: View {
             
             ZashiButton(String(localizable: .restoreInfoGotIt)) {
                 store.send(.closeHelpSheetTapped)
+            }
+            .padding(.bottom, Design.Spacing.sheetBottomSpace)
+        }
+    }
+
+    @ViewBuilder private func failureSheetContent() -> some View {
+        VStack(spacing: 0) {
+            Asset.Assets.Icons.alertOutline.image
+                .zImage(size: 20, style: Design.Utility.ErrorRed._500)
+                .background {
+                    Circle()
+                        .fill(Design.Utility.ErrorRed._100.color(colorScheme))
+                        .frame(width: 44, height: 44)
+                }
+                .padding(.top, 48)
+
+            Text(localizable: .keystoneAddHWWalletFailureTitle)
+                .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                .padding(.top, 16)
+                .padding(.bottom, 12)
+
+            Text(localizable: .keystoneAddHWWalletFailureDesc)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.center)
+                .lineSpacing(2)
+                .padding(.bottom, 32)
+
+            ZashiButton(
+                String(localizable: .keystoneAddHWWalletTryAgain),
+                type: .destructive2
+            ) {
+                store.send(.tryAgainTapped)
+            }
+            .padding(.bottom, 12)
+
+            ZashiButton(String(localizable: .keystoneAddHWWalletContactSupport)) {
+                store.send(.contactSupportTapped)
             }
             .padding(.bottom, Design.Spacing.sheetBottomSpace)
         }

--- a/secant/Sources/Features/RestoreInfo/RestoreInfoStore.swift
+++ b/secant/Sources/Features/RestoreInfo/RestoreInfoStore.swift
@@ -13,6 +13,7 @@ struct RestoreInfo {
     struct State: Equatable {
         var isAcknowledged = true
         var isKeystoneFlow = false
+        var isProcessing = false
         var isResyncFlow = false
     }
     

--- a/secant/Sources/Features/RestoreInfo/RestoreInfoView.swift
+++ b/secant/Sources/Features/RestoreInfo/RestoreInfoView.swift
@@ -95,13 +95,26 @@ struct RestoreInfoView: View {
                 }
                 .padding(.leading, 1)
 
-                ZashiButton((store.isKeystoneFlow || store.isResyncFlow)
-                            ? String(localizable: .generalOk).uppercased()
-                            : String(localizable: .restoreInfoGotIt)
-                ) {
-                    store.send(.gotItTapped)
+                if store.isProcessing {
+                    ZashiButton(
+                        (store.isKeystoneFlow || store.isResyncFlow)
+                        ? String(localizable: .generalOk).uppercased()
+                        : String(localizable: .restoreInfoGotIt),
+                        accessoryView: ProgressView()
+                    ) {
+                        store.send(.gotItTapped)
+                    }
+                    .disabled(true)
+                    .padding(.vertical, 24)
+                } else {
+                    ZashiButton((store.isKeystoneFlow || store.isResyncFlow)
+                                ? String(localizable: .generalOk).uppercased()
+                                : String(localizable: .restoreInfoGotIt)
+                    ) {
+                        store.send(.gotItTapped)
+                    }
+                    .padding(.vertical, 24)
                 }
-                .padding(.vertical, 24)
             }
             .zashiBack(hidden: true)
         }

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
@@ -16,7 +16,9 @@
 //
 
 import Testing
+import Foundation
 import ComposableArchitecture
+@preconcurrency import KeystoneSDK
 @testable import zodl_internal
 @testable @preconcurrency import ZcashLightClientKit
 
@@ -98,7 +100,58 @@ import ComposableArchitecture
         #expect(store.state.messageToBeShared == nil)
     }
 
+    // MARK: - Successful import (repro: failure sheet must NOT show on success)
+
+    @Test func successfulImportPushesSuccessScreenWithoutFailureSheet() async throws {
+        var elementState = AddKeystoneHWWallet.State.initial
+        elementState.zcashAccounts = Self.makeZcashAccounts()
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.path.append(.keystoneDeviceReady(elementState))
+
+        let importCount = LockIsolated(0)
+        let uuid = AccountUUID(id: [UInt8](repeating: 0x01, count: 16))
+        let store = Store(initialState: initialState) {
+            AddKeystoneHWWalletCoordFlow()
+        } withDependencies: {
+            $0.audioServices.systemSoundVibrate = { }
+            $0.sdkSynchronizer = .mocked(
+                importAccount: { _, _, _, _, _, _, _ in
+                    importCount.withValue { $0 += 1 }
+                    return uuid
+                },
+                walletAccounts: { [] }
+            )
+        }
+        let id = store.state.path.ids.first!
+
+        store.send(.path(.element(id: id, action: .keystoneDeviceReady(.unlockTapped(nil)))))
+
+        // Effects chain asynchronously (unlockTapped -> accountImported -> accountImportSucceeded);
+        // poll until the success screen lands or we give up.
+        for _ in 0..<50 {
+            if store.state.path.contains(where: { if case .keystoneConnected = $0 { true } else { false } }) { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+
+        #expect(importCount.value == 1)
+        #expect(store.state.path.contains(where: { if case .keystoneConnected = $0 { true } else { false } }))
+        #expect(store.state.isFailureSheetPresented == false)
+        #expect(store.state.errMsg.isEmpty)
+    }
+
     // MARK: - Helpers
+
+    private static func makeZcashAccounts() -> ZcashAccounts {
+        // ZcashAccounts has internal memberwise inits; decode via Codable instead.
+        let json = Data("""
+            {
+                "seedFingerprint": "\(String(repeating: "aa", count: 32))",
+                "accounts": [{"ufvk": "utest1abc", "index": 0, "name": "Keystone"}]
+            }
+            """.utf8)
+        // swiftlint:disable:next force_try
+        return try! JSONDecoder().decode(ZcashAccounts.self, from: json)
+    }
 
     private func makeStore(
         initialState: AddKeystoneHWWalletCoordFlow.State = AddKeystoneHWWalletCoordFlow.State()

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
@@ -51,6 +51,29 @@ import ComposableArchitecture
         #expect(store.state.errMsg.isEmpty)
     }
 
+    @Test func accountImportFailedAfterSuccessScreenStillClearsRestoreInfoProcessing() async {
+        // Even when the failure sheet is suppressed (success screen on the stack),
+        // any RestoreInfo element must not be left with a stuck spinner.
+        var restoreInfoState = RestoreInfo.State.initial
+        restoreInfoState.isKeystoneFlow = true
+        restoreInfoState.isProcessing = true
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.path.append(.keystoneDeviceReady(AddKeystoneHWWallet.State.initial))
+        initialState.path.append(.restoreInfo(restoreInfoState))
+        initialState.path.append(.keystoneConnected(AddKeystoneHWWallet.State.initial))
+        let store = makeStore(initialState: initialState)
+        let id = store.state.path.ids.first!
+
+        store.send(.path(.element(id: id, action: .keystoneDeviceReady(.accountImportFailed("duplicate")))))
+
+        #expect(store.state.isFailureSheetPresented == false)
+        #expect(store.state.errMsg.isEmpty)
+        let restoreInfoIsProcessing = store.state.path.compactMap {
+            if case .restoreInfo(let element) = $0 { element.isProcessing } else { nil }
+        }.first
+        #expect(restoreInfoIsProcessing == false)
+    }
+
     // MARK: - cancelFailureTapped
 
     @Test func cancelFailureTappedHidesSheet() async {
@@ -123,7 +146,7 @@ import ComposableArchitecture
 
     @Test func successfulImportPushesSuccessScreenWithoutFailureSheet() async throws {
         var elementState = AddKeystoneHWWallet.State.initial
-        elementState.zcashAccounts = Self.makeZcashAccounts()
+        elementState.zcashAccounts = ZcashAccounts.testFixture()
         var initialState = AddKeystoneHWWalletCoordFlow.State()
         initialState.path.append(.keystoneDeviceReady(elementState))
 
@@ -159,18 +182,6 @@ import ComposableArchitecture
     }
 
     // MARK: - Helpers
-
-    private static func makeZcashAccounts() -> ZcashAccounts {
-        // ZcashAccounts has internal memberwise inits; decode via Codable instead.
-        let json = Data("""
-            {
-                "seedFingerprint": "\(String(repeating: "aa", count: 32))",
-                "accounts": [{"ufvk": "utest1abc", "index": 0, "name": "Keystone"}]
-            }
-            """.utf8)
-        // swiftlint:disable:next force_try
-        return try! JSONDecoder().decode(ZcashAccounts.self, from: json)
-    }
 
     private func makeStore(
         initialState: AddKeystoneHWWalletCoordFlow.State = AddKeystoneHWWalletCoordFlow.State()

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
@@ -95,7 +95,13 @@ import ComposableArchitecture
 
     @Test func sendSupportMailFinishedClearsSupportData() async {
         var initialState = AddKeystoneHWWalletCoordFlow.State()
-        initialState.supportData = SupportDataGenerator.generate("")
+        // generate() reads walletStorage; this call runs in test code, outside
+        // the store's dependency scope, so it needs its own override.
+        initialState.supportData = withDependencies {
+            $0.walletStorage = .noOp
+        } operation: {
+            SupportDataGenerator.generate("")
+        }
         let store = makeStore(initialState: initialState)
 
         store.send(.sendSupportMailFinished)
@@ -173,6 +179,8 @@ import ComposableArchitecture
             AddKeystoneHWWalletCoordFlow()
         } withDependencies: {
             $0.audioServices.systemSoundVibrate = { }
+            // SupportDataGenerator.generate (contactSupportTapped) reads walletStorage.
+            $0.walletStorage = .noOp
         }
     }
 }

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
@@ -1,0 +1,112 @@
+//
+//  AddKeystoneHWWalletCoordFlowTests.swift
+//  zodlTests
+//
+//  Covers the coordinator-level error-handling state added for #1920:
+//  - accountImportFailed bubbles up from a path element and shows the failure sheet
+//  - cancelFailureTapped hides the sheet and exits the flow
+//  - contactSupportTapped routes to mail or share depending on device capability
+//  - sendSupportMailFinished / shareFinished clear their respective state
+//  (Features/CoordFlows/AddKeystoneHWWalletCoordFlow*.swift)
+//
+//  AddKeystoneHWWalletCoordFlow.State is not Equatable (it contains a non-Equatable StackState),
+//  so these tests drive a plain Store and read state directly after sending actions —
+//  the same approach used by ScanCoordFlowZip321Tests. Initial state is set up before
+//  Store creation (never via store.state mutation, which is get-only on a plain Store).
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) @MainActor struct AddKeystoneHWWalletCoordFlowTests {
+
+    // MARK: - accountImportFailed from keystoneDeviceReady
+
+    @Test func accountImportFailedShowsFailureSheet() async {
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.path.append(.keystoneDeviceReady(AddKeystoneHWWallet.State.initial))
+        let store = makeStore(initialState: initialState)
+        let id = store.state.path.ids.first!
+
+        store.send(.path(.element(id: id, action: .keystoneDeviceReady(.accountImportFailed("boom")))))
+
+        #expect(store.state.isFailureSheetPresented == true)
+        #expect(store.state.errMsg == "boom")
+    }
+
+    // MARK: - cancelFailureTapped
+
+    @Test func cancelFailureTappedHidesSheet() async {
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.isFailureSheetPresented = true
+        let store = makeStore(initialState: initialState)
+
+        store.send(.cancelFailureTapped)
+
+        #expect(store.state.isFailureSheetPresented == false)
+    }
+
+    // MARK: - contactSupportTapped
+
+    @Test func contactSupportTappedWithMailCapabilitySetsSupportData() async {
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.isFailureSheetPresented = true
+        initialState.canSendMail = true
+        initialState.errMsg = "ZRUST0067: rust error"
+        let store = makeStore(initialState: initialState)
+
+        store.send(.contactSupportTapped)
+
+        #expect(store.state.isFailureSheetPresented == false)
+        #expect(store.state.supportData != nil)
+    }
+
+    @Test func contactSupportTappedWithoutMailSetsMessageToBeShared() async {
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.isFailureSheetPresented = true
+        initialState.canSendMail = false
+        initialState.errMsg = "ZRUST0067: rust error"
+        let store = makeStore(initialState: initialState)
+
+        store.send(.contactSupportTapped)
+
+        #expect(store.state.isFailureSheetPresented == false)
+        #expect(store.state.messageToBeShared != nil)
+    }
+
+    // MARK: - Mail / share cleanup
+
+    @Test func sendSupportMailFinishedClearsSupportData() async {
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.supportData = SupportDataGenerator.generate("")
+        let store = makeStore(initialState: initialState)
+
+        store.send(.sendSupportMailFinished)
+
+        #expect(store.state.supportData == nil)
+    }
+
+    @Test func shareFinishedClearsMessageToBeShared() async {
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.messageToBeShared = "some message"
+        let store = makeStore(initialState: initialState)
+
+        store.send(.shareFinished)
+
+        #expect(store.state.messageToBeShared == nil)
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore(
+        initialState: AddKeystoneHWWalletCoordFlow.State = AddKeystoneHWWalletCoordFlow.State()
+    ) -> StoreOf<AddKeystoneHWWalletCoordFlow> {
+        Store(initialState: initialState) {
+            AddKeystoneHWWalletCoordFlow()
+        } withDependencies: {
+            $0.audioServices.systemSoundVibrate = { }
+        }
+    }
+}

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
@@ -38,6 +38,19 @@ import ComposableArchitecture
         #expect(store.state.errMsg == "boom")
     }
 
+    @Test func accountImportFailedAfterSuccessScreenIsIgnored() async {
+        var initialState = AddKeystoneHWWalletCoordFlow.State()
+        initialState.path.append(.keystoneDeviceReady(AddKeystoneHWWallet.State.initial))
+        initialState.path.append(.keystoneConnected(AddKeystoneHWWallet.State.initial))
+        let store = makeStore(initialState: initialState)
+        let id = store.state.path.ids.first!
+
+        store.send(.path(.element(id: id, action: .keystoneDeviceReady(.accountImportFailed("duplicate")))))
+
+        #expect(store.state.isFailureSheetPresented == false)
+        #expect(store.state.errMsg.isEmpty)
+    }
+
     // MARK: - cancelFailureTapped
 
     @Test func cancelFailureTappedHidesSheet() async {

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
@@ -98,7 +98,7 @@ import ComposableArchitecture
 
     @MainActor @Test func unlockTappedSDKThrowSendsAccountImportFailed() async {
         var state = AddKeystoneHWWallet.State()
-        state.zcashAccounts = makeZcashAccounts()
+        state.zcashAccounts = ZcashAccounts.testFixture()
         let store = TestStore(initialState: state) {
             AddKeystoneHWWallet()
         } withDependencies: {
@@ -111,9 +111,24 @@ import ComposableArchitecture
         await store.receive(\.accountImportFailed)
     }
 
+    @MainActor @Test func unlockTappedNilImportResultSendsAccountImportFailed() async {
+        // The interface types importAccount as AccountUUID?; a nil result must
+        // clear isImportingAccount via accountImportFailed, not hang the UI.
+        var state = AddKeystoneHWWallet.State()
+        state.zcashAccounts = ZcashAccounts.testFixture()
+        let store = TestStore(initialState: state) {
+            AddKeystoneHWWallet()
+        } withDependencies: {
+            $0.sdkSynchronizer = .mocked(importAccount: { _, _, _, _, _, _, _ in nil })
+        }
+        store.exhaustivity = .off
+        await store.send(.unlockTapped(nil))
+        await store.receive(\.accountImportFailed)
+    }
+
     @MainActor @Test func unlockTappedIgnoresRetapsWhileImportInFlight() async {
         var state = AddKeystoneHWWallet.State()
-        state.zcashAccounts = makeZcashAccounts()
+        state.zcashAccounts = ZcashAccounts.testFixture()
         let importCount = LockIsolated(0)
         let store = TestStore(initialState: state) {
             AddKeystoneHWWallet()
@@ -172,19 +187,6 @@ import ComposableArchitecture
     // MARK: - Helpers
 
     private enum TestError: Error { case importFailed, loadFailed }
-
-    private func makeZcashAccounts() -> ZcashAccounts {
-        // ZcashAccounts/ZcashUnifiedFullViewingKey have internal memberwise inits (inaccessible from
-        // this test module), so decode from JSON using their Codable conformance instead.
-        let json = Data("""
-            {
-                "seedFingerprint": "\(String(repeating: "aa", count: 32))",
-                "accounts": [{"ufvk": "utest1abc", "index": 0, "name": "Keystone"}]
-            }
-            """.utf8)
-        // swiftlint:disable:next force_try
-        return try! JSONDecoder().decode(ZcashAccounts.self, from: json)
-    }
 
     private func walletAccount(idByte: UInt8) -> WalletAccount {
         WalletAccount(Account(

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
@@ -111,6 +111,40 @@ import ComposableArchitecture
         await store.receive(\.accountImportFailed)
     }
 
+    @MainActor @Test func unlockTappedIgnoresRetapsWhileImportInFlight() async {
+        var state = AddKeystoneHWWallet.State()
+        state.zcashAccounts = makeZcashAccounts()
+        let importCount = LockIsolated(0)
+        let store = TestStore(initialState: state) {
+            AddKeystoneHWWallet()
+        } withDependencies: {
+            $0.sdkSynchronizer = .mocked(
+                importAccount: { _, _, _, _, _, _, _ in
+                    importCount.withValue { $0 += 1 }
+                    try await Task.sleep(for: .milliseconds(100))
+                    return AccountUUID(id: [UInt8](repeating: 0x01, count: 16))
+                },
+                walletAccounts: { [] }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.unlockTapped(nil)) { $0.isImportingAccount = true }
+        await store.send(.unlockTapped(nil))
+        await store.receive(\.accountImportSucceeded, timeout: .seconds(2))
+        await store.finish()
+
+        #expect(importCount.value == 1)
+    }
+
+    @MainActor @Test func accountImportFailedClearsImportingFlag() async {
+        var state = AddKeystoneHWWallet.State()
+        state.isImportingAccount = true
+        let store = TestStore(initialState: state) { AddKeystoneHWWallet() }
+
+        await store.send(.accountImportFailed("boom")) { $0.isImportingAccount = false }
+    }
+
     @MainActor @Test func accountImportedWalletLoadThrowSendsAccountImportFailed() async {
         let uuid = AccountUUID(id: [UInt8](repeating: 0x01, count: 16))
         let store = TestStore(initialState: AddKeystoneHWWallet.State()) {

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
@@ -10,6 +10,7 @@
 import Testing
 import Foundation
 import ComposableArchitecture
+@preconcurrency import KeystoneSDK
 @testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
@@ -86,6 +87,42 @@ import ComposableArchitecture
         }
     }
 
+    // MARK: - accountImportFailed
+
+    @MainActor @Test func accountImportFailedIsNoOpOnElementStore() async {
+        // The element store just passes the error string along; the coordinator
+        // owns the failure-sheet state and handles the visual side.
+        let store = TestStore(initialState: AddKeystoneHWWallet.State()) { AddKeystoneHWWallet() }
+        await store.send(.accountImportFailed("ZRUST0067: some rust error"))
+    }
+
+    @MainActor @Test func unlockTappedSDKThrowSendsAccountImportFailed() async {
+        var state = AddKeystoneHWWallet.State()
+        state.zcashAccounts = makeZcashAccounts()
+        let store = TestStore(initialState: state) {
+            AddKeystoneHWWallet()
+        } withDependencies: {
+            $0.sdkSynchronizer = .mocked(importAccount: { _, _, _, _, _, _, _ in
+                throw TestError.importFailed
+            })
+        }
+        store.exhaustivity = .off
+        await store.send(.unlockTapped(nil))
+        await store.receive(\.accountImportFailed)
+    }
+
+    @MainActor @Test func accountImportedWalletLoadThrowSendsAccountImportFailed() async {
+        let uuid = AccountUUID(id: [UInt8](repeating: 0x01, count: 16))
+        let store = TestStore(initialState: AddKeystoneHWWallet.State()) {
+            AddKeystoneHWWallet()
+        } withDependencies: {
+            $0.sdkSynchronizer.walletAccounts = { throw TestError.loadFailed }
+        }
+        store.exhaustivity = .off
+        await store.send(.accountImported(uuid))
+        await store.receive(\.accountImportFailed)
+    }
+
     // MARK: - Derived state
 
     @Test func keystoneNameDefaultsToKeystoneWalletWithoutScannedAccount() {
@@ -99,6 +136,21 @@ import ComposableArchitecture
     }
 
     // MARK: - Helpers
+
+    private enum TestError: Error { case importFailed, loadFailed }
+
+    private func makeZcashAccounts() -> ZcashAccounts {
+        // ZcashAccounts/ZcashUnifiedFullViewingKey have internal memberwise inits (inaccessible from
+        // this test module), so decode from JSON using their Codable conformance instead.
+        let json = Data("""
+            {
+                "seedFingerprint": "\(String(repeating: "aa", count: 32))",
+                "accounts": [{"ufvk": "utest1abc", "index": 0, "name": "Keystone"}]
+            }
+            """.utf8)
+        // swiftlint:disable:next force_try
+        return try! JSONDecoder().decode(ZcashAccounts.self, from: json)
+    }
 
     private func walletAccount(idByte: UInt8) -> WalletAccount {
         WalletAccount(Account(

--- a/zodlTests/AddKeystoneHWWalletTests/ZcashAccountsTestFixture.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/ZcashAccountsTestFixture.swift
@@ -1,0 +1,24 @@
+//
+//  ZcashAccountsTestFixture.swift
+//  zodlTests
+//
+//  Shared ZcashAccounts fixture for the AddKeystoneHWWallet suites.
+//
+
+import Foundation
+@preconcurrency import KeystoneSDK
+
+extension ZcashAccounts {
+    /// ZcashAccounts/ZcashUnifiedFullViewingKey have internal memberwise inits (inaccessible from
+    /// this test module), so decode from JSON using their Codable conformance instead.
+    static func testFixture() -> ZcashAccounts {
+        let json = Data("""
+            {
+                "seedFingerprint": "\(String(repeating: "aa", count: 32))",
+                "accounts": [{"ufvk": "utest1abc", "index": 0, "name": "Keystone"}]
+            }
+            """.utf8)
+        // swiftlint:disable:next force_try
+        return try! JSONDecoder().decode(ZcashAccounts.self, from: json)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #1920. Two related fixes to the add-Keystone flow:

**1. Import failures are surfaced (originally silent).** A failed Keystone account import used to do nothing (`// TODO: error handling` in `AddHWWalletStore`), leaving the user stuck on the "keep ZODL open" screen with a dead OK button. Failures now present a "Connection Failed" sheet (same UI pattern as `DisconnectHWWallet`) at the coordinator level, so it works from both entry points that trigger the import — "Connect new device" (`KeystoneDeviceReadyView`) and the restore/birthday flow. The sheet offers **Contact Support** (mail, or share sheet when Apple Mail isn't available) and **Cancel**, which exits the whole flow so the user is never stranded. (An earlier revision had a **Try Again** action; it was removed — the user can't tell whether a retry will help, and the firmware guidance already covers the fix.)

**2. The failure sheet no longer pops over the success screen.** With the error flow in place, a *successful* connect could still show the failure sheet on top of the success screen. Root cause: the buttons that start the import stayed enabled with no feedback while `importAccount` ran (a slow, network-bound call), so re-taps started **duplicate imports**; the duplicate throws "account already exists" and that error surfaced as a bogus Connection Failed sheet. Fixed in three layers:
- `unlockTapped` now guards against re-entry via an `isImportingAccount` flag (cleared on success/failure so genuine retries work).
- The connect/OK buttons show a `ProgressView` and disable while the import runs (established `accessoryView: ProgressView()` pattern; the restore-info OK button gets it via a new `RestoreInfo.State.isProcessing` flag managed by the coordinator).
- Belt-and-braces: the coordinator drops an `accountImportFailed` that arrives after `keystoneConnected` is already on the stack.

Also fixes a previously **unhandled `try`** when reloading wallet accounts after a successful import.

## Privacy
The string carried into the support message is `error.localizedDescription` **only**. For `ZcashError` that resolves to a static `"<code>: <message>"` (e.g. `ZRUST0067: Error from rust layer when calling ZcashRustBackend.importAccountUfvk`). The raw Rust error associated value — which could in principle contain key material — is **not** interpolated into `localizedDescription`, and we never use `String(describing:)`/`"\(error)"`. So **no UFVK/seed/fingerprint can leak** into logs or support emails. This matches the existing safe pattern in `DisconnectHWWallet`.

## Changes
- `AddHWWalletStore.swift` — `accountImportFailed` carries the (safe) error string; both throw sites route to it; `isImportingAccount` in-flight guard.
- `AddKeystoneHWWalletCoordFlowStore/Coordinator/View.swift` — failure + support state, the failure sheet, restore-info `isProcessing` wiring, and the drop-late-failures guard.
- `KeystoneDeviceReadyView.swift` / `RestoreInfoView.swift` / `RestoreInfoStore.swift` — progress + disabled states on the import buttons.
- `Localizable.xcstrings` — new keys for the failure sheet (en + es).
- `CHANGELOG.md` — Fixed entries.

## Testing
- ✅ New Swift Testing coverage: element store (hex parsing, unlock guard, re-tap suppression, failure propagation, flag resets) and coordinator (failure sheet shown/hidden, late-failure ignored, cancel/contact-support routing, and a success-path regression test asserting exactly one `importAccount` call with no failure sheet).
- ✅ Fixed the support-flow tests that hit the live `walletStorage` dependency when actually run.
- ✅ `AddKeystoneHWWalletTests` + `AddKeystoneHWWalletCoordFlowTests`: 23/23 passing.
- ✅ Verified manually in the UI: failure path shows the sheet; successful connect shows only the success screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)