### PR TITLE
Ironwood sync support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ## [Unreleased]
 
+### Added
+- [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
+- [Ironwood] A transfer that moves funds into the Ironwood pool now shows the amount that actually moved, in both the transaction list and the transaction detail screen. Previously such a transfer displayed only its fee.
+
+### Changed
+- [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.
+
 ### Fixed
+- [Ironwood] The automatic recovery from another wallet's leftover data (see MOB-1512 below) keeps working with the updated Zcash SDK. The SDK now reports that mismatch as an error rather than a status, so ZODL maps it back onto the same recovery and the wallet still heals itself instead of stopping on an initialization error.
 - [#1943] Fixed a wallet initialization bug: initialization is now single-flight, so repeated startup triggers while the wallet is still initializing are ignored until it finishes.
 - [#1920] Connecting a Keystone hardware wallet that fails now shows a clear "Connection Failed" message (with Contact Support and Cancel options) instead of silently doing nothing. Cancel leaves the flow so the user is never stuck on the connection screen. The support message includes a safe error identifier and never exposes any wallet keys.
 - [#1920] The "Connection Failed" sheet no longer appears on top of the success screen when connecting a Keystone device actually succeeds. Tapping the connect/OK button again while the import was still running started a duplicate import whose failure surfaced as a bogus error; the button now shows a progress indicator and extra taps are ignored.

--- a/secant/Sources/Dependencies/URIParser/URIParserInterface.swift
+++ b/secant/Sources/Dependencies/URIParser/URIParserInterface.swift
@@ -29,8 +29,17 @@ extension ParserContext {
         case .mainnet:
             ParserContext.mainnet
         case .testnet, .regtest:
-            // Regtest (SDK networkId 2, custom activation heights) has no URI context of its own;
-            // its addresses are testnet-encoded, so the testnet context is the correct parser.
+            // `.regtest` is aliased onto the testnet context only to satisfy exhaustiveness. It is
+            // a known simplification, NOT a correct mapping: `ParserContext` declares its own
+            // `.regtest` with different HRPs (`zregtestsapling`/`uregtest`/`texregtest`/`t3`), and
+            // custom-network addresses are regtest-encoded, not testnet-encoded. Unreachable today
+            // because `TargetConstants.zcashNetwork` only ever builds `.mainnet`/`.testnet`.
+            //
+            // A real regtest build must not simply add a `.regtest` arm here: the SDK hardcodes
+            // `networkType = .regtest` for every custom network regardless of its base, so
+            // `NetworkType` alone cannot say whether addresses are regtest- or mainnet-encoded
+            // (a `base: .mainnet` Ironwood chain derives mainnet addresses). Dispatch on
+            // `ZcashNetwork.customNetworkBase ?? networkType` instead of `NetworkType`.
             ParserContext.testnet
         }
     }

--- a/secant/Sources/Dependencies/URIParser/URIParserInterface.swift
+++ b/secant/Sources/Dependencies/URIParser/URIParserInterface.swift
@@ -28,7 +28,9 @@ extension ParserContext {
         switch networkType {
         case .mainnet:
             ParserContext.mainnet
-        case .testnet:
+        case .testnet, .regtest:
+            // Regtest (SDK networkId 2, custom activation heights) has no URI context of its own;
+            // its addresses are testnet-encoded, so the testnet context is the correct parser.
             ParserContext.testnet
         }
     }

--- a/secant/Sources/Dependencies/VotingAPIClient/RoundAuthenticator.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/RoundAuthenticator.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import CryptoKit
 import Foundation
 
@@ -77,3 +78,4 @@ enum RoundAuthenticator {
         return false
     }
 }
+#endif

--- a/secant/Sources/Dependencies/VotingAPIClient/ServerHealthTracker.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/ServerHealthTracker.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import Foundation
 
 // MARK: - Server Health Tracker
@@ -189,3 +190,4 @@ actor ServerHealthTracker {
         probeTask = nil
     }
 }
+#endif

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientInterface.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientInterface.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 
@@ -83,3 +84,4 @@ struct VotingAPIClient {
     /// Returns nil if the TX is not yet in a block (404 or network error).
     var fetchTxConfirmation: @Sendable (_ txHash: String) async throws -> TxConfirmation?
 }
+#endif

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 
@@ -1110,3 +1111,4 @@ extension VotingAPIClient: DependencyKey {
         )
     }
 }
+#endif

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientTestKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientTestKey.swift
@@ -1,6 +1,8 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 
 extension VotingAPIClient: TestDependencyKey {
     static let testValue = Self()
 }
+#endif

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientInterface.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientInterface.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 @preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
@@ -261,3 +262,4 @@ struct VotingCryptoClient {
     /// Append new server URLs to a share delegation's sent_to_urls.
     var addSentServers: @Sendable (_ roundId: String, _ bundleIndex: UInt32, _ proposalId: UInt32, _ shareIndex: UInt32, _ newURLs: [String]) async throws -> Void
 }
+#endif

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 @preconcurrency import Combine
 import ComposableArchitecture
 import Foundation
@@ -875,3 +876,4 @@ private extension VotingVoteRecord {
         )
     }
 }
+#endif

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientTestKey.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientTestKey.swift
@@ -1,6 +1,8 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 
 extension VotingCryptoClient: TestDependencyKey {
     static let testValue = Self()
 }
+#endif

--- a/secant/Sources/Dependencies/VotingMetadataProvider/VotingMetadataProviderInterface.swift
+++ b/secant/Sources/Dependencies/VotingMetadataProvider/VotingMetadataProviderInterface.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  VotingMetadataProviderInterface.swift
 //  Zashi
@@ -45,3 +46,4 @@ struct VotingMetadataProviderClient {
     var setRecord: @Sendable (_ record: PersistedVotingRecord, _ roundId: String) -> Void
     var clearRecord: @Sendable (_ roundId: String) -> Void
 }
+#endif

--- a/secant/Sources/Dependencies/VotingMetadataProvider/VotingMetadataProviderLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingMetadataProvider/VotingMetadataProviderLiveKey.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  VotingMetadataProviderLiveKey.swift
 //  Zashi
@@ -33,3 +34,4 @@ extension VotingMetadataProviderClient: DependencyKey {
 extension VotingMetadataStorage {
     static let live = VotingMetadataStorage()
 }
+#endif

--- a/secant/Sources/Dependencies/VotingMetadataProvider/VotingMetadataStorage.swift
+++ b/secant/Sources/Dependencies/VotingMetadataProvider/VotingMetadataStorage.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  VotingMetadataStorage.swift
 //  Zashi
@@ -329,3 +330,4 @@ extension VotingMetadata {
         }
     }
 }
+#endif

--- a/secant/Sources/Dependencies/VotingStorageClient/VotingStorageClientInterface.swift
+++ b/secant/Sources/Dependencies/VotingStorageClient/VotingStorageClientInterface.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 
@@ -18,3 +19,4 @@ struct VotingStorageClient {
     var loadSession: @Sendable (_ roundId: Data) async -> VotingSession?
     var clearRound: @Sendable (_ roundId: Data) async -> Void
 }
+#endif

--- a/secant/Sources/Dependencies/VotingStorageClient/VotingStorageClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingStorageClient/VotingStorageClientLiveKey.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 
@@ -66,3 +67,4 @@ extension VotingStorageClient: DependencyKey {
         )
     }
 }
+#endif

--- a/secant/Sources/Dependencies/VotingStorageClient/VotingStorageClientTestKey.swift
+++ b/secant/Sources/Dependencies/VotingStorageClient/VotingStorageClientTestKey.swift
@@ -1,6 +1,8 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 
 extension VotingStorageClient: TestDependencyKey {
     static let testValue = Self()
 }
+#endif

--- a/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
+++ b/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
@@ -171,14 +171,14 @@ struct Balances {
                 return .send(.updateBalance(accountsBalances[account.id]))
 
             case .updateBalance(let accountBalance):
-                state.changePending = (accountBalance?.saplingBalance.changePendingConfirmation ?? .zero) +
-                    (accountBalance?.orchardBalance.changePendingConfirmation ?? .zero)
-                state.pendingTransactions = (accountBalance?.saplingBalance.valuePendingSpendability ?? .zero) +
-                    (accountBalance?.orchardBalance.valuePendingSpendability ?? .zero)
-                state.shieldedBalance = (accountBalance?.saplingBalance.spendableValue ?? .zero) + (accountBalance?.orchardBalance.spendableValue ?? .zero)
+                // Pool-agnostic accessors: sum sapling + orchard + ironwood (and any future
+                // shielded pool) instead of hand-summing individual pools.
+                state.changePending = accountBalance?.shieldedChangePendingConfirmation ?? .zero
+                state.pendingTransactions = accountBalance?.shieldedValuePendingSpendability ?? .zero
+                state.shieldedBalance = accountBalance?.shieldedSpendableValue ?? .zero
                 state.transparentBalance = accountBalance?.unshielded ?? .zero
 
-                state.shieldedWithPendingBalance = (accountBalance?.saplingBalance.total() ?? .zero) + (accountBalance?.orchardBalance.total() ?? .zero)
+                state.shieldedWithPendingBalance = accountBalance?.shieldedTotal() ?? .zero
                 state.totalBalance = state.shieldedWithPendingBalance + state.transparentBalance + (accountBalance?.awaitingResolution ?? .zero)
 
                 let everythingCondition = state.shieldedBalance.amount > 0 && ((state.shieldedBalance == state.totalBalance)

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/RoundSession.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/RoundSession.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  RoundSession.swift
 //  Zashi
@@ -294,3 +295,4 @@ extension RoundSession {
         return nil
     }
 }
+#endif

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  VotingCoordFlowCoordinator.swift
 //  Zashi
@@ -3762,3 +3763,4 @@ private enum DelegationTxConfirmationStatus: Sendable {
     case failed(code: UInt32, log: String)
     case notFound
 }
+#endif

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  VotingCoordFlowStore.swift
 //  Zashi
@@ -416,3 +417,4 @@ struct SkippedQuestionsSheetData: Equatable {
     let roundId: String
     let skippedDisplayIndices: [Int]
 }
+#endif

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  VotingCoordFlowView.swift
 //  Zashi
@@ -172,3 +173,4 @@ struct VotingCoordFlowView: View {
         }
     }
 }
+#endif

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -344,13 +344,31 @@ extension Root {
                     state.isInitializingSDK = true
                     return .run { send in
                         do {
-                            let result = try await sdkSynchronizer.prepareWith(
-                                seedBytes,
-                                birthday,
-                                walletMode,
-                                String(localizable: .accountsZashi),
-                                String(localizable: .accountsZashi).lowercased()
-                            )
+                            let result: Initializer.InitializationResult
+                            do {
+                                result = try await sdkSynchronizer.prepareWith(
+                                    seedBytes,
+                                    birthday,
+                                    walletMode,
+                                    String(localizable: .accountsZashi),
+                                    String(localizable: .accountsZashi).lowercased()
+                                )
+                            } catch ZcashError.initializerSeedMismatch {
+                                // The SDK now runs this same integrity check inside
+                                // Initializer.initialize and throws instead of returning, for
+                                // exactly the case reconcileWalletDatabaseWithSeed below already
+                                // exists to heal. Map the throw onto .seedNotRelevant so that
+                                // knownStale: true heal still runs unchanged.
+                                //
+                                // Safe unconditionally: wipe() below leaves no accounts in the
+                                // database, so the re-prepare that follows cannot hit this
+                                // mismatch again. And prepare() throws before the synchronizer
+                                // ever leaves .unprepared (SDKSynchronizer.prepare only advances
+                                // status once initialize() returns successfully), so that
+                                // re-prepare isn't blocked by prepare's own
+                                // `guard status == .unprepared` early-return either.
+                                result = .seedNotRelevant
+                            }
 
                             let healed: Bool
                             switch result {

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -614,7 +614,9 @@ extension Root {
                     state.walletAccounts.forEach { account in
                         try? userMetadataProvider.resetAccount(account.account)
                         try? addressBook.resetAccount(account.account)
+                        #if VOTING_ENABLED
                         try? votingMetadata.resetAccount(account.account)
+                        #endif
                     }
                 }
                 state.walletAccounts.forEach { account in
@@ -622,7 +624,9 @@ extension Root {
                 }
                 state.autoUpdateSwapCandidates.removeAll()
                 try? userMetadataProvider.reset()
+                #if VOTING_ENABLED
                 votingMetadata.reset()
+                #endif
                 state.$walletStatus.withLock { $0 = .none }
                 state.$selectedWalletAccount.withLock { $0 = nil }
                 state.$walletAccounts.withLock { $0 = [] }

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -116,8 +116,10 @@ extension Root {
                 
                 // update flexa balance
                 if let accountBalance = latestState.data.accountsBalances[account.id] {
-                    let shieldedBalance = accountBalance.saplingBalance.spendableValue + accountBalance.orchardBalance.spendableValue
-                    let shieldedWithPendingBalance = accountBalance.saplingBalance.total() + accountBalance.orchardBalance.total()
+                    // Pool-agnostic accessors: sum sapling + orchard + ironwood (and any future
+                    // shielded pool) instead of hand-summing individual pools.
+                    let shieldedBalance = accountBalance.shieldedSpendableValue
+                    let shieldedWithPendingBalance = accountBalance.shieldedTotal()
 
                     flexaHandler.updateBalance(shieldedWithPendingBalance, shieldedBalance)
                 }

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -312,7 +312,9 @@ struct Root {
     @Dependency(\.userDefaults) var userDefaults
     @Dependency(\.userMetadataProvider) var userMetadataProvider
     @Dependency(\.userStoredPreferences) var userStoredPreferences
+    #if VOTING_ENABLED
     @Dependency(\.votingMetadata) var votingMetadata
+    #endif
     @Dependency(\.walletConfigProvider) var walletConfigProvider
     @Dependency(\.walletStorage) var walletStorage
     @Dependency(\.readTransactionsStorage) var readTransactionsStorage
@@ -604,6 +606,7 @@ extension Root {
         userDefaults.remove(Constants.udIsRestoringWallet)
         userDefaults.remove(Constants.udIsResyncingWallet)
         userDefaults.remove(Constants.udLeavesScreenOpen)
+        #if VOTING_ENABLED
         userDefaults.remove(.hasSeenHowToVote)
         userDefaults.remove(.hasSeenHowToVoteKeystone)
         // Drop the user-supplied voting chain override and the saved
@@ -632,6 +635,7 @@ extension Root {
             where key.hasPrefix("voting.voteRecord.") || key.hasPrefix("voting.draftVotes.") {
             standardDefaults.removeObject(forKey: key)
         }
+        #endif
         flexaHandler.signOut()
         userStoredPreferences.removeAll()
         try? readTransactionsStorage.resetZashi()

--- a/secant/Sources/Features/Scan/ScanChecker.swift
+++ b/secant/Sources/Features/Scan/ScanChecker.swift
@@ -102,6 +102,7 @@ struct SwapStringScanChecker: ScanChecker, Equatable {
     }
 }
 
+#if VOTING_ENABLED
 struct KeystoneVotingDelegationPcztScanChecker: ScanChecker, Equatable {
     let id = 5
 
@@ -123,6 +124,7 @@ struct KeystoneVotingDelegationPcztScanChecker: ScanChecker, Equatable {
         return nil
     }
 }
+#endif
 
 struct ScanCheckerWrapper: Equatable, Sendable {
     let checker: any ScanChecker
@@ -132,7 +134,9 @@ struct ScanCheckerWrapper: Equatable, Sendable {
     static let keystoneScanChecker = ScanCheckerWrapper(KeystoneScanChecker())
     static let keystonePCZTScanChecker = ScanCheckerWrapper(KeystonePcztScanChecker())
     static let swapStringScanChecker = ScanCheckerWrapper(SwapStringScanChecker())
+    #if VOTING_ENABLED
     static let keystoneVotingDelegationPCZTScanChecker = ScanCheckerWrapper(KeystoneVotingDelegationPcztScanChecker())
+    #endif
 
     static func == (lhs: ScanCheckerWrapper, rhs: ScanCheckerWrapper) -> Bool {
         return lhs.checker.id == rhs.checker.id

--- a/secant/Sources/Features/Scan/ScanStore.swift
+++ b/secant/Sources/Features/Scan/ScanStore.swift
@@ -78,7 +78,9 @@ struct Scan {
         case foundRequestZec(ParserResult)
         case foundAccounts(ZcashAccounts)
         case foundPCZT(Data)
+        #if VOTING_ENABLED
         case foundVotingDelegationPCZT(Data)
+        #endif
         case animatedQRProgress(Int, Int?, Int?)
         case scanFailed(ScanImageResult)
         case scan(RedactableString)
@@ -142,11 +144,13 @@ struct Scan {
                 state.progress = nil
                 return .none
 
+            #if VOTING_ENABLED
             case .foundVotingDelegationPCZT:
                 state.isAnythingFound = true
                 state.progress = nil
                 return .none
-                
+            #endif
+
             case .foundString:
                 state.isAnythingFound = true
                 return .none

--- a/secant/Sources/Features/Settings/SettingsCoordinator.swift
+++ b/secant/Sources/Features/Settings/SettingsCoordinator.swift
@@ -234,6 +234,7 @@ extension Settings {
                 state.path.append(.advancedSettings(AdvancedSettings.State.initial))
                 return .none
 
+            #if VOTING_ENABLED
             case .coinholderPollingTapped:
                 guard let account = state.selectedWalletAccount else { return .none }
                 var votingState = VotingCoordFlow.State()
@@ -245,6 +246,7 @@ extension Settings {
             case .votingCoordFlow(.presented(.dismissFlow)):
                 state.votingCoordFlow = nil
                 return .none
+            #endif
 
             case .whatsNewTapped:
                 state.path.append(.whatsNew(WhatsNew.State.initial))

--- a/secant/Sources/Features/Settings/SettingsStore.swift
+++ b/secant/Sources/Features/Settings/SettingsStore.swift
@@ -42,11 +42,13 @@ struct Settings {
         var isResyncHelpSheetPresented = false
         var isTorOn = false
         var path = StackState<Path.State>()
+        #if VOTING_ENABLED
         /// fullScreenCover for the new voting CoordFlow. Isolating its
         /// NavigationStack via fullScreenCover avoids SwiftUI's
         /// `AnyNavigationPath.Error.comparisonTypeMismatch` that fires when
         /// two NavigationStacks are nested.
         @Presents var votingCoordFlow: VotingCoordFlow.State?
+        #endif
         var resyncBirthday: BlockHeight? = nil
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
         var txidToEnhance = ""
@@ -78,8 +80,10 @@ struct Settings {
         case binding(BindingAction<Settings.State>)
         case checkFundsForAddress(String)
         case closeResyncHelpSheetTapped
+        #if VOTING_ENABLED
         case coinholderPollingTapped
         case votingCoordFlow(PresentationAction<VotingCoordFlow.Action>)
+        #endif
         case currencyConversionTapped
         case enableEnhanceTransactionMode
         case enableRecoverFundsMode
@@ -137,6 +141,7 @@ struct Settings {
                     }
                 }
 
+            #if VOTING_ENABLED
             case .coinholderPollingTapped:
                 // Handled in coordinatorReduce; no-op here so the body's
                 // exhaustive switch over the Action enum still compiles.
@@ -146,6 +151,7 @@ struct Settings {
                 // through .ifLet at the body level + the coordinator's
                 // dismiss handler.
                 return .none
+            #endif
 
             case .currencyConversionTapped:
                 return .none
@@ -193,8 +199,10 @@ struct Settings {
             }
         }
         .forEach(\.path, action: \.path)
+        #if VOTING_ENABLED
         .ifLet(\.$votingCoordFlow, action: \.votingCoordFlow) {
             VotingCoordFlow()
         }
+        #endif
     }
 }

--- a/secant/Sources/Features/Settings/SettingsView.swift
+++ b/secant/Sources/Features/Settings/SettingsView.swift
@@ -34,12 +34,14 @@ struct SettingsView: View {
                                 }
                             }
                             
+                            #if VOTING_ENABLED
                             ActionRow(
                                 icon: Asset.Assets.Icons.checkVerified.image,
                                 title: String(localizable: .settingsCoinholderPolling)
                             ) {
                                 store.send(.coinholderPollingTapped)
                             }
+                            #endif
 
                             ActionRow(
                                 icon: Asset.Assets.Icons.settings.image,
@@ -162,6 +164,7 @@ struct SettingsView: View {
             .zashiSheet(isPresented: $store.isResyncHelpSheetPresented) {
                 resyncHelpSheetContent()
             }
+            #if VOTING_ENABLED
             .fullScreenCover(
                 item: $store.scope(state: \.votingCoordFlow, action: \.votingCoordFlow)
             ) { votingStore in
@@ -172,6 +175,7 @@ struct SettingsView: View {
                     VotingCoordFlowView(store: votingStore)
                 }
             }
+            #endif
         }
     }
     

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -346,7 +346,9 @@ struct SmartBanner {
                 let snapshot = SyncStatusSnapshot.snapshotFor(state: latestState.data.syncStatus)
                 
                 if let account = state.selectedWalletAccount, let accountBalance = latestState.data.accountsBalances[account.id] {
-                    state.spendableBalance = accountBalance.saplingBalance.spendableValue + accountBalance.orchardBalance.spendableValue
+                    // Pool-agnostic accessor: sum sapling + orchard + ironwood (and any future
+                    // shielded pool) instead of hand-summing individual pools.
+                    state.spendableBalance = accountBalance.shieldedSpendableValue
                 }
 
                 if snapshot.syncStatus != state.synchronizerStatusSnapshot.syncStatus {
@@ -519,11 +521,12 @@ struct SmartBanner {
             case .evaluatePriority8:
                 if let account = state.selectedWalletAccount {
                     if let accountBalance = sdkSynchronizer.latestState().accountsBalances[account.id] {
-                        let orchard = accountBalance.orchardBalance.total().amount
-                        let sapling = accountBalance.saplingBalance.total().amount
+                        // Pool-agnostic accessor: sums sapling + orchard + ironwood (and any
+                        // future shielded pool) instead of hand-summing individual pools.
+                        let shielded = accountBalance.shieldedTotal().amount
                         let unshielded = accountBalance.unshielded.amount
-                        
-                        if orchard + sapling + unshielded == 0 {
+
+                        if shielded + unshielded == 0 {
                             return .send(.evaluatePriority9)
                         }
                     }

--- a/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionStore.swift
+++ b/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ConfirmSubmissionStore.swift
 //  Zashi
@@ -22,3 +23,4 @@ struct ConfirmSubmission {
         EmptyReducer()
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
+++ b/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ConfirmSubmissionView.swift
 //  Zashi
@@ -526,3 +527,4 @@ private extension BatchSubmissionStatus {
         }
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  DelegationSigningStore.swift
 //  Zashi
@@ -508,3 +509,4 @@ struct DelegationSigningView: View {
         }
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/HowToVote/HowToVoteView.swift
+++ b/secant/Sources/Features/Voting/HowToVote/HowToVoteView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  HowToVoteView.swift
 //  Zashi
@@ -166,3 +167,4 @@ struct HowToVoteView: View {
         String(localizable: .coinVoteHowToVoteSubtitle)
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/Ineligible/IneligibleStore.swift
+++ b/secant/Sources/Features/Voting/Ineligible/IneligibleStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  IneligibleStore.swift
 //  Zashi
@@ -22,3 +23,4 @@ struct Ineligible {
         EmptyReducer()
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/Ineligible/IneligibleView.swift
+++ b/secant/Sources/Features/Voting/Ineligible/IneligibleView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  IneligibleView.swift
 //  Zashi
@@ -51,3 +52,4 @@ struct IneligibleView: View {
         }
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/NoRounds/NoRoundsView.swift
+++ b/secant/Sources/Features/Voting/NoRounds/NoRoundsView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  NoRoundsView.swift
 //  Zashi
@@ -138,3 +139,4 @@ struct PollsListSkeletonCard: View {
             .clipShape(RoundedRectangle(cornerRadius: 4))
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/PollsList/PollsListView.swift
+++ b/secant/Sources/Features/Voting/PollsList/PollsListView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  PollsListView.swift
 //  Zashi
@@ -523,3 +524,4 @@ private struct PollStatusPillStyle {
     let backgroundColor: Color
     let borderColor: Color
 }
+#endif

--- a/secant/Sources/Features/Voting/ProposalDetail/ProposalDetailStore.swift
+++ b/secant/Sources/Features/Voting/ProposalDetail/ProposalDetailStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ProposalDetailStore.swift
 //  Zashi
@@ -37,3 +38,4 @@ struct ProposalDetail {
         EmptyReducer()
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/ProposalDetail/ProposalDetailView.swift
+++ b/secant/Sources/Features/Voting/ProposalDetail/ProposalDetailView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ProposalDetailView.swift
 //  Zashi
@@ -351,3 +352,4 @@ struct ProposalDetailView: View {
         submittedChoice ?? draftChoice
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/ProposalList/ProposalListStore.swift
+++ b/secant/Sources/Features/Voting/ProposalList/ProposalListStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ProposalListStore.swift
 //  Zashi
@@ -22,3 +23,4 @@ struct ProposalList {
         EmptyReducer()
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/ProposalList/ProposalListView.swift
+++ b/secant/Sources/Features/Voting/ProposalList/ProposalListView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ProposalListView.swift
 //  Zashi
@@ -563,3 +564,4 @@ private struct ExpandableTextCollapsedHeightKey: PreferenceKey {
         value = max(value, nextValue())
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/Results/ResultsStore.swift
+++ b/secant/Sources/Features/Voting/Results/ResultsStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ResultsStore.swift
 //  Zashi
@@ -22,3 +23,4 @@ struct Results {
         EmptyReducer()
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/Results/ResultsView.swift
+++ b/secant/Sources/Features/Voting/Results/ResultsView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ResultsView.swift
 //  Zashi
@@ -523,3 +524,4 @@ private struct ResultsExpandableTextCollapsedHeightKey: PreferenceKey {
         value = max(value, nextValue())
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/ReviewVotes/ReviewVotesStore.swift
+++ b/secant/Sources/Features/Voting/ReviewVotes/ReviewVotesStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  ReviewVotesStore.swift
 //  Zashi
@@ -40,3 +41,4 @@ struct ReviewDrafts {
         EmptyReducer()
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/Tallying/TallyingStore.swift
+++ b/secant/Sources/Features/Voting/Tallying/TallyingStore.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  TallyingStore.swift
 //  Zashi
@@ -22,3 +23,4 @@ struct Tallying {
         EmptyReducer()
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/Tallying/TallyingView.swift
+++ b/secant/Sources/Features/Voting/Tallying/TallyingView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  TallyingView.swift
 //  Zashi
@@ -75,3 +76,4 @@ struct TallyingView: View {
         }
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/VotingConfigSettings.swift
+++ b/secant/Sources/Features/Voting/VotingConfigSettings.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 
@@ -550,3 +551,4 @@ extension VotingConfigSettings.State {
         }
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/VotingConfigSettingsView.swift
+++ b/secant/Sources/Features/Voting/VotingConfigSettingsView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import SwiftUI
 import ComposableArchitecture
 
@@ -640,3 +641,4 @@ private var bottomBar: some View {
         }
     )
 }
+#endif

--- a/secant/Sources/Features/Voting/VotingError/VotingErrorView.swift
+++ b/secant/Sources/Features/Voting/VotingError/VotingErrorView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  VotingErrorView.swift
 //  Zashi
@@ -83,3 +84,4 @@ struct VotingErrorView: View {
         }
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/VotingErrorSheet.swift
+++ b/secant/Sources/Features/Voting/VotingErrorSheet.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import SwiftUI
 
 // Shared bottom-sheet content for the voting flow: icon + title + body and one
@@ -339,3 +340,4 @@ extension View {
         )
     }
 }
+#endif

--- a/secant/Sources/Features/Voting/VotingHelpers.swift
+++ b/secant/Sources/Features/Voting/VotingHelpers.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  VotingHelpers.swift
 //  Zashi
@@ -576,3 +577,4 @@ func votingDataFromHex(_ hex: String) -> Data {
     }
     return data
 }
+#endif

--- a/secant/Sources/Features/Voting/WalletSyncing/WalletSyncingView.swift
+++ b/secant/Sources/Features/Voting/WalletSyncing/WalletSyncingView.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 //
 //  WalletSyncingView.swift
 //  Zashi
@@ -52,3 +53,4 @@ struct WalletSyncingView: View {
         }
     }
 }
+#endif

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -187,8 +187,10 @@ struct WalletBalances {
                 }
                 
             case .balanceUpdated(let accountBalance):
-                state.shieldedBalance = (accountBalance?.saplingBalance.spendableValue ?? .zero) + (accountBalance?.orchardBalance.spendableValue ?? .zero)
-                state.shieldedWithPendingBalance = (accountBalance?.saplingBalance.total() ?? .zero) + (accountBalance?.orchardBalance.total() ?? .zero)
+                // Pool-agnostic accessors: sum sapling + orchard + ironwood (and any future
+                // shielded pool) instead of hand-summing individual pools.
+                state.shieldedBalance = accountBalance?.shieldedSpendableValue ?? .zero
+                state.shieldedWithPendingBalance = accountBalance?.shieldedTotal() ?? .zero
                 state.transparentBalance = accountBalance?.unshielded ?? .zero
                 state.totalBalance = state.shieldedWithPendingBalance + state.transparentBalance + (accountBalance?.awaitingResolution ?? .zero)
                

--- a/secant/Sources/Models/RoundListItem.swift
+++ b/secant/Sources/Models/RoundListItem.swift
@@ -3,6 +3,7 @@
 //  Zashi
 //
 
+#if VOTING_ENABLED
 import Foundation
 
 /// A single entry in the polls list: a voting round paired with the index
@@ -25,3 +26,4 @@ struct RoundListItem: Equatable, Identifiable {
             : session.title
     }
 }
+#endif

--- a/secant/Sources/Models/TransactionState.swift
+++ b/secant/Sources/Models/TransactionState.swift
@@ -49,6 +49,14 @@ struct TransactionState: Equatable, Identifiable {
     var hasTransparentOutputs = false
     var totalSpent: Zatoshi?
     var totalReceived: Zatoshi?
+    /// The SDK's per-transaction note counts, carried so the display amount can adopt Android's
+    /// migration-self-send fallback (see `netValue`). Default 0 for the non-SDK inits (a pending
+    /// send, a swap deposit). The swap-deposit init DOES land on the same 0/0 "note-less" shape,
+    /// but it sets `totalReceived = .zero`; `netValue`'s `totalReceived.amount > 0` guard keeps
+    /// that (and any other genuinely amount-less state) on the `zecAmount` path — only a real
+    /// migration crossing, which carries a positive `totalReceived`, takes the fallback.
+    var sentNoteCount = 0
+    var receivedNoteCount = 0
 
     var rawID: Data? = nil
     
@@ -288,9 +296,21 @@ struct TransactionState: Equatable, Identifiable {
     }
     
     var netValue: String {
-        isShieldingTransaction
-        ? Zatoshi(totalSpent?.amount ?? 0).atLeastThreeDecimalsZashiFormatted()
-        : zecAmount.atLeastThreeDecimalsZashiFormatted()
+        if isShieldingTransaction {
+            return Zatoshi(totalSpent?.amount ?? 0).atLeastThreeDecimalsZashiFormatted()
+        }
+        // An Orchard -> Ironwood turnstile transfer is a self-send: it collapses to a fee-only
+        // net value (`zecAmount`), which hides the real amount that crossed. Mirror Android's
+        // fallback (TransactionRepository.kt): a transaction with no counted sent OR received
+        // notes shows `totalReceived` — the true crossing amount — instead of the fee-collapsed
+        // net. Both the transaction list (TransactionRowView) and the detail screen
+        // (TransactionDetailsView) render this property, so both pick up the fallback
+        // consistently. Every other transaction kind keeps at least one note, so the guard
+        // leaves them byte-identical.
+        if sentNoteCount == 0, receivedNoteCount == 0, let totalReceived, totalReceived.amount > 0 {
+            return totalReceived.atLeastThreeDecimalsZashiFormatted()
+        }
+        return zecAmount.atLeastThreeDecimalsZashiFormatted()
     }
 
     var amountWithoutFee: Zatoshi {
@@ -398,6 +418,8 @@ extension TransactionState {
         memoCount = transaction.memoCount
         totalSpent = transaction.totalSpent
         totalReceived = transaction.totalReceived
+        sentNoteCount = transaction.sentNoteCount
+        receivedNoteCount = transaction.receivedNoteCount
 
         let isPending = isSentTransaction ? minedHeight == nil : transaction.state == .pending
         // Fallback for when the SDK's `expired_unmined` column lags (e.g. an unmined sent tx

--- a/zodlTests/BalancesTests/BalancesTests.swift
+++ b/zodlTests/BalancesTests/BalancesTests.swift
@@ -96,6 +96,36 @@ import ComposableArchitecture
         #expect(store.state.spendability == .something)
     }
 
+    // Ironwood is a third shielded pool (NU6.3 / Orchard note-version V3). The reducer must
+    // pick it up through the SDK's pool-agnostic `shielded*` accessors on `AccountBalance`
+    // rather than a hand-summed sapling+orchard pair, or Ironwood funds would be invisible.
+    @MainActor @Test func updateBalanceAggregatesSaplingOrchardIronwoodAndTransparent() async {
+        let store = TestStore(initialState: state(autoShieldingThreshold: Zatoshi(1_000_000))) {
+            Balances()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        }
+        store.exhaustivity = .off
+
+        let balance = AccountBalance(
+            saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
+            orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
+            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
+            unshielded: Zatoshi(5),
+            awaitingResolution: Zatoshi(1)
+        )
+
+        await store.send(.updateBalance(balance))
+
+        #expect(store.state.changePending == Zatoshi(90))              // 10 + 30 + 50
+        #expect(store.state.pendingTransactions == Zatoshi(120))       // 20 + 40 + 60
+        #expect(store.state.shieldedBalance == Zatoshi(600))           // 100 + 200 + 300
+        #expect(store.state.transparentBalance == Zatoshi(5))          // unshielded
+        #expect(store.state.shieldedWithPendingBalance == Zatoshi(810)) // 130 + 270 + 410 totals
+        #expect(store.state.totalBalance == Zatoshi(816))              // 810 + 5 + 1 awaiting
+        #expect(store.state.spendability == .something)
+    }
+
     @MainActor @Test func shieldingProcessorRequestedMarksShielding() async {
         let store = TestStore(initialState: state()) { Balances() }
 

--- a/zodlTests/ModelsTests/TransactionStateTests.swift
+++ b/zodlTests/ModelsTests/TransactionStateTests.swift
@@ -48,6 +48,26 @@ import Foundation
         )
     }
 
+    /// The SDK-backed init must carry the transaction's note counts onto the state rather than
+    /// leaving them at their struct defaults. `sentNoteCount` and `receivedNoteCount` are given
+    /// distinct, non-default values here, so deleting either wiring line in
+    /// `TransactionState.init(transaction:)` (`sentNoteCount = transaction.sentNoteCount` /
+    /// `receivedNoteCount = transaction.receivedNoteCount`) makes the corresponding property fall
+    /// back to 0 and fails this test - unlike asserting against 0, which those defaults would
+    /// satisfy whether or not the wiring exists.
+    @Test func noteCountsAreWiredFromSDKTransaction() {
+        let state = TransactionState(
+            transaction: overview(
+                sentNoteCount: 3,
+                receivedNoteCount: 2,
+                value: Zatoshi(25_000_000)
+            )
+        )
+
+        #expect(state.sentNoteCount == 3)
+        #expect(state.receivedNoteCount == 2)
+    }
+
     /// The migration shape: a self-send whose net value collapses to the fee, with no counted
     /// sent or received notes but a real `totalReceived`. netValue must show the crossing amount
     /// (`totalReceived`), not the misleading fee-collapsed net (`zecAmount`).
@@ -61,10 +81,7 @@ import Foundation
             )
         )
 
-        #expect(state.sentNoteCount == 0)
-        #expect(state.receivedNoteCount == 0)
         #expect(state.netValue == Zatoshi(25_000_000).atLeastThreeDecimalsZashiFormatted())
-        #expect(state.netValue != state.zecAmount.atLeastThreeDecimalsZashiFormatted())
     }
 
     /// A shielding transaction keeps the `totalSpent` path even with 0/0 note counts: that
@@ -89,9 +106,9 @@ import Foundation
 
     /// Guard hardening: a note-less (0/0) shape whose `totalReceived` is `.zero` — the same shape
     /// the swap-deposit initialiser produces — must stay on the `zecAmount` path rather than
-    /// misreport a zero crossing amount. `zecAmount` is deliberately non-zero here so the two
-    /// paths are distinguishable: a guard that checks presence alone (not `> 0`) would return the
-    /// zero `totalReceived` and fail the second assertion.
+    /// misreport a zero crossing amount. `zecAmount` is deliberately non-zero here, so a guard
+    /// that checks presence alone (not `> 0`) would return the zero `totalReceived` instead and
+    /// be caught by the assertion below.
     @Test func noteslessStateWithZeroTotalReceivedKeepsZecAmountPath() {
         let state = TransactionState(
             transaction: overview(
@@ -103,7 +120,6 @@ import Foundation
         )
 
         #expect(state.netValue == state.zecAmount.atLeastThreeDecimalsZashiFormatted())
-        #expect(state.netValue != Zatoshi.zero.atLeastThreeDecimalsZashiFormatted())
     }
 
     /// The non-SDK initialisers (a pending send, a swap deposit) never touch the note-count

--- a/zodlTests/ModelsTests/TransactionStateTests.swift
+++ b/zodlTests/ModelsTests/TransactionStateTests.swift
@@ -1,0 +1,164 @@
+//
+//  TransactionStateTests.swift
+//  zodlTests
+//
+//  Covers the migration self-send display fallback on TransactionState.netValue
+//  (Models/TransactionState.swift). An Orchard -> Ironwood turnstile transfer is a self-send:
+//  its net value collapses to just the fee, so without the fallback the transaction list and
+//  detail screen would show a fee-sized amount instead of the amount that actually crossed the
+//  turnstile. When the SDK reports no counted sent or received notes, netValue falls back to
+//  totalReceived (the real crossing amount), mirroring Android's TransactionRepository. Pure
+//  model logic, no shared/global state -> no `.serialized`.
+//
+
+import Testing
+import Foundation
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct TransactionStateTests {
+    private let testAccountUUID = AccountUUID(id: [UInt8](repeating: 0, count: 16))
+
+    private func overview(
+        isShielding: Bool = false,
+        sentNoteCount: Int,
+        receivedNoteCount: Int,
+        value: Zatoshi,
+        totalSpent: Zatoshi? = nil,
+        totalReceived: Zatoshi? = nil
+    ) -> ZcashTransaction.Overview {
+        ZcashTransaction.Overview(
+            accountUUID: testAccountUUID,
+            blockTime: 1_699_290_621,
+            expiryHeight: nil,
+            fee: Zatoshi(10_000),
+            index: nil,
+            isShielding: isShielding,
+            hasChange: false,
+            memoCount: 0,
+            minedHeight: BlockHeight(1),
+            raw: nil,
+            rawID: Data([0x01, 0x02, 0x03, 0x04]),
+            receivedNoteCount: receivedNoteCount,
+            sentNoteCount: sentNoteCount,
+            value: value,
+            isExpiredUmined: nil,
+            totalSpent: totalSpent,
+            totalReceived: totalReceived
+        )
+    }
+
+    /// The migration shape: a self-send whose net value collapses to the fee, with no counted
+    /// sent or received notes but a real `totalReceived`. netValue must show the crossing amount
+    /// (`totalReceived`), not the misleading fee-collapsed net (`zecAmount`).
+    @Test func migrationSelfSendWithNoNotesDisplaysTotalReceived() {
+        let state = TransactionState(
+            transaction: overview(
+                sentNoteCount: 0,
+                receivedNoteCount: 0,
+                value: Zatoshi(-10_000),
+                totalReceived: Zatoshi(25_000_000)
+            )
+        )
+
+        #expect(state.sentNoteCount == 0)
+        #expect(state.receivedNoteCount == 0)
+        #expect(state.netValue == Zatoshi(25_000_000).atLeastThreeDecimalsZashiFormatted())
+        #expect(state.netValue != state.zecAmount.atLeastThreeDecimalsZashiFormatted())
+    }
+
+    /// A shielding transaction keeps the `totalSpent` path even with 0/0 note counts: that
+    /// branch has priority and must be checked before the note-count fallback. `totalReceived`
+    /// is deliberately a different value, so an ordering bug (fallback checked first) would be
+    /// caught by the assertion below.
+    @Test func shieldingTransactionKeepsTotalSpentPathEvenWithNoNotes() {
+        let state = TransactionState(
+            transaction: overview(
+                isShielding: true,
+                sentNoteCount: 0,
+                receivedNoteCount: 0,
+                value: Zatoshi(-10_000),
+                totalSpent: Zatoshi(1_000_000),
+                totalReceived: Zatoshi(990_000)
+            )
+        )
+
+        #expect(state.isShieldingTransaction)
+        #expect(state.netValue == Zatoshi(1_000_000).atLeastThreeDecimalsZashiFormatted())
+    }
+
+    /// Guard hardening: a note-less (0/0) shape whose `totalReceived` is `.zero` — the same shape
+    /// the swap-deposit initialiser produces — must stay on the `zecAmount` path rather than
+    /// misreport a zero crossing amount. `zecAmount` is deliberately non-zero here so the two
+    /// paths are distinguishable: a guard that checks presence alone (not `> 0`) would return the
+    /// zero `totalReceived` and fail the second assertion.
+    @Test func noteslessStateWithZeroTotalReceivedKeepsZecAmountPath() {
+        let state = TransactionState(
+            transaction: overview(
+                sentNoteCount: 0,
+                receivedNoteCount: 0,
+                value: Zatoshi(-10_000),
+                totalReceived: .zero
+            )
+        )
+
+        #expect(state.netValue == state.zecAmount.atLeastThreeDecimalsZashiFormatted())
+        #expect(state.netValue != Zatoshi.zero.atLeastThreeDecimalsZashiFormatted())
+    }
+
+    /// The non-SDK initialisers (a pending send, a swap deposit) never touch the note-count
+    /// fields, so they must default to 0 and keep compiling unchanged. Both produce a 0/0
+    /// "note-less" shape too; the pending send has no `totalReceived` at all and the swap deposit
+    /// sets it to `.zero`, so both correctly stay on the `zecAmount` path.
+    @Test func nonSDKInitsDefaultNoteCountsToZeroAndKeepZecAmountPath() {
+        let pendingSend = TransactionState(pendingSendId: "pending-send", zecAmount: Zatoshi(15_000_000))
+        #expect(pendingSend.sentNoteCount == 0)
+        #expect(pendingSend.receivedNoteCount == 0)
+        #expect(pendingSend.netValue == Zatoshi(15_000_000).atLeastThreeDecimalsZashiFormatted())
+
+        let swapDeposit = TransactionState(
+            depositAddress: "t1SwapDepositAddress",
+            timestamp: 1_699_290_621,
+            swapStatus: .pending
+        )
+        #expect(swapDeposit.sentNoteCount == 0)
+        #expect(swapDeposit.receivedNoteCount == 0)
+        #expect(swapDeposit.totalReceived == .zero)
+        #expect(swapDeposit.netValue == Zatoshi.zero.atLeastThreeDecimalsZashiFormatted())
+    }
+
+    /// An ordinary send keeps at least one sent note, so the fallback must not apply, even when
+    /// `totalReceived` (change) is present — the display stays the fee-collapsed net
+    /// (`zecAmount`). `totalReceived` is deliberately different from `zecAmount`, so a broken
+    /// `sentNoteCount` wiring (SDK -> TransactionState) would be caught here.
+    @Test func ordinarySendWithNotesIsUnchanged() {
+        let state = TransactionState(
+            transaction: overview(
+                sentNoteCount: 1,
+                receivedNoteCount: 0,
+                value: Zatoshi(-25_010_000),
+                totalReceived: Zatoshi(5_000)
+            )
+        )
+
+        #expect(state.sentNoteCount == 1)
+        #expect(state.netValue == Zatoshi(25_010_000).atLeastThreeDecimalsZashiFormatted())
+    }
+
+    /// Mirror case: an ordinary receive keeps at least one received note, so the fallback must
+    /// not apply either. `totalReceived` is deliberately different from `zecAmount`, so a broken
+    /// `receivedNoteCount` wiring would be caught here.
+    @Test func ordinaryReceiveWithNotesIsUnchanged() {
+        let state = TransactionState(
+            transaction: overview(
+                sentNoteCount: 0,
+                receivedNoteCount: 1,
+                value: Zatoshi(25_000_000),
+                totalReceived: Zatoshi(24_500_000)
+            )
+        )
+
+        #expect(state.receivedNoteCount == 1)
+        #expect(state.netValue == Zatoshi(25_000_000).atLeastThreeDecimalsZashiFormatted())
+    }
+}

--- a/zodlTests/SmartBannerTests/SmartBannerTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerTests.swift
@@ -110,45 +110,59 @@ import ComposableArchitecture
     /// pool-agnostic `shieldedTotal()` rather than a hand-summed sapling+orchard pair, or the
     /// currency-conversion prompt would be skipped for Ironwood-only holders.
     @MainActor @Test func evaluatePriority8TreatsIronwoodOnlyBalanceAsNonZero() async {
-        let account = WalletAccount(
-            Account(
-                id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
-                name: "Zodl",
-                keySource: nil,
-                seedFingerprint: nil,
-                hdAccountIndex: Zip32AccountIndex(0),
-                ufvk: nil,
-                uivk: nil
+        // Pin the process-global `@Shared(.inMemory(.selectedWalletAccount))` storage to a fresh,
+        // isolated `InMemoryStorage` for the duration of the test. `@Suite(.serialized)` only
+        // serializes tests within this suite - Swift Testing still runs suites in parallel, so a
+        // concurrently running suite that nils or overwrites `selectedWalletAccount` (e.g.
+        // AddKeystoneHWWalletTests, ExportTransactionHistoryTests) can clobber it between
+        // `withLock` and `.evaluatePriority8`. Without the pin, `state.selectedWalletAccount` can
+        // read nil, the balance branch's `if let account ... if let accountBalance` falls through
+        // with no `else`, and the reducer still reaches `.triggerPriority` via the exchange-rate
+        // check below - so the test would pass vacuously, even against the pre-Ironwood
+        // orchard+sapling sum it exists to guard.
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let account = WalletAccount(
+                Account(
+                    id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+                    name: "Zodl",
+                    keySource: nil,
+                    seedFingerprint: nil,
+                    hdAccountIndex: Zip32AccountIndex(0),
+                    ufvk: nil,
+                    uivk: nil
+                )
             )
-        )
 
-        let accountBalance = AccountBalance(
-            saplingBalance: .zero,
-            orchardBalance: .zero,
-            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: .zero, valuePendingSpendability: .zero),
-            unshielded: .zero
-        )
+            let accountBalance = AccountBalance(
+                saplingBalance: .zero,
+                orchardBalance: .zero,
+                ironwoodBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: .zero, valuePendingSpendability: .zero),
+                unshielded: .zero
+            )
 
-        let synchronizerState: SynchronizerState = {
-            var value = SynchronizerState.zero
-            value.accountsBalances = [account.id: accountBalance]
-            return value
-        }()
+            let synchronizerState: SynchronizerState = {
+                var value = SynchronizerState.zero
+                value.accountsBalances = [account.id: accountBalance]
+                return value
+            }()
 
-        var state = SmartBanner.State()
-        state.$selectedWalletAccount.withLock { $0 = account }
+            var state = SmartBanner.State()
+            state.$selectedWalletAccount.withLock { $0 = account }
 
-        let store = TestStore(initialState: state) {
-            SmartBanner()
-        } withDependencies: {
-            $0.sdkSynchronizer = .mocked(latestState: { synchronizerState })
+            let store = TestStore(initialState: state) {
+                SmartBanner()
+            } withDependencies: {
+                $0.sdkSynchronizer = .mocked(latestState: { synchronizerState })
+            }
+            store.exhaustivity = .off
+            store.dependencies.mainQueue = .immediate
+
+            await store.send(.evaluatePriority8)
+            // Falls through to the exchange-rate check (and triggers priority8) instead of
+            // short-circuiting straight to priority9 as if the balance were empty.
+            await store.receive(\.triggerPriority)
         }
-        store.exhaustivity = .off
-        store.dependencies.mainQueue = .immediate
-
-        await store.send(.evaluatePriority8)
-        // Falls through to the exchange-rate check (and triggers priority8) instead of
-        // short-circuiting straight to priority9 as if the balance were empty.
-        await store.receive(\.triggerPriority)
     }
 }

--- a/zodlTests/SmartBannerTests/SmartBannerTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerTests.swift
@@ -10,7 +10,7 @@
 import Testing
 import Foundation
 import ComposableArchitecture
-@preconcurrency import ZcashLightClientKit
+@testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite(.serialized) struct SmartBannerTests {
@@ -100,5 +100,55 @@ import ComposableArchitecture
         await store.send(.torSettingsRequested) {
             $0.isSyncTimedOutSheetPresented = false
         }
+    }
+
+    // MARK: - evaluatePriority8 zero-balance check
+
+    /// A wallet holding funds only in the Ironwood pool (sapling and orchard both empty) must not
+    /// be treated as an empty balance. Ironwood is a third shielded pool (NU6.3 / Orchard
+    /// note-version V3); the reducer must fold it into the zero-balance check via the SDK's
+    /// pool-agnostic `shieldedTotal()` rather than a hand-summed sapling+orchard pair, or the
+    /// currency-conversion prompt would be skipped for Ironwood-only holders.
+    @MainActor @Test func evaluatePriority8TreatsIronwoodOnlyBalanceAsNonZero() async {
+        let account = WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+
+        let accountBalance = AccountBalance(
+            saplingBalance: .zero,
+            orchardBalance: .zero,
+            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: .zero, valuePendingSpendability: .zero),
+            unshielded: .zero
+        )
+
+        let synchronizerState: SynchronizerState = {
+            var value = SynchronizerState.zero
+            value.accountsBalances = [account.id: accountBalance]
+            return value
+        }()
+
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = account }
+
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.sdkSynchronizer = .mocked(latestState: { synchronizerState })
+        }
+        store.exhaustivity = .off
+        store.dependencies.mainQueue = .immediate
+
+        await store.send(.evaluatePriority8)
+        // Falls through to the exchange-rate check (and triggers priority8) instead of
+        // short-circuiting straight to priority9 as if the balance were empty.
+        await store.receive(\.triggerPriority)
     }
 }

--- a/zodlTests/UtilTests/RootInitializeSDKHealTests.swift
+++ b/zodlTests/UtilTests/RootInitializeSDKHealTests.swift
@@ -382,10 +382,12 @@ extension Root.State: @retroactive Equatable {
         #expect(signOutIndex < wipeIndex, "the Flexa session must be cleared before the database is wiped")
         #expect(userPrefsIndex < wipeIndex, "cached preferences must be cleared before the database is wiped")
 
+        #if VOTING_ENABLED
         #expect(
             removedKeys.value.contains(.votingConfigOverrideURL),
             "the voting chain override must be cleared before healing a stale database"
         )
+        #endif
 
         await drain(store)
     }

--- a/zodlTests/UtilTests/RootInitializeSDKHealTests.swift
+++ b/zodlTests/UtilTests/RootInitializeSDKHealTests.swift
@@ -63,9 +63,12 @@ extension Root.State: @retroactive Equatable {
     /// `setUserDefaultsBools`) or a benign no-op, so the whole effect — including the
     /// `.initializationSuccessfullyDone` fan-out (SmartBanner priority evaluation, contacts,
     /// user metadata, the battery-state subscription, …) — runs to completion without ever
-    /// touching an unimplemented dependency closure. When `reprepareError` is non-nil, the
-    /// second (re-prepare, `.restoreWallet`-mode) `prepareWith` call throws it instead of
-    /// succeeding, for exercising the `WalletDatabaseHealError.reprepareFailed` recovery route.
+    /// touching an unimplemented dependency closure. When `firstPrepareError` is non-nil, the
+    /// first `prepareWith` call throws it instead of returning `firstPrepareResult`, for
+    /// exercising the `ZcashError.initializerSeedMismatch` heal-mapping path. When `reprepareError`
+    /// is non-nil, the second (re-prepare, `.restoreWallet`-mode) `prepareWith` call throws it
+    /// instead of succeeding, for exercising the `WalletDatabaseHealError.reprepareFailed`
+    /// recovery route.
     private func makeStore(
         calls: LockIsolated<[String]>,
         removedUserDefaultsKeys: LockIsolated<[String]>,
@@ -73,6 +76,7 @@ extension Root.State: @retroactive Equatable {
         firstPrepareResult: Initializer.InitializationResult,
         isSeedRelevant: Bool,
         walletAccountsResult: [WalletAccount] = [RootInitializeSDKHealTests.seedDerivedAccount],
+        firstPrepareError: Error? = nil,
         reprepareError: Error? = nil,
         isStaleWalletHealedAlertPending: Bool = false,
         destination: Root.DestinationState.Destination = .welcome
@@ -147,6 +151,9 @@ extension Root.State: @retroactive Equatable {
                             throw reprepareError
                         }
                         return .success
+                    }
+                    if let firstPrepareError {
+                        throw firstPrepareError
                     }
                     return firstPrepareResult
                 },
@@ -312,6 +319,63 @@ extension Root.State: @retroactive Equatable {
             !recordedCalls[..<wipeIndex].contains("walletAccounts"),
             "a database already known stale (.seedNotRelevant) must not be probed for a derived account"
         )
+
+        await drain(store)
+    }
+
+    // MARK: - Scenario 2b: prepare() throwing initializerSeedMismatch heals like .seedNotRelevant
+
+    /// SDK 2.6.0 moved the seed/account integrity check inside `Initializer.initialize`, so a
+    /// stale database can now surface as a **thrown** `ZcashError.initializerSeedMismatch` from
+    /// the first `prepareWith` call instead of (only) a returned `.seedNotRelevant`.
+    /// `RootInitialization` must map that throw onto the same `knownStale: true` heal — this is
+    /// the throw-based mirror of `seedNotRelevantHealsWithoutProbingRelevanceOrDerivation` above.
+    @Test func prepareThrowingSeedMismatchHealsWithoutProbingRelevanceOrDerivation() async throws {
+        let calls = LockIsolated<[String]>([])
+        let removedKeys = LockIsolated<[String]>([])
+        let setBools = LockIsolated<[String: Bool]>([:])
+        let store = makeStore(
+            calls: calls,
+            removedUserDefaultsKeys: removedKeys,
+            setUserDefaultsBools: setBools,
+            firstPrepareResult: .success,
+            // If the F1 guard regresses and this gets consulted despite the database already
+            // being known stale, answering "yes, relevant" makes reconcile bail out with no
+            // heal — so a regression fails this test instead of coincidentally passing it.
+            isSeedRelevant: true,
+            firstPrepareError: ZcashError.initializerSeedMismatch
+        )
+
+        await store.send(.initialization(.initializeSDK(.existingWallet)))
+
+        await store.receive(
+            { action in
+                guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
+                return true
+            },
+            timeout: .seconds(5)
+        ) { state in
+            state.isRestoringWallet = true
+            state.$walletStatus.withLock { $0 = .restoring }
+            state.isStaleWalletHealedAlertPending = true
+        }
+
+        let recordedCalls = calls.value
+        let wipeIndex = try #require(recordedCalls.firstIndex(of: "wipe"))
+        #expect(
+            !recordedCalls[..<wipeIndex].contains("isSeedRelevant"),
+            "a mismatch thrown by prepare() is already known stale and must not be probed for relevance"
+        )
+        #expect(
+            !recordedCalls[..<wipeIndex].contains("walletAccounts"),
+            "a mismatch thrown by prepare() is already known stale and must not be probed for a derived account"
+        )
+
+        // `.initialization(.initializationFailed)` is the only other place the reducer sets
+        // these — their absence confirms the thrown mismatch healed instead of dead-ending the
+        // user on that alert.
+        #expect(store.state.alert == nil, "the mismatch must heal in place, not surface initializationFailed")
+        #expect(store.state.appInitializationState != .failed, "the mismatch must heal in place, not surface initializationFailed")
 
         await drain(store)
     }

--- a/zodlTests/VotingTests/VotingAPIResponseParserTests.swift
+++ b/zodlTests/VotingTests/VotingAPIResponseParserTests.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import Foundation
 import Testing
 @testable import zodl_internal
@@ -95,3 +96,4 @@ import Testing
         return response
     }
 }
+#endif

--- a/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 import Testing
@@ -1119,3 +1120,4 @@ private enum TestError: LocalizedError {
         }
     }
 }
+#endif

--- a/zodlTests/VotingTests/VotingHelpersTests.swift
+++ b/zodlTests/VotingTests/VotingHelpersTests.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import ComposableArchitecture
 import Foundation
 import Testing
@@ -223,3 +224,4 @@ private final class VotingHelpersMetadataBox: @unchecked Sendable {
     var submittedVotes: [String: [String: UInt32]] = [:]
     var records: [String: PersistedVotingRecord] = [:]
 }
+#endif

--- a/zodlTests/VotingTests/VotingServiceConfigTests.swift
+++ b/zodlTests/VotingTests/VotingServiceConfigTests.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import CryptoKit
 import Foundation
 import Testing
@@ -945,3 +946,4 @@ private func makeRecoverySharePayload(index: UInt32 = 0) -> SharePayload {
         submitAt: 99
     )
 }
+#endif

--- a/zodlTests/VotingTests/VotingSessionTests.swift
+++ b/zodlTests/VotingTests/VotingSessionTests.swift
@@ -1,3 +1,4 @@
+#if VOTING_ENABLED
 import Testing
 import Foundation
 @testable import zodl_internal
@@ -67,3 +68,4 @@ import Foundation
         )
     }
 }
+#endif

--- a/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
@@ -3,8 +3,8 @@
 //  zodlTests
 //
 //  Batch 3 — balances. Covers WalletBalances exchange-rate handling, nil-balance spendability,
-//  and computed props (Features/WalletBalances/WalletBalancesStore.swift).
-//  NOTE: the non-nil AccountBalance aggregation path is deferred (needs an SDK PoolBalance fixture).
+//  non-nil AccountBalance aggregation (including the Ironwood shielded pool), and computed props
+//  (Features/WalletBalances/WalletBalancesStore.swift).
 //
 
 import Testing
@@ -49,6 +49,33 @@ import ComposableArchitecture
         #expect(store.state.shieldedBalance == .zero)
         #expect(store.state.totalBalance == .zero)
         #expect(store.state.spendability == .everything)
+    }
+
+    // Ironwood is a third shielded pool (NU6.3 / Orchard note-version V3). The reducer must
+    // pick it up through the SDK's pool-agnostic `shielded*` accessors on `AccountBalance`
+    // rather than a hand-summed sapling+orchard pair, or Ironwood funds would be invisible.
+    @MainActor @Test func balanceUpdatedAggregatesSaplingOrchardIronwoodAndTransparent() async {
+        let store = TestStore(initialState: WalletBalances.State()) {
+            WalletBalances()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        }
+        store.exhaustivity = .off
+
+        let balance = AccountBalance(
+            saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
+            orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
+            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
+            unshielded: Zatoshi(5),
+            awaitingResolution: Zatoshi(1)
+        )
+
+        await store.send(.balanceUpdated(balance))
+
+        #expect(store.state.shieldedBalance == Zatoshi(600))            // 100 + 200 + 300 spendable
+        #expect(store.state.shieldedWithPendingBalance == Zatoshi(810)) // 130 + 270 + 410 totals
+        #expect(store.state.transparentBalance == Zatoshi(5))           // unshielded
+        #expect(store.state.totalBalance == Zatoshi(816))               // 810 + 5 + 1 awaiting
     }
 
     // MARK: - exchangeRateEvent


### PR DESCRIPTION
Makes ZODL build and sync correctly against the Ironwood-capable SDK (local `../zcash-swift-wallet-sdk` @ `release/2.6.0`), so Ironwood (NU6.3) funds are received, counted and displayed once NU6.3 activates and a lightwalletd serves the Ironwood fields.

## What's here

**Voting is parked, not ported.** The SDK's voting stack moved to upstream `zcash_voting` 1.0, which is a breaking API change (`generateHotkey(seed:)` → `(storedSecret:)`, DB-path/account-UUID parameters replacing note+seed arguments, and the removal of `decomposeWeight` / `encryptShares` / `signCastVote` / `storeCommitmentBundle`). Rather than port it, Voting is disabled behind a `VOTING_ENABLED` compilation condition that is **deliberately never defined**, and the Coinholder Polling entry point is hidden from Settings. No code was deleted — re-enabling is a one-line build-setting change per target, though the parked code will need the 1.0 port before it compiles again.

**Ironwood funds are now counted.** `AccountBalance` gained a third shielded pool, `ironwoodBalance`. The app was hand-summing only sapling + orchard in four places, so Ironwood funds would have been invisible. Those now use the SDK's pool-agnostic accessors (`shieldedSpendableValue`, `shieldedTotal()`, `shieldedChangePendingConfirmation`, `shieldedValuePendingSpendability`), so a future shielded pool flows through without touching these call sites.

**The stale-database heal stays reachable.** SDK 2.6.0 validates the seed against existing accounts inside `Initializer.initialize` and *throws* `initializerSeedMismatch` where it previously let the app's own probe (from #1918 / MOB-1512) find the mismatch and heal. That throw pre-empted the heal and dead-ended on `initializationFailed`; it is now mapped onto the existing `.seedNotRelevant` path so a stale database still self-heals.

**Ironwood transfers show their real amount.** An Orchard → Ironwood turnstile self-send collapses to a fee-only net value. `TransactionState` now carries the SDK's note counts and falls back to `totalReceived` for that shape, mirroring Android's `TransactionRepository.kt`.

Plus the one-line `.regtest` arm in `ParserContext.from(networkType:)` that the new `NetworkType` case requires.

## Not in scope

- The Orchard → Ironwood **migration** feature.
- A **regtest / custom-network** build target. Not needed: NU6.3 activation heights are compiled into the pinned Rust core (mainnet 3,428,143 / testnet 4,134,000), so the existing `zodl-testnet` scheme reaches the public Ironwood testnet directly.
- Porting Voting to `zcash_voting` 1.0.

## Testing

`xcodebuild test -project secant.xcodeproj -scheme zodl-internal -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -skipMacroValidation`

→ `578 tests in 97 suites passed`, zero compile errors. The one reported known issue is the pre-existing pinned `withKnownIssue` in `CurrencyConversionSetupTests` (MOB-1364 §6.2), unchanged by this branch.

New coverage for the Ironwood balance aggregation (Balances, WalletBalances, SmartBanner), the `initializerSeedMismatch` heal, and the transaction-display fallback.

**Manual verification against the public Ironwood testnet:** build the `zodl-testnet` scheme, then Settings → Server → custom entry, and point it at an Ironwood-aware testnet lightwalletd. Check that the wallet syncs past height 4,134,000 without error, that Ironwood funds appear in the home balance and the Balances breakdown, and that an Orchard → Ironwood transfer in the history shows its crossing amount rather than just a fee. Note that a lightwalletd *without* Ironwood support degrades quietly — `UpdateSubtreeRootsAction` skips Ironwood subtree roots rather than erroring — so confirm the server actually serves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
