### PR TITLE
[MOB-1510] Require Keystone firmware 3.0.1 or newer at signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Added
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
 - [Ironwood] A transfer that moves funds into the Ironwood pool now shows the amount that actually moved, in both the transaction list and the transaction detail screen. Previously such a transfer displayed only its fee.
+- [MOB-1510] Signing with a Keystone device now requires firmware 3.0.1 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast.
 
 ### Changed
 - [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Added
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
 - [Ironwood] A transfer that moves funds into the Ironwood pool now shows the amount that actually moved, in both the transaction list and the transaction detail screen. Previously such a transfer displayed only its fee.
-- [MOB-1510] Signing with a Keystone device now requires firmware 3.0.1 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast.
 
 ### Changed
 - [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.
+- [MOB-1510] Signing with a Keystone device now requires firmware 3.0.1 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast.
 
 ### Fixed
 - [Ironwood] The automatic recovery from another wallet's leftover data (see MOB-1512 below) keeps working with the updated Zcash SDK. The SDK now reports that mismatch as an error rather than a status, so ZODL maps it back onto the same recovery and the wallet still heals itself instead of stopping on an initialization error.

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -9238,6 +9238,74 @@
         }
       }
     },
+    "keystone.firmwareUpdate.body" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Keystone's firmware (%1$@) is below the minimum supported version (%2$@). Update your device's firmware, then try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "El firmware de tu Keystone (%1$@) está por debajo de la versión mínima admitida (%2$@). Actualiza el firmware de tu dispositivo y vuelve a intentarlo."
+          }
+        }
+      }
+    },
+    "keystone.firmwareUpdate.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cerrar"
+          }
+        }
+      }
+    },
+    "keystone.firmwareUpdate.legacyBody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Keystone's firmware is too old to report its version and is below the minimum supported version (%1$@). Update your device's firmware, then try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "El firmware de tu Keystone es demasiado antiguo para informar su versión y está por debajo de la versión mínima admitida (%1$@). Actualiza el firmware de tu dispositivo y vuelve a intentarlo."
+          }
+        }
+      }
+    },
+    "keystone.firmwareUpdate.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keystone Firmware Update Required"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Actualización de Firmware de Keystone Requerida"
+          }
+        }
+      }
+    },
     "keystone.scanInfo" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -9255,23 +9255,6 @@
         }
       }
     },
-    "keystone.firmwareUpdate.close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Cerrar"
-          }
-        }
-      }
-    },
     "keystone.firmwareUpdate.legacyBody" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -142,7 +142,32 @@ extension ScanCoordFlow {
                     }
                 }
                 return .none
-                
+
+            // MOB-1510: pushed on top of whatever's on the path (`.sending` is always there by
+            // this point — `.scan(.foundPCZT)` above already pushed it before forwarding into
+            // `confirmWithKeystone`) rather than branching on the top element like `pcztSendFailed`
+            // above — a firmware violation is detected strictly before any broadcast attempt, so
+            // there is no "failed during/after broadcast" case to distinguish here.
+            case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
+                for element in state.path {
+                    if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                    }
+                }
+                return .none
+
+            // Close: pop back to `confirmWithKeystone` (discarding `.scan`/`.sending`/
+            // `.keystoneFirmwareUpdate` above it) so `getSignatureTapped` can drive a fresh scan
+            // once the user has updated their device's firmware — the PCZT/proposal already built
+            // is still valid, so there is no need to rebuild it from the send form.
+            case .path(.element(id: _, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))):
+                for (id, element) in zip(state.path.ids, state.path) {
+                    if element.is(\.confirmWithKeystone) {
+                        state.path.pop(to: id)
+                    }
+                }
+                return .none
+
                 // MARK: - Request ZEC Confirmation
                 
             case .path(.element(id: _, action: .requestZecConfirmation(.goBackTappedFromRequestZec))):

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -143,29 +143,30 @@ extension ScanCoordFlow {
                 }
                 return .none
 
-            // MOB-1510: pushed on top of whatever's on the path (`.sending` is always there by
-            // this point — `.scan(.foundPCZT)` above already pushed it before forwarding into
-            // `confirmWithKeystone`) rather than branching on the top element like `pcztSendFailed`
-            // above — a firmware violation is detected strictly before any broadcast attempt, so
-            // there is no "failed during/after broadcast" case to distinguish here.
+            // MOB-1510: pop to `confirmWithKeystone` first so this only ever applies once (`break`)
+            // and drops the stale `.scan`/`.sending` pushed underneath before the append.
             case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
-                for element in state.path {
+                for (id, element) in zip(state.path.ids, state.path) {
                     if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        state.path.pop(to: id)
                         state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                        break
                     }
                 }
                 return .none
 
-            // Close: pop back to `confirmWithKeystone` (discarding `.scan`/`.sending`/
-            // `.keystoneFirmwareUpdate` above it) so `getSignatureTapped` can drive a fresh scan
-            // once the user has updated their device's firmware — the PCZT/proposal already built
-            // is still valid, so there is no need to rebuild it from the send form.
+            // Reset `confirmWithKeystone` here (not in its own reducer) so a fresh scan after a
+            // firmware update isn't silently dropped by the `isKeystoneCodeFound` guard in `foundPCZT`.
             case .path(.element(id: _, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))):
                 for (id, element) in zip(state.path.ids, state.path) {
                     if element.is(\.confirmWithKeystone) {
                         state.path.pop(to: id)
+                        state.path[id: id, case: \.confirmWithKeystone]?.detectedKeystoneFirmware = nil
+                        state.path[id: id, case: \.confirmWithKeystone]?.isKeystoneCodeFound = false
+                        break
                     }
                 }
+                keystoneHandler.resetQRDecoder()
                 return .none
 
                 // MARK: - Request ZEC Confirmation

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowStore.swift
@@ -17,6 +17,7 @@ struct ScanCoordFlow {
         case addressBook(AddressBook)
         case addressBookContact(AddressBook)
         case confirmWithKeystone(SendConfirmation)
+        case keystoneFirmwareUpdate(SendConfirmation)
         case preSendingFailure(SendConfirmation)
         case requestZecConfirmation(SendConfirmation)
         case scan(Scan)

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowStore.swift
@@ -63,6 +63,7 @@ struct ScanCoordFlow {
     }
 
     @Dependency(\.audioServices) var audioServices
+    @Dependency(\.keystoneHandler) var keystoneHandler
     @Dependency(\.mainQueue) var mainQueue
     @Dependency(\.numberFormatter) var numberFormatter
     @Dependency(\.sdkSynchronizer) var sdkSynchronizer

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowView.swift
@@ -38,6 +38,8 @@ struct ScanCoordFlowView: View {
                     AddressBookContactView(store: store)
                 case let .confirmWithKeystone(store):
                     SignWithKeystoneView(store: store, tokenName: tokenName)
+                case let .keystoneFirmwareUpdate(store):
+                    KeystoneFirmwareUpdateView(store: store)
                 case let .preSendingFailure(store):
                     PreSendingFailureView(store: store, tokenName: tokenName)
                 case let .scan(store):

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
@@ -135,6 +135,31 @@ extension SendCoordFlow {
                 }
                 return .none
 
+            // MOB-1510: pushed on top of whatever's on the path (`.sending` is always there by
+            // this point — `.scan(.foundPCZT)` above already pushed it before forwarding into
+            // `confirmWithKeystone`) rather than branching on the top element like `pcztSendFailed`
+            // above — a firmware violation is detected strictly before any broadcast attempt, so
+            // there is no "failed during/after broadcast" case to distinguish here.
+            case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
+                for element in state.path {
+                    if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                    }
+                }
+                return .none
+
+            // Close: pop back to `confirmWithKeystone` (discarding `.scan`/`.sending`/
+            // `.keystoneFirmwareUpdate` above it) so `getSignatureTapped` can drive a fresh scan
+            // once the user has updated their device's firmware — the PCZT/proposal already built
+            // is still valid, so there is no need to rebuild it from the send form.
+            case .path(.element(id: _, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))):
+                for (id, element) in zip(state.path.ids, state.path) {
+                    if element.is(\.confirmWithKeystone) {
+                        state.path.pop(to: id)
+                    }
+                }
+                return .none
+
                 // MARK: - Request ZEC Confirmation
                 
             case .path(.element(id: _, action: .requestZecConfirmation(.goBackTappedFromRequestZec))):

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
@@ -135,29 +135,30 @@ extension SendCoordFlow {
                 }
                 return .none
 
-            // MOB-1510: pushed on top of whatever's on the path (`.sending` is always there by
-            // this point — `.scan(.foundPCZT)` above already pushed it before forwarding into
-            // `confirmWithKeystone`) rather than branching on the top element like `pcztSendFailed`
-            // above — a firmware violation is detected strictly before any broadcast attempt, so
-            // there is no "failed during/after broadcast" case to distinguish here.
+            // MOB-1510: pop to `confirmWithKeystone` first so this only ever applies once (`break`)
+            // and drops the stale `.scan`/`.sending` pushed underneath before the append.
             case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
-                for element in state.path {
+                for (id, element) in zip(state.path.ids, state.path) {
                     if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        state.path.pop(to: id)
                         state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                        break
                     }
                 }
                 return .none
 
-            // Close: pop back to `confirmWithKeystone` (discarding `.scan`/`.sending`/
-            // `.keystoneFirmwareUpdate` above it) so `getSignatureTapped` can drive a fresh scan
-            // once the user has updated their device's firmware — the PCZT/proposal already built
-            // is still valid, so there is no need to rebuild it from the send form.
+            // Reset `confirmWithKeystone` here (not in its own reducer) so a fresh scan after a
+            // firmware update isn't silently dropped by the `isKeystoneCodeFound` guard in `foundPCZT`.
             case .path(.element(id: _, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))):
                 for (id, element) in zip(state.path.ids, state.path) {
                     if element.is(\.confirmWithKeystone) {
                         state.path.pop(to: id)
+                        state.path[id: id, case: \.confirmWithKeystone]?.detectedKeystoneFirmware = nil
+                        state.path[id: id, case: \.confirmWithKeystone]?.isKeystoneCodeFound = false
+                        break
                     }
                 }
+                keystoneHandler.resetQRDecoder()
                 return .none
 
                 // MARK: - Request ZEC Confirmation

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowStore.swift
@@ -46,6 +46,7 @@ struct SendCoordFlow {
     }
 
     @Dependency(\.audioServices) var audioServices
+    @Dependency(\.keystoneHandler) var keystoneHandler
     @Dependency(\.numberFormatter) var numberFormatter
 
     init() { }

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowStore.swift
@@ -16,6 +16,7 @@ struct SendCoordFlow {
         case addressBook(AddressBook)
         case addressBookContact(AddressBook)
         case confirmWithKeystone(SendConfirmation)
+        case keystoneFirmwareUpdate(SendConfirmation)
         case preSendingFailure(SendConfirmation)
         case requestZecConfirmation(SendConfirmation)
         case scan(Scan)

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowView.swift
@@ -47,6 +47,8 @@ struct SendCoordFlowView: View {
                     AddressBookContactView(store: store)
                 case let .confirmWithKeystone(store):
                     SignWithKeystoneView(store: store, tokenName: tokenName)
+                case let .keystoneFirmwareUpdate(store):
+                    KeystoneFirmwareUpdateView(store: store)
                 case let .preSendingFailure(store):
                     PreSendingFailureView(store: store, tokenName: tokenName)
                 case let .scan(store):

--- a/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowCoordinator.swift
@@ -79,7 +79,22 @@ extension SignWithKeystoneCoordFlow {
                     }
                 }
                 return .none
-                
+
+            // MOB-1510: `sendConfirmationState` lives at the flow's root here (no `.confirmWithKeystone`
+            // path element in this coordinator — the root screen already IS the Keystone confirm
+            // screen), so this arrives as a root-level `.sendConfirmation` action rather than a
+            // `.path(...)`-wrapped one, unlike the other 3 send-side coordinators.
+            case .sendConfirmation(.keystoneFirmwareUpdateRequired):
+                state.path.append(.keystoneFirmwareUpdate(state.sendConfirmationState))
+                return .none
+
+            // Close: there is no `.confirmWithKeystone` path element to pop back to (the root
+            // screen already is one) — clear the whole path, landing back on the root
+            // `SignWithKeystoneView`, ready for a fresh `getSignatureTapped` once firmware is updated.
+            case .path(.element(id: _, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))):
+                state.path.removeAll()
+                return .none
+
             default: return .none
             }
         }

--- a/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowCoordinator.swift
@@ -80,19 +80,21 @@ extension SignWithKeystoneCoordFlow {
                 }
                 return .none
 
-            // MOB-1510: `sendConfirmationState` lives at the flow's root here (no `.confirmWithKeystone`
-            // path element in this coordinator — the root screen already IS the Keystone confirm
-            // screen), so this arrives as a root-level `.sendConfirmation` action rather than a
-            // `.path(...)`-wrapped one, unlike the other 3 send-side coordinators.
+            // MOB-1510: root-level `.sendConfirmation` action, not `.path(...)`-wrapped — this
+            // coordinator has no `.confirmWithKeystone` path element; the root screen already is it.
+            // Clearing first drops the stale `.scan`/`.sending` pushed before the gate ran.
             case .sendConfirmation(.keystoneFirmwareUpdateRequired):
+                state.path.removeAll()
                 state.path.append(.keystoneFirmwareUpdate(state.sendConfirmationState))
                 return .none
 
-            // Close: there is no `.confirmWithKeystone` path element to pop back to (the root
-            // screen already is one) — clear the whole path, landing back on the root
-            // `SignWithKeystoneView`, ready for a fresh `getSignatureTapped` once firmware is updated.
+            // No `.confirmWithKeystone` element to pop back to — clear the path and reset the root
+            // state directly so a fresh scan isn't dropped by the `isKeystoneCodeFound` guard.
             case .path(.element(id: _, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))):
                 state.path.removeAll()
+                state.sendConfirmationState.detectedKeystoneFirmware = nil
+                state.sendConfirmationState.isKeystoneCodeFound = false
+                keystoneHandler.resetQRDecoder()
                 return .none
 
             default: return .none

--- a/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowStore.swift
@@ -13,6 +13,7 @@ import ComposableArchitecture
 struct SignWithKeystoneCoordFlow {
     @Reducer
     enum Path {
+        case keystoneFirmwareUpdate(SendConfirmation)
         case preSendingFailure(SendConfirmation)
         case scan(Scan)
         case sending(SendConfirmation)

--- a/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowStore.swift
@@ -38,6 +38,7 @@ struct SignWithKeystoneCoordFlow {
     }
 
     @Dependency(\.audioServices) var audioServices
+    @Dependency(\.keystoneHandler) var keystoneHandler
     @Dependency(\.walletStorage) var walletStorage
 
     init() { }

--- a/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowView.swift
@@ -33,6 +33,8 @@ struct SignWithKeystoneCoordFlowView: View {
                 .navigationBarHidden(true)
             } destination: { store in
                 switch store.case {
+                case let .keystoneFirmwareUpdate(store):
+                    KeystoneFirmwareUpdateView(store: store)
                 case let .preSendingFailure(store):
                     PreSendingFailureView(store: store, tokenName: tokenName)
                 case let .scan(store):

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
@@ -83,28 +83,6 @@ extension SwapAndPayCoordFlow {
             case .path(.element(id: _, action: .scan(.foundPCZT(let pcztWithSigs)))):
                 for (id, element) in zip(state.path.ids, state.path) {
                     if case .confirmWithKeystone(let sendConfirmationState) = element {
-                        let depositAddress = state.swapAndPayState.quote?.depositAddress ?? state.swapAndPayState.address
-                        let crosspay = state.swapAndPayState.isSwapExperienceEnabled
-                        
-                        if let provider = state.swapAndPayState.selectedAsset?.provider {
-                            let totalFees = state.swapAndPayState.totalFees
-                            let totalUSDFees = state.swapAndPayState.totalUSDFees
-                            userMetadataProvider.markTransactionAsSwapFor(
-                                depositAddress,
-                                provider,
-                                totalFees,
-                                totalUSDFees,
-                                state.swapAndPayState.zecAsset?.id ?? "",
-                                state.swapAndPayState.selectedAsset?.id ?? "",
-                                !crosspay,
-                                SwapConstants.pendingDeposit,
-                                state.swapAndPayState.zecToBeSpendInQuoteUSFormat
-                            )
-                            if let account = state.selectedWalletAccount?.account {
-                                try? userMetadataProvider.store(account)
-                            }
-                        }
-
                         state.path.append(.sending(sendConfirmationState))
                         return .send(.path(.element(id: id, action: .confirmWithKeystone(.foundPCZT(pcztWithSigs)))))
                     }
@@ -163,29 +141,57 @@ extension SwapAndPayCoordFlow {
                 }
                 return .none
 
-            // MOB-1510: pushed on top of whatever's on the path (`.sending` is always there by
-            // this point — `.scan(.foundPCZT)` above already pushed it before forwarding into
-            // `confirmWithKeystone`) rather than branching on the top element like `pcztSendFailed`
-            // above — a firmware violation is detected strictly before any broadcast attempt, so
-            // there is no "failed during/after broadcast" case to distinguish here.
+            // MOB-1510: pop to `confirmWithKeystone` first so this only ever applies once (`break`)
+            // and drops the stale `.scan`/`.sending` pushed underneath before the append.
             case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
-                for element in state.path {
+                for (id, element) in zip(state.path.ids, state.path) {
                     if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        state.path.pop(to: id)
                         state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                        break
                     }
                 }
                 return .none
 
-            // Close: pop back to `confirmWithKeystone` (discarding `.scan`/`.sending`/
-            // `.keystoneFirmwareUpdate` above it) so `getSignatureTapped` can drive a fresh scan
-            // once the user has updated their device's firmware — the PCZT/proposal already built
-            // is still valid, so there is no need to rebuild it from the send form.
+            // MOB-1510: deferred until the firmware gate accepts — writing this any earlier (from
+            // `.scan(.foundPCZT)`) would record a swap for a transaction the gate is about to
+            // block, and `UserMetadataProviderInterface` has no unmark/remove API to undo that.
+            case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareAccepted))):
+                let depositAddress = state.swapAndPayState.quote?.depositAddress ?? state.swapAndPayState.address
+                let crosspay = state.swapAndPayState.isSwapExperienceEnabled
+
+                if let provider = state.swapAndPayState.selectedAsset?.provider {
+                    let totalFees = state.swapAndPayState.totalFees
+                    let totalUSDFees = state.swapAndPayState.totalUSDFees
+                    userMetadataProvider.markTransactionAsSwapFor(
+                        depositAddress,
+                        provider,
+                        totalFees,
+                        totalUSDFees,
+                        state.swapAndPayState.zecAsset?.id ?? "",
+                        state.swapAndPayState.selectedAsset?.id ?? "",
+                        !crosspay,
+                        SwapConstants.pendingDeposit,
+                        state.swapAndPayState.zecToBeSpendInQuoteUSFormat
+                    )
+                    if let account = state.selectedWalletAccount?.account {
+                        try? userMetadataProvider.store(account)
+                    }
+                }
+                return .none
+
+            // Reset `confirmWithKeystone` here (not in its own reducer) so a fresh scan after a
+            // firmware update isn't silently dropped by the `isKeystoneCodeFound` guard in `foundPCZT`.
             case .path(.element(id: _, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))):
                 for (id, element) in zip(state.path.ids, state.path) {
                     if element.is(\.confirmWithKeystone) {
                         state.path.pop(to: id)
+                        state.path[id: id, case: \.confirmWithKeystone]?.detectedKeystoneFirmware = nil
+                        state.path[id: id, case: \.confirmWithKeystone]?.isKeystoneCodeFound = false
+                        break
                     }
                 }
+                keystoneHandler.resetQRDecoder()
                 return .none
 
                 // MARK: - Scan

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
@@ -163,6 +163,31 @@ extension SwapAndPayCoordFlow {
                 }
                 return .none
 
+            // MOB-1510: pushed on top of whatever's on the path (`.sending` is always there by
+            // this point — `.scan(.foundPCZT)` above already pushed it before forwarding into
+            // `confirmWithKeystone`) rather than branching on the top element like `pcztSendFailed`
+            // above — a firmware violation is detected strictly before any broadcast attempt, so
+            // there is no "failed during/after broadcast" case to distinguish here.
+            case .path(.element(id: _, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))):
+                for element in state.path {
+                    if case .confirmWithKeystone(let sendConfirmationState) = element {
+                        state.path.append(.keystoneFirmwareUpdate(sendConfirmationState))
+                    }
+                }
+                return .none
+
+            // Close: pop back to `confirmWithKeystone` (discarding `.scan`/`.sending`/
+            // `.keystoneFirmwareUpdate` above it) so `getSignatureTapped` can drive a fresh scan
+            // once the user has updated their device's firmware — the PCZT/proposal already built
+            // is still valid, so there is no need to rebuild it from the send form.
+            case .path(.element(id: _, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))):
+                for (id, element) in zip(state.path.ids, state.path) {
+                    if element.is(\.confirmWithKeystone) {
+                        state.path.pop(to: id)
+                    }
+                }
+                return .none
+
                 // MARK: - Scan
                 
             case .path(.element(id: _, action: .scan(.foundString(let address)))):

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
@@ -93,6 +93,7 @@ struct SwapAndPayCoordFlow {
     }
 
     @Dependency(\.audioServices) var audioServices
+    @Dependency(\.keystoneHandler) var keystoneHandler
     @Dependency(\.localAuthentication) var localAuthentication
     @Dependency(\.derivationTool) var derivationTool
     @Dependency(\.mainQueue) var mainQueue

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
@@ -17,6 +17,7 @@ struct SwapAndPayCoordFlow {
         case addressBookContact(AddressBook)
         case confirmWithKeystone(SendConfirmation)
         case crossPayConfirmation(SwapAndPay)
+        case keystoneFirmwareUpdate(SendConfirmation)
         case preSendingFailure(SendConfirmation)
         case scan(Scan)
         case sending(SendConfirmation)

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowView.swift
@@ -77,6 +77,8 @@ struct SwapAndPayCoordFlowView: View {
                         SignWithKeystoneView(store: store, tokenName: tokenName)
                     case let .crossPayConfirmation(store):
                         CrossPayConfirmationView(store: store, tokenName: tokenName)
+                    case let .keystoneFirmwareUpdate(store):
+                        KeystoneFirmwareUpdateView(store: store)
                     case let .preSendingFailure(store):
                         PreSendingFailureView(store: store, tokenName: tokenName)
                     case let .scan(store):

--- a/secant/Sources/Features/SendConfirmation/KeystoneFirmwareUpdateView.swift
+++ b/secant/Sources/Features/SendConfirmation/KeystoneFirmwareUpdateView.swift
@@ -2,16 +2,9 @@
 //  KeystoneFirmwareUpdateView.swift
 //  Zashi
 //
-//  MOB-1510: Keystone minimum-firmware gate failure screen — mirrors `PreSendingFailureView`'s
-//  structure exactly (illustration, title, body, `applyFailureScreenBackground()`, `ZashiButton`).
-//  Presented as a coordinator path element from every send-side Keystone signing surface (the 4
-//  send `CoordFlowCoordinator`s) once `SendConfirmationStore.foundPCZT` detects firmware below
-//  `KeystoneFirmwareVersion.minimumSupported`, or no version stamp at all.
-//
-//  `KeystoneFirmwareUpdateContent` below carries the illustration/title/body only (no button, no
-//  screen-centering spacers), so any other presentation of the same gate — a sheet in a flow with
-//  no `SendConfirmation` of its own to scope a store from — can reuse the SAME copy and visual
-//  without depending on this feature's store or its full-screen layout.
+//  MOB-1510's firmware gate failure screen; mirrors `PreSendingFailureView`'s structure.
+//  `KeystoneFirmwareUpdateContent` below is split out (store-less) so a presentation without
+//  its own `SendConfirmation` store can still reuse the same copy.
 //
 
 import SwiftUI
@@ -29,11 +22,11 @@ struct KeystoneFirmwareUpdateView: View {
             VStack(spacing: 0) {
                 Spacer()
 
-                KeystoneFirmwareUpdateContent(detectedVersion: store.detectedKeystoneFirmware)
+                KeystoneFirmwareUpdateContent(illustration: store.failureIlustration, detectedVersion: store.detectedKeystoneFirmware)
 
                 Spacer()
 
-                ZashiButton(String(localizable: .keystoneFirmwareUpdateClose)) {
+                ZashiButton(String(localizable: .generalClose)) {
                     store.send(.keystoneFirmwareUpdateCloseTapped)
                 }
                 .padding(.bottom, 24)
@@ -46,20 +39,21 @@ struct KeystoneFirmwareUpdateView: View {
     }
 }
 
-/// Illustration + title + body for MOB-1510's firmware-update prompt. Used by the full-screen
-/// `KeystoneFirmwareUpdateView` above (the 4 send-side coordinators), and factored out so a
-/// store-less presentation of the same gate can reuse it — see this file's header comment.
+/// Illustration + title + body for the firmware-update prompt; store-less so other presentations
+/// of the gate can reuse it.
 struct KeystoneFirmwareUpdateContent: View {
+    let illustration: Image
     let detectedVersion: KeystoneFirmwareVersion?
 
     var body: some View {
         VStack(spacing: 0) {
-            Asset.Assets.Illustrations.failure3.image
+            illustration
                 .resizable()
                 .frame(width: 148, height: 148)
 
             Text(String(localizable: .keystoneFirmwareUpdateTitle))
                 .zFont(.semiBold, size: 28, style: Design.Text.primary)
+                .multilineTextAlignment(.center)
                 .padding(.top, 16)
 
             Text(bodyText)

--- a/secant/Sources/Features/SendConfirmation/KeystoneFirmwareUpdateView.swift
+++ b/secant/Sources/Features/SendConfirmation/KeystoneFirmwareUpdateView.swift
@@ -1,0 +1,90 @@
+//
+//  KeystoneFirmwareUpdateView.swift
+//  Zashi
+//
+//  MOB-1510: Keystone minimum-firmware gate failure screen — mirrors `PreSendingFailureView`'s
+//  structure exactly (illustration, title, body, `applyFailureScreenBackground()`, `ZashiButton`).
+//  Presented as a coordinator path element from every send-side Keystone signing surface (the 4
+//  send `CoordFlowCoordinator`s) once `SendConfirmationStore.foundPCZT` detects firmware below
+//  `KeystoneFirmwareVersion.minimumSupported`, or no version stamp at all.
+//
+//  `KeystoneFirmwareUpdateContent` below carries the illustration/title/body only (no button, no
+//  screen-centering spacers), so any other presentation of the same gate — a sheet in a flow with
+//  no `SendConfirmation` of its own to scope a store from — can reuse the SAME copy and visual
+//  without depending on this feature's store or its full-screen layout.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct KeystoneFirmwareUpdateView: View {
+    @Perception.Bindable var store: StoreOf<SendConfirmation>
+
+    init(store: StoreOf<SendConfirmation>) {
+        self.store = store
+    }
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                Spacer()
+
+                KeystoneFirmwareUpdateContent(detectedVersion: store.detectedKeystoneFirmware)
+
+                Spacer()
+
+                ZashiButton(String(localizable: .keystoneFirmwareUpdateClose)) {
+                    store.send(.keystoneFirmwareUpdateCloseTapped)
+                }
+                .padding(.bottom, 24)
+            }
+        }
+        .navigationBarBackButtonHidden()
+        .padding(.vertical, 1)
+        .screenHorizontalPadding()
+        .applyFailureScreenBackground()
+    }
+}
+
+/// Illustration + title + body for MOB-1510's firmware-update prompt. Used by the full-screen
+/// `KeystoneFirmwareUpdateView` above (the 4 send-side coordinators), and factored out so a
+/// store-less presentation of the same gate can reuse it — see this file's header comment.
+struct KeystoneFirmwareUpdateContent: View {
+    let detectedVersion: KeystoneFirmwareVersion?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Asset.Assets.Illustrations.failure3.image
+                .resizable()
+                .frame(width: 148, height: 148)
+
+            Text(String(localizable: .keystoneFirmwareUpdateTitle))
+                .zFont(.semiBold, size: 28, style: Design.Text.primary)
+                .padding(.top, 16)
+
+            Text(bodyText)
+                .zFont(size: 14, style: Design.Text.primary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(1.5)
+                .screenHorizontalPadding()
+        }
+    }
+
+    private var bodyText: String {
+        if let detectedVersion {
+            return String(
+                localizable: .keystoneFirmwareUpdateBody(
+                    detectedVersion.versionString,
+                    KeystoneFirmwareVersion.minimumSupported.versionString
+                )
+            )
+        }
+        return String(localizable: .keystoneFirmwareUpdateLegacyBody(KeystoneFirmwareVersion.minimumSupported.versionString))
+    }
+}
+
+#Preview {
+    NavigationView {
+        KeystoneFirmwareUpdateView(store: SendConfirmation.initial)
+    }
+}

--- a/secant/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
+++ b/secant/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
@@ -1,0 +1,73 @@
+//
+//  KeystoneFirmwareVersion.swift
+//  Zashi
+//
+//  MOB-1510: Keystone hardware-wallet firmware version, read off a signed PCZT's proprietary
+//  fields. KeystoneSDK 0.8.6 exposes no firmware API of its own — device firmware
+//  (KeystoneHQ/keystone3-firmware#2134, shipped in releases >= 2.4.6) stamps
+//  `global.proprietary["keystone:fw_version"]` (3 raw bytes: major, minor, build) into every Zcash
+//  PCZT it signs, so the app reads the version back out of the raw signed bytes instead of calling
+//  into the vendor SDK.
+//
+
+import Foundation
+
+struct KeystoneFirmwareVersion: Equatable, Comparable, Sendable {
+    let major: Int
+    let minor: Int
+    let build: Int
+
+    /// Minimum Keystone firmware this app will accept a signature from — set by product
+    /// (MOB-1510). Single point of change if the minimum is ever raised. Always enforced — there
+    /// is no "0.0.0 disables the check" escape hatch.
+    static let minimumSupported = KeystoneFirmwareVersion(major: 3, minor: 0, build: 1)
+
+    var versionString: String {
+        "\(major).\(minor).\(build)"
+    }
+
+    static func < (lhs: KeystoneFirmwareVersion, rhs: KeystoneFirmwareVersion) -> Bool {
+        (lhs.major, lhs.minor, lhs.build) < (rhs.major, rhs.minor, rhs.build)
+    }
+}
+
+extension Data {
+    /// Interim mechanism for reading the Keystone firmware version stamped into a signed PCZT
+    /// (MOB-1510) — KeystoneSDK 0.8.6 exposes no firmware API, so this byte-scans the raw signed
+    /// PCZT `Data` for the ASCII proprietary-field key `keystone:fw_version`, postcard's
+    /// length-prefix byte for a 3-byte value (`0x03`), and the 3 version bytes that follow.
+    /// Every occurrence of the key is scanned in order; a truncated or wrong-length-prefix
+    /// occurrence is skipped (not treated as fatal) rather than short-circuiting the scan, since a
+    /// later occurrence may still be well-formed. Returns `nil` when no valid occurrence exists at
+    /// all — either the firmware predates the stamping feature, or the scan is malformed.
+    ///
+    /// A proper FFI reader over the PCZT's own parsed proprietary fields is a possible future
+    /// improvement, once the vendor SDK or the local PCZT fork exposes one.
+    func keystoneFirmwareVersion() -> KeystoneFirmwareVersion? {
+        let key = Array("keystone:fw_version".utf8)
+        let bytes = [UInt8](self)
+        guard bytes.count >= key.count else { return nil }
+
+        let lastPossibleKeyStart = bytes.count - key.count
+        var searchIndex = 0
+        while searchIndex <= lastPossibleKeyStart {
+            guard Array(bytes[searchIndex..<(searchIndex + key.count)]) == key else {
+                searchIndex += 1
+                continue
+            }
+
+            let lengthPrefixIndex = searchIndex + key.count
+            let versionStart = lengthPrefixIndex + 1
+            let versionEnd = versionStart + 3
+            if lengthPrefixIndex < bytes.count, bytes[lengthPrefixIndex] == 0x03, versionEnd <= bytes.count {
+                return KeystoneFirmwareVersion(
+                    major: Int(bytes[versionStart]),
+                    minor: Int(bytes[versionStart + 1]),
+                    build: Int(bytes[versionStart + 2])
+                )
+            }
+            searchIndex += 1
+        }
+        return nil
+    }
+}

--- a/secant/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
+++ b/secant/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
@@ -2,71 +2,55 @@
 //  KeystoneFirmwareVersion.swift
 //  Zashi
 //
-//  MOB-1510: Keystone hardware-wallet firmware version, read off a signed PCZT's proprietary
-//  fields. KeystoneSDK 0.8.6 exposes no firmware API of its own — device firmware
-//  (KeystoneHQ/keystone3-firmware#2134, shipped in releases >= 2.4.6) stamps
-//  `global.proprietary["keystone:fw_version"]` (3 raw bytes: major, minor, build) into every Zcash
-//  PCZT it signs, so the app reads the version back out of the raw signed bytes instead of calling
-//  into the vendor SDK.
+//  MOB-1510: device firmware stamps `global.proprietary["keystone:fw_version"]` (3 raw bytes)
+//  into every signed PCZT; KeystoneSDK 0.8.6 exposes no firmware API of its own.
 //
 
 import Foundation
 
 struct KeystoneFirmwareVersion: Equatable, Comparable, Sendable {
-    let major: Int
-    let minor: Int
-    let build: Int
-
     /// Minimum Keystone firmware this app will accept a signature from — set by product
     /// (MOB-1510). Single point of change if the minimum is ever raised. Always enforced — there
     /// is no "0.0.0 disables the check" escape hatch.
     static let minimumSupported = KeystoneFirmwareVersion(major: 3, minor: 0, build: 1)
 
+    let major: Int
+    let minor: Int
+    let build: Int
+
     var versionString: String {
         "\(major).\(minor).\(build)"
     }
+}
 
+extension KeystoneFirmwareVersion {
     static func < (lhs: KeystoneFirmwareVersion, rhs: KeystoneFirmwareVersion) -> Bool {
         (lhs.major, lhs.minor, lhs.build) < (rhs.major, rhs.minor, rhs.build)
     }
 }
 
 extension Data {
-    /// Interim mechanism for reading the Keystone firmware version stamped into a signed PCZT
-    /// (MOB-1510) — KeystoneSDK 0.8.6 exposes no firmware API, so this byte-scans the raw signed
-    /// PCZT `Data` for the ASCII proprietary-field key `keystone:fw_version`, postcard's
-    /// length-prefix byte for a 3-byte value (`0x03`), and the 3 version bytes that follow.
-    /// Every occurrence of the key is scanned in order; a truncated or wrong-length-prefix
-    /// occurrence is skipped (not treated as fatal) rather than short-circuiting the scan, since a
-    /// later occurrence may still be well-formed. Returns `nil` when no valid occurrence exists at
-    /// all — either the firmware predates the stamping feature, or the scan is malformed.
-    ///
-    /// A proper FFI reader over the PCZT's own parsed proprietary fields is a possible future
-    /// improvement, once the vendor SDK or the local PCZT fork exposes one.
+    /// Byte-scans a signed PCZT for the key `keystone:fw_version`, postcard's length-prefix byte
+    /// for a 3-byte value (`0x03`), and the 3 version bytes that follow (MOB-1510) — interim until
+    /// a proper FFI reader exists over the PCZT's parsed proprietary fields. Occurrences are
+    /// scanned in order; a truncated or wrong-length-prefix one is skipped, not fatal. `nil` when
+    /// no valid occurrence exists.
     func keystoneFirmwareVersion() -> KeystoneFirmwareVersion? {
-        let key = Array("keystone:fw_version".utf8)
-        let bytes = [UInt8](self)
-        guard bytes.count >= key.count else { return nil }
+        let key = Data("keystone:fw_version".utf8)
+        var searchRange = startIndex..<endIndex
 
-        let lastPossibleKeyStart = bytes.count - key.count
-        var searchIndex = 0
-        while searchIndex <= lastPossibleKeyStart {
-            guard Array(bytes[searchIndex..<(searchIndex + key.count)]) == key else {
-                searchIndex += 1
-                continue
-            }
-
-            let lengthPrefixIndex = searchIndex + key.count
+        while let keyRange = range(of: key, in: searchRange) {
+            let lengthPrefixIndex = keyRange.upperBound
             let versionStart = lengthPrefixIndex + 1
             let versionEnd = versionStart + 3
-            if lengthPrefixIndex < bytes.count, bytes[lengthPrefixIndex] == 0x03, versionEnd <= bytes.count {
+            if versionEnd <= endIndex, self[lengthPrefixIndex] == 0x03 {
                 return KeystoneFirmwareVersion(
-                    major: Int(bytes[versionStart]),
-                    minor: Int(bytes[versionStart + 1]),
-                    build: Int(bytes[versionStart + 2])
+                    major: Int(self[versionStart]),
+                    minor: Int(self[versionStart + 1]),
+                    build: Int(self[versionStart + 2])
                 )
             }
-            searchIndex += 1
+            searchRange = keyRange.upperBound..<endIndex
         }
         return nil
     }

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -175,8 +175,10 @@ struct SendConfirmation {
         case foundPCZT(Pczt)
         // MOB-1510: Keystone minimum-firmware gate — `keystoneFirmwareUpdateRequired` fires from
         // `foundPCZT` in place of scheduling `createTransactionFromPCZT` when the signed PCZT's
-        // firmware is unstamped or below `KeystoneFirmwareVersion.minimumSupported`;
+        // firmware is unstamped or below `KeystoneFirmwareVersion.minimumSupported`; on an accepted
+        // firmware, `foundPCZT` fires `keystoneFirmwareAccepted` for the coordinators to observe.
         // `keystoneFirmwareUpdateCloseTapped` is `KeystoneFirmwareUpdateView`'s Close button.
+        case keystoneFirmwareAccepted
         case keystoneFirmwareUpdateCloseTapped
         case keystoneFirmwareUpdateRequired
         case pcztResolved(Pczt)
@@ -485,23 +487,25 @@ struct SendConfirmation {
                     }
 
                     state.pcztWithSigs = pcztWithSigs
-                    return .run { send in
-                        try? await mainQueue.sleep(for: .seconds(Constants.delay))
-                        await send(.createTransactionFromPCZT)
-                    }
+                    return .merge(
+                        .send(.keystoneFirmwareAccepted),
+                        .run { send in
+                            try? await mainQueue.sleep(for: .seconds(Constants.delay))
+                            await send(.createTransactionFromPCZT)
+                        }
+                    )
                 }
+                return .none
+
+            case .keystoneFirmwareAccepted:
                 return .none
 
             case .keystoneFirmwareUpdateRequired:
                 return .none
 
             case .keystoneFirmwareUpdateCloseTapped:
-                // Mirrors `getSignatureTapped`'s reset so a fresh scan (after the device's firmware
-                // is updated) is processed rather than silently dropped by the `isKeystoneCodeFound`
-                // guard above.
-                state.detectedKeystoneFirmware = nil
-                state.isKeystoneCodeFound = false
-                keystoneHandler.resetQRDecoder()
+                // Handled by the coordinators: they pop this path element before this reducer would
+                // see the action, same shape as `backFromPCZTFailureTapped`.
                 return .none
 
             case .resolvePCZT:

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -41,6 +41,10 @@ struct SendConfirmation {
         var amount: Zatoshi
         var canSendMail = false
         var currencyAmount: RedactableString
+        /// MOB-1510: firmware version detected on the most recent `foundPCZT` scan that failed the
+        /// minimum-firmware gate — `nil` when the scan carried no version stamp at all (firmware
+        /// older than the stamping feature). Drives the copy on `KeystoneFirmwareUpdateView`.
+        var detectedKeystoneFirmware: KeystoneFirmwareVersion?
         var failedCode: Int?
         var failedDescription: String?
         var isAnchorError = false
@@ -169,6 +173,12 @@ struct SendConfirmation {
         case backFromPCZTFailureTapped
         case createTransactionFromPCZT
         case foundPCZT(Pczt)
+        // MOB-1510: Keystone minimum-firmware gate — `keystoneFirmwareUpdateRequired` fires from
+        // `foundPCZT` in place of scheduling `createTransactionFromPCZT` when the signed PCZT's
+        // firmware is unstamped or below `KeystoneFirmwareVersion.minimumSupported`;
+        // `keystoneFirmwareUpdateCloseTapped` is `KeystoneFirmwareUpdateView`'s Close button.
+        case keystoneFirmwareUpdateCloseTapped
+        case keystoneFirmwareUpdateRequired
         case pcztResolved(Pczt)
         case pcztSendFailed(ZcashError?)
         case pcztWithProofsResolved(Pczt)
@@ -464,12 +474,34 @@ struct SendConfirmation {
                 }
                 if !state.isKeystoneCodeFound {
                     state.isKeystoneCodeFound = true
+
+                    // MOB-1510: firmware >= 2.4.6 stamps its version into every signed PCZT, two
+                    // releases before the minimum this gate enforces — an unstamped PCZT is
+                    // therefore necessarily below minimum, never merely "unknown".
+                    let detectedFirmware = pcztWithSigs.keystoneFirmwareVersion()
+                    guard let detectedFirmware, detectedFirmware >= KeystoneFirmwareVersion.minimumSupported else {
+                        state.detectedKeystoneFirmware = detectedFirmware
+                        return .send(.keystoneFirmwareUpdateRequired)
+                    }
+
                     state.pcztWithSigs = pcztWithSigs
                     return .run { send in
                         try? await mainQueue.sleep(for: .seconds(Constants.delay))
                         await send(.createTransactionFromPCZT)
                     }
                 }
+                return .none
+
+            case .keystoneFirmwareUpdateRequired:
+                return .none
+
+            case .keystoneFirmwareUpdateCloseTapped:
+                // Mirrors `getSignatureTapped`'s reset so a fresh scan (after the device's firmware
+                // is updated) is processed rather than silently dropped by the `isKeystoneCodeFound`
+                // guard above.
+                state.detectedKeystoneFirmware = nil
+                state.isKeystoneCodeFound = false
+                keystoneHandler.resetQRDecoder()
                 return .none
 
             case .resolvePCZT:

--- a/zodlTests/SendTests/KeystoneFirmwareCoordFlowTests.swift
+++ b/zodlTests/SendTests/KeystoneFirmwareCoordFlowTests.swift
@@ -1,0 +1,333 @@
+//
+//  KeystoneFirmwareCoordFlowTests.swift
+//  zodlTests
+//
+//  MOB-1510 — coordinator-level regressions in the Keystone minimum-firmware gate, found by code
+//  review. `KeystoneFirmwareTests.swift` only drives the `SendConfirmation` store in isolation;
+//  the push (`.keystoneFirmwareUpdateRequired`) and close (`.keystoneFirmwareUpdateCloseTapped`)
+//  handling actually lives in four coordinators (SendCoordFlow, ScanCoordFlow, SwapAndPayCoordFlow,
+//  SignWithKeystoneCoordFlow), which is what these tests exercise.
+//
+//  CoordFlow `State` is not `Equatable`, so these tests drive a plain `Store` (not `TestStore`) and
+//  poll for the expected outcome with a private `waitFor…` helper (same approach as
+//  `ScanCoordFlowZip321Tests`). Each test binds a fresh in-memory store via
+//  `withDependencies { $0.defaultInMemoryStorage = InMemoryStorage() }` so parallel suites cannot
+//  clobber process-global `@Shared` state.
+//
+//  The close-action fix intentionally has the coordinator pop the `.keystoneFirmwareUpdate` path
+//  element as part of the very reduce cycle that handles the action addressed to it. TCA's own
+//  `.forEach` machinery independently (and redundantly) rechecks that same id afterward, finds it
+//  already gone, and reports a "missing element" runtime issue — a harmless, unavoidable artifact
+//  of that ordering (it fires even against the pre-fix code) and not something these tests are
+//  checking, so it's silenced locally via `withIssueReporters([])` around just the `send` call.
+
+import Foundation
+import Testing
+import ComposableArchitecture
+import XCTestDynamicOverlay
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct KeystoneFirmwareCoordFlowTests {
+    private var testWalletAccount: WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: 0, count: 16)),
+                name: "Test",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private func signedPczt(firmware: (major: Int, minor: Int, build: Int)) -> Pczt {
+        var data = Data()
+        data.append(contentsOf: Array("keystone:fw_version".utf8))
+        data.append(contentsOf: [0x03, UInt8(firmware.major), UInt8(firmware.minor), UInt8(firmware.build)])
+        return Pczt(data)
+    }
+
+    // MARK: - Push: `.keystoneFirmwareUpdateRequired`
+
+    /// Review bug: the push handler loops the whole path with no `break`, appending one
+    /// `.keystoneFirmwareUpdate` screen per `.confirmWithKeystone` element it finds.
+    @Test func pushesExactlyOneUpdateScreenWhenTwoConfirmElementsOnPath() async throws {
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = SendCoordFlow.State()
+            initialState.path.append(.confirmWithKeystone(SendConfirmation.State.initial))
+            initialState.path.append(.confirmWithKeystone(SendConfirmation.State.initial))
+            // The fix's loop always operates on the first (bottommost) `.confirmWithKeystone` it
+            // finds, regardless of which id the action is addressed to — so address it there too.
+            let triggerId = try #require(initialState.path.ids.first)
+
+            let store = Store(initialState: initialState) {
+                SendCoordFlow()
+            }
+
+            store.send(.path(.element(id: triggerId, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))))
+
+            await waitForCoordFlowStore {
+                !store.state.path.filter { $0.is(\.keystoneFirmwareUpdate) }.isEmpty
+            }
+
+            #expect(store.state.path.filter { $0.is(\.keystoneFirmwareUpdate) }.count == 1)
+        }
+    }
+
+    /// Review bug: the push handler appends `.keystoneFirmwareUpdate` on top of the path without
+    /// popping the stale `.scan`/`.sending` elements pushed underneath it first.
+    @Test func pushDropsStaleScanAndSendingElements() async throws {
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = SendCoordFlow.State()
+            initialState.path.append(.confirmWithKeystone(SendConfirmation.State.initial))
+            initialState.path.append(.scan(Scan.State.initial))
+            initialState.path.append(.sending(SendConfirmation.State.initial))
+            let confirmId = try #require(initialState.path.ids.first)
+
+            let store = Store(initialState: initialState) {
+                SendCoordFlow()
+            }
+
+            store.send(.path(.element(id: confirmId, action: .confirmWithKeystone(.keystoneFirmwareUpdateRequired))))
+
+            await waitForCoordFlowStore {
+                !store.state.path.filter { $0.is(\.keystoneFirmwareUpdate) }.isEmpty
+            }
+
+            #expect(store.state.path.count == 2)
+            #expect(store.state.path.first?.is(\.confirmWithKeystone) == true)
+            #expect(store.state.path.last?.is(\.keystoneFirmwareUpdate) == true)
+        }
+    }
+
+    /// The `SignWithKeystone` variant of the same bug. That flow's `.scan(.foundPCZT)` also pushes
+    /// `.sending` before the gate runs, and the confirm screen is the flow root rather than a path
+    /// element — so the update screen must replace the whole path, not stack on top of it.
+    @Test func pushDropsStaleScanAndSendingElementsInSignWithKeystoneFlow() async throws {
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = SignWithKeystoneCoordFlow.State()
+            let rootState = initialState.sendConfirmationState
+            initialState.path.append(.scan(Scan.State.initial))
+            initialState.path.append(.sending(rootState))
+
+            let store = Store(initialState: initialState) {
+                SignWithKeystoneCoordFlow()
+            }
+
+            store.send(.sendConfirmation(.keystoneFirmwareUpdateRequired))
+
+            await waitForCoordFlowStore {
+                !store.state.path.filter { $0.is(\.keystoneFirmwareUpdate) }.isEmpty
+            }
+
+            #expect(store.state.path.count == 1)
+            #expect(store.state.path.last?.is(\.keystoneFirmwareUpdate) == true)
+        }
+    }
+
+    // MARK: - Close: `.keystoneFirmwareUpdateCloseTapped`
+
+    /// Review bug: the coordinator pops the `.keystoneFirmwareUpdate` path element before the child
+    /// `SendConfirmation` reducer ever sees the close action, so its reset of
+    /// `isKeystoneCodeFound`/`detectedKeystoneFirmware` never runs — and even if it did, it would
+    /// reset the wrong (discarded) state, not the surviving `confirmWithKeystone` element.
+    @Test func closeResetsTheSurvivingConfirmElement() async throws {
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var confirmState = SendConfirmation.State.initial
+            confirmState.isKeystoneCodeFound = true
+            confirmState.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+
+            var initialState = SendCoordFlow.State()
+            initialState.path.append(.confirmWithKeystone(confirmState))
+            initialState.path.append(.keystoneFirmwareUpdate(confirmState))
+            let updateId = try #require(initialState.path.ids.last)
+
+            let store = Store(initialState: initialState) {
+                SendCoordFlow()
+            } withDependencies: {
+                $0.keystoneHandler.resetQRDecoder = { }
+            }
+
+            withIssueReporters([]) {
+                store.send(.path(.element(id: updateId, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))))
+            }
+
+            await waitForCoordFlowStore {
+                store.state.path.count == 1
+            }
+
+            if case .confirmWithKeystone(let survivor) = store.state.path.last {
+                #expect(survivor.isKeystoneCodeFound == false)
+                #expect(survivor.detectedKeystoneFirmware == nil)
+            } else {
+                Issue.record("Expected the surviving path element to be confirmWithKeystone")
+            }
+        }
+    }
+
+    /// Same bug as `closeResetsTheSurvivingConfirmElement`, but for the one coordinator
+    /// (`SignWithKeystoneCoordFlow`) where the confirm screen is the flow's root state rather than a
+    /// path element.
+    @Test func closeResetsRootStateInSignWithKeystoneFlow() async throws {
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = SignWithKeystoneCoordFlow.State()
+            initialState.sendConfirmationState.isKeystoneCodeFound = true
+            initialState.sendConfirmationState.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+            initialState.path.append(.keystoneFirmwareUpdate(initialState.sendConfirmationState))
+            let updateId = try #require(initialState.path.ids.last)
+
+            let store = Store(initialState: initialState) {
+                SignWithKeystoneCoordFlow()
+            } withDependencies: {
+                $0.keystoneHandler.resetQRDecoder = { }
+            }
+
+            withIssueReporters([]) {
+                store.send(.path(.element(id: updateId, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))))
+            }
+
+            await waitForCoordFlowStore {
+                store.state.path.isEmpty
+            }
+
+            #expect(store.state.path.isEmpty)
+            #expect(store.state.sendConfirmationState.isKeystoneCodeFound == false)
+            #expect(store.state.sendConfirmationState.detectedKeystoneFirmware == nil)
+        }
+    }
+
+    /// The other symptom of the same bug: because the child reducer's close handler never runs (see
+    /// `closeResetsTheSurvivingConfirmElement`), `keystoneHandler.resetQRDecoder()` never fires
+    /// either.
+    @Test func closeResetsTheQRDecoder() async throws {
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var confirmState = SendConfirmation.State.initial
+            confirmState.isKeystoneCodeFound = true
+            confirmState.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+
+            var initialState = SendCoordFlow.State()
+            initialState.path.append(.confirmWithKeystone(confirmState))
+            initialState.path.append(.keystoneFirmwareUpdate(confirmState))
+            let updateId = try #require(initialState.path.ids.last)
+
+            let resetCalls = LockIsolated(0)
+            let store = Store(initialState: initialState) {
+                SendCoordFlow()
+            } withDependencies: {
+                $0.keystoneHandler.resetQRDecoder = { resetCalls.withValue { $0 += 1 } }
+            }
+
+            withIssueReporters([]) {
+                store.send(.path(.element(id: updateId, action: .keystoneFirmwareUpdate(.keystoneFirmwareUpdateCloseTapped))))
+            }
+
+            // Short timeout: pre-fix this condition never becomes true, and the usual 60s default
+            // would otherwise make this specific RED run needlessly slow.
+            await waitForCoordFlowStore(timeoutNanoseconds: 3_000_000_000) {
+                resetCalls.value == 1
+            }
+
+            #expect(resetCalls.value == 1)
+        }
+    }
+
+    // MARK: - Swap metadata deferral
+
+    /// Review bug: `SwapAndPayCoordFlowCoordinator` writes the swap metadata (and stores the
+    /// account) from `.scan(.foundPCZT)`, strictly before forwarding into `confirmWithKeystone`
+    /// where the firmware gate is actually evaluated — so the write happens even when the gate is
+    /// about to block the signature. `UserMetadataProviderInterface` has no unmark/remove API, so
+    /// this would leave a permanent phantom swap record for a transaction that never happens.
+    @Test func blockedSwapWritesNoSwapMetadata() async throws {
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let markCalls = LockIsolated(0)
+            let store = try makeSwapAndPayStore(markCalls: markCalls)
+
+            store.send(.path(.element(id: try #require(store.state.path.ids.last), action: .scan(.foundPCZT(signedPczt(firmware: (2, 4, 6)))))))
+
+            await waitForCoordFlowStore {
+                !store.state.path.filter { $0.is(\.keystoneFirmwareUpdate) }.isEmpty
+            }
+
+            #expect(markCalls.value == 0)
+        }
+    }
+
+    /// Regression guard: firmware exactly at the minimum must still record swap metadata once the
+    /// gate accepts it — proves the fix defers the write rather than dropping it.
+    @Test func acceptedSwapWritesSwapMetadata() async throws {
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let markCalls = LockIsolated(0)
+            let store = try makeSwapAndPayStore(markCalls: markCalls)
+
+            store.send(.path(.element(id: try #require(store.state.path.ids.last), action: .scan(.foundPCZT(signedPczt(firmware: (3, 0, 1)))))))
+
+            await waitForCoordFlowStore {
+                markCalls.value == 1
+            }
+
+            #expect(markCalls.value == 1)
+        }
+    }
+
+    private func makeSwapAndPayStore(markCalls: LockIsolated<Int>) -> StoreOf<SwapAndPayCoordFlow> {
+        var initialState = SwapAndPayCoordFlow.State()
+        initialState.swapAndPayState.address = "utestdepositaddress"
+        initialState.swapAndPayState.selectedAsset = SwapAsset(
+            provider: "near",
+            chain: "eth",
+            token: "ETH",
+            assetId: "eth-id",
+            usdPrice: 1,
+            decimals: 18
+        )
+        initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+
+        var confirmState = SendConfirmation.State.initial
+        confirmState.proposal = .testOnlyFakeProposal(totalFee: 10_000)
+        initialState.path.append(.confirmWithKeystone(confirmState))
+        initialState.path.append(.scan(Scan.State.initial))
+
+        return Store(initialState: initialState) {
+            SwapAndPayCoordFlow()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            $0.userMetadataProvider.markTransactionAsSwapFor = { _, _, _, _, _, _, _, _, _ in
+                markCalls.withValue { $0 += 1 }
+            }
+            $0.userMetadataProvider.store = { _ in }
+        }
+    }
+}
+
+@MainActor
+private func waitForCoordFlowStore(
+    timeoutNanoseconds: UInt64 = 60_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for CoordFlow store state", sourceLocation: sourceLocation)
+}

--- a/zodlTests/SendTests/KeystoneFirmwareTests.swift
+++ b/zodlTests/SendTests/KeystoneFirmwareTests.swift
@@ -7,9 +7,8 @@
 //  `SendConfirmationStore` gate at `.foundPCZT` that blocks below-minimum/unstamped firmware
 //  before `createTransactionFromPCZT` ever schedules.
 //
-//  `KeystoneFirmwareGateTests`: `SendConfirmation.State` carries `@Shared(.inMemory(...))`
-//  process-global storage, so — mirroring `MultiServerSubmitPCZTRoutingTests`'s own reasoning —
-//  the suite is serialized. The reader/Comparable suites are pure/dependency-free, so unserialized.
+//  The reader/Comparable suites are pure and dependency-free, so they run unserialized; see
+//  `KeystoneFirmwareGateTests` below for why the gate suite needs more than that.
 //
 
 import Testing
@@ -117,8 +116,10 @@ import ComposableArchitecture
 // MARK: - SendConfirmationStore gate
 
 // `SendConfirmation.State` carries `@Shared(.inMemory(...))` process-global storage (address book
-// contacts, feature flags, wallet accounts) — serialized to avoid cross-suite races on that
-// storage, mirroring `MultiServerSubmitPCZTRoutingTests`'s own reasoning.
+// contacts, feature flags, wallet accounts). `.serialized` only orders this suite's own tests — it
+// does NOT prevent other suites from running in parallel with it — so each test also binds a fresh
+// in-memory store via `withDependencies { $0.defaultInMemoryStorage = InMemoryStorage() }`, which is
+// what actually isolates this suite from cross-suite races on that storage.
 @Suite(.serialized) @MainActor struct KeystoneFirmwareGateTests {
     private func makeStore() -> TestStore<SendConfirmation.State, SendConfirmation.Action> {
         let initialState = SendConfirmation.State(
@@ -129,15 +130,17 @@ import ComposableArchitecture
             proposal: .testOnlyFakeProposal(totalFee: 10_000)
         )
 
-        let store = TestStore(initialState: initialState) {
+        return TestStore(initialState: initialState) {
             SendConfirmation()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            // `KeystoneHandlerClient` provides only `liveValue` (no `testValue`), so the override
+            // must happen in this construction-time closure: mutating `store.dependencies`
+            // afterward would read (and fail on) the missing test value before the override is
+            // ever applied. Same idiom as `AddKeystoneHWWalletTests.swift`'s `readyToScanTapped`
+            // test.
+            $0.keystoneHandler.resetQRDecoder = { }
         }
-        store.dependencies.mainQueue = .immediate
-        // `KeystoneHandlerClient` has no `testValue` (only `liveValue`), so a `TestStore` requires
-        // a full override rather than a partial-property mutation — the latter reads the current
-        // (missing) test value first and fails before the override is ever applied.
-        store.dependencies.keystoneHandler = .noOp
-        return store
     }
 
     private func signedPczt(firmware: (major: Int, minor: Int, build: Int)?) -> Pczt {
@@ -149,86 +152,88 @@ import ComposableArchitecture
         return Pczt(data)
     }
 
-    @Test func belowMinimumFirmwarePresentsUpdateScreenAndNeverSchedulesCreateTransaction() async {
-        let store = makeStore()
-        let pczt = signedPczt(firmware: (2, 4, 6))
+    // Below-minimum firmware in two shapes — a clearly-old version and the boundary case one build
+    // below the 3.0.1 minimum — both must still be blocked and must never schedule
+    // `createTransactionFromPCZT`.
+    @Test(arguments: [(2, 4, 6), (3, 0, 0)])
+    func belowMinimumFirmwarePresentsUpdateScreen(major: Int, minor: Int, build: Int) async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore()
+            let pczt = signedPczt(firmware: (major, minor, build))
 
-        await store.send(.foundPCZT(pczt)) {
-            $0.isKeystoneCodeFound = true
-            $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+            await store.send(.foundPCZT(pczt)) {
+                $0.isKeystoneCodeFound = true
+                $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: major, minor: minor, build: build)
+            }
+            await store.receive(.keystoneFirmwareUpdateRequired)
+            // No further action arrives: `createTransactionFromPCZT` is never scheduled. An
+            // exhaustive `TestStore` fails on any unasserted action, so reaching `finish()`
+            // cleanly here IS the "never schedules" assertion.
+            await store.finish()
+
+            #expect(store.state.pcztWithSigs == nil)
         }
-        await store.receive(.keystoneFirmwareUpdateRequired)
-        // No further action arrives: `createTransactionFromPCZT` is never scheduled. An exhaustive
-        // `TestStore` fails on any unasserted action, so reaching `finish()` cleanly here IS the
-        // "never schedules" assertion.
-        await store.finish()
-
-        #expect(store.state.pcztWithSigs == nil)
-    }
-
-    // Just-below-minimum boundary: 3.0.0 is one build below the 3.0.1 minimum and must still be
-    // blocked.
-    @Test func oneBuildBelowMinimumFirmwarePresentsUpdateScreen() async {
-        let store = makeStore()
-        let pczt = signedPczt(firmware: (3, 0, 0))
-
-        await store.send(.foundPCZT(pczt)) {
-            $0.isKeystoneCodeFound = true
-            $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 3, minor: 0, build: 0)
-        }
-        await store.receive(.keystoneFirmwareUpdateRequired)
-        // No further action arrives: `createTransactionFromPCZT` is never scheduled. An exhaustive
-        // `TestStore` fails on any unasserted action, so reaching `finish()` cleanly here IS the
-        // "never schedules" assertion.
-        await store.finish()
-
-        #expect(store.state.pcztWithSigs == nil)
     }
 
     @Test func atMinimumFirmwareProceedsUnchanged() async {
-        let store = makeStore()
-        let pczt = signedPczt(firmware: (3, 0, 1))
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore()
+            let pczt = signedPczt(firmware: (3, 0, 1))
 
-        await store.send(.foundPCZT(pczt)) {
-            $0.isKeystoneCodeFound = true
-            $0.pcztWithSigs = pczt
+            await store.send(.foundPCZT(pczt)) {
+                $0.isKeystoneCodeFound = true
+                $0.pcztWithSigs = pczt
+            }
+            await store.receive(.keystoneFirmwareAccepted)
+            // `createTransactionFromPCZT`'s own guard bails with no state change: `pcztWithProofs`
+            // was never set, so this proves scheduling happened without needing to mock the
+            // synchronizer.
+            await store.receive(.createTransactionFromPCZT)
+            await store.finish()
+
+            #expect(store.state.detectedKeystoneFirmware == nil)
         }
-        // `createTransactionFromPCZT`'s own guard bails with no state change: `pcztWithProofs` was
-        // never set, so this proves scheduling happened without needing to mock the synchronizer.
-        await store.receive(.createTransactionFromPCZT)
-        await store.finish()
-
-        #expect(store.state.detectedKeystoneFirmware == nil)
     }
 
     @Test func unstampedFirmwarePresentsUpdateScreenWithNilDetectedVersion() async {
-        let store = makeStore()
-        let pczt = signedPczt(firmware: nil)
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore()
+            let pczt = signedPczt(firmware: nil)
 
-        await store.send(.foundPCZT(pczt)) {
-            $0.isKeystoneCodeFound = true
+            await store.send(.foundPCZT(pczt)) {
+                $0.isKeystoneCodeFound = true
+            }
+            await store.receive(.keystoneFirmwareUpdateRequired)
+            await store.finish()
+
+            #expect(store.state.detectedKeystoneFirmware == nil)
+            #expect(store.state.pcztWithSigs == nil)
         }
-        await store.receive(.keystoneFirmwareUpdateRequired)
-        await store.finish()
-
-        #expect(store.state.detectedKeystoneFirmware == nil)
-        #expect(store.state.pcztWithSigs == nil)
     }
 
     @Test func closeClearsStateForRescan() async {
-        let store = makeStore()
-        let pczt = signedPczt(firmware: (2, 4, 6))
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore()
+            let pczt = signedPczt(firmware: (2, 4, 6))
 
-        await store.send(.foundPCZT(pczt)) {
-            $0.isKeystoneCodeFound = true
-            $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
-        }
-        await store.receive(.keystoneFirmwareUpdateRequired)
+            await store.send(.foundPCZT(pczt)) {
+                $0.isKeystoneCodeFound = true
+                $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+            }
+            await store.receive(.keystoneFirmwareUpdateRequired)
 
-        await store.send(.keystoneFirmwareUpdateCloseTapped) {
-            $0.detectedKeystoneFirmware = nil
-            $0.isKeystoneCodeFound = false
+            // The reset now lives in the coordinators, not here: they pop this path element before
+            // this reducer would see the action. Covered by `KeystoneFirmwareCoordFlowTests`.
+            await store.send(.keystoneFirmwareUpdateCloseTapped)
+            await store.finish()
         }
-        await store.finish()
     }
 }

--- a/zodlTests/SendTests/KeystoneFirmwareTests.swift
+++ b/zodlTests/SendTests/KeystoneFirmwareTests.swift
@@ -1,0 +1,234 @@
+//
+//  KeystoneFirmwareTests.swift
+//  zodlTests
+//
+//  Covers MOB-1510 (Keystone minimum-firmware check): the `Data.keystoneFirmwareVersion()`
+//  byte-scan reader, `KeystoneFirmwareVersion`'s `Comparable` conformance, and the
+//  `SendConfirmationStore` gate at `.foundPCZT` that blocks below-minimum/unstamped firmware
+//  before `createTransactionFromPCZT` ever schedules.
+//
+//  `KeystoneFirmwareGateTests`: `SendConfirmation.State` carries `@Shared(.inMemory(...))`
+//  process-global storage, so — mirroring `MultiServerSubmitPCZTRoutingTests`'s own reasoning —
+//  the suite is serialized. The reader/Comparable suites are pure/dependency-free, so unserialized.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// MARK: - Data.keystoneFirmwareVersion() reader
+
+@Suite struct KeystoneFirmwareVersionReaderTests {
+    private static let key = Array("keystone:fw_version".utf8)
+
+    @Test func stampedVersionAtMinimumParses() {
+        var data = Data([0x00, 0x01])
+        data.append(contentsOf: Self.key)
+        data.append(contentsOf: [0x03, 3, 0, 1])
+
+        #expect(data.keystoneFirmwareVersion() == KeystoneFirmwareVersion(major: 3, minor: 0, build: 1))
+    }
+
+    @Test func stampedVersionBelowMinimumParses() {
+        var data = Data()
+        data.append(contentsOf: Self.key)
+        data.append(contentsOf: [0x03, 2, 4, 6])
+
+        #expect(data.keystoneFirmwareVersion() == KeystoneFirmwareVersion(major: 2, minor: 4, build: 6))
+    }
+
+    @Test func missingKeyReturnsNil() {
+        let data = Data([0x00, 0x01, 0x02, 0x03, 0x04])
+
+        #expect(data.keystoneFirmwareVersion() == nil)
+    }
+
+    @Test func keyPresentButTruncatedValueReturnsNil() {
+        var data = Data()
+        data.append(contentsOf: Self.key)
+        data.append(contentsOf: [0x03, 3, 0]) // only 2 of the 3 version bytes
+
+        #expect(data.keystoneFirmwareVersion() == nil)
+    }
+
+    @Test func keyPresentWithWrongLengthPrefixReturnsNil() {
+        var data = Data()
+        data.append(contentsOf: Self.key)
+        data.append(contentsOf: [0x04, 3, 0, 0]) // wrong prefix, not postcard's 0x03
+
+        #expect(data.keystoneFirmwareVersion() == nil)
+    }
+
+    @Test func multipleOccurrencesFirstValidOneWins() {
+        var data = Data()
+        // First occurrence: wrong length prefix, invalid.
+        data.append(contentsOf: Self.key)
+        data.append(contentsOf: [0x05, 9, 9, 9])
+        // Second occurrence: valid.
+        data.append(contentsOf: Self.key)
+        data.append(contentsOf: [0x03, 3, 1, 2])
+
+        #expect(data.keystoneFirmwareVersion() == KeystoneFirmwareVersion(major: 3, minor: 1, build: 2))
+    }
+
+    @Test func versionBytesAtVeryEndOfDataParses() {
+        var data = Data([0xFF])
+        data.append(contentsOf: Self.key)
+        data.append(contentsOf: [0x03, 4, 5, 6])
+
+        #expect(data.count == 1 + Self.key.count + 4)
+        #expect(data.keystoneFirmwareVersion() == KeystoneFirmwareVersion(major: 4, minor: 5, build: 6))
+    }
+
+    @Test func emptyDataReturnsNil() {
+        #expect(Data().keystoneFirmwareVersion() == nil)
+    }
+}
+
+// MARK: - KeystoneFirmwareVersion.Comparable
+
+@Suite struct KeystoneFirmwareVersionComparableTests {
+    @Test func lowerMajorIsBelowMinimum() {
+        #expect(KeystoneFirmwareVersion(major: 2, minor: 9, build: 9) < KeystoneFirmwareVersion.minimumSupported)
+    }
+
+    @Test func minimumIsExactlyThreeZeroOne() {
+        #expect(KeystoneFirmwareVersion.minimumSupported == KeystoneFirmwareVersion(major: 3, minor: 0, build: 1))
+    }
+
+    @Test func minimumIsNotBelowItself() {
+        #expect(!(KeystoneFirmwareVersion.minimumSupported < KeystoneFirmwareVersion.minimumSupported))
+    }
+
+    @Test func higherBuildIsAboveMinimum() {
+        #expect(KeystoneFirmwareVersion(major: 3, minor: 0, build: 2) > KeystoneFirmwareVersion.minimumSupported)
+    }
+
+    @Test func comparisonIsLexicographicOnMajorThenMinorThenBuild() {
+        // A higher minor must not be shadowed by comparing major alone.
+        #expect(KeystoneFirmwareVersion(major: 2, minor: 99, build: 99) < KeystoneFirmwareVersion(major: 3, minor: 0, build: 0))
+        // A higher build must not be shadowed by comparing major/minor alone.
+        #expect(KeystoneFirmwareVersion(major: 3, minor: 0, build: 0) < KeystoneFirmwareVersion(major: 3, minor: 0, build: 1))
+    }
+}
+
+// MARK: - SendConfirmationStore gate
+
+// `SendConfirmation.State` carries `@Shared(.inMemory(...))` process-global storage (address book
+// contacts, feature flags, wallet accounts) — serialized to avoid cross-suite races on that
+// storage, mirroring `MultiServerSubmitPCZTRoutingTests`'s own reasoning.
+@Suite(.serialized) @MainActor struct KeystoneFirmwareGateTests {
+    private func makeStore() -> TestStore<SendConfirmation.State, SendConfirmation.Action> {
+        let initialState = SendConfirmation.State(
+            address: "ztestaddr",
+            amount: Zatoshi(100_000),
+            feeRequired: Zatoshi(10_000),
+            message: "",
+            proposal: .testOnlyFakeProposal(totalFee: 10_000)
+        )
+
+        let store = TestStore(initialState: initialState) {
+            SendConfirmation()
+        }
+        store.dependencies.mainQueue = .immediate
+        // `KeystoneHandlerClient` has no `testValue` (only `liveValue`), so a `TestStore` requires
+        // a full override rather than a partial-property mutation — the latter reads the current
+        // (missing) test value first and fails before the override is ever applied.
+        store.dependencies.keystoneHandler = .noOp
+        return store
+    }
+
+    private func signedPczt(firmware: (major: Int, minor: Int, build: Int)?) -> Pczt {
+        var data = Data()
+        if let firmware {
+            data.append(contentsOf: Array("keystone:fw_version".utf8))
+            data.append(contentsOf: [0x03, UInt8(firmware.major), UInt8(firmware.minor), UInt8(firmware.build)])
+        }
+        return Pczt(data)
+    }
+
+    @Test func belowMinimumFirmwarePresentsUpdateScreenAndNeverSchedulesCreateTransaction() async {
+        let store = makeStore()
+        let pczt = signedPczt(firmware: (2, 4, 6))
+
+        await store.send(.foundPCZT(pczt)) {
+            $0.isKeystoneCodeFound = true
+            $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+        }
+        await store.receive(.keystoneFirmwareUpdateRequired)
+        // No further action arrives: `createTransactionFromPCZT` is never scheduled. An exhaustive
+        // `TestStore` fails on any unasserted action, so reaching `finish()` cleanly here IS the
+        // "never schedules" assertion.
+        await store.finish()
+
+        #expect(store.state.pcztWithSigs == nil)
+    }
+
+    // Just-below-minimum boundary: 3.0.0 is one build below the 3.0.1 minimum and must still be
+    // blocked.
+    @Test func oneBuildBelowMinimumFirmwarePresentsUpdateScreen() async {
+        let store = makeStore()
+        let pczt = signedPczt(firmware: (3, 0, 0))
+
+        await store.send(.foundPCZT(pczt)) {
+            $0.isKeystoneCodeFound = true
+            $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 3, minor: 0, build: 0)
+        }
+        await store.receive(.keystoneFirmwareUpdateRequired)
+        // No further action arrives: `createTransactionFromPCZT` is never scheduled. An exhaustive
+        // `TestStore` fails on any unasserted action, so reaching `finish()` cleanly here IS the
+        // "never schedules" assertion.
+        await store.finish()
+
+        #expect(store.state.pcztWithSigs == nil)
+    }
+
+    @Test func atMinimumFirmwareProceedsUnchanged() async {
+        let store = makeStore()
+        let pczt = signedPczt(firmware: (3, 0, 1))
+
+        await store.send(.foundPCZT(pczt)) {
+            $0.isKeystoneCodeFound = true
+            $0.pcztWithSigs = pczt
+        }
+        // `createTransactionFromPCZT`'s own guard bails with no state change: `pcztWithProofs` was
+        // never set, so this proves scheduling happened without needing to mock the synchronizer.
+        await store.receive(.createTransactionFromPCZT)
+        await store.finish()
+
+        #expect(store.state.detectedKeystoneFirmware == nil)
+    }
+
+    @Test func unstampedFirmwarePresentsUpdateScreenWithNilDetectedVersion() async {
+        let store = makeStore()
+        let pczt = signedPczt(firmware: nil)
+
+        await store.send(.foundPCZT(pczt)) {
+            $0.isKeystoneCodeFound = true
+        }
+        await store.receive(.keystoneFirmwareUpdateRequired)
+        await store.finish()
+
+        #expect(store.state.detectedKeystoneFirmware == nil)
+        #expect(store.state.pcztWithSigs == nil)
+    }
+
+    @Test func closeClearsStateForRescan() async {
+        let store = makeStore()
+        let pczt = signedPczt(firmware: (2, 4, 6))
+
+        await store.send(.foundPCZT(pczt)) {
+            $0.isKeystoneCodeFound = true
+            $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+        }
+        await store.receive(.keystoneFirmwareUpdateRequired)
+
+        await store.send(.keystoneFirmwareUpdateCloseTapped) {
+            $0.detectedKeystoneFirmware = nil
+            $0.isKeystoneCodeFound = false
+        }
+        await store.finish()
+    }
+}


### PR DESCRIPTION
## Summary

Ports the Keystone minimum-firmware gate from #1916 onto the `release/3.8.0` line, with the enforced minimum **raised from 3.0.0 to 3.0.1**. #1916 merged into the Ironwood feature branch, so the release line currently ships without the gate — a Keystone on old firmware can still sign a PCZT that ZODL will broadcast.

**Mechanism** (unchanged from #1916): KeystoneSDK 0.8.6 exposes no firmware API, so the device firmware (shipped ≥ 2.4.6) stamps `global.proprietary["keystone:fw_version"]` (3 bytes) into every signed Zcash PCZT, and `Data.keystoneFirmwareVersion()` byte-scans the signed bytes for it — malformed occurrences are skipped, first valid one wins.

- **Minimum**: `KeystoneFirmwareVersion.minimumSupported = 3.0.1`, always enforced, no escape hatch. **Unstamped blocks too**: stamping shipped well below the enforced minimum, so a version-less PCZT is necessarily too old rather than merely "unknown".
- **The gate fires strictly before `createTransactionFromPCZT` is ever scheduled**, so a below-minimum signature never reaches the network.
- **Four signing surfaces gated** — the shared `SendConfirmation.foundPCZT` hook covers Scan, Send, SwapAndPay and SignWithKeystone. A below-minimum or unstamped signature pushes the new `KeystoneFirmwareUpdateView` (a `.keystoneFirmwareUpdate` path case, mirroring `.preSendingFailure`'s idiom) instead of proceeding; Close resets the scan state so an updated device can retry against the same, still-valid proposal. In `SignWithKeystone` the confirm screen *is* the flow root, so the action arrives root-level rather than path-wrapped and Close clears the whole path.
- Two copy variants (detected-version vs legacy/unstamped), 4 new `keystone.firmwareUpdate.*` strings (EN translated, ES needs_review).

### Scope note

#1916 gated five surfaces; the fifth was the Ironwood migration Keystone ceremony. `MigrationCoordFlow*` does not exist on this branch — that flow lives only on the Ironwood feature branch, and its gate travels with it. Nothing to port here.

`KeystoneFirmwareUpdateContent` (the store-less illustration/title/body split out of the full-screen view) is kept, since it is what a sheet presentation of the same gate consumes; its comments were reworded to stop naming a file that does not exist on this branch.

## Tests

`KeystoneFirmwareTests` — reader matrix (stamped / below-min / absent / truncated / wrong length prefix / multiple occurrences / bytes at end of buffer / empty), `Comparable` ordering, and the store gate (below-min blocks and never schedules `createTransactionFromPCZT`; at-min proceeds unchanged; unstamped blocks with a nil detected version; Close clears for rescan).

Added for the raised minimum: a **one-build-below-minimum boundary test** — 3.0.0 is now blocked, which nothing covered while 3.0.0 *was* the minimum. Written test-first: it failed against the old 3.0.0 minimum (together with the retargeted `minimumIsExactlyThreeZeroOne`) and passed once the minimum was raised.

## Gate

- `xcodebuild build -skipMacroValidation`: **BUILD SUCCEEDED** for both `zodl-internal` and `zodl-testnet`.
- Full `zodlTests` suite via the `zodl-internal` scheme: **597 tests / 100 suites passed**, `** TEST SUCCEEDED **`. The single reported "known issue" is the pre-existing, intentionally-recorded `CurrencyConversionSetupTests` Tor/swap-access expectation, untouched by this change.

## Review round

A code review of the port found defects in the gate's coordinator wiring. Three follow-up commits fix them; each fix was written test-first against the unfixed code and observed to fail before being made to pass.

- **The Close handler was dead code in all four flows.** Every coordinator composes `coordinatorReduce()` before `.forEach(\.path)`, so the coordinator popped the path element before `SendConfirmation` could see the action — and the element it targeted was a discarded value copy regardless. None of its three statements ran. Rescan worked only because `getSignatureTapped` independently performs the identical reset. The reset now happens in each coordinator against the element that survives the pop (or the root state in `SignWithKeystone`), and the store's case is a bare `return .none`, matching `backFromPCZTFailureTapped`.
- **The push handler had no `break`**, appending one update screen per `confirmWithKeystone` element on the path. With two on the stack the user had to tap Close twice, and the first Close discarded the second element's state.
- **The update screen stacked on top of `.scan`/`.sending`**, leaving a still-animating "Sending" screen mounted underneath a refusal. The handler now pops to `confirmWithKeystone` first.
- **A blocked swap left a permanent phantom record.** `SwapAndPay` wrote its pending-swap metadata to disk in `.scan(.foundPCZT)`, before the gate ran; there is no unmark API to undo it, so a blocked attempt would later misclassify any ordinary payment to that deposit address as a swap. The write is deferred behind a new `keystoneFirmwareAccepted` signal the gate emits only on success.
- **Screen consistency**: the wrapping title now centres (it was the only title in this family long enough to wrap, and rendered left-aligned against a centred illustration and body), the illustration uses the store's randomized one like its two siblings, and the Close button reuses the existing fully-translated `general.close` instead of a duplicate key, which is removed.
- **Reader performance**: the byte scan copied the whole PCZT and heap-allocated a 19-byte array at every index, on the main actor while the QR camera session was live. Rewritten on `Data.range(of:in:)` with semantics preserved byte-for-byte — all eight reader tests pass untouched.

New `KeystoneFirmwareCoordFlowTests` covers the four push/close handlers, which previously had no tests at all — which is why all of the above shipped green.

### Gate (after fixes)

- **BUILD SUCCEEDED** for `zodl-internal` and `zodl-testnet`.
- Full `zodlTests`: **604 tests / 101 suites passed**, `** TEST SUCCEEDED **` — up from 597/100, same single pre-existing `CurrencyConversionSetupTests` known issue, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
