### PR TITLE
Add the 3.8.0 What's New entry

### DIFF
--- a/secant/Resources/WhatsNew/whatsNew.json
+++ b/secant/Resources/WhatsNew/whatsNew.json
@@ -1,6 +1,25 @@
 {
     "releases": [
         {
+            "version": "3.8.0",
+            "date": "25-07-2026",
+            "timestamp": 1784981874,
+            "sections": [
+                {
+                    "title": "Added:",
+                    "bulletpoints": [
+                        "We added support for Zcash's Ironwood network upgrade (NU6.3), keeping your wallet fully compatible with the latest network changes. Support for moving funds to the new Ironwood pool will arrive in a future update."
+                    ]
+                },
+                {
+                    "title": "Fixed:",
+                    "bulletpoints": [
+                        "We fixed an issue where some wallets showed an incorrect balance or couldn't shield funds. The app now detects and repairs this automatically when you open it."
+                    ]
+                }
+            ]
+        },
+        {
             "version": "3.7.4",
             "date": "22-07-2026",
             "timestamp": 1784719803,

--- a/secant/Resources/WhatsNew/whatsNew_es.json
+++ b/secant/Resources/WhatsNew/whatsNew_es.json
@@ -1,6 +1,25 @@
 {
     "releases": [
         {
+            "version": "3.8.0",
+            "date": "25-07-2026",
+            "timestamp": 1784981874,
+            "sections": [
+                {
+                    "title": "Añadido:",
+                    "bulletpoints": [
+                        "Agregamos compatibilidad con la actualización de red Ironwood (NU6.3) de Zcash, para mantener tu billetera totalmente compatible con los últimos cambios de la red. La función para mover fondos al nuevo pool de Ironwood llegará en una próxima actualización."
+                    ]
+                },
+                {
+                    "title": "Corregido:",
+                    "bulletpoints": [
+                        "Corregimos un problema por el cual algunas billeteras mostraban un saldo incorrecto o no podían proteger fondos. Ahora la app lo detecta y lo repara automáticamente al abrirla."
+                    ]
+                }
+            ]
+        },
+        {
             "version": "3.7.4",
             "date": "22-07-2026",
             "timestamp": 1784719803,


### PR DESCRIPTION
Adds the 3.8.0 entry to the in-app What's New, in English and Spanish.

Covers the two user-facing changes in this release:

- **Added** — support for Zcash's Ironwood network upgrade (NU6.3), with a note that moving funds into the Ironwood pool arrives in a future update.
- **Fixed** — wallets that showed an incorrect balance or could not shield funds are now detected and repaired automatically on open.

Generated with the `update-whatsnew` skill, so both files get a pure top-of-array insert: existing entries are untouched and unreformatted, and all three of version, date and timestamp are shared across the two languages (`3.8.0` / `25-07-2026` / `1784981874`).

The matching App Store Connect text was produced alongside this and handed over separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
