### PR TITLE
[MOB-140] Fix missing shield badge on the Sapling address icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Fixed
 - [Ironwood] The automatic recovery from another wallet's leftover data (see MOB-1512 below) keeps working with the updated Zcash SDK. The SDK now reports that mismatch as an error rather than a status, so ZODL maps it back onto the same recovery and the wallet still heals itself instead of stopping on an initialization error.
+- [MOB-140] On the Receive screen, the Zcash Sapling address (testnet debug builds only) now shows the same shield badge on its icon as the Zcash Shielded Address, instead of an incomplete badge that made the address look unshielded.
 - [#1943] Fixed a wallet initialization bug: initialization is now single-flight, so repeated startup triggers while the wallet is still initializing are ignored until it finishes.
 - [#1920] Connecting a Keystone hardware wallet that fails now shows a clear "Connection Failed" message (with Contact Support and Cancel options) instead of silently doing nothing. Cancel leaves the flow so the user is never stuck on the connection screen. The support message includes a safe error identifier and never exposes any wallet keys.
 - [#1920] The "Connection Failed" sheet no longer appears on top of the success screen when connecting a Keystone device actually succeeds. Tapping the connect/OK button again while the import was still running started a duplicate import whose failure surfaced as a bogus error; the button now shows a progress indicator and extra taps are ignored.

--- a/secant/Sources/Features/Receive/ReceiveView.swift
+++ b/secant/Sources/Features/Receive/ReceiveView.swift
@@ -123,6 +123,7 @@ struct ReceiveView: View {
                                         iconFg: Design.Text.primary,
                                         iconBg: Design.Surfaces.bgTertiary,
                                         bcgColor: .clear,
+                                        shieldBcgColor: Asset.Colors.background.color,
                                         expanded: store.currentFocus == .saplingAddress,
                                         shield: true
                                     ) {
@@ -290,6 +291,7 @@ struct ReceiveView: View {
         iconFg: Colorable,
         iconBg: Colorable,
         bcgColor: Color,
+        shieldBcgColor: Color? = nil,
         expanded: Bool,
         shield: Bool = false,
         copyButton: Bool = true,
@@ -306,7 +308,7 @@ struct ReceiveView: View {
                         .padding(.trailing, 16)
                         .overlay {
                             Asset.Assets.Icons.shieldBcg.image
-                                .zImage(size: 18, color: bcgColor)
+                                .zImage(size: 18, color: shieldBcgColor ?? bcgColor)
                                 .offset(x: 6, y: 14)
                                 .overlay {
                                     Asset.Assets.Icons.shieldTickFilled.image


### PR DESCRIPTION
## Problem

On the Receive screen, the **Zcash Sapling Address** icon was missing the shield accessory that the **Zcash Shielded Address** icon has, so a shielded address visually read as unshielded.

## Before / After

| Before | After (light) | After (dark) |
|:---:|:---:|:---:|
| <img src="https://raw.githubusercontent.com/zodl-inc/zodl-ios/assets/mob-140-screenshots/before.jpeg" width="260"> | <img src="https://raw.githubusercontent.com/zodl-inc/zodl-ios/assets/mob-140-screenshots/after-light.jpeg" width="260"> | <img src="https://raw.githubusercontent.com/zodl-inc/zodl-ios/assets/mob-140-screenshots/after-dark.jpeg" width="260"> |

In *Before*, the Sapling icon carries only a bare circular tick. In *After*, it shows the same shield-with-tick silhouette as the Shielded row at the top, and reads correctly in both light and dark mode.

## Cause

`addressBlock` draws the badge as an `Asset.Assets.Icons.shieldBcg` silhouette tinted with the row's `bcgColor`, with `shieldTickFilled` layered on top. That tinted silhouette is what separates the shield from the dark brandmark circle beneath it.

`bcgColor` did double duty — it also fills the row's card background. The testnet-only Sapling row has no card, so it passed `bcgColor: .clear`; the shield silhouette rendered transparent and only the bare tick survived.

## Fix

Decouple the two: `addressBlock` gains a `shieldBcgColor` parameter defaulting to `bcgColor`, so all existing call sites are unchanged in behaviour. The Sapling row passes `Asset.Colors.background.color` — the colour actually visible behind it.

## Scope

The Sapling row is `#if DEBUG` + testnet only, so this is visible in testnet dev builds, not in production or internal mainnet builds.

## Verification

- Visually confirmed on device in a testnet build — see the screenshots above (light and dark mode).
- `zodl-testnet` builds clean for the **iOS Simulator** and for a **physical device** (`generic/platform=iOS`) — `** BUILD SUCCEEDED **`, no compile errors.
- SwiftLint: no new violations. The two pre-existing `error`-level findings on this file (`function_parameter_count`, `type_body_length`) are identical before and after — the new parameter has a default, so the parameter count is unchanged. SwiftLint's build phase is commented out in the project.
- Changelog entry added.

> Screenshots are hosted on the `assets/mob-140-screenshots` branch so they stay out of this PR's diff and out of `release/3.8.0` history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)