### PR TITLE
[MOB-1513] Make the Keystone re-tap guard test deterministic

### DIFF
--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
@@ -130,13 +130,17 @@ import ComposableArchitecture
         var state = AddKeystoneHWWallet.State()
         state.zcashAccounts = ZcashAccounts.testFixture()
         let importCount = LockIsolated(0)
+        // Hold the import in flight until the test releases it. A wall-clock sleep here raced
+        // parallel-suite load: the first import could finish (downing the guard) before the second
+        // tap was sent, so the re-tap legitimately imported again and the count read 2.
+        let (releaseStream, releaseContinuation) = AsyncStream<Void>.makeStream()
         let store = TestStore(initialState: state) {
             AddKeystoneHWWallet()
         } withDependencies: {
             $0.sdkSynchronizer = .mocked(
                 importAccount: { _, _, _, _, _, _, _ in
                     importCount.withValue { $0 += 1 }
-                    try await Task.sleep(for: .milliseconds(100))
+                    for await _ in releaseStream { break }
                     return AccountUUID(id: [UInt8](repeating: 0x01, count: 16))
                 },
                 walletAccounts: { [] }
@@ -146,6 +150,8 @@ import ComposableArchitecture
 
         await store.send(.unlockTapped(nil)) { $0.isImportingAccount = true }
         await store.send(.unlockTapped(nil))
+        releaseContinuation.yield()
+        releaseContinuation.finish()
         await store.receive(\.accountImportSucceeded, timeout: .seconds(2))
         await store.finish()
 


### PR DESCRIPTION
## Summary

`AddKeystoneHWWalletTests/unlockTappedIgnoresRetapsWhileImportInFlight` failed intermittently in full-parallel `zodlTests` runs (`importCount.value → 2) == 1`) while passing standalone — reproduced on both current working branches.

**Root cause (test defect, store guard is sound):** the mock held the import in flight with `Task.sleep(for: .milliseconds(100))`. Under parallel-suite load, more than 100 ms could elapse between the two `store.send(.unlockTapped)` calls, so the first import completed, the success path cleared `isImportingAccount`, and the second tap legitimately started a second import. The store's guard itself is race-free — the flag is set synchronously in the reducer before the effect starts.

**Fix:** replace the wall-clock sleep with the repo's established `AsyncStream<Void>.makeStream()` release-gate (same pattern as `MigrationTransferPlanTests`): the mocked `importAccount` blocks on the stream and the test yields it only after the re-tap, making the in-flight window deterministic regardless of scheduler load.

## Verification

- Guard-catch check: with the store's in-flight guard temporarily disabled, the rewritten test fails (`importCount → 2`) — it still pins the #1920 behavior. Restored, it passes.
- Suite standalone: green.
- Full `zodlTests` target run 3× consecutively: all three runs green (previously the flake reproduced in full-target runs on both branches tried).

No app code changed; no CHANGELOG entry (test-only, no user-facing impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)