### PR TITLE
[#1943] Make wallet initialization single-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Fixed
+- [#1943] Fixed a wallet initialization bug: initialization is now single-flight, so repeated startup triggers while the wallet is still initializing are ignored until it finishes.
 - [#1920] Connecting a Keystone hardware wallet that fails now shows a clear "Connection Failed" message (with Contact Support and Cancel options) instead of silently doing nothing. Cancel leaves the flow so the user is never stuck on the connection screen. The support message includes a safe error identifier and never exposes any wallet keys.
 - [#1920] The "Connection Failed" sheet no longer appears on top of the success screen when connecting a Keystone device actually succeeds. Tapping the connect/OK button again while the import was still running started a duplicate import whose failure surfaced as a bogus error; the button now shows a progress indicator and extra taps are ignored.
 - [PRO-325] Swaps out of ZEC and CrossPays that fail on the swap provider's side now show "Swap Failed" / "Payment Failed" (with the contact-support option) instead of appearing to stay in progress forever. Long-running swaps in this direction also correctly show their processing state.

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
@@ -147,7 +147,7 @@ extension SDKSynchronizerClient {
         exchangeRateUSDStream: @escaping @Sendable () -> AnyPublisher<FiatCurrencyResult?, Never> = { Empty().eraseToAnyPublisher() },
         latestState: @escaping @Sendable () -> SynchronizerState = { .zero },
         latestScannedHeight: @escaping @Sendable () -> BlockHeight = { 0 },
-        prepareWith: @escaping @Sendable ([UInt8], BlockHeight, WalletInitMode, String, String?) throws -> Initializer.InitializationResult = { _, _, _, _, _ in .success },
+        prepareWith: @escaping @Sendable ([UInt8], BlockHeight, WalletInitMode, String, String?) async throws -> Initializer.InitializationResult = { _, _, _, _, _ in .success },
         start: @escaping @Sendable (_ retry: Bool) throws -> Void = { _ in },
         stop: @escaping @Sendable () -> Void = { },
         isSyncing: @escaping @Sendable () -> Bool = { false },

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -27,6 +27,7 @@ extension Root {
         case checkWalletInitialization
         case checkWalletConfig
         case initializeSDK(WalletInitMode)
+        case initializeSDKFinished
         case staleWalletDatabaseHealed
         case presentStaleWalletHealedAlert
         case initialSetups
@@ -321,6 +322,12 @@ extension Root {
                 /// Stored wallet is present, database files may or may not be present, trying to initialize app state variables and environments.
                 /// When initialization succeeds user is taken to the home screen.
             case .initialization(.initializeSDK(let walletMode)):
+                // First prepare wins: a foreground transition (or any other re-entry into the
+                // initialization chain) while `prepareWith` is still in flight must not start a
+                // second concurrent prepare — see `isInitializingSDK`. Dropping the action is
+                // safe: the in-flight effect always ends in one of the terminal actions that
+                // clear the latch and drive navigation themselves.
+                guard !state.isInitializingSDK else { return .none }
                 do {
                     let storedWallet: StoredWallet
                     do {
@@ -331,7 +338,8 @@ extension Root {
                     let birthday = storedWallet.birthday?.value() ?? zcashSDKEnvironment.latestCheckpoint()
                     try mnemonic.isValid(storedWallet.seedPhrase.value())
                     let seedBytes = try mnemonic.toSeed(storedWallet.seedPhrase.value())
-                    
+
+                    state.isInitializingSDK = true
                     return .run { send in
                         do {
                             let result = try await sdkSynchronizer.prepareWith(
@@ -436,7 +444,9 @@ extension Root {
                             // `initializationFailed` alert for (that only recovers on relaunch).
                             // Recompute wallet-initialization state in-session instead: with the
                             // database gone this resolves to `.filesMissing`, which re-enters the
-                            // existing restore path.
+                            // existing restore path. The latch must drop first or the re-entry's
+                            // own `.initializeSDK` would be swallowed by the single-flight guard.
+                            await send(.initialization(.initializeSDKFinished))
                             await send(.initialization(.checkWalletInitialization))
                         } catch {
                             await send(.initialization(.initializationFailed(error.toZcashError())))
@@ -473,7 +483,12 @@ extension Root {
                 state.alert = AlertState.staleWalletDatabaseHealed()
                 return .none
 
+            case .initialization(.initializeSDKFinished):
+                state.isInitializingSDK = false
+                return .none
+
             case .initialization(.initializationSuccessfullyDone):
+                state.isInitializingSDK = false
                 return .merge(
                     .send(.initialization(.registerForSynchronizersUpdate)),
                     .publisher {
@@ -782,6 +797,7 @@ extension Root {
                 return .none
 
             case .initialization(.initializationFailed(let error)):
+                state.isInitializingSDK = false
                 state.appInitializationState = .failed
                 state.alert = AlertState.initializationFailed(error)
                 return .none

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -63,6 +63,13 @@ struct Root {
         var exportLogsState: ExportLogs.State
         @Shared(.inMemory(.featureFlags)) var featureFlags: FeatureFlags = .initial
         var homeState: Home.State = .initial
+        /// Single-flight latch for `.initialization(.initializeSDK)`. The SDK reports an
+        /// unprepared status until `prepare` fully returns, so `willEnterForeground` (and any
+        /// other re-entry into the initialization chain) would otherwise dispatch a second
+        /// concurrent `prepareWith`. Initialization must never run concurrently ([#1943]):
+        /// the first prepare wins and re-entries are dropped until the in-flight effect
+        /// signals completion on every terminal path.
+        var isInitializingSDK = false
         var isLockedInKeychainUnavailableState = false
         var isRestoringWallet = false
         var isStaleWalletHealedAlertPending = false

--- a/zodlTests/UtilTests/RootInitializeSDKSingleFlightTests.swift
+++ b/zodlTests/UtilTests/RootInitializeSDKSingleFlightTests.swift
@@ -1,0 +1,190 @@
+//
+//  RootInitializeSDKSingleFlightTests.swift
+//  zodlTests
+//
+//  Regression test for [#1943]: wallet initialization must be single-flight.
+//
+//  `.initialization(.initializeSDK)` runs `sdkSynchronizer.prepareWith` in an effect, and
+//  the SDK reports an unprepared status until `prepare` fully returns, so
+//  `.appDelegate(.willEnterForeground)` re-enters
+//  `.initialSetups → .checkWalletInitialization → .initializeSDK` while a first prepare is
+//  still in flight. The `isInitializingSDK` latch makes the first prepare win and drops
+//  re-entries until the in-flight effect signals completion. This test holds the first
+//  `prepareWith` open on a gate, fires the foreground re-entry, and asserts no second
+//  `prepareWith` is dispatched.
+//
+
+@preconcurrency import Combine
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// `Root.State: Equatable` is provided test-target-wide by RootInitializeSDKHealTests.swift.
+//
+// `.initialSetups` logs through the process-global `LoggerProxy`, and the effects under test
+// mutate TCA `@Shared` in-memory state (`walletStatus`, `walletAccounts`), so this suite is
+// serialized per repo convention.
+@Suite(.serialized) @MainActor struct RootInitializeSDKSingleFlightTests {
+    /// Resumable gate the mocked `prepareWith` suspends on, keeping the first prepare
+    /// "in flight" for as long as the test needs the race window held open.
+    private final class PrepareGate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuations: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                continuations.append(continuation)
+                lock.unlock()
+            }
+        }
+
+        func open() {
+            lock.lock()
+            let waiting = continuations
+            continuations = []
+            lock.unlock()
+            waiting.forEach { $0.resume() }
+        }
+    }
+
+    private static let seedDerivedAccount = WalletAccount(
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: "Zashi",
+            keySource: "zashi",
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    )
+
+    /// Wires a `Root` `TestStore` so the full launch chain
+    /// (`didFinishLaunching → initialSetups → checkWalletInitialization →
+    /// respondToWalletInitializationState(.initialized) → initializeSDK(.restoreWallet)`)
+    /// runs against recorded fakes. `udIsRestoringWallet == true` routes `.initialized` into
+    /// `.restoreWallet` mode — the mid-restore situation the race needs — and the mocked
+    /// synchronizer's `latestState` stays `.zero` (`.unprepared`) throughout, exactly as the
+    /// real SDK reports while a `prepare` call is still in flight. Every `prepareWith` call
+    /// suspends on `gate` until the test opens it.
+    private func makeStore(
+        prepareModes: LockIsolated<[String]>,
+        gate: PrepareGate
+    ) -> TestStore<Root.State, Root.Action> {
+        let seedDerivedAccount = Self.seedDerivedAccount
+        let initialState = Root.State(
+            destinationState: Root.DestinationState(internalDestination: .welcome),
+            exportLogsState: ExportLogs.State(),
+            onboardingState: RestoreWalletCoordFlow.State(),
+            phraseDisplayState: RecoveryPhraseDisplay.State(),
+            walletConfig: .initial,
+            welcomeState: Welcome.State()
+        )
+
+        let store = TestStore(
+            initialState: initialState
+        ) {
+            Root()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+
+            $0.exchangeRate = .noOp
+            $0.autolockHandler = .noOp
+            $0.shieldingProcessor = ShieldingProcessorClient(
+                observe: { Empty().eraseToAnyPublisher() },
+                shieldFunds: { }
+            )
+
+            $0.mnemonic = .noOp
+
+            $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+
+            $0.databaseFiles = .noOp
+            $0.databaseFiles.areDbFilesPresentFor = { _ in true }
+
+            $0.walletStorage = .noOp
+            $0.walletStorage.areKeysPresent = { true }
+            $0.walletStorage.exportWallet = { .placeholder }
+
+            $0.userDefaults.objectForKey = { key in
+                key == Root.Constants.udIsRestoringWallet ? true : nil
+            }
+            $0.userDefaults.setValue = { _, _ in }
+            $0.userDefaults.remove = { _ in }
+
+            $0.readTransactionsStorage = .noOp
+
+            $0.addressBook.allLocalContacts = { _ in (AddressBookContacts.empty, .notAttempted) }
+
+            $0.userMetadataProvider.load = { _ in }
+
+            $0.sdkSynchronizer = .mocked(
+                stateStream: { Empty().eraseToAnyPublisher() },
+                prepareWith: { _, _, walletMode, _, _ in
+                    let modeLabel: String
+                    switch walletMode {
+                    case .newWallet: modeLabel = "newWallet"
+                    case .restoreWallet: modeLabel = "restoreWallet"
+                    case .existingWallet: modeLabel = "existingWallet"
+                    }
+                    prepareModes.withValue { $0.append(modeLabel) }
+                    await gate.wait()
+                    return .success
+                },
+                getAllTransactions: { _ in [] },
+                isSeedRelevantToAnyDerivedAccount: { _ in true },
+                walletAccounts: { [seedDerivedAccount] }
+            )
+        }
+        store.exhaustivity = .off
+        return store
+    }
+
+    /// Polls until `condition` holds or the timeout elapses; the launch chain under test hops
+    /// between effects, so there is no single action to `receive` on deterministically with
+    /// exhaustivity off. Also used with an unmet condition as a bounded settle window when
+    /// proving an action does NOT happen.
+    private func waitUntil(iterations: Int = 200, _ condition: @escaping @Sendable () -> Bool) async {
+        for _ in 0..<iterations where !condition() {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    /// Same rationale as RootInitializeSDKHealTests.drain: let the `.initializeSDK` cascade
+    /// settle without asserting on it, then silence the store's bookkeeping.
+    private func drain(_ store: TestStore<Root.State, Root.Action>) async {
+        await store.send(.cancelAllRunningEffects)
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+    }
+
+    @Test func foregroundWhileUnpreparedDoesNotDispatchSecondPrepare() async throws {
+        let prepareModes = LockIsolated<[String]>([])
+        let gate = PrepareGate()
+        let store = makeStore(prepareModes: prepareModes, gate: gate)
+
+        await store.send(.initialization(.appDelegate(.didFinishLaunching)))
+        await waitUntil { prepareModes.value.count >= 1 }
+        #expect(prepareModes.value == ["restoreWallet"], "launch must reach exactly one prepareWith(.restoreWallet)")
+
+        // The first prepare is now suspended on the gate and the synchronizer still reports
+        // `.unprepared` — as it does for the entire duration of a real in-flight prepare — so
+        // foregrounding takes the `.initialSetups` branch and re-enters the initialization
+        // chain. The single-flight latch must swallow the re-entry's `.initializeSDK`.
+        await store.send(.initialization(.appDelegate(.willEnterForeground)))
+
+        // Bounded settle window: before the fix the second prepareWith arrived within a few
+        // milliseconds of the re-entry, so a second dispatch would be observed here.
+        await waitUntil(iterations: 50) { prepareModes.value.count >= 2 }
+        #expect(
+            prepareModes.value == ["restoreWallet"],
+            "a foreground re-entry must not dispatch another prepareWith while one is in flight"
+        )
+
+        gate.open()
+        await drain(store)
+    }
+}


### PR DESCRIPTION
Closes zodl-inc/zodl-ios#1943. Resolves MOB-1527

Fixes a wallet initialization bug: initialization is now single-flight. `.initialization(.initializeSDK)` sets a first-wins latch (`isInitializingSDK`) that drops re-entries into the initialization chain until the in-flight initialization completes; every terminal path releases the latch, and the `reprepareFailed` recovery releases it before re-entering `checkWalletInitialization` so the heal path keeps working.

`SDKSynchronizerClient.mocked(prepareWith:)` becomes `async` (the interface field already was; existing sync-closure call sites compile unchanged) so tests can hold a prepare open.

## Testing

* New `RootInitializeSDKSingleFlightTests` holds the first `prepareWith` open, triggers a re-entry into the initialization chain, and asserts no second `prepareWith` is dispatched.
* Full `zodlTests` target green (666 tests / 107 suites; the one recorded known issue is the pre-existing [MOB-1364](https://linear.app/zodl/issue/MOB-1364/security-tor-enablement-does-not-update-the-shared-network-flag-until) gap in `CurrencyConversionSetupTests`).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)