### PR TITLE
[MOB-1533] Add Ironwood announcement screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Added
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
 - [Ironwood] A transfer that moves funds into the Ironwood pool now shows the amount that actually moved, in both the transaction list and the transaction detail screen. Previously such a transfer displayed only its fee.
+- [Ironwood] Once ZODL sees that the Ironwood network upgrade is live on the network, it shows a short one-time screen introducing the change, with a link to a support article. It appears once per device — after you continue past it, it never comes back.
 
 ### Changed
 - [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -8541,6 +8541,66 @@
         }
       }
     },
+    "ironwoodAnnouncement.body" : {
+      "comment" : "MARK: - Ironwood Announcement. Placeholder copy — replace when the final Ironwood news copy arrives, and add the Spanish translation at the same time.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ZODL now supports Zcash's Ironwood network upgrade. Final copy pending."
+          }
+        }
+      }
+    },
+    "ironwoodAnnouncement.continue" : {
+      "comment" : "Placeholder copy — replace when the final Ironwood news copy arrives, and add the Spanish translation at the same time.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        }
+      }
+    },
+    "ironwoodAnnouncement.debugReset" : {
+      "comment" : "Debug-only, compiled in behind #if !SECANT_DISTRIB. Never ships to users, so it needs no translation — not now, not later.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset Ironwood announcement"
+          }
+        }
+      }
+    },
+    "ironwoodAnnouncement.learnMore" : {
+      "comment" : "Placeholder copy — replace when the final Ironwood news copy arrives, and add the Spanish translation at the same time.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Learn more"
+          }
+        }
+      }
+    },
+    "ironwoodAnnouncement.title" : {
+      "comment" : "Placeholder copy — replace when the final Ironwood news copy arrives, and add the Spanish translation at the same time.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ironwood is here"
+          }
+        }
+      }
+    },
     "keepScreenOnRestoring" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -8542,7 +8542,7 @@
       }
     },
     "ironwoodAnnouncement.body1" : {
-      "comment" : "MARK: - Ironwood Announcement. Spanish deliberately pending: this copy makes precise claims about shielded pools and about what becomes public when value leaves Orchard, so it must be translated by a person, not machine-translated.",
+      "comment" : "MARK: - Ironwood Announcement. Copy and its Spanish translation both come from MOB-1533; the English is verbatim from the approved design.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -8550,11 +8550,17 @@
             "state" : "translated",
             "value" : "Ironwood is a new shielded pool: the same protocol as Orchard, now formally verified and independently audited. Your funds are safe and your addresses still work."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ironwood es un nuevo grupo protegido: el mismo protocolo que Orchard, ahora verificado formalmente y auditado de forma independiente. Tus fondos están seguros y tus direcciones siguen funcionando."
+          }
         }
       }
     },
     "ironwoodAnnouncement.body2" : {
-      "comment" : "Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "comment" : "Copy and Spanish translation from MOB-1533.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -8562,11 +8568,17 @@
             "state" : "translated",
             "value" : "Your Orchard funds stay until you move them. You can still spend them, but value leaving Orchard is public, so spending publishes an amount on-chain, and it can be larger than you send."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus fondos en Orchard permanecen ahí hasta que los muevas. Puedes seguir gastándolos, pero el valor que sale de Orchard es público: al gastar se publica un monto en la cadena de bloques, y puede ser mayor que el que envías."
+          }
         }
       }
     },
     "ironwoodAnnouncement.body3" : {
-      "comment" : "Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "comment" : "Copy and Spanish translation from MOB-1533.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -8574,17 +8586,29 @@
             "state" : "translated",
             "value" : "A more private migration is coming in a later update. It moves your funds in standard-sized pieces that don't identify you, so we recommend waiting."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una migración más privada llegará en una actualización posterior. Mueve tus fondos en partes de tamaño estándar que no te identifican, por eso recomendamos esperar."
+          }
         }
       }
     },
     "ironwoodAnnouncement.continue" : {
-      "comment" : "Primary button. The mixed-case \"Zodl\" is intentional and matches the approved design — do NOT change it to the all-uppercase \"ZODL\" used elsewhere in the app. A test pins this exact string. Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "comment" : "Primary button. The mixed-case \"Zodl\" is intentional in both languages and matches the approved design — do NOT change it to the all-uppercase \"ZODL\" used elsewhere in the app. A test pins the English string. Spanish from MOB-1533.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Go to Zodl"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ir a Zodl"
           }
         }
       }
@@ -8602,7 +8626,7 @@
       }
     },
     "ironwoodAnnouncement.guideLink" : {
-      "comment" : "The tappable link run inside the guide sentence. Rendered semibold, underlined and in the link colour, and concatenated between ironwoodAnnouncement.guidePrefix and .guideSuffix. Translate as the noun phrase only, with no surrounding spaces or punctuation. Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "comment" : "The tappable link run inside the guide sentence, concatenated between guidePrefix and guideSuffix. Rendered semibold, underlined and in the link colour. Translate as the noun phrase only, with no surrounding spaces or punctuation. Spanish from MOB-1533.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -8610,11 +8634,17 @@
             "state" : "translated",
             "value" : "our guide"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nuestra guía"
+          }
         }
       }
     },
     "ironwoodAnnouncement.guidePrefix" : {
-      "comment" : "First of three fragments concatenated into one sentence: guidePrefix + guideLink + guideSuffix. The TRAILING SPACE is significant — without it the sentence renders as \"waitour guide\". Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "comment" : "First of three fragments concatenated into one sentence: guidePrefix + guideLink + guideSuffix. The TRAILING SPACE is significant in every language — without it the sentence renders as \"waitour guide\". Spanish from MOB-1533.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -8622,11 +8652,17 @@
             "state" : "translated",
             "value" : "If you'd rather not wait, "
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si prefieres no esperar, "
+          }
         }
       }
     },
     "ironwoodAnnouncement.guideSuffix" : {
-      "comment" : "Last of three fragments concatenated into one sentence: guidePrefix + guideLink + guideSuffix. The LEADING SPACE is significant — without it the sentence renders as \"our guideexplains\". Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "comment" : "Last of three fragments concatenated into one sentence: guidePrefix + guideLink + guideSuffix. The LEADING SPACE is significant in every language — without it the sentence renders as \"our guideexplains\". Spanish from MOB-1533.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -8634,11 +8670,17 @@
             "state" : "translated",
             "value" : " explains how to move funds manually."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " explica cómo mover los fondos manualmente."
+          }
         }
       }
     },
     "ironwoodAnnouncement.learnMore" : {
-      "comment" : "Secondary button. Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "comment" : "Secondary button. NOTE: this Spanish is NOT from MOB-1533 — that ticket describes only the inline guide link and the primary button, so it carries no translation for this one. \"Más información\" is the standard iOS Spanish for this label and should be confirmed by a translator.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -8646,17 +8688,29 @@
             "state" : "translated",
             "value" : "Learn more"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más información"
+          }
         }
       }
     },
     "ironwoodAnnouncement.title" : {
-      "comment" : "Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "comment" : "Copy and Spanish translation from MOB-1533.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zcash Upgraded to Ironwood"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zcash se actualizó a Ironwood"
           }
         }
       }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -8541,26 +8541,50 @@
         }
       }
     },
-    "ironwoodAnnouncement.body" : {
-      "comment" : "MARK: - Ironwood Announcement. Placeholder copy — replace when the final Ironwood news copy arrives, and add the Spanish translation at the same time.",
+    "ironwoodAnnouncement.body1" : {
+      "comment" : "MARK: - Ironwood Announcement. Spanish deliberately pending: this copy makes precise claims about shielded pools and about what becomes public when value leaves Orchard, so it must be translated by a person, not machine-translated.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ZODL now supports Zcash's Ironwood network upgrade. Final copy pending."
+            "value" : "Ironwood is a new shielded pool: the same protocol as Orchard, now formally verified and independently audited. Your funds are safe and your addresses still work."
+          }
+        }
+      }
+    },
+    "ironwoodAnnouncement.body2" : {
+      "comment" : "Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Orchard funds stay until you move them. You can still spend them, but value leaving Orchard is public, so spending publishes an amount on-chain, and it can be larger than you send."
+          }
+        }
+      }
+    },
+    "ironwoodAnnouncement.body3" : {
+      "comment" : "Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A more private migration is coming in a later update. It moves your funds in standard-sized pieces that don't identify you, so we recommend waiting."
           }
         }
       }
     },
     "ironwoodAnnouncement.continue" : {
-      "comment" : "Placeholder copy — replace when the final Ironwood news copy arrives, and add the Spanish translation at the same time.",
+      "comment" : "Primary button. The mixed-case \"Zodl\" is intentional and matches the approved design — do NOT change it to the all-uppercase \"ZODL\" used elsewhere in the app. A test pins this exact string. Spanish deliberately pending — see ironwoodAnnouncement.body1.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continue"
+            "value" : "Go to Zodl"
           }
         }
       }
@@ -8577,8 +8601,44 @@
         }
       }
     },
+    "ironwoodAnnouncement.guideLink" : {
+      "comment" : "The tappable link run inside the guide sentence. Rendered semibold, underlined and in the link colour, and concatenated between ironwoodAnnouncement.guidePrefix and .guideSuffix. Translate as the noun phrase only, with no surrounding spaces or punctuation. Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "our guide"
+          }
+        }
+      }
+    },
+    "ironwoodAnnouncement.guidePrefix" : {
+      "comment" : "First of three fragments concatenated into one sentence: guidePrefix + guideLink + guideSuffix. The TRAILING SPACE is significant — without it the sentence renders as \"waitour guide\". Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you'd rather not wait, "
+          }
+        }
+      }
+    },
+    "ironwoodAnnouncement.guideSuffix" : {
+      "comment" : "Last of three fragments concatenated into one sentence: guidePrefix + guideLink + guideSuffix. The LEADING SPACE is significant — without it the sentence renders as \"our guideexplains\". Spanish deliberately pending — see ironwoodAnnouncement.body1.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " explains how to move funds manually."
+          }
+        }
+      }
+    },
     "ironwoodAnnouncement.learnMore" : {
-      "comment" : "Placeholder copy — replace when the final Ironwood news copy arrives, and add the Spanish translation at the same time.",
+      "comment" : "Secondary button. Spanish deliberately pending — see ironwoodAnnouncement.body1.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -8590,13 +8650,13 @@
       }
     },
     "ironwoodAnnouncement.title" : {
-      "comment" : "Placeholder copy — replace when the final Ironwood news copy arrives, and add the Spanish translation at the same time.",
+      "comment" : "Spanish deliberately pending — see ironwoodAnnouncement.body1.",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ironwood is here"
+            "value" : "Zcash Upgraded to Ironwood"
           }
         }
       }

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorage.swift
@@ -29,6 +29,11 @@ struct WalletStorage {
         static let zcashStoredTorSetupFlag = "zcashStoredTorSetupFlag"
         static let zcashStoredVotingHotkey = "zcashStoredVotingHotkey"
         static let zcashStoredZodlAnnouncementFlag = "zcashStoredZodlAnnouncementFlag"
+        // This key is deliberately NOT removed in `resetZashi`. The Ironwood announcement is shown once
+        // per device and must survive a wallet reset and an app reinstall; wiping it here would re-show
+        // the screen after every restore. It gets added to the reset method only when we decide to
+        // retire the announcement screen.
+        static let zcashStoredIronwoodAnnouncementFlag = "zcashStoredIronwoodAnnouncementFlag"
 
         /// Versioning of the stored data
         static let zcashKeychainVersion = 1
@@ -433,6 +438,36 @@ struct WalletStorage {
             return nil
         }
         
+        return try? decode(json: reqData, as: Bool.self)
+    }
+
+    func importIronwoodAnnouncementFlag(_ enabled: Bool) throws {
+        guard let data = try? encode(object: enabled) else {
+            throw KeychainError.encoding
+        }
+
+        do {
+            try setData(data, forKey: Constants.zcashStoredIronwoodAnnouncementFlag)
+        } catch KeychainError.duplicate {
+            try updateData(data, forKey: Constants.zcashStoredIronwoodAnnouncementFlag)
+        } catch {
+            throw WalletStorageError.storageError(error)
+        }
+    }
+
+    func exportIronwoodAnnouncementFlag() -> Bool? {
+        let reqData: Data?
+
+        do {
+            reqData = try data(forKey: Constants.zcashStoredIronwoodAnnouncementFlag)
+        } catch {
+            return nil
+        }
+
+        guard let reqData else {
+            return nil
+        }
+
         return try? decode(json: reqData, as: Bool.self)
     }
 

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageInterface.swift
@@ -104,6 +104,11 @@ struct WalletStorageClient {
     var importTorSetupFlag: @Sendable (Bool) throws -> Void
     var exportTorSetupFlag: @Sendable () -> Bool? = { nil }
 
+    /// Ironwood announcement flag. `true` once the announcement screen has been shown
+    /// and acknowledged on this device. Absent or `false` means "not yet shown".
+    var importIronwoodAnnouncementFlag: @Sendable (Bool) throws -> Void
+    var exportIronwoodAnnouncementFlag: @Sendable () -> Bool? = { nil }
+
     /// Per-account voting hotkey. Scoped by `AccountUUID` so two accounts on
     /// the same device get distinct hotkeys (and therefore distinct on-chain
     /// voter identities), instead of being linkable via a shared hotkey.

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageLiveKey.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageLiveKey.swift
@@ -86,6 +86,12 @@ extension WalletStorageClient: DependencyKey {
             exportTorSetupFlag: {
                 walletStorage.exportTorSetupFlag()
             },
+            importIronwoodAnnouncementFlag: { enabled in
+                try walletStorage.importIronwoodAnnouncementFlag(enabled)
+            },
+            exportIronwoodAnnouncementFlag: {
+                walletStorage.exportIronwoodAnnouncementFlag()
+            },
             importVotingHotkey: { phrase, accountId in
                 try walletStorage.importVotingHotkey(phrase, accountId: accountId)
             },

--- a/secant/Sources/Dependencies/WalletStorage/WalletStorageTestKey.swift
+++ b/secant/Sources/Dependencies/WalletStorage/WalletStorageTestKey.swift
@@ -32,6 +32,12 @@ extension WalletStorageClient {
         exportShieldingAcknowledged: { false },
         importTorSetupFlag: { _ in },
         exportTorSetupFlag: { false },
+        // `true` (not `nil`) is deliberate: `.noOp` is used at many test sites, several of which drive
+        // the app's Root reducer through launch and sync and assert it lands on Home. `true` means
+        // "already acknowledged", which keeps the Ironwood announcement gate closed for all of them.
+        // Do not "fix" this to `nil` — that would make the announcement pop up across those tests.
+        importIronwoodAnnouncementFlag: { _ in },
+        exportIronwoodAnnouncementFlag: { true },
         importVotingHotkey: { _, _ in },
         exportVotingHotkey: { _ in .init(seedPhrase: .init(""), version: 0) }
     )

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
@@ -120,6 +120,10 @@ struct ZcashSDKEnvironment {
     }
     var exchangeRateIPRateLimit: @Sendable () -> TimeInterval = { 0 }
     var exchangeRateStaleLimit: @Sendable () -> TimeInterval = { 0 }
+    /// The height at which the Ironwood (NU6.3) network upgrade activates on the current network.
+    /// `BlockHeight.max` is a deliberate fail-closed default: an unknown network is treated as
+    /// "Ironwood never activates" rather than "Ironwood already activated".
+    var ironwoodActivationHeight: @Sendable () -> BlockHeight = { BlockHeight.max }
     var memoCharLimit: @Sendable () -> Int = { 0 }
     var mnemonicWordsMaxCount: @Sendable () -> Int = { 0 }
     var network: @Sendable () -> ZcashNetwork = { ZcashNetworkBuilder.network(for: .testnet) }

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
@@ -22,6 +22,22 @@ extension ZcashSDKEnvironment: DependencyKey {
             },
             exchangeRateIPRateLimit: { 120 },
             exchangeRateStaleLimit: { 15 * 60 },
+            ironwoodActivationHeight: {
+                switch network.networkType {
+                case .mainnet:
+                    // Hand-mirrored consensus constant from librustzcash `zcash_protocol` 0.10.0 (NU6.3
+                    // "Ironwood" mainnet activation height). A Rust-sourced getter is the natural
+                    // replacement once the SDK exposes NU6.3's activation height directly.
+                    return 3_428_143
+                case .testnet:
+                    // Hand-mirrored consensus constant from librustzcash `zcash_protocol` 0.10.0 (NU6.3
+                    // "Ironwood" testnet activation height). A Rust-sourced getter is the natural
+                    // replacement once the SDK exposes NU6.3's activation height directly.
+                    return 4_134_000
+                case .regtest:
+                    return network.customActivationHeights?.nu6_3 ?? BlockHeight.max
+                }
+            },
             memoCharLimit: { MemoBytes.capacity },
             mnemonicWordsMaxCount: { ZcashSDKConstants.mnemonicWordsMaxCount },
             network: { network },

--- a/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
+++ b/secant/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
@@ -19,6 +19,8 @@ extension ZcashSDKEnvironment: TestDependencyKey {
             endpoint: { defaultEndpoint(for: .testnet) },
             exchangeRateIPRateLimit: { 120 },
             exchangeRateStaleLimit: { 15 * 60 },
+            // Mirrors the testnet Ironwood activation height used by `live(network:)`.
+            ironwoodActivationHeight: { 4_134_000 },
             memoCharLimit: { MemoBytes.capacity },
             mnemonicWordsMaxCount: { ZcashSDKConstants.mnemonicWordsMaxCount },
             network: { ZcashNetworkBuilder.network(for: .testnet) },

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
@@ -31,6 +31,13 @@ extension RestoreWalletCoordFlow {
                     // store the wallet to the keychain
                     try walletStorage.importWallet(newRandomPhrase, birthday, .english, false)
 
+                    // A wallet created here starts fresh on an Ironwood-active chain, so there is
+                    // no Ironwood news to announce to it — and creation is immediately followed by
+                    // the recovery-phrase backup flow, the worst possible moment to interrupt with
+                    // a full-screen announcement. Marking it acknowledged up front keeps the
+                    // announcement out of onboarding entirely.
+                    try? walletStorage.importIronwoodAnnouncementFlag(true)
+
                     return .send(.newWalletSuccessfulyCreated)
                 } catch {
                     state.alert = AlertState.cantCreateNewWallet(error.toZcashError())
@@ -57,7 +64,13 @@ extension RestoreWalletCoordFlow {
                     try mnemonic.isValid(seedPhrase)
 
                     try walletStorage.importWallet(seedPhrase, birthday, .english, false)
-                    
+
+                    // Deliberately NOT marking the Ironwood announcement acknowledged here, unlike
+                    // .createNewWalletRequested. Restoring a seed means a returning user who may
+                    // have missed the Ironwood news, so this path leaves the flag untouched and
+                    // lets the one-time announcement screen appear for them. This asymmetry with
+                    // wallet creation is intentional — do not "fix" it.
+
                     // update the backup phrase validation flag
                     try walletStorage.markUserPassedPhraseBackupTest(true)
 

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
@@ -31,13 +31,11 @@ extension RestoreWalletCoordFlow {
                     // store the wallet to the keychain
                     try walletStorage.importWallet(newRandomPhrase, birthday, .english, false)
 
-                    // A wallet created here starts fresh on an Ironwood-active chain, so there is
-                    // no Ironwood news to announce to it — and creation is immediately followed by
-                    // the recovery-phrase backup flow, the worst possible moment to interrupt with
-                    // a full-screen announcement. Marking it acknowledged up front keeps the
-                    // announcement out of onboarding entirely.
-                    try? walletStorage.importIronwoodAnnouncementFlag(true)
-
+                    // Deliberately does NOT pre-acknowledge the Ironwood announcement. Ironwood is
+                    // news about the network, not about this wallet, so a brand-new wallet gets it
+                    // like everyone else once the chain tip is known. Root's safety gate is what
+                    // keeps it from landing mid-onboarding — it requires the user to be idle on
+                    // Home with no flow pushed.
                     return .send(.newWalletSuccessfulyCreated)
                 } catch {
                     state.alert = AlertState.cantCreateNewWallet(error.toZcashError())
@@ -64,12 +62,6 @@ extension RestoreWalletCoordFlow {
                     try mnemonic.isValid(seedPhrase)
 
                     try walletStorage.importWallet(seedPhrase, birthday, .english, false)
-
-                    // Deliberately NOT marking the Ironwood announcement acknowledged here, unlike
-                    // .createNewWalletRequested. Restoring a seed means a returning user who may
-                    // have missed the Ironwood news, so this path leaves the flag untouched and
-                    // lets the one-time announcement screen appear for them. This asymmetry with
-                    // wallet creation is intentional — do not "fix" it.
 
                     // update the backup phrase validation flag
                     try walletStorage.markUserPassedPhraseBackupTest(true)

--- a/secant/Sources/Features/IronwoodAnnouncement/IronwoodAnnouncementStore.swift
+++ b/secant/Sources/Features/IronwoodAnnouncement/IronwoodAnnouncementStore.swift
@@ -1,0 +1,51 @@
+//
+//  IronwoodAnnouncementStore.swift
+//  Zashi
+//
+//  Created by Michal Fousek on 25.07.2026.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct IronwoodAnnouncement {
+    @ObservableState
+    struct State: Equatable {
+        var isInAppBrowserOn = false
+    }
+
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<IronwoodAnnouncement.State>)
+        case learnMoreTapped
+        case continueTapped
+    }
+
+    @Dependency(\.walletStorage) var walletStorage
+
+    init() { }
+
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+
+            case .learnMoreTapped:
+                state.isInAppBrowserOn = true
+                return .none
+
+            case .continueTapped:
+                // Deliberately returns `.none` without navigating anywhere: the Root reducer
+                // observes this same `.continueTapped` action and performs the transition to
+                // Home itself. Do not "fix" this by adding navigation here.
+                // `try?` is deliberate too: a keychain write failure must not trap the user on
+                // this one-time announcement screen, so the failure is swallowed rather than
+                // surfaced or retried.
+                try? walletStorage.importIronwoodAnnouncementFlag(true)
+                return .none
+            }
+        }
+    }
+}

--- a/secant/Sources/Features/IronwoodAnnouncement/IronwoodAnnouncementStore.swift
+++ b/secant/Sources/Features/IronwoodAnnouncement/IronwoodAnnouncementStore.swift
@@ -17,6 +17,7 @@ struct IronwoodAnnouncement {
     enum Action: BindableAction, Equatable {
         case binding(BindingAction<IronwoodAnnouncement.State>)
         case learnMoreTapped
+        case guideTapped
         case continueTapped
     }
 
@@ -33,6 +34,14 @@ struct IronwoodAnnouncement {
                 return .none
 
             case .learnMoreTapped:
+                state.isInAppBrowserOn = true
+                return .none
+
+            case .guideTapped:
+                // Mirrors `learnMoreTapped` exactly: both just open the same article in the
+                // in-app browser. Opening the guide is deliberately NOT acknowledgement of the
+                // announcement — only `continueTapped` writes the keychain flag below, so this
+                // case must never touch `walletStorage`.
                 state.isInAppBrowserOn = true
                 return .none
 

--- a/secant/Sources/Features/IronwoodAnnouncement/IronwoodAnnouncementView.swift
+++ b/secant/Sources/Features/IronwoodAnnouncement/IronwoodAnnouncementView.swift
@@ -1,0 +1,84 @@
+//
+//  IronwoodAnnouncementView.swift
+//  Zashi
+//
+//  Created by Michal Fousek on 25.07.2026.
+//
+
+// This screen is intentionally minimal. Final copy and artwork for the Ironwood
+// announcement are still pending, so this is a placeholder layout built entirely
+// from existing design-system pieces (title, body, and the two footer buttons).
+
+import SwiftUI
+import ComposableArchitecture
+
+// PLACEHOLDER. This is the Ironwood support article used elsewhere in the app; it is
+// about moving funds, not the general Ironwood news. Swap it for the real FAQ/news
+// article when that exists.
+private let ironwoodAnnouncementFAQURL = "https://support.zodl.com/article/42-moving-your-funds-to-ironwood"
+
+struct IronwoodAnnouncementView: View {
+    @Perception.Bindable var store: StoreOf<IronwoodAnnouncement>
+
+    init(store: StoreOf<IronwoodAnnouncement>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(localizable: .ironwoodAnnouncementTitle)
+                    .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                    .padding(.top, 40)
+
+                Text(localizable: .ironwoodAnnouncementBody)
+                    .zFont(size: 14, style: Design.Text.primary)
+                    .padding(.top, 12)
+
+                Spacer()
+
+                ZashiButton(String(localizable: .ironwoodAnnouncementLearnMore), type: .tertiary) {
+                    store.send(.learnMoreTapped)
+                }
+                .padding(.bottom, 8)
+
+                ZashiButton(String(localizable: .ironwoodAnnouncementContinue)) {
+                    store.send(.continueTapped)
+                }
+                .padding(.bottom, 24)
+            }
+            .sheet(isPresented: $store.isInAppBrowserOn) {
+                if let url = URL(string: ironwoodAnnouncementFAQURL) {
+                    InAppBrowserView(url: url)
+                }
+            }
+        }
+        .navigationBarHidden(true)
+        .screenHorizontalPadding()
+        .applyScreenBackground()
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    NavigationView {
+        IronwoodAnnouncementView(store: IronwoodAnnouncement.initial)
+    }
+}
+
+// MARK: - Store
+
+extension IronwoodAnnouncement {
+    @MainActor static let initial = StoreOf<IronwoodAnnouncement>(
+        initialState: .initial
+    ) {
+        IronwoodAnnouncement()
+    }
+}
+
+// MARK: - Placeholders
+
+extension IronwoodAnnouncement.State {
+    static let initial = IronwoodAnnouncement.State()
+}

--- a/secant/Sources/Features/IronwoodAnnouncement/IronwoodAnnouncementView.swift
+++ b/secant/Sources/Features/IronwoodAnnouncement/IronwoodAnnouncementView.swift
@@ -5,19 +5,16 @@
 //  Created by Michal Fousek on 25.07.2026.
 //
 
-// This screen is intentionally minimal. Final copy and artwork for the Ironwood
-// announcement are still pending, so this is a placeholder layout built entirely
-// from existing design-system pieces (title, body, and the two footer buttons).
-
 import SwiftUI
 import ComposableArchitecture
 
-// PLACEHOLDER. This is the Ironwood support article used elsewhere in the app; it is
-// about moving funds, not the general Ironwood news. Swap it for the real FAQ/news
-// article when that exists.
+// This is the Ironwood support article: it is about moving funds, not the general Ironwood
+// news. Both the "Learn more" button and the tappable "our guide" link in the guide line below
+// point at this same article by decision.
 private let ironwoodAnnouncementFAQURL = "https://support.zodl.com/article/42-moving-your-funds-to-ironwood"
 
 struct IronwoodAnnouncementView: View {
+    @Environment(\.colorScheme) private var colorScheme
     @Perception.Bindable var store: StoreOf<IronwoodAnnouncement>
 
     init(store: StoreOf<IronwoodAnnouncement>) {
@@ -27,26 +24,104 @@ struct IronwoodAnnouncementView: View {
     var body: some View {
         WithPerceptionTracking {
             VStack(alignment: .leading, spacing: 0) {
-                Text(localizable: .ironwoodAnnouncementTitle)
-                    .zFont(.semiBold, size: 24, style: Design.Text.primary)
-                    .padding(.top, 40)
+                // Items 1-7 of the design live in this ScrollView. The Figma frame draws this copy
+                // as fixed with the buttons pinned below it, which has ample slack on the 852pt
+                // frame it was drawn at but almost none on a 667pt iPhone SE — where the guide
+                // line ends directly above the buttons. Any longer translation of this copy, or a
+                // smaller device, tips it over. The text column therefore scrolls while the
+                // buttons stay pinned outside it. Do not "simplify" this back to a plain VStack.
+                //
+                // Note this screen's text does NOT grow with the user's text-size setting: `zFont`
+                // uses `Font.custom(_:size:)` without `relativeTo:`, so the whole app renders at
+                // fixed point sizes. If Dynamic Type is ever adopted, this ScrollView is already
+                // what keeps the buttons reachable.
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        // 1. Brandmark pair. Dark mark first so the yellow mark draws on top of it.
+                        //
+                        // The ZODL badge is composed rather than taken from `zashiLogoWithBackground`:
+                        // that asset ships a black-on-white variant for light mode and a
+                        // white-on-black one for dark, so it blends into whatever is behind it
+                        // instead of staying a fixed badge — in light mode it renders as a bare
+                        // dark glyph with no circle at all. Compositing the transparent mark over a
+                        // filled circle keeps it a badge, and `Design.Logo.primary` / `.opposite`
+                        // invert together so it stays legible in both colour schemes.
+                        HStack(spacing: -3) {
+                            Asset.Assets.zashiLogo.image
+                                .zImage(size: 26, style: Design.Logo.primary)
+                                .frame(width: 48, height: 48)
+                                .background {
+                                    Circle()
+                                        .foregroundColor(Design.Logo.opposite.color(colorScheme))
+                                }
 
-                Text(localizable: .ironwoodAnnouncementBody)
-                    .zFont(size: 14, style: Design.Text.primary)
-                    .padding(.top, 12)
+                            Asset.Assets.zcashZecLogo.image
+                                .resizable()
+                                .frame(width: 48, height: 48)
+                        }
+                        // Extra offset for this header block itself, on top of the hidden
+                        // app-bar spacing applied to the whole content below. Together they
+                        // reproduce the Figma frame's `opacity-0` status bar + top app bar,
+                        // which are invisible but still occupy layout space.
+                        .padding(.top, Design.Spacing._lg)
 
+                        // 3. Title
+                        Text(localizable: .ironwoodAnnouncementTitle)
+                            .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, Design.Spacing._xl)
+
+                        // 5. Three paragraphs, 12pt apart.
+                        Text(localizable: .ironwoodAnnouncementBody1)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, Design.Spacing._lg)
+
+                        Text(localizable: .ironwoodAnnouncementBody2)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, Design.Spacing._lg)
+
+                        Text(localizable: .ironwoodAnnouncementBody3)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, Design.Spacing._lg)
+
+                        // 7. Guide line: prefix + tappable link + suffix. Tapping the link opens
+                        // the in-app browser instead of leaving the app.
+                        Text(guideAttributedString())
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, Design.Spacing._3xl)
+                            .environment(\.openURL, OpenURLAction { _ in
+                                store.send(.guideTapped)
+                                return .handled
+                            })
+                    }
+                }
+                .scrollBounceBasedOnSizeIfAvailable()
+
+                // 8. Flexible space: absorbs any leftover height so the buttons stay pinned to
+                // the bottom when the content above is short, and shrinks to nothing (letting
+                // the ScrollView above take over and scroll) when the content overflows.
                 Spacer()
 
-                ZashiButton(String(localizable: .ironwoodAnnouncementLearnMore), type: .tertiary) {
-                    store.send(.learnMoreTapped)
-                }
-                .padding(.bottom, 8)
+                // 9. Buttons, 12pt apart, pinned outside the scroll view.
+                VStack(alignment: .leading, spacing: Design.Spacing._lg) {
+                    ZashiButton(String(localizable: .ironwoodAnnouncementLearnMore), type: .tertiary) {
+                        store.send(.learnMoreTapped)
+                    }
 
-                ZashiButton(String(localizable: .ironwoodAnnouncementContinue)) {
-                    store.send(.continueTapped)
+                    ZashiButton(String(localizable: .ironwoodAnnouncementContinue)) {
+                        store.send(.continueTapped)
+                    }
                 }
-                .padding(.bottom, 24)
+                .padding(.bottom, Design.Spacing._3xl)
             }
+            // In the Figma frame the status bar and the top app bar are present but at
+            // `opacity-0` — invisible, yet they still occupy space, which is why the content
+            // starts well down the screen. This reproduces that reserved space: 12pt top inset +
+            // 36pt bar height + 12pt bottom inset = 60pt. Not an arbitrary magic number.
+            .padding(.top, 60)
             .sheet(isPresented: $store.isInAppBrowserOn) {
                 if let url = URL(string: ironwoodAnnouncementFAQURL) {
                     InAppBrowserView(url: url)
@@ -56,6 +131,42 @@ struct IronwoodAnnouncementView: View {
         .navigationBarHidden(true)
         .screenHorizontalPadding()
         .applyScreenBackground()
+    }
+
+    /// Builds the guide sentence (prefix + tappable link + suffix) as a single `AttributedString`
+    /// concatenated from three separately-localized fragments, so each stays translatable and the
+    /// link range is known by construction rather than found by searching the rendered string.
+    private func guideAttributedString() -> AttributedString {
+        var prefix = AttributedString(String(localizable: .ironwoodAnnouncementGuidePrefix))
+        prefix.font = Font.custom(FontFamily.Inter.medium.name, size: 14)
+        prefix.foregroundColor = Design.Text.primary.color(colorScheme)
+
+        var link = AttributedString(String(localizable: .ironwoodAnnouncementGuideLink))
+        link.font = Font.custom(FontFamily.Inter.semiBold.name, size: 14)
+        link.underlineStyle = .single
+        link.foregroundColor = Design.Text.link.color(colorScheme)
+        link.link = URL(string: ironwoodAnnouncementFAQURL)
+
+        var suffix = AttributedString(String(localizable: .ironwoodAnnouncementGuideSuffix))
+        suffix.font = Font.custom(FontFamily.Inter.medium.name, size: 14)
+        suffix.foregroundColor = Design.Text.primary.color(colorScheme)
+
+        return prefix + link + suffix
+    }
+}
+
+private extension View {
+    /// `scrollBounceBehavior` requires iOS 16.4 and the app deploys to 16.0, so it is applied only
+    /// where available. Without it a screen whose content already fits still rubber-bands, which
+    /// reads as sloppy; on 16.0-16.3 that bounce is accepted rather than dropping the ScrollView,
+    /// which is what keeps the buttons reachable on a small device.
+    @ViewBuilder
+    func scrollBounceBasedOnSizeIfAvailable() -> some View {
+        if #available(iOS 16.4, *) {
+            self.scrollBounceBehavior(.basedOnSize)
+        } else {
+            self
+        }
     }
 }
 

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -252,6 +252,26 @@ extension Root {
                 state.path = .serverSwitch
                 return .none
 
+                // MARK: - Ironwood Announcement
+
+            case .ironwoodAnnouncement(.continueTapped):
+                // The feature reducer already wrote the keychain acknowledgment flag; Root owns
+                // navigation. Routing through `.updateDestination` (rather than assigning
+                // `destinationState.destination` directly) is what lets a pending
+                // stale-wallet-healed notice be delivered on this arrival at Home — see
+                // `presentStaleWalletHealedAlertEffect` (RootStore.swift).
+                return .send(.destination(.updateDestination(.home)))
+
+            case .settings(.path(.element(id: _, action: .advancedSettings(.debugResetIronwoodAnnouncementTapped)))):
+                // The debug row itself writes the keychain flag; without also clearing this
+                // session's latch here, the reset wouldn't take effect until the app is
+                // relaunched (the latch is what keeps the already-acknowledged path from
+                // re-reading the keychain more than once per session). No `#if` needed: this
+                // action is unreachable in a production build because the row that sends it is
+                // compiled out (see AdvancedSettingsView).
+                state.ironwoodAnnouncementResolved = false
+                return .none
+
                 // MARK: - Keystone
 
             case .sendCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.rejectTapped)))),

