### PR TITLE
[MOB-1535] Implement detailed pool balance bottom sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Added
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
 - [Ironwood] A transfer that moves funds into the Ironwood pool now shows the amount that actually moved, in both the transaction list and the transaction detail screen. Previously such a transfer displayed only its fee.
+- [MOB-1535] Tapping your balance on the home screen now opens a "Total Balance Across Pools" breakdown showing how much ZEC sits in each Zcash pool — Orchard, Sapling, Transparent and Ironwood — so you can see exactly where your funds are. When currency conversion is turned on, each pool also shows its value in your selected currency. Pools you hold nothing in are still listed, and with balances hidden every amount stays masked.
 
 ### Changed
 - [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -9785,7 +9785,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tu saldo de ZEC ahora está desglosado por pool de Zcash, para que veas exactamente dónde están tus fondos."
+            "value" : "Tu saldo de ZEC ahora se desglosa por pool de Zcash, para que veas exactamente dónde están tus fondos."
           }
         }
       }
@@ -9870,7 +9870,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Saldo total entre pools"
+            "value" : "Saldo Total En Todos Los Pools"
           }
         }
       }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -9772,6 +9772,143 @@
         }
       }
     },
+    "poolBalances.desc" : {
+      "comment" : "MARK: - Pool Balances",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your ZEC balance is now broken down by Zcash pool, so you can see exactly where your funds sit."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu saldo de ZEC ahora está desglosado por pool de Zcash, para que veas exactamente dónde están tus fondos."
+          }
+        }
+      }
+    },
+    "poolBalances.gotIt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got it"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entendido"
+          }
+        }
+      }
+    },
+    "poolBalances.ironwood" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ironwood"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ironwood"
+          }
+        }
+      }
+    },
+    "poolBalances.orchard" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orchard"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orchard"
+          }
+        }
+      }
+    },
+    "poolBalances.sapling" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sapling"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sapling"
+          }
+        }
+      }
+    },
+    "poolBalances.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total Balance Across Pools"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saldo total entre pools"
+          }
+        }
+      }
+    },
+    "poolBalances.totalBalance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total Balance"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saldo total"
+          }
+        }
+      }
+    },
+    "poolBalances.transparent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparent"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparente"
+          }
+        }
+      }
+    },
     "privateDataConsent.confirmation" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Features/Home/HomeStore.swift
+++ b/secant/Sources/Features/Home/HomeStore.swift
@@ -20,6 +20,7 @@ struct Home {
         var migratingDatabase = true
         var moreRequest = false
         var payRequest = false
+        var poolBalancesRequest = false
         var smartBannerState = SmartBanner.State.initial
         var walletConfig: WalletConfig
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
@@ -80,6 +81,7 @@ struct Home {
         case onDisappear
         case payTapped
         case payWithNearTapped
+        case poolBalancesDismissTapped
         case presentKeystoneWeb
         case rateTooltipTapped
         case receiveScreenRequested
@@ -287,6 +289,14 @@ struct Home {
                     return .none
                 }
                 state.isRateTooltipEnabled = state.walletBalancesState.isExchangeRateStale
+                return .none
+
+            case .walletBalances(.balanceTapped):
+                state.poolBalancesRequest = true
+                return .none
+
+            case .poolBalancesDismissTapped:
+                state.poolBalancesRequest = false
                 return .none
 
             case .alert(.presented(let action)):

--- a/secant/Sources/Features/Home/HomeView.swift
+++ b/secant/Sources/Features/Home/HomeView.swift
@@ -26,7 +26,8 @@ struct HomeView: View {
                     ),
                     tokenName: tokenName,
                     couldBeHidden: true,
-                    shortened: true
+                    shortened: true,
+                    balanceTappable: true
                 )
                 .padding(.top, 1)
 
@@ -115,6 +116,9 @@ struct HomeView: View {
             .zashiSheet(isPresented: $store.payRequest, horizontalPadding: 0) {
                 // FIXME: delete this
                 payRequestContent()
+            }
+            .zashiSheet(isPresented: $store.poolBalancesRequest) {
+                poolBalancesContent()
             }
             .navigationBarItems(
                 leading:

--- a/secant/Sources/Features/Home/PoolBalancesSheet.swift
+++ b/secant/Sources/Features/Home/PoolBalancesSheet.swift
@@ -67,15 +67,21 @@ extension HomeView {
                             .zFont(.semiBold, size: 16, style: Design.Text.tertiary)
                     }
                 }
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
             } else {
                 ZatoshiText(balance, .expanded, tokenName)
                     .zFont(.semiBold, size: 16, style: Design.Text.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
             }
 
             if store.walletBalancesState.isFiatAvailable {
                 Text(store.walletBalancesState.fiatValue(balance))
                     .hiddenIfSet()
                     .zFont(size: 12, style: Design.Text.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/secant/Sources/Features/Home/PoolBalancesSheet.swift
+++ b/secant/Sources/Features/Home/PoolBalancesSheet.swift
@@ -59,7 +59,9 @@ extension HomeView {
 
             if dimmedToken {
                 HStack(spacing: 4) {
-                    ZatoshiText(balance, .expanded)
+                    // .abbreviated matches the home screen's balance label: floored to 0.001 ZEC,
+                    // always three fraction digits.
+                    ZatoshiText(balance, .abbreviated)
                         .zFont(.semiBold, size: 16, style: Design.Text.primary)
 
                     if !isSensitiveContentHidden {
@@ -70,7 +72,7 @@ extension HomeView {
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
             } else {
-                ZatoshiText(balance, .expanded, tokenName)
+                ZatoshiText(balance, .abbreviated, tokenName)
                     .zFont(.semiBold, size: 16, style: Design.Text.primary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)

--- a/secant/Sources/Features/Home/PoolBalancesSheet.swift
+++ b/secant/Sources/Features/Home/PoolBalancesSheet.swift
@@ -1,0 +1,94 @@
+//
+//  PoolBalancesSheet.swift
+//  modules
+//
+//  Created by Michal Fousek on 25.07.2026.
+//
+
+import SwiftUI
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+extension HomeView {
+    @ViewBuilder func poolBalancesContent() -> some View {
+        WithPerceptionTracking {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(localizable: .poolBalancesTitle)
+                    .zFont(.semiBold, size: 20, style: Design.Text.primary)
+                    .padding(.top, 32)
+
+                Text(localizable: .poolBalancesDesc)
+                    .zFont(size: 14, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .multilineTextAlignment(.leading)
+                    .padding(.top, 4)
+                    .padding(.bottom, 24)
+
+                poolCard(
+                    title: String(localizable: .poolBalancesTotalBalance),
+                    balance: store.walletBalancesState.totalBalance,
+                    dimmedToken: true
+                )
+                .padding(.bottom, 8)
+
+                HStack(spacing: 8) {
+                    poolCard(title: String(localizable: .poolBalancesOrchard), balance: store.walletBalancesState.orchardPoolBalance)
+                    poolCard(title: String(localizable: .poolBalancesSapling), balance: store.walletBalancesState.saplingPoolBalance)
+                }
+                .padding(.bottom, 8)
+
+                HStack(spacing: 8) {
+                    poolCard(title: String(localizable: .poolBalancesTransparent), balance: store.walletBalancesState.transparentPoolBalance)
+                    poolCard(title: String(localizable: .poolBalancesIronwood), balance: store.walletBalancesState.ironwoodPoolBalance)
+                }
+                .padding(.bottom, 32)
+
+                ZashiButton(String(localizable: .poolBalancesGotIt)) {
+                    store.send(.poolBalancesDismissTapped)
+                }
+                .padding(.bottom, Design.Spacing.sheetBottomSpace)
+            }
+        }
+    }
+
+    @ViewBuilder private func poolCard(title: String, balance: Zatoshi, dimmedToken: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .zFont(.medium, size: 14, style: Design.Text.tertiary)
+                .padding(.bottom, 4)
+
+            if dimmedToken {
+                HStack(spacing: 4) {
+                    ZatoshiText(balance, .expanded)
+                        .zFont(.semiBold, size: 16, style: Design.Text.primary)
+
+                    Text(tokenName)
+                        .zFont(.semiBold, size: 16, style: Design.Text.tertiary)
+                }
+            } else {
+                ZatoshiText(balance, .expanded, tokenName)
+                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
+            }
+
+            if store.walletBalancesState.isFiatAvailable {
+                Text(store.walletBalancesState.fiatValue(balance))
+                    .hiddenIfSet()
+                    .zFont(size: 12, style: Design.Text.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background {
+            RoundedRectangle(cornerRadius: Design.Radius._2xl)
+                .fill(Design.Surfaces.bgSecondary.color(colorScheme))
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    HomeView(store: Home.placeholder, tokenName: "ZEC")
+        .poolBalancesContent()
+}

--- a/secant/Sources/Features/Home/PoolBalancesSheet.swift
+++ b/secant/Sources/Features/Home/PoolBalancesSheet.swift
@@ -62,8 +62,10 @@ extension HomeView {
                     ZatoshiText(balance, .expanded)
                         .zFont(.semiBold, size: 16, style: Design.Text.primary)
 
-                    Text(tokenName)
-                        .zFont(.semiBold, size: 16, style: Design.Text.tertiary)
+                    if !isSensitiveContentHidden {
+                        Text(tokenName)
+                            .zFont(.semiBold, size: 16, style: Design.Text.tertiary)
+                    }
                 }
             } else {
                 ZatoshiText(balance, .expanded, tokenName)

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -30,23 +30,37 @@ struct WalletBalances {
         var spendability: Spendability = .everything
         var totalBalance: Zatoshi
         var transparentBalance: Zatoshi
+        var awaitingResolutionBalance: Zatoshi = .zero
+        var ironwoodPoolBalance: Zatoshi = .zero
+        var orchardPoolBalance: Zatoshi = .zero
+        var saplingPoolBalance: Zatoshi = .zero
 
         var isExchangeRateUSDInFlight: Bool {
             fiatCurrencyResult?.state == .fetching
         }
-        
+
         var isProcessingZeroAvailableBalance: Bool {
             if shieldedBalance.amount == 0 && transparentBalance.amount > autoShieldingThreshold.amount {
                 return false
             }
-            
+
             return totalBalance.amount != shieldedBalance.amount && shieldedBalance.amount == 0
+        }
+
+        // Display-only: deliberately not folded into `transparentBalance`, which feeds
+        // `isProcessingZeroAvailableBalance`, the auto-shielding threshold comparison, and spendability.
+        var transparentPoolBalance: Zatoshi {
+            transparentBalance + awaitingResolutionBalance
         }
 
         var currencyValue: String {
             currencyConversion?.convert(totalBalance) ?? ""
         }
-        
+
+        var isFiatAvailable: Bool {
+            isExchangeRateFeatureOn && currencyConversion != nil
+        }
+
         init(
             fiatCurrencyResult: FiatCurrencyResult? = nil,
             isAvailableBalanceTappable: Bool = true,
@@ -70,10 +84,15 @@ struct WalletBalances {
             self.totalBalance = totalBalance
             self.transparentBalance = transparentBalance
         }
+
+        func fiatValue(_ balance: Zatoshi) -> String {
+            currencyConversion?.convert(balance) ?? ""
+        }
     }
-    
+
     enum Action: Equatable {
         case availableBalanceTapped
+        case balanceTapped
         case balanceUpdated(AccountBalance?)
         case exchangeRateRefreshTapped
         case exchangeRateEvent(ExchangeRateClient.EchangeRateEvent)
@@ -128,6 +147,10 @@ struct WalletBalances {
                 )
                 
             case .availableBalanceTapped:
+                return .none
+
+            case .balanceTapped:
+                // No-op — the parent feature decides what tapping the balance means.
                 return .none
 
             case .exchangeRateRefreshTapped:
@@ -193,7 +216,11 @@ struct WalletBalances {
                 state.shieldedWithPendingBalance = accountBalance?.shieldedTotal() ?? .zero
                 state.transparentBalance = accountBalance?.unshielded ?? .zero
                 state.totalBalance = state.shieldedWithPendingBalance + state.transparentBalance + (accountBalance?.awaitingResolution ?? .zero)
-               
+                state.saplingPoolBalance = accountBalance?.saplingBalance.total() ?? .zero
+                state.orchardPoolBalance = accountBalance?.orchardBalance.total() ?? .zero
+                state.ironwoodPoolBalance = accountBalance?.ironwoodBalance.total() ?? .zero
+                state.awaitingResolutionBalance = accountBalance?.awaitingResolution ?? .zero
+
                 let everythingCondition = state.shieldedBalance.amount > 0 && ((state.shieldedBalance == state.totalBalance)
                 || (state.transparentBalance < zcashSDKEnvironment.shieldingThreshold() && state.shieldedBalance == state.totalBalance - state.transparentBalance))
                 || state.totalBalance == .zero

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -54,7 +54,7 @@ struct WalletBalances {
         }
 
         var currencyValue: String {
-            currencyConversion?.convert(totalBalance) ?? ""
+            fiatValue(totalBalance)
         }
 
         var isFiatAvailable: Bool {

--- a/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
@@ -17,8 +17,6 @@ struct WalletBalancesView: View {
     let shortened: Bool
     let balanceTappable: Bool
 
-    @Shared(.appStorage(.sensitiveContent)) var isSensitiveContentHidden = false
-
     init(
         store: StoreOf<WalletBalances>,
         tokenName: String,
@@ -76,7 +74,7 @@ struct WalletBalancesView: View {
     }
     
     @ViewBuilder private func tappableBalanceContent() -> some View {
-        if balanceTappable && !isSensitiveContentHidden {
+        if balanceTappable {
             Button {
                 store.send(.balanceTapped)
             } label: {

--- a/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
@@ -15,23 +15,28 @@ struct WalletBalancesView: View {
     let tokenName: String
     let couldBeHidden: Bool
     let shortened: Bool
+    let balanceTappable: Bool
+
+    @Shared(.appStorage(.sensitiveContent)) var isSensitiveContentHidden = false
 
     init(
         store: StoreOf<WalletBalances>,
         tokenName: String,
         couldBeHidden: Bool = false,
-        shortened: Bool = false
+        shortened: Bool = false,
+        balanceTappable: Bool = false
     ) {
         self.store = store
         self.tokenName = tokenName
         self.couldBeHidden = couldBeHidden
         self.shortened = shortened
+        self.balanceTappable = balanceTappable
     }
 
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                balanceContent()
+                tappableBalanceContent()
                     .padding(.top, 40)
                     .anchorPreference(
                         key: ExchangeRateFeaturePreferenceKey.self,
@@ -70,6 +75,19 @@ struct WalletBalancesView: View {
         }
     }
     
+    @ViewBuilder private func tappableBalanceContent() -> some View {
+        if balanceTappable && !isSensitiveContentHidden {
+            Button {
+                store.send(.balanceTapped)
+            } label: {
+                balanceContent()
+            }
+            .accessibilityIdentifier(AccessibilityID.Home.totalBalanceButton)
+        } else {
+            balanceContent()
+        }
+    }
+
     @ViewBuilder private func balanceContent() -> some View {
         HStack(spacing: 0) {
             ZcashSymbol()

--- a/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
@@ -79,6 +79,7 @@ struct WalletBalancesView: View {
                 store.send(.balanceTapped)
             } label: {
                 balanceContent()
+                    .contentShape(Rectangle())
             }
             .accessibilityIdentifier(AccessibilityID.Home.totalBalanceButton)
         } else {

--- a/secant/Sources/Utils/AccessibilityID.swift
+++ b/secant/Sources/Utils/AccessibilityID.swift
@@ -18,6 +18,7 @@ enum AccessibilityID {
         static let payButton = "home.payButton"
         static let swapButton = "home.swapButton"
         static let moreButton = "home.moreButton"
+        static let totalBalanceButton = "home.totalBalanceButton"
     }
 
     enum MoreSheet {

--- a/zodlTests/HomeTests/HomeTests.swift
+++ b/zodlTests/HomeTests/HomeTests.swift
@@ -30,4 +30,35 @@ import ComposableArchitecture
 
         await store.finish()
     }
+
+    @MainActor @Test func balanceTappedPresentsPoolBalancesSheet() async {
+        let store = TestStore(
+            initialState: .initial
+        ) {
+            Home()
+        }
+
+        await store.send(.walletBalances(.balanceTapped)) {
+            $0.poolBalancesRequest = true
+        }
+
+        await store.finish()
+    }
+
+    @MainActor @Test func poolBalancesDismissTappedHidesPoolBalancesSheet() async {
+        var initialState = Home.State.initial
+        initialState.poolBalancesRequest = true
+
+        let store = TestStore(
+            initialState: initialState
+        ) {
+            Home()
+        }
+
+        await store.send(.poolBalancesDismissTapped) {
+            $0.poolBalancesRequest = false
+        }
+
+        await store.finish()
+    }
 }

--- a/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
@@ -36,6 +36,31 @@ import ComposableArchitecture
         #expect(!state.currencyValue.isEmpty)
     }
 
+    @Test func isFiatAvailableReflectsFeatureFlagAndConversion() {
+        var state = WalletBalances.State()
+
+        // Conversion already set here so this proves the flag itself gates
+        // availability, rather than trivially passing because both are unset.
+        state.$currencyConversion.withLock { $0 = CurrencyConversion(.usd, ratio: 30, timestamp: 0) }
+        #expect(!state.isFiatAvailable)
+
+        state.$currencyConversion.withLock { $0 = nil }
+        state.isExchangeRateFeatureOn = true
+        #expect(!state.isFiatAvailable)
+
+        state.$currencyConversion.withLock { $0 = CurrencyConversion(.usd, ratio: 30, timestamp: 0) }
+        #expect(state.isFiatAvailable)
+    }
+
+    @Test func fiatValueEmptyWithoutConversionAndFormattedWithIt() {
+        var state = WalletBalances.State()
+        state.$currencyConversion.withLock { $0 = nil }
+        #expect(state.fiatValue(Zatoshi(100_000_000)).isEmpty)
+
+        state.$currencyConversion.withLock { $0 = CurrencyConversion(.usd, ratio: 30, timestamp: 0) }
+        #expect(!state.fiatValue(Zatoshi(100_000_000)).isEmpty)
+    }
+
     // MARK: - balanceUpdated(nil)
 
     @MainActor @Test func balanceUpdatedWithNilZerosBalancesAndMarksEverythingSpendable() async {
@@ -78,6 +103,75 @@ import ComposableArchitecture
         #expect(store.state.totalBalance == Zatoshi(816))               // 810 + 5 + 1 awaiting
     }
 
+    // MARK: - Pool balances
+
+    @MainActor @Test func balanceUpdatedPopulatesPerPoolBalances() async {
+        let store = TestStore(initialState: WalletBalances.State()) {
+            WalletBalances()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        }
+        store.exhaustivity = .off
+
+        let balance = fullPoolAccountBalance()
+        await store.send(.balanceUpdated(balance))
+
+        #expect(store.state.saplingPoolBalance == balance.saplingBalance.total())
+        #expect(store.state.orchardPoolBalance == balance.orchardBalance.total())
+        #expect(store.state.ironwoodPoolBalance == balance.ironwoodBalance.total())
+        #expect(store.state.awaitingResolutionBalance == balance.awaitingResolution)
+    }
+
+    @MainActor @Test func transparentPoolBalanceIncludesAwaitingResolution() async {
+        let store = TestStore(initialState: WalletBalances.State()) {
+            WalletBalances()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.balanceUpdated(fullPoolAccountBalance()))
+
+        #expect(store.state.transparentPoolBalance == store.state.transparentBalance + store.state.awaitingResolutionBalance)
+    }
+
+    // The four displayed pool values must sum to totalBalance in every sync state — that
+    // identity is what lets the pool-breakdown sheet show numbers that add up to the
+    // home-screen total.
+    @MainActor @Test func poolBalancesSumToTotalBalance() async {
+        let store = TestStore(initialState: WalletBalances.State()) {
+            WalletBalances()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.balanceUpdated(fullPoolAccountBalance()))
+
+        let sum = store.state.saplingPoolBalance
+            + store.state.orchardPoolBalance
+            + store.state.ironwoodPoolBalance
+            + store.state.transparentPoolBalance
+        #expect(sum == store.state.totalBalance)
+    }
+
+    @MainActor @Test func balanceUpdatedWithNilZeroesPoolBalances() async {
+        let store = TestStore(initialState: WalletBalances.State()) {
+            WalletBalances()
+        } withDependencies: {
+            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.balanceUpdated(fullPoolAccountBalance()))
+        await store.send(.balanceUpdated(nil))
+
+        #expect(store.state.saplingPoolBalance == .zero)
+        #expect(store.state.orchardPoolBalance == .zero)
+        #expect(store.state.ironwoodPoolBalance == .zero)
+        #expect(store.state.awaitingResolutionBalance == .zero)
+    }
+
     // MARK: - exchangeRateEvent
 
     @MainActor @Test func exchangeRateValueSetsConversionAndClearsStale() async {
@@ -114,6 +208,16 @@ import ComposableArchitecture
 
     private func fiatResult(rate: Double) -> FiatCurrencyResult {
         FiatCurrencyResult(date: Date(timeIntervalSince1970: 1000), rate: NSDecimalNumber(value: rate), state: .success)
+    }
+
+    private func fullPoolAccountBalance() -> AccountBalance {
+        AccountBalance(
+            saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
+            orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
+            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
+            unshielded: Zatoshi(5),
+            awaitingResolution: Zatoshi(1)
+        )
     }
 
     @MainActor


### PR DESCRIPTION
Closes MOB-1535.

Tapping the balance on the home screen now opens a **Total Balance Across Pools** sheet, breaking the wallet total down into Orchard, Sapling, Transparent and Ironwood — with each pool's fiat value underneath when Currency Conversion is on.

## Approach

**No new reducer.** The sheet's only control is a dismiss button and it does no async work, so a `@Reducer` for it would have been empty scaffolding. Three small pieces instead:

- `WalletBalances` derives the four pool values inside its existing `.balanceUpdated` case, from the very same `AccountBalance` the home total is computed from. That costs no extra SDK call, and — more importantly — the pools can never disagree with the number rendered directly above the sheet.
- A `balanceTapped` signal, a no-op in `WalletBalances`' own reducer exactly like the existing `availableBalanceTapped`, leaving the parent to decide what it means. `WalletBalancesView` is shared with the Send and Swap/Pay forms, so the tap target is opt-in via a new `balanceTappable` flag that only Home passes.
- `Home` owns presentation: a `poolBalancesRequest` bool plus `PoolBalancesSheet.swift`, an `extension HomeView` following the existing `MoreSheet.swift` / `WalletAccountsSheet.swift` convention.

**The underlying values sum to the total exactly, in every sync state.** The home total is `shieldedTotal + transparent + awaitingResolution`, and `shieldedTotal` is sapling + orchard + ironwood, so `awaitingResolution` is folded into the Transparent card via a new display-only `transparentPoolBalance`. The existing `transparentBalance` is deliberately left untouched — it drives spendability, the zero-available-balance indicator and the auto-shielding threshold comparison, so display and logic stay separate.

**Amounts use the same format as the home balance label** — abbreviated, floored to 0.001 ZEC, always three fraction digits — so the sheet's Total card reads identically to the number on the screen behind it. See the caveat below.

Everything reuses the existing design system — `zashiSheet`, `ZashiButton`, `ZatoshiText` and the `Design.*` tokens. No new components.

## Behaviour

- Opens every time, including after a previous dismissal; "Got it" and swipe-down both dismiss and persist nothing.
- All four cards are always shown; a pool with no funds reads `0.000 ZEC` rather than collapsing.
- With balances hidden, every value renders `-----` — including the Total card, whose token suffix is suppressed so it matches the pool cards — while the labels stay readable.
- Fiat appears exactly when Currency Conversion is enabled and a rate is available, and nowhere otherwise.
- English and Spanish strings both added.

## Testing

- Full suite green: 587 tests across 97 suites, including 8 new ones. The load-bearing test asserts the four pool *values* sum to `totalBalance` with non-zero pending values in every pool **and** a non-zero `awaitingResolution` — an equality between two independently-computed values, not against a constant.
- Walked the acceptance criteria by hand on an iPhone SE (3rd gen) simulator — 375 pt, the narrowest width the iOS 16.0 deployment target supports — in light and dark mode, with conversion on and off and with balances shown and hidden.

## Notes for the reviewer

- **Displayed pool amounts can add up to slightly less than the displayed Total.** Each pool is floored to 0.001 ZEC independently, so with four pools the visible sum can fall up to 0.003 ZEC short of the Total card above them. This is the deliberate cost of matching the home screen's format exactly; the underlying values are exact, only the rendering is floored. Four pools holding 0.0009 each is the pathological case: every card reads `0.000` while the Total reads `0.003`.
- The exchange-rate API needs `PartnerKeys.plist`, which isn't in the repo, so the fiat variant was verified by temporarily stubbing a rate locally rather than against the live API.
- Per-card fiat values can differ from the Total card's fiat by a cent or two, since each is rounded to 2 decimals independently.
- Below iOS 26, `ZashiSheet` captures its detent height in a `.task` that never re-measures. If the exchange rate arrives while this sheet is open, the content grows but the detent doesn't, so the button can be pushed out of view. Pre-existing component limitation that this sheet happens to be the first to exercise — swipe-down still dismisses, so it isn't a trap.
- Unrelated, but noticed while working here: the SwiftLint invocations in the project's build phases are commented out on all three targets, so builds are silently unlinted and CI runs only `xcodebuild test`. Probably worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