--- a/secant/Sources/Features/Root/RootDestination.swift
+++ b/secant/Sources/Features/Root/RootDestination.swift
@@ -17,6 +17,7 @@ extension Root {
     struct DestinationState {
         enum Destination {
             case deeplinkWarning
+            case ironwoodAnnouncement
             case notEnoughFreeSpace
             case onboarding
             case osStatusError

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -70,6 +70,12 @@ extension Root {
                     }
                 }
                 state.appStartState = .willEnterForeground
+                // Placed after the biometric re-auth block above so that block's possible
+                // `splashAppeared = false` has already landed before the safety gate reads it.
+                // The tip survives backgrounding in memory (`sdkSynchronizer.latestState()`),
+                // which is what makes this call site immediate rather than waiting for a fresh
+                // sync tick to repopulate it via `.synchronizerStateChanged`.
+                presentIronwoodAnnouncementIfNeeded(state: &state, tip: sdkSynchronizer.latestState().latestBlockHeight)
                 if state.isLockedInKeychainUnavailableState || !sdkSynchronizer.latestState().syncStatus.isPrepared {
                     return .send(.initialization(.initialSetups))
                 } else {
@@ -108,6 +114,13 @@ extension Root {
                 }
                 
             case .synchronizerStateChanged(let latestState):
+                // Must run above the `selectedWalletAccount` guard and the background-task
+                // branch below — both early-return, but the announcement gate has to keep
+                // evaluating on every sync tick regardless of whether an account is selected
+                // (normal on a fresh install) or a background task is in flight (already
+                // excluded by `canPresentIronwoodAnnouncement`'s own `bgTask == nil` term).
+                presentIronwoodAnnouncementIfNeeded(state: &state, tip: latestState.data.latestBlockHeight)
+
                 let snapshot = SyncStatusSnapshot.snapshotFor(state: latestState.data.syncStatus)
 
                 guard let account = state.selectedWalletAccount else {
@@ -846,5 +859,47 @@ extension Root {
             return true
         default: return false
         }
+    }
+
+    /// Presents the one-time Ironwood announcement screen once the device hasn't acknowledged
+    /// it yet, Ironwood is active on chain, and it is safe to take the screen over. Called from
+    /// both `.synchronizerStateChanged` (cold start and the tail of a restore) and
+    /// `.appDelegate(.willEnterForeground)` (returning to the foreground, where the tip is
+    /// already known in memory from before backgrounding) — together the two cover every moment
+    /// the tip or the safety gate can newly satisfy the predicate.
+    ///
+    /// Each guard below is load-bearing and deliberately ordered:
+    /// 1. the in-memory per-session latch short-circuits every call once the gate has already
+    ///    "resolved" this session (presented, or found already-acknowledged in the keychain);
+    /// 2. the tip/activation check runs before any keychain access — cheap, and it keeps the
+    ///    (overwhelmingly common, pre-activation) path from ever touching the keychain. `tip > 0`
+    ///    is a deliberate fail-safe: the chain tip is in-memory only and reads `0` before the
+    ///    first successful server round-trip, and an unknown tip must count as "not active" —
+    ///    never as a false positive that skips straight past activation;
+    /// 3. the keychain read happens at most once per session: as soon as it reports
+    ///    already-acknowledged, the latch is set so this guard is never evaluated again;
+    /// 4. the safety gate is re-checked on every call and deliberately does NOT set the latch on
+    ///    failure, so a blocked attempt (e.g. mid-flow) retries on a later tick instead of being
+    ///    silently skipped for the rest of the session.
+    func presentIronwoodAnnouncementIfNeeded(state: inout Root.State, tip: BlockHeight) {
+        guard !state.ironwoodAnnouncementResolved else { return }
+        guard tip > 0, tip >= zcashSDKEnvironment.ironwoodActivationHeight() else { return }
+        guard walletStorage.exportIronwoodAnnouncementFlag() != true else {
+            state.ironwoodAnnouncementResolved = true
+            return
+        }
+        guard state.canPresentIronwoodAnnouncement else { return }
+        state.ironwoodAnnouncementResolved = true
+        // Assigned directly rather than sending `.destination(.updateDestination(...))`: the
+        // two call sites below have several early-return paths of their own, and merging an
+        // effect into all of them would be invasive. The two things `updateDestination` adds
+        // over a direct assignment — the deeplink-warning guard and the deferred
+        // stale-wallet-healed alert hook — are both no-ops here: `canPresentIronwoodAnnouncement`
+        // already requires `destination == .home`, so the deeplink-warning screen can't be in
+        // play, and the heal hook only fires when the destination is moving TO `.home`, not away
+        // from it. There is precedent for a direct assignment in this same file — see
+        // `state.destinationState.destination = .home` in the `.phraseDisplay(.finishedTapped)` /
+        // `.onboarding(.newWalletSuccessfulyCreated)` arm above.
+        state.destinationState.destination = .ironwoodAnnouncement
     }
 }

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -63,6 +63,16 @@ struct Root {
         var exportLogsState: ExportLogs.State
         @Shared(.inMemory(.featureFlags)) var featureFlags: FeatureFlags = .initial
         var homeState: Home.State = .initial
+        /// In-memory, per-session latch set once the Ironwood announcement gate has "resolved"
+        /// this session — either the screen was presented, or the keychain flag was already
+        /// found `true` (acknowledged on a previous session). Its purpose is twofold: it keeps
+        /// the keychain read (`walletStorage.exportIronwoodAnnouncementFlag`) to at most once
+        /// per session on the already-acknowledged path, and it keeps the announcement from
+        /// presenting more than once per session. Deliberately NOT persisted: a user who
+        /// force-quits while the announcement is on screen without tapping Continue (so the
+        /// keychain flag was never written) should see it again next session, not have it
+        /// suppressed by a stale "resolved" flag surviving the relaunch.
+        var ironwoodAnnouncementResolved = false
         /// Single-flight latch for `.initialization(.initializeSDK)`. The SDK reports an
         /// unprepared status until `prepare` fully returns, so `willEnterForeground` (and any
         /// other re-entry into the initialization chain) would otherwise dispatch a second
@@ -112,6 +122,7 @@ struct Root {
 
         var addKeystoneHWWalletCoordFlowState = AddKeystoneHWWalletCoordFlow.State.initial
         var currencyConversionSetupState = CurrencyConversionSetup.State.initial
+        var ironwoodAnnouncementState = IronwoodAnnouncement.State.initial
         var receiveState = Receive.State.initial
         var requestZecCoordFlowState = RequestZecCoordFlow.State.initial
         var scanCoordFlowState = ScanCoordFlow.State.initial
@@ -159,6 +170,31 @@ struct Root {
         /// Gate for applying an automatic server switch.
         var canApplyAutoServerSwitch: Bool {
             bgTask == nil && !isServerSetupVisible && !isSensitiveFlowActive
+        }
+
+        /// Gate for taking the screen over with the one-time Ironwood announcement.
+        ///
+        /// `path == nil` alone already excludes every `Path` case — send, scan, swap, settings
+        /// (and voting, which lives under it since it has no `Path` case of its own),
+        /// transactions, receive, request-ZEC, currency conversion, Tor setup, server switch,
+        /// wallet backup, and the Keystone add flow — so the remaining terms only need to cover
+        /// the presentation states that are NOT `Path` cases: the Keystone signing popover, the
+        /// Server Setup full-screen cover, a background task in flight, and any alert already
+        /// on screen.
+        ///
+        /// Home's own informational sheets (e.g. the smart banner) are deliberately NOT gated
+        /// here: enumerating `Home.State`'s bindings would be brittle, and the cost of losing
+        /// that race is purely cosmetic — the sheet unmounts along with Home and re-presents on
+        /// return, since its binding lives in `homeState`, not here — whereas every term that IS
+        /// gated above protects a place where losing the race could lose in-progress user work.
+        var canPresentIronwoodAnnouncement: Bool {
+            destinationState.destination == .home
+                && path == nil
+                && !signWithKeystoneCoordFlowBinding
+                && !serverSetupViewBinding
+                && bgTask == nil
+                && alert == nil
+                && splashAppeared
         }
 
         init(
@@ -227,6 +263,7 @@ struct Root {
 
         case addKeystoneHWWalletCoordFlow(AddKeystoneHWWalletCoordFlow.Action)
         case currencyConversionSetup(CurrencyConversionSetup.Action)
+        case ironwoodAnnouncement(IronwoodAnnouncement.Action)
         case receive(Receive.Action)
         case requestZecCoordFlow(RequestZecCoordFlow.Action)
         case scanCoordFlow(ScanCoordFlow.Action)
@@ -408,6 +445,10 @@ struct Root {
 
         Scope(state: \.swapAndPayCoordFlowState, action: \.swapAndPayCoordFlow) {
             SwapAndPayCoordFlow()
+        }
+
+        Scope(state: \.ironwoodAnnouncementState, action: \.ironwoodAnnouncement) {
+            IronwoodAnnouncement()
         }
 
         initializationReduce()

--- a/secant/Sources/Features/Root/RootView.swift
+++ b/secant/Sources/Features/Root/RootView.swift
@@ -277,6 +277,17 @@ private extension RootView {
                         store.send(.splashRemovalRequested)
                     }
 
+                case .ironwoodAnnouncement:
+                    IronwoodAnnouncementView(
+                        store: store.scope(
+                            state: \.ironwoodAnnouncementState,
+                            action: \.ironwoodAnnouncement
+                        )
+                    )
+                    .overlayedWithSplash(store.splashAppeared) {
+                        store.send(.splashRemovalRequested)
+                    }
+
                 case .welcome:
                     WelcomeView(
                         store: store.scope(

--- a/secant/Sources/Features/Settings/AdvancedSettingsStore.swift
+++ b/secant/Sources/Features/Settings/AdvancedSettingsStore.swift
@@ -34,17 +34,31 @@ struct AdvancedSettings {
     }
 
     enum Action: Equatable {
+        case debugResetIronwoodAnnouncementTapped
         case operationAccessCheck(State.Operation)
         case operationAccessGranted(State.Operation)
     }
 
     @Dependency(\.localAuthentication) var localAuthentication
+    @Dependency(\.walletStorage) var walletStorage
 
     init() { }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .debugResetIronwoodAnnouncementTapped:
+                // Debug-only row, compiled out of the App Store build (see AdvancedSettingsView).
+                // Clears the Ironwood-announcement keychain flag so the one-time announcement
+                // screen can be retriggered for testing. That flag deliberately survives app
+                // deletion and wallet reset, so without this affordance the screen could never be
+                // seen again on a device that already acknowledged it. This only writes the
+                // keychain — Root separately observes this same action to clear its in-memory
+                // "already shown this session" latch, without which the reset wouldn't take
+                // effect until the next app launch. No biometric gate: this destroys nothing.
+                try? walletStorage.importIronwoodAnnouncementFlag(false)
+                return .none
+
             case .operationAccessCheck(let operation):
                 switch operation {
                 case .chooseServer, .torSetup:

--- a/secant/Sources/Features/Settings/AdvancedSettingsView.swift
+++ b/secant/Sources/Features/Settings/AdvancedSettingsView.swift
@@ -17,7 +17,19 @@ struct AdvancedSettingsView: View {
     init(store: StoreOf<AdvancedSettings>) {
         self.store = store
     }
-    
+
+    // `disconnectHWWallet` below is coded as the last row (divider: false) since nothing follows
+    // it there. On non-App-Store builds the debug-only Ironwood-announcement reset row is appended
+    // after it, so it is no longer last in that case and needs its divider shown to keep the row
+    // separators consistent.
+    private var isDisconnectHWWalletRowDividerVisible: Bool {
+        #if !SECANT_DISTRIB
+        return true
+        #else
+        return false
+        #endif
+    }
+
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
@@ -73,11 +85,25 @@ struct AdvancedSettingsView: View {
                             ActionRow(
                                 icon: Asset.Assets.Icons.hardDrive.image,
                                 title: String(localizable: .disconnectHWWalletCta),
-                                divider: false
+                                divider: isDisconnectHWWalletRowDividerVisible
                             ) {
                                 store.send(.operationAccessCheck(.disconnectHWWallet))
                             }
                         }
+
+                        // Debug-only affordance, never compiled into the App Store build: clears
+                        // the Ironwood-announcement keychain flag so QA/dev builds can retrigger
+                        // the one-time announcement screen. That flag deliberately survives app
+                        // deletion and wallet reset, so without this row it could not be retested.
+                        #if !SECANT_DISTRIB
+                        ActionRow(
+                            icon: Asset.Assets.Icons.refreshSingleCCW.image,
+                            title: String(localizable: .ironwoodAnnouncementDebugReset),
+                            divider: false
+                        ) {
+                            store.send(.debugResetIronwoodAnnouncementTapped)
+                        }
+                        #endif
                     }
                     .listRowInsets(EdgeInsets())
                     .listRowBackground(Asset.Colors.background.color)

--- a/zodlTests/IronwoodAnnouncementTests/IronwoodAnnouncementCopyTests.swift
+++ b/zodlTests/IronwoodAnnouncementTests/IronwoodAnnouncementCopyTests.swift
@@ -1,0 +1,84 @@
+//
+//  IronwoodAnnouncementCopyTests.swift
+//  zodlTests
+//
+//  Covers the nine `ironwoodAnnouncement.*` keys in secant/Resources/Localizable.xcstrings behind
+//  the Ironwood announcement screen's approved final copy. These are cheap guards against classes
+//  of mistake that are invisible in code review: a catalogue entry that silently fails to resolve
+//  at runtime, a significant space quietly trimmed from one of the guide-sentence fragments, and
+//  someone "fixing" the intentionally mixed-case button text back to the app's usual house style.
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+
+@Suite struct IronwoodAnnouncementCopyTests {
+    // MARK: - Fixtures
+
+    /// One resolved catalogue entry paired with a short, human-readable name, so a failing
+    /// assertion in the parameterised test below points at the specific key, not an opaque index.
+    struct Entry: Sendable {
+        let name: String
+        let value: String
+    }
+
+    private static let entries: [Entry] = [
+        Entry(name: "title", value: String(localizable: .ironwoodAnnouncementTitle)),
+        Entry(name: "body1", value: String(localizable: .ironwoodAnnouncementBody1)),
+        Entry(name: "body2", value: String(localizable: .ironwoodAnnouncementBody2)),
+        Entry(name: "body3", value: String(localizable: .ironwoodAnnouncementBody3)),
+        Entry(name: "guidePrefix", value: String(localizable: .ironwoodAnnouncementGuidePrefix)),
+        Entry(name: "guideLink", value: String(localizable: .ironwoodAnnouncementGuideLink)),
+        Entry(name: "guideSuffix", value: String(localizable: .ironwoodAnnouncementGuideSuffix)),
+        Entry(name: "learnMore", value: String(localizable: .ironwoodAnnouncementLearnMore)),
+        Entry(name: "continue", value: String(localizable: .ironwoodAnnouncementContinue))
+    ]
+
+    // MARK: - Case 1: every key resolves to real, non-empty copy
+
+    /// A mistyped or forgotten catalogue entry does not crash and does not fail to compile — it
+    /// silently falls back to rendering the raw key itself (e.g. "ironwoodAnnouncement.title") at
+    /// runtime, which is easy to miss in review and would only surface as a screen full of raw
+    /// keys in a screenshot or on a device. Guard all nine keys at once: each must resolve to
+    /// non-empty text, and none may contain the catalogue namespace, which is what that
+    /// failed-lookup fallback would produce.
+    @Test(arguments: entries)
+    func keyResolvesToNonEmptyTranslatedText(_ entry: Entry) {
+        #expect(!entry.value.isEmpty, "ironwoodAnnouncement.\(entry.name) resolved to an empty string")
+        #expect(
+            !entry.value.contains("ironwoodAnnouncement"),
+            "ironwoodAnnouncement.\(entry.name) resolved to '\(entry.value)', which looks like a failed lookup"
+        )
+    }
+
+    // MARK: - Case 2: the guide sentence concatenates correctly
+
+    /// `guidePrefix`, `guideLink` and `guideSuffix` are concatenated directly with no separator
+    /// added at the call site, so the significant trailing space on the prefix and leading space
+    /// on the suffix live only inside the string catalogue. Losing either — e.g. to an editor
+    /// silently trimming trailing whitespace — glues words together ("waitour guide" /
+    /// "guideexplains") without breaking compilation or showing up in a code-review diff context.
+    @Test func guideSentenceConcatenatesToApprovedCopy() {
+        let prefix = String(localizable: .ironwoodAnnouncementGuidePrefix)
+        let link = String(localizable: .ironwoodAnnouncementGuideLink)
+        let suffix = String(localizable: .ironwoodAnnouncementGuideSuffix)
+
+        #expect(prefix + link + suffix == "If you'd rather not wait, our guide explains how to move funds manually.")
+
+        // If the assertion above ever fails, these two point straight at which fragment lost its space.
+        #expect(prefix.hasSuffix(" "), "guidePrefix must keep its trailing space, or the sentence reads 'waitour guide'")
+        #expect(suffix.hasPrefix(" "), "guideSuffix must keep its leading space, or the sentence reads 'guideexplains'")
+    }
+
+    // MARK: - Case 3: the primary button's intentional mixed-case exception
+
+    /// Elsewhere in the app the product name is always written all-uppercase "ZODL" (see this
+    /// repo's CLAUDE.md, "App name"). This button is an explicit, approved exception to that house
+    /// rule per the final design and must read "Zodl", mixed case. If this test ever fails because
+    /// someone "corrected" the catalogue value to "ZODL", the fix is to revert that change — this
+    /// test is the guard, not the bug.
+    @Test func continueButtonReadsGoToZodlWithApprovedMixedCase() {
+        #expect(String(localizable: .ironwoodAnnouncementContinue) == "Go to Zodl")
+    }
+}

--- a/zodlTests/IronwoodAnnouncementTests/IronwoodAnnouncementCopyTests.swift
+++ b/zodlTests/IronwoodAnnouncementTests/IronwoodAnnouncementCopyTests.swift
@@ -71,6 +71,31 @@ import Foundation
         #expect(suffix.hasPrefix(" "), "guideSuffix must keep its leading space, or the sentence reads 'guideexplains'")
     }
 
+    // MARK: - Case 2b: the same guide sentence, in every shipped language
+
+    /// The significant-space trap above is not an English-only risk — it is *more* likely in a
+    /// translation, where the fragments are handed over individually and a trailing space looks
+    /// like an accident. This walks every localisation the app ships and asserts the two outer
+    /// fragments still carry their spaces, so a future language cannot land the "waitour guide"
+    /// bug unnoticed. Reads the compiled `.lproj` catalogues directly, since `String(localizable:)`
+    /// only ever resolves the test process's own locale.
+    @Test func guideFragmentsKeepTheirSignificantSpacesInEveryLanguage() throws {
+        let localizations = Bundle.main.localizations.filter { $0 != "Base" }
+        #expect(localizations.contains("es"), "expected the Spanish catalogue to ship")
+
+        for code in localizations {
+            let bundle = try #require(
+                Bundle.main.path(forResource: code, ofType: "lproj").flatMap { Bundle(path: $0) },
+                "no compiled catalogue for \(code)"
+            )
+            let prefix = bundle.localizedString(forKey: "ironwoodAnnouncement.guidePrefix", value: nil, table: "Localizable")
+            let suffix = bundle.localizedString(forKey: "ironwoodAnnouncement.guideSuffix", value: nil, table: "Localizable")
+
+            #expect(prefix.hasSuffix(" "), "[\(code)] guidePrefix lost its trailing space: \(prefix)")
+            #expect(suffix.hasPrefix(" "), "[\(code)] guideSuffix lost its leading space: \(suffix)")
+        }
+    }
+
     // MARK: - Case 3: the primary button's intentional mixed-case exception
 
     /// Elsewhere in the app the product name is always written all-uppercase "ZODL" (see this

--- a/zodlTests/IronwoodAnnouncementTests/IronwoodAnnouncementTests.swift
+++ b/zodlTests/IronwoodAnnouncementTests/IronwoodAnnouncementTests.swift
@@ -1,0 +1,62 @@
+//
+//  IronwoodAnnouncementTests.swift
+//  zodlTests
+//
+//  Created by Michal Fousek on 25.07.2026.
+//
+//  Covers Features/IronwoodAnnouncement/IronwoodAnnouncementStore.swift: showing the
+//  in-app browser for "Learn more", and that "Continue" persists the acknowledgement
+//  flag exactly once and never traps the user even if the keychain write fails.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite struct IronwoodAnnouncementTests {
+    private struct KeychainWriteFailure: Error { }
+
+    @MainActor @Test func learnMoreTappedShowsInAppBrowser() async {
+        let store = TestStore(initialState: IronwoodAnnouncement.State()) {
+            IronwoodAnnouncement()
+        }
+
+        await store.send(.learnMoreTapped) {
+            $0.isInAppBrowserOn = true
+        }
+
+        await store.finish()
+    }
+
+    @MainActor @Test func continueTappedPersistsAcknowledgementFlagExactlyOnce() async {
+        let calls = LockIsolated<[Bool]>([])
+
+        let store = TestStore(initialState: IronwoodAnnouncement.State()) {
+            IronwoodAnnouncement()
+        } withDependencies: {
+            $0.walletStorage.importIronwoodAnnouncementFlag = { flag in calls.withValue { $0.append(flag) } }
+        }
+
+        await store.send(.continueTapped)
+
+        #expect(calls.value == [true])
+
+        await store.finish()
+    }
+
+    /// A keychain write failure must not trap the user on this one-time announcement screen:
+    /// `continueTapped` swallows the error with `try?` instead of surfacing or retrying it, so
+    /// the action still completes cleanly with no state change and no effect.
+    @MainActor @Test func continueTappedSwallowsKeychainWriteFailure() async {
+        let store = TestStore(initialState: IronwoodAnnouncement.State()) {
+            IronwoodAnnouncement()
+        } withDependencies: {
+            $0.walletStorage.importIronwoodAnnouncementFlag = { _ in throw KeychainWriteFailure() }
+        }
+
+        await store.send(.continueTapped)
+
+        await store.finish()
+    }
+}

--- a/zodlTests/IronwoodAnnouncementTests/IronwoodAnnouncementTests.swift
+++ b/zodlTests/IronwoodAnnouncementTests/IronwoodAnnouncementTests.swift
@@ -29,6 +29,40 @@ import ComposableArchitecture
         await store.finish()
     }
 
+    @MainActor @Test func guideTappedShowsInAppBrowser() async {
+        let store = TestStore(initialState: IronwoodAnnouncement.State()) {
+            IronwoodAnnouncement()
+        }
+
+        await store.send(.guideTapped) {
+            $0.isInAppBrowserOn = true
+        }
+
+        await store.finish()
+    }
+
+    /// Opening the guide is NOT acknowledgement of the announcement: unlike `continueTapped`,
+    /// `guideTapped` must never write the keychain flag. This records every call to the
+    /// dependency and asserts the list stays empty, so a regression that starts treating the
+    /// guide link as acknowledgement would fail here.
+    @MainActor @Test func guideTappedIsNotAcknowledgement() async {
+        let calls = LockIsolated<[Bool]>([])
+
+        let store = TestStore(initialState: IronwoodAnnouncement.State()) {
+            IronwoodAnnouncement()
+        } withDependencies: {
+            $0.walletStorage.importIronwoodAnnouncementFlag = { flag in calls.withValue { $0.append(flag) } }
+        }
+
+        await store.send(.guideTapped) {
+            $0.isInAppBrowserOn = true
+        }
+
+        #expect(calls.value.isEmpty)
+
+        await store.finish()
+    }
+
     @MainActor @Test func continueTappedPersistsAcknowledgementFlagExactlyOnce() async {
         let calls = LockIsolated<[Bool]>([])
 

--- a/zodlTests/RestoreWalletTests/RestoreWalletAnnouncementFlagTests.swift
+++ b/zodlTests/RestoreWalletTests/RestoreWalletAnnouncementFlagTests.swift
@@ -2,12 +2,14 @@
 //  RestoreWalletAnnouncementFlagTests.swift
 //  zodlTests
 //
-//  Ironwood announcement, workstream 3 — Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
-//  marks the Ironwood-announcement keychain flag acknowledged up front when a wallet is freshly
-//  created (nothing to announce on a brand-new wallet, and creation is immediately followed by the
-//  recovery-phrase backup flow — the worst moment to interrupt with the announcement screen), but
-//  deliberately leaves the flag untouched when a wallet is restored (a returning user may have
-//  missed the announcement, so the one-time screen must remain eligible to show for them).
+//  Ironwood announcement — neither wallet-creation nor wallet-restore
+//  (Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift) may touch the
+//  Ironwood-announcement keychain flag. Ironwood is news about the network, not about a
+//  particular wallet, so both paths must leave the flag untouched and let Root's normal
+//  activation gate decide. An earlier revision pre-acknowledged the flag on creation; that made
+//  "fresh install, create a wallet" the one path on which the screen could never appear, which
+//  is also the most obvious way to test the feature by hand. These tests are what stop it
+//  coming back.
 //
 //  RestoreWalletCoordFlow.State is not Equatable (it holds a non-Equatable StackState, and its
 //  Action type — referenced via Action-typed AlertState — isn't Equatable either), so TestStore
@@ -25,13 +27,17 @@ import ComposableArchitecture
 @testable import zodl_internal
 
 @Suite(.serialized) @MainActor struct RestoreWalletAnnouncementFlagTests {
-    @Test func createNewWalletRequestedWritesIronwoodAnnouncementFlagTrueExactlyOnce() async {
+    @Test func createNewWalletRequestedNeverWritesIronwoodAnnouncementFlag() async {
         let calls = LockIsolated<[Bool]>([])
         let store = makeStore(initialState: RestoreWalletCoordFlow.State(), flagCalls: calls)
 
         store.send(.createNewWalletRequested)
 
-        #expect(calls.value == [true])
+        // Creating a wallet must leave the flag completely untouched — not even written `true`.
+        // Writing it here would permanently suppress the announcement for every user who starts
+        // with a fresh wallet, and would make the feature untestable by hand without the debug
+        // reset row. Asserting an empty call list is what catches a reintroduction.
+        #expect(calls.value.isEmpty)
     }
 
     @Test func resolveRestoreNeverWritesIronwoodAnnouncementFlag() async {
@@ -42,11 +48,8 @@ import ComposableArchitecture
 
         store.send(.resolveRestore)
 
-        // Restoring a seed must leave the Ironwood-announcement flag completely untouched — not
-        // even written `false` — so the one-time announcement screen remains eligible to show for
-        // this returning user. Asserting an empty call list (rather than inspecting the argument
-        // of some expected call) is what would catch someone "fixing" this asymmetry later by
-        // adding a call here to mirror .createNewWalletRequested.
+        // Restoring a seed likewise leaves the flag untouched, so the one-time announcement
+        // screen remains eligible to show for a returning user.
         #expect(calls.value.isEmpty)
     }
 

--- a/zodlTests/RestoreWalletTests/RestoreWalletAnnouncementFlagTests.swift
+++ b/zodlTests/RestoreWalletTests/RestoreWalletAnnouncementFlagTests.swift
@@ -1,0 +1,69 @@
+//
+//  RestoreWalletAnnouncementFlagTests.swift
+//  zodlTests
+//
+//  Ironwood announcement, workstream 3 — Features/CoordFlows/RestoreWalletCoordFlowCoordinator.swift
+//  marks the Ironwood-announcement keychain flag acknowledged up front when a wallet is freshly
+//  created (nothing to announce on a brand-new wallet, and creation is immediately followed by the
+//  recovery-phrase backup flow — the worst moment to interrupt with the announcement screen), but
+//  deliberately leaves the flag untouched when a wallet is restored (a returning user may have
+//  missed the announcement, so the one-time screen must remain eligible to show for them).
+//
+//  RestoreWalletCoordFlow.State is not Equatable (it holds a non-Equatable StackState, and its
+//  Action type — referenced via Action-typed AlertState — isn't Equatable either), so TestStore
+//  will not compile against it. These tests instead drive a plain Store and read/record state
+//  directly after sending actions — the same approach used by AddKeystoneHWWalletCoordFlowTests
+//  (see its header comment) and ScanCoordFlowZip321Tests. Initial state is set up before Store
+//  creation, never via store.state mutation (get-only on a plain Store).
+//
+//  Both cases under test perform their walletStorage calls synchronously inside the reducer body,
+//  before any returned effect runs, so no polling/waiting is needed after `send`.
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct RestoreWalletAnnouncementFlagTests {
+    @Test func createNewWalletRequestedWritesIronwoodAnnouncementFlagTrueExactlyOnce() async {
+        let calls = LockIsolated<[Bool]>([])
+        let store = makeStore(initialState: RestoreWalletCoordFlow.State(), flagCalls: calls)
+
+        store.send(.createNewWalletRequested)
+
+        #expect(calls.value == [true])
+    }
+
+    @Test func resolveRestoreNeverWritesIronwoodAnnouncementFlag() async {
+        var initialState = RestoreWalletCoordFlow.State()
+        initialState.birthday = 1_000_000
+        let calls = LockIsolated<[Bool]>([])
+        let store = makeStore(initialState: initialState, flagCalls: calls)
+
+        store.send(.resolveRestore)
+
+        // Restoring a seed must leave the Ironwood-announcement flag completely untouched — not
+        // even written `false` — so the one-time announcement screen remains eligible to show for
+        // this returning user. Asserting an empty call list (rather than inspecting the argument
+        // of some expected call) is what would catch someone "fixing" this asymmetry later by
+        // adding a call here to mirror .createNewWalletRequested.
+        #expect(calls.value.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore(
+        initialState: RestoreWalletCoordFlow.State,
+        flagCalls: LockIsolated<[Bool]>
+    ) -> StoreOf<RestoreWalletCoordFlow> {
+        Store(initialState: initialState) {
+            RestoreWalletCoordFlow()
+        } withDependencies: {
+            $0.mnemonic = .noOp
+            $0.walletStorage = .noOp
+            $0.walletStorage.importIronwoodAnnouncementFlag = { value in
+                flagCalls.withValue { $0.append(value) }
+            }
+        }
+    }
+}

--- a/zodlTests/SettingsTests/AdvancedSettingsDebugResetTests.swift
+++ b/zodlTests/SettingsTests/AdvancedSettingsDebugResetTests.swift
@@ -1,0 +1,39 @@
+//
+//  AdvancedSettingsDebugResetTests.swift
+//  zodlTests
+//
+//  Ironwood announcement, workstream 3 — the debug-only Advanced Settings row
+//  (Features/Settings/AdvancedSettingsStore.swift) that lets non-App-Store builds clear the
+//  Ironwood-announcement keychain flag for retesting. Unlike the other Advanced Settings rows it
+//  must NOT route through the local-authentication gate (`operationAccessCheck`), since it
+//  destroys nothing. Complements AdvancedSettingsTests / AdvancedSettingsAuthGateTests.
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite(.serialized) struct AdvancedSettingsDebugResetTests {
+    @MainActor @Test func debugResetWritesFlagFalseExactlyOnceWithoutAuthenticationOrFurtherActions() async {
+        let calls = LockIsolated<[Bool]>([])
+        let store = TestStore(initialState: AdvancedSettings.State()) {
+            AdvancedSettings()
+        } withDependencies: {
+            $0.walletStorage.importIronwoodAnnouncementFlag = { value in
+                calls.withValue { $0.append(value) }
+            }
+            // localAuthentication is intentionally left unimplemented: this debug-only reset must
+            // never route through the biometric gate the sensitive production rows use. If it
+            // accidentally did, the unimplemented closure would fail this test.
+        }
+
+        await store.send(.debugResetIronwoodAnnouncementTapped)
+
+        // Exactly one call, writing `false` (the gate only treats exactly `true` as "already
+        // shown", so `false` is equivalent to clearing the flag).
+        #expect(calls.value == [false])
+
+        // No further action was produced (exhaustive TestStore would fail on an unreceived one).
+        await store.finish()
+    }
+}

--- a/zodlTests/UtilTests/RootIronwoodAnnouncementGateTests.swift
+++ b/zodlTests/UtilTests/RootIronwoodAnnouncementGateTests.swift
@@ -1,0 +1,456 @@
+//
+//  RootIronwoodAnnouncementGateTests.swift
+//  zodlTests
+//
+//  Covers the Root-reducer wiring for the one-time Ironwood announcement screen: the
+//  presentation predicate (`Root.presentIronwoodAnnouncementIfNeeded`), its two call sites
+//  (`.synchronizerStateChanged` and `.initialization(.appDelegate(.willEnterForeground))`), the
+//  `.ironwoodAnnouncement(.continueTapped)` navigation back to Home, and the debug reset arm
+//  (Features/Root/RootStore.swift, RootInitialization.swift, RootCoordinator.swift).
+//
+//  `extension Root.State: @retroactive Equatable` already exists, module-wide, at
+//  RootInitializeSDKHealTests.swift. Declaring a second one anywhere in this target is a
+//  duplicate-conformance compile error, so this file does NOT use `TestStore` for `Root`.
+//  Instead it drives a plain `Store` and reads state directly after sending actions — the same
+//  approach used by AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift (see its
+//  header comment) and ScanTests/ScanCoordFlowZip321Tests.swift, and already applied to a plain
+//  `Root` store specifically by FlexaTests/FlexaSecurityTests.swift.
+//
+
+@preconcurrency import Combine
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// Serialized: drives a plain `Root` store touching process-global `@Shared(.inMemory(...))`
+// state (`selectedWalletAccount`, `featureFlags`, ...). Each test additionally scopes a fresh
+// `InMemoryStorage()` via `withDependencies` so parallel suites can't clobber that shared state
+// either — the same belt-and-suspenders approach used by FlexaSecurityTests/ScanCoordFlowZip321Tests.
+@Suite(.serialized) @MainActor struct RootIronwoodAnnouncementGateTests {
+    // MARK: - Fixtures
+
+    /// A `Root.State` sitting on `.home` with every safety-gate term satisfied, so
+    /// `canPresentIronwoodAnnouncement` reads `true` unless a test deliberately flips one term.
+    private func makeState() -> Root.State {
+        var state = Root.State.initial
+        state.destinationState.destination = .home
+        state.splashAppeared = true
+        return state
+    }
+
+    private func fixtureSyncState(tip: BlockHeight) -> RedactableSynchronizerState {
+        var syncState = SynchronizerState.zero
+        syncState.syncStatus = .upToDate
+        syncState.latestBlockHeight = tip
+        return syncState.redacted
+    }
+
+    /// Builds a `Root` store wired for driving the announcement gate through
+    /// `.synchronizerStateChanged` / `.ironwoodAnnouncement` / the debug reset action. Only the
+    /// two dependencies the gate itself reads (`zcashSDKEnvironment.ironwoodActivationHeight`,
+    /// `walletStorage.exportIronwoodAnnouncementFlag`) are stubbed to fixture values; a
+    /// `.synchronizerStateChanged` tick with no selected account (the default, `Root.State`'s
+    /// `@Shared` `selectedWalletAccount`) short-circuits everything else in that case body as a
+    /// pure, side-effect-free early return, so nothing further needs stubbing.
+    private func makeGateStore(
+        state: Root.State? = nil,
+        activationHeight: BlockHeight,
+        announcementFlag: Bool?,
+        exportCallCount: LockIsolated<Int>? = nil
+    ) -> StoreOf<Root> {
+        Store(initialState: state ?? makeState()) {
+            Root()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { activationHeight }
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportIronwoodAnnouncementFlag = {
+                exportCallCount?.withValue { $0 += 1 }
+                return announcementFlag
+            }
+        }
+    }
+
+    // MARK: - Case 1: tip boundary, flag absent, gate open
+
+    @Test func tipBoundaryWithFlagAbsentPresentsAtAndAboveActivation() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            // `@MainActor` is required: `withDependencies`' `operation:` closure is nonisolated,
+            // so a local function declared inside it does not inherit the suite's isolation and
+            // could not otherwise call the main-actor-isolated fixtures below.
+            @MainActor func presented(forTip tip: BlockHeight) -> Bool {
+                let store = makeGateStore(activationHeight: activation, announcementFlag: nil)
+                store.send(.synchronizerStateChanged(fixtureSyncState(tip: tip)))
+                return store.state.destinationState.destination == .ironwoodAnnouncement
+            }
+
+            #expect(!presented(forTip: 0), "tip 0 is the in-memory-only sentinel and must never present")
+            #expect(!presented(forTip: activation - 1), "below activation must not present")
+            #expect(presented(forTip: activation), "exactly at activation must present")
+            #expect(presented(forTip: activation + 1), "above activation must present")
+        }
+    }
+
+    // MARK: - Case 2: flag `true` is a latch; keychain read at most once per session
+
+    @Test func acknowledgedFlagNeverPresentsAndReadsKeychainAtMostOnce() async throws {
+        let activation: BlockHeight = 1_000_000
+        let exportCalls = LockIsolated<Int>(0)
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeGateStore(activationHeight: activation, announcementFlag: true, exportCallCount: exportCalls)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation + 1)))
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation + 2)))
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+
+            #expect(exportCalls.value == 1, "the keychain must be read at most once per session once acknowledged")
+        }
+    }
+
+    // MARK: - Case 3: flag `false` is NOT acknowledged
+
+    @Test func unacknowledgedFalseFlagPresents() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeGateStore(activationHeight: activation, announcementFlag: false)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+
+            #expect(store.state.destinationState.destination == .ironwoodAnnouncement, "only `true` counts as acknowledged")
+        }
+    }
+
+    // MARK: - Case 4: presents exactly once across repeated above-activation ticks
+
+    @Test func twoConsecutiveAboveActivationTicksPresentExactlyOnce() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeGateStore(activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+            #expect(store.state.destinationState.destination == .ironwoodAnnouncement)
+            #expect(store.state.destinationState.previousDestination == .home)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation + 5)))
+            #expect(store.state.destinationState.destination == .ironwoodAnnouncement)
+            // `previousDestination` only moves when the destination-assignment line actually
+            // runs. If the second tick presented again, it would flip to `.ironwoodAnnouncement`
+            // (what `internalDestination` held going into that erroneous second assignment)
+            // instead of staying `.home` — proving the second tick was a no-op.
+            #expect(store.state.destinationState.previousDestination == .home)
+        }
+    }
+
+    // MARK: - Case 5: runs above the `selectedWalletAccount` early return
+
+    @Test func presentsWithNoSelectedWalletAccount() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.$selectedWalletAccount.withLock { $0 = nil }
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+
+            #expect(store.state.destinationState.destination == .ironwoodAnnouncement)
+        }
+    }
+
+    // MARK: - Case 6: safety gate, one term at a time
+    //
+    // `bgTask == nil` is deliberately NOT covered below: `BGProcessingTask` has no public
+    // initializer, so it cannot be constructed in tests. `RootAutoServerGatingTests`
+    // (AutoServerSelectionClientTests.swift) documents the identical gap for the sibling
+    // `canApplyAutoServerSwitch` gate, which has the same `bgTask == nil` term.
+
+    @Test func safetyGateBlocksWhilePathIsActive() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.path = .receive
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+        }
+    }
+
+    @Test func safetyGateBlocksWhenDestinationIsNotHome() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.destinationState.destination = .onboarding
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+        }
+    }
+
+    @Test func safetyGateBlocksWhileSigningWithKeystone() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.signWithKeystoneCoordFlowBinding = true
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+        }
+    }
+
+    @Test func safetyGateBlocksWhileServerSetupIsVisible() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.serverSetupViewBinding = true
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+        }
+    }
+
+    @Test func safetyGateBlocksWhileAnAlertIsPresented() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.alert = AlertState.cantLoadSeedPhrase()
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+        }
+    }
+
+    @Test func safetyGateBlocksBeforeSplashHasAppeared() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.splashAppeared = false
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement)
+        }
+    }
+
+    // MARK: - Case 7: a blocked attempt does not consume the latch
+
+    @Test func blockedAttemptRetriesOnceTheGateReopens() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.path = .receive
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+            #expect(store.state.destinationState.destination != .ironwoodAnnouncement, "blocked while `path` is active")
+
+            store.send(.receive(.backToHomeTapped))
+            #expect(store.state.path == nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation + 1)))
+            #expect(
+                store.state.destinationState.destination == .ironwoodAnnouncement,
+                "the earlier blocked tick must not have consumed the latch"
+            )
+        }
+    }
+
+    // MARK: - Case 8: foreground call site
+
+    @Test func foregroundCallSitePresentsAnnouncementForAboveActivationTip() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            // Keeps the foreground biometric re-auth block (which may clear `splashAppeared`)
+            // from fighting this test's own control of `splashAppeared`.
+            state.$featureFlags.withLock { $0 = FeatureFlags(appLaunchBiometric: false) }
+
+            // Built as a `let` via an immediately-invoked closure: the `@Sendable` dependency
+            // closure below captures it, and a captured `var` is not allowed there.
+            let latest: SynchronizerState = {
+                var syncState = SynchronizerState.zero
+                syncState.syncStatus = .upToDate
+                syncState.latestBlockHeight = activation
+                return syncState
+            }()
+
+            let store = Store(initialState: state) {
+                Root()
+            } withDependencies: {
+                $0.mainQueue = .immediate
+                $0.zcashSDKEnvironment.ironwoodActivationHeight = { activation }
+                $0.walletStorage = .noOp
+                $0.walletStorage.exportIronwoodAnnouncementFlag = { nil }
+                $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+                // `latestState` is a `let` on `SDKSynchronizerClient`, so it cannot be assigned
+                // after the fact — the `.mocked(...)` factory is the only way to inject a tip.
+                // Everything else is pinned inert (empty state stream, no transactions) so this
+                // case exercises only the announcement gate.
+                //
+                // `isPrepared: true` (from `.upToDate` above) routes `.willEnterForeground` to
+                // `.retryStart`, which unconditionally tries `sdkSynchronizer.start` in a `.run`
+                // effect after this case returns. Throwing routes that deferred effect to the
+                // harmless `.synchronizerStartFailed -> .none` dead end instead of the full
+                // sync-start cascade. Either way this test's assertion is unaffected: it reads
+                // state synchronously, before that effect's `Task` ever gets a chance to run.
+                $0.sdkSynchronizer = .mocked(
+                    stateStream: { Empty().eraseToAnyPublisher() },
+                    latestState: { latest },
+                    start: { _ in throw GateTestStubError() },
+                    getAllTransactions: { _ in [] }
+                )
+            }
+
+            store.send(.initialization(.appDelegate(.willEnterForeground)))
+
+            #expect(store.state.destinationState.destination == .ironwoodAnnouncement)
+        }
+    }
+
+    // MARK: - Case 9: `.continueTapped` navigates Root to Home
+
+    @Test func continueTappedNavigatesRootToHome() async throws {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.destinationState.destination = .ironwoodAnnouncement
+            let store = makeGateStore(state: state, activationHeight: 1, announcementFlag: nil)
+
+            store.send(.ironwoodAnnouncement(.continueTapped))
+
+            #expect(store.state.destinationState.destination == .home)
+        }
+    }
+
+    // MARK: - Case 10: debug reset clears the session latch
+
+    @Test func debugResetClearsTheSessionLatchSoTheGateCanReopen() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.ironwoodAnnouncementResolved = true
+            state.settingsState.path.append(.advancedSettings(AdvancedSettings.State.initial))
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: false)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+            #expect(
+                store.state.destinationState.destination != .ironwoodAnnouncement,
+                "the session latch must block presentation before the debug reset"
+            )
+
+            let pathId = try #require(store.state.settingsState.path.ids.first)
+            let debugResetAction = Root.Action.settings(
+                .path(.element(id: pathId, action: .advancedSettings(.debugResetIronwoodAnnouncementTapped)))
+            )
+            store.send(debugResetAction)
+            #expect(!store.state.ironwoodAnnouncementResolved)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation + 1)))
+            #expect(
+                store.state.destinationState.destination == .ironwoodAnnouncement,
+                "clearing the latch must let the gate re-evaluate and present"
+            )
+        }
+    }
+
+    // MARK: - Case 11: stale-wallet-healed ordering
+
+    @Test func staleWalletHealedNoticeWaitsBehindTheAnnouncementThenDeliversOnContinue() async throws {
+        let activation: BlockHeight = 1_000_000
+
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = makeState()
+            state.isStaleWalletHealedAlertPending = true
+            let store = makeGateStore(state: state, activationHeight: activation, announcementFlag: nil)
+
+            store.send(.synchronizerStateChanged(fixtureSyncState(tip: activation)))
+            #expect(store.state.destinationState.destination == .ironwoodAnnouncement)
+            #expect(store.state.alert == nil, "the heal notice must not appear over the announcement")
+
+            store.send(.ironwoodAnnouncement(.continueTapped))
+            #expect(store.state.destinationState.destination == .home)
+
+            await waitForGateStore { store.state.alert != nil }
+
+            #expect(store.state.alert?.title == AlertState.staleWalletDatabaseHealed().title)
+            #expect(!store.state.isStaleWalletHealedAlertPending)
+        }
+    }
+}
+
+private struct GateTestStubError: Error { }
+
+@MainActor
+private func waitForGateStore(
+    timeoutNanoseconds: UInt64 = 5_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for Root store state", sourceLocation: sourceLocation)
+}

--- a/zodlTests/UtilTests/SecItemClientTests.swift
+++ b/zodlTests/UtilTests/SecItemClientTests.swift
@@ -8,6 +8,7 @@
 import Testing
 import Foundation
 import Security
+import os
 @testable import zodl_internal
 
 extension WalletStorage.KeychainError {
@@ -131,5 +132,88 @@ extension WalletStorage.KeychainError {
         #expect(throws: (any Error).self) {
             try walletStorage.deleteData(forKey: "")
         }
+    }
+
+    // MARK: - Ironwood announcement flag
+
+    @Test func importIronwoodAnnouncementFlag_DuplicateAddResultsInUpdate() throws {
+        let updateWasCalled = OSAllocatedUnfairLock<Bool>(initialState: false)
+
+        let secItem = SecItemClient(
+            copyMatching: { _, _ in errSecSuccess },
+            add: { _, _ in errSecDuplicateItem },
+            update: { _, _ in
+                updateWasCalled.withLock { $0 = true }
+                return errSecSuccess
+            },
+            delete: { _ in errSecSuccess }
+        )
+
+        let walletStorage = WalletStorage(secItem: secItem)
+
+        try walletStorage.importIronwoodAnnouncementFlag(true)
+
+        #expect(updateWasCalled.withLock { $0 }, "A duplicate `add` must be followed by an `update` call.")
+    }
+
+    @Test func exportIronwoodAnnouncementFlag_ReturnsNilWhenItemNotFound() {
+        let secItem = SecItemClient(
+            copyMatching: { _, _ in errSecItemNotFound },
+            add: { _, _ in errSecSuccess },
+            update: { _, _ in errSecSuccess },
+            delete: { _ in errSecSuccess }
+        )
+
+        let walletStorage = WalletStorage(secItem: secItem)
+
+        #expect(walletStorage.exportIronwoodAnnouncementFlag() == nil)
+    }
+
+    @Test func exportIronwoodAnnouncementFlag_ReturnsTrueWhenStoredDataDecodesToTrue() throws {
+        let storedData = try JSONEncoder().encode(true)
+
+        let secItem = SecItemClient(
+            copyMatching: { _, result in
+                result = storedData as CFTypeRef
+                return errSecSuccess
+            },
+            add: { _, _ in errSecSuccess },
+            update: { _, _ in errSecSuccess },
+            delete: { _ in errSecSuccess }
+        )
+
+        let walletStorage = WalletStorage(secItem: secItem)
+
+        #expect(walletStorage.exportIronwoodAnnouncementFlag() == true)
+    }
+
+    /// The Ironwood announcement is shown once per device and must survive a wallet reset (and an app
+    /// reinstall), so `resetZashi` must never delete `zcashStoredIronwoodAnnouncementFlag`. This is
+    /// deliberate, not an oversight -- see the comment on `WalletStorage.Constants.zcashStoredIronwoodAnnouncementFlag`.
+    @Test func resetZashi_DoesNotDeleteIronwoodAnnouncementFlag_BecauseItMustSurviveAWalletReset() throws {
+        let deletedServices = OSAllocatedUnfairLock<[String]>(initialState: [])
+
+        let secItem = SecItemClient(
+            copyMatching: { _, _ in errSecSuccess },
+            add: { _, _ in errSecSuccess },
+            update: { _, _ in errSecSuccess },
+            delete: { query in
+                if let attributes = query as? [String: Any], let service = attributes[kSecAttrService as String] as? String {
+                    deletedServices.withLock { $0.append(service) }
+                }
+                return errSecSuccess
+            }
+        )
+
+        let walletStorage = WalletStorage(secItem: secItem)
+
+        try walletStorage.resetZashi()
+
+        let services = deletedServices.withLock { $0 }
+        #expect(!services.isEmpty, "Sanity check: resetZashi should have issued some deletes.")
+        #expect(
+            !services.contains(WalletStorage.Constants.zcashStoredIronwoodAnnouncementFlag),
+            "resetZashi must not delete the Ironwood announcement flag -- it survives a wallet reset by design."
+        )
     }
 }

--- a/zodlTests/UtilTests/ZcashSDKEnvironmentActivationHeightTests.swift
+++ b/zodlTests/UtilTests/ZcashSDKEnvironmentActivationHeightTests.swift
@@ -1,0 +1,40 @@
+//
+//  ZcashSDKEnvironmentActivationHeightTests.swift
+//  zodlTests
+//
+//  Covers `ZcashSDKEnvironment.ironwoodActivationHeight` — the NU6.3 ("Ironwood") activation height
+//  per network (Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironment{Interface,LiveKey,TestKey}.swift).
+//
+
+import Testing
+@preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite struct ZcashSDKEnvironmentActivationHeightTests {
+    @Test func mainnetReturnsHandMirroredActivationHeight() {
+        let environment = ZcashSDKEnvironment.live(network: ZcashNetworkBuilder.network(for: .mainnet))
+        #expect(environment.ironwoodActivationHeight() == 3_428_143)
+    }
+
+    @Test func testnetReturnsHandMirroredActivationHeight() {
+        let environment = ZcashSDKEnvironment.live(network: ZcashNetworkBuilder.network(for: .testnet))
+        #expect(environment.ironwoodActivationHeight() == 4_134_000)
+    }
+
+    @Test func regtestWithExplicitNU63ReturnsConfiguredHeight() {
+        let network = ZcashNetworkBuilder.regtest(activationHeights: NetworkActivationHeights(nu6_3: 1_234))
+        let environment = ZcashSDKEnvironment.live(network: network)
+        #expect(environment.ironwoodActivationHeight() == 1_234)
+    }
+
+    @Test func regtestWithoutNU63ReturnsBlockHeightMax() {
+        let network = ZcashNetworkBuilder.regtest(activationHeights: NetworkActivationHeights())
+        let environment = ZcashSDKEnvironment.live(network: network)
+        #expect(environment.ironwoodActivationHeight() == BlockHeight.max)
+    }
+
+    @Test func dependencyClientMemberwiseDefaultIsBlockHeightMax() {
+        let environment = ZcashSDKEnvironment()
+        #expect(environment.ironwoodActivationHeight() == BlockHeight.max)
+    }
+}


### PR DESCRIPTION
Implements [MOB-1533](https://linear.app/zodl/issue/MOB-1533/implement-ironwood-in-app-announcement) — a one-time full-screen screen introducing the Ironwood upgrade, built to the [Ironwood Announcement Explainer](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=4711-8521) design.

## Against the ticket's acceptance criteria

| Criterion | Status |
|---|---|
| Sees the screen once, before wallet home | ⚠️ once — but a few seconds in, not before Home (see below) |
| Zero balance never sees it | ❌ **not implemented** (see below) |
| Force-quit before dismissal re-shows it; after dismissal never returns, incl. later updates | ✅ |
| "our guide" opens the guide in an in-app web view | ✅ |
| "Go to Zodl" dismisses to wallet home | ✅ |
| No back button or title in the top bar | ✅ |
| Copy renders without clipping on the smallest supported device at default text size | ✅ verified on an iPhone SE |
| Scroll container ("consider implementing") | ✅ |
| Spanish copy | ✅ from the ticket |

### Two gaps worth a decision before merge

**1. The balance gate is not implemented.** The ticket says the screen is only for users with a non-zero balance to migrate; zero balance should never see it. Right now every user sees it once Ironwood is active. Wiring it in is small — the predicate is evaluated on every sync tick, so a balance term naturally starts false while syncing and flips true when balances land, which is exactly what the ticket's "wallet still syncing so balance reads zero — wait for sync!" edge case asks for. What needs deciding is **which balance**: "to migrate" most precisely means a non-zero *Orchard* balance, since a user holding only transparent or only Ironwood funds has nothing to migrate. Happy to add it on a word.

**2. Trigger timing.** The ticket says "first launch after updating to 3.8.0, before wallet home". This implementation instead gates on **Ironwood actually being active on chain** (tip ≥ NU6.3 activation height) and presents a few seconds into the session, over Home.

Both differences are forced by the same fact: the chain tip is in-memory only and reads `0` until the first successful server round-trip, well after the launch path runs — so neither "is Ironwood live?" nor "does this user have a balance?" can be answered before Home renders. The ticket's own syncing edge case already concedes this. The activation gate is additionally a correctness guard: without it, a mainnet 3.8.0 shipped before activation day would announce an upgrade that has not happened yet.

## How it works

Three conditions: the keychain flag says this device has never acknowledged the screen, the chain is at/past the Ironwood activation height, and it is safe to take the screen over.

Evaluated from `.synchronizerStateChanged` (covers cold start and the tail of a restore, and catches the crossing live on activation day) and from `.willEnterForeground` (tip already in memory, so immediate). An in-memory session latch keeps the keychain read to once per session; it is deliberately **not** persisted, so force-quitting on the screen shows it again — the ticket's re-show criterion.

**Safety gate:** presents only when the user is idle on Home — no pushed flow, no Keystone signing, no server setup, no background task, no alert, splash cleared. A blocked attempt does not consume the latch, so it retries. This is also what keeps the screen out of onboarding.

**The flag survives resets.** Not wiped by `resetZashi`, so "once ever" holds across a wallet reset and an app reinstall. A test asserts the absence of that delete.

## Design notes

- Copy is verbatim from the design, including the mixed-case **"Go to Zodl"** — a deliberate exception to the all-caps house rule for the app name, confirmed by Michal. A test pins the string so a well-meaning correction fails rather than landing silently.
- The guide line is assembled from three separately-localized fragments, so each stays translatable and the link range is known by construction. The outer fragments' leading/trailing spaces are load-bearing; a test walks every shipped `.lproj` and asserts they survive, since a translator is more likely to trim them than the original author.
- The ZODL badge is composed (transparent mark over a filled circle, `Design.Logo.primary`/`.opposite`) rather than using `zashiLogoWithBackground` — that asset has light/dark appearance variants and blends into the background, rendering in light mode as a bare glyph with no circle.
- Link colour uses the app's semantic `Design.Text.link` rather than the design's exact `#155EEF`, so it matches every other link in the app and adapts to dark mode.
- The design's "Learn more" button is not mentioned in the ticket; it is implemented per the design, and both it and the inline link open the support article.

## Debug reset

Mainnet's gate stays closed until the network upgrades, and once acknowledged the screen is gone for the life of the device — so **Advanced Settings → "Reset Ironwood announcement"**, behind `#if !SECANT_DISTRIB` (testnet and internal builds only). It clears the keychain flag *and* the session latch; without the latter the reset would not take effect until an app restart.

Test loop on `zodl-testnet`: tap reset, then background and foreground — give it a few seconds for the tip. It will not appear while Settings is still open; that is the safety gate, not a bug.

## Testing

- **616 tests in 103 suites pass** (from 579 at the branch point); the one known issue in `CurrencyConversionSetupTests` is pre-existing.
- `zodl-AppStore` (`Release-AppStore`) builds clean, proving the debug row compiles out.
- Verified on the simulator against testnet: fresh install → create wallet shows it; Continue dismisses and it stays gone across a relaunch; debug reset brings it back; renders correctly in **light**, **dark**, **Spanish**, and on an **iPhone SE**.

One gap reported rather than faked: the `bgTask == nil` term of the safety gate has no test, because `BGProcessingTask` has no public initializer — the same documented gap as the existing auto-server gating tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)