### PR TITLE
[MOB-1510] Normalize the Keystone firmware stamp so the minimum-firmware gate actually blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Changed
 - [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.
-- [MOB-1510] Signing with a Keystone device now requires firmware 3.0.1 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast.
+- [MOB-1510] Signing with a Keystone device now requires firmware 3.0.3 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast, and the prompt reports the firmware version exactly as your Keystone displays it.
 
 ### Fixed
 - [Ironwood] The automatic recovery from another wallet's leftover data (see MOB-1512 below) keeps working with the updated Zcash SDK. The SDK now reports that mismatch as an error rather than a status, so ZODL maps it back onto the same recovery and the wallet still heals itself instead of stopping on an initialization error.

--- a/secant/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
+++ b/secant/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
@@ -42,7 +42,7 @@ struct KeystoneFirmwareVersion: Equatable, Comparable, Sendable {
     /// Minimum Keystone firmware this app will accept a signature from — set by product
     /// (MOB-1510), in the numbering the device displays. Single point of change if the minimum is
     /// ever raised. Always enforced — there is no "0.0.0 disables the check" escape hatch.
-    static let minimumSupported = KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 1)
+    static let minimumSupported = KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 3)
 
     let major: Int
     let minor: Int

--- a/secant/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
+++ b/secant/Sources/Features/SendConfirmation/KeystoneFirmwareVersion.swift
@@ -5,14 +5,44 @@
 //  MOB-1510: device firmware stamps `global.proprietary["keystone:fw_version"]` (3 raw bytes)
 //  into every signed PCZT; KeystoneSDK 0.8.6 exposes no firmware API of its own.
 //
+//  Two numberings are in play and must never be mixed — hence two types. `KeystoneFirmwareStamp`
+//  is what the wire carries, `KeystoneFirmwareVersion` is what the device screen shows and what
+//  the minimum is written in. `fromStamp` is the only bridge between them.
+//
 
 import Foundation
 
+/// The three bytes exactly as the device wrote them, before any normalization.
+///
+/// This is the firmware's *internal* major, which is not what the device displays — see
+/// `KeystoneFirmwareVersion.stampedMajorOffset`. Kept distinct from `KeystoneFirmwareVersion` so
+/// a raw triple can never be compared against the minimum by accident.
+struct KeystoneFirmwareStamp: Equatable, Sendable {
+    let major: Int
+    let minor: Int
+    let build: Int
+
+    var rawString: String {
+        "\(major).\(minor).\(build)"
+    }
+}
+
 struct KeystoneFirmwareVersion: Equatable, Comparable, Sendable {
+    /// Keystone's `src/config/version.h` carries `SOFTWARE_VERSION_MAJOR` as the displayed major
+    /// plus `SOFTWARE_VERSION_MAJOR_OFFSET` (10, unchanged across every firmware tag from 2.2.8
+    /// through 3.0.0), and `src/config/version.c` renders `MAJOR - OFFSET` on the device. The
+    /// stamp is generated straight from the raw macro, so a Keystone whose screen reads 3.0.1
+    /// stamps `[13, 0, 1]`. Confirmed on a physical device.
+    ///
+    /// Keystone treats this as the contract rather than an oversight: their SDK specifies the
+    /// equivalent field on the batch-signing envelope as the raw triple and documents that
+    /// display offsets are deliberately not applied to it.
+    static let stampedMajorOffset = 10
+
     /// Minimum Keystone firmware this app will accept a signature from — set by product
-    /// (MOB-1510). Single point of change if the minimum is ever raised. Always enforced — there
-    /// is no "0.0.0 disables the check" escape hatch.
-    static let minimumSupported = KeystoneFirmwareVersion(major: 3, minor: 0, build: 1)
+    /// (MOB-1510), in the numbering the device displays. Single point of change if the minimum is
+    /// ever raised. Always enforced — there is no "0.0.0 disables the check" escape hatch.
+    static let minimumSupported = KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 1)
 
     let major: Int
     let minor: Int
@@ -21,9 +51,32 @@ struct KeystoneFirmwareVersion: Equatable, Comparable, Sendable {
     var versionString: String {
         "\(major).\(minor).\(build)"
     }
+
+    /// The only initializer, and it names its numbering. Declaring it suppresses the synthesized
+    /// memberwise `init(major:minor:build:)`, so a raw stamp cannot become a version without
+    /// going through `fromStamp` and having the offset applied.
+    init(displayMajor: Int, minor: Int, build: Int) {
+        self.major = displayMajor
+        self.minor = minor
+        self.build = build
+    }
 }
 
 extension KeystoneFirmwareVersion {
+    /// Normalizes a raw device stamp into the displayed numbering.
+    ///
+    /// A raw major below `stampedMajorOffset` is taken as already normalized. That arm exists so
+    /// that if Keystone ever starts applying the offset firmware-side, this gate degrades to
+    /// correct rather than rejecting every device — a corrected stamp of 3 would otherwise read
+    /// as -7. It is ambiguous only for a device whose *displayed* major reaches 10.
+    static func fromStamp(_ stamp: KeystoneFirmwareStamp) -> KeystoneFirmwareVersion {
+        KeystoneFirmwareVersion(
+            displayMajor: stamp.major >= stampedMajorOffset ? stamp.major - stampedMajorOffset : stamp.major,
+            minor: stamp.minor,
+            build: stamp.build
+        )
+    }
+
     static func < (lhs: KeystoneFirmwareVersion, rhs: KeystoneFirmwareVersion) -> Bool {
         (lhs.major, lhs.minor, lhs.build) < (rhs.major, rhs.minor, rhs.build)
     }
@@ -35,7 +88,10 @@ extension Data {
     /// a proper FFI reader exists over the PCZT's parsed proprietary fields. Occurrences are
     /// scanned in order; a truncated or wrong-length-prefix one is skipped, not fatal. `nil` when
     /// no valid occurrence exists.
-    func keystoneFirmwareVersion() -> KeystoneFirmwareVersion? {
+    ///
+    /// Returns the bytes as written. Use `KeystoneFirmwareVersion.fromStamp` to compare the
+    /// result against anything.
+    func keystoneFirmwareStamp() -> KeystoneFirmwareStamp? {
         let key = Data("keystone:fw_version".utf8)
         var searchRange = startIndex..<endIndex
 
@@ -44,7 +100,7 @@ extension Data {
             let versionStart = lengthPrefixIndex + 1
             let versionEnd = versionStart + 3
             if versionEnd <= endIndex, self[lengthPrefixIndex] == 0x03 {
-                return KeystoneFirmwareVersion(
+                return KeystoneFirmwareStamp(
                     major: Int(self[versionStart]),
                     minor: Int(self[versionStart + 1]),
                     build: Int(self[versionStart + 2])

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -481,10 +481,17 @@ struct SendConfirmation {
                     // releases before the minimum this gate enforces — an unstamped PCZT is
                     // therefore necessarily below minimum, never merely "unknown".
                     let detectedFirmware = pcztWithSigs.keystoneFirmwareVersion()
+                    let minimumFirmware = KeystoneFirmwareVersion.minimumSupported.versionString
                     guard let detectedFirmware, detectedFirmware >= KeystoneFirmwareVersion.minimumSupported else {
+                        LoggerProxy.warn(
+                            "Keystone firmware gate: stamp \(detectedFirmware?.versionString ?? "absent"), minimum \(minimumFirmware), blocked"
+                        )
                         state.detectedKeystoneFirmware = detectedFirmware
                         return .send(.keystoneFirmwareUpdateRequired)
                     }
+                    LoggerProxy.info(
+                        "Keystone firmware gate: stamp \(detectedFirmware.versionString), minimum \(minimumFirmware), allowed"
+                    )
 
                     state.pcztWithSigs = pcztWithSigs
                     return .merge(

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -480,18 +480,21 @@ struct SendConfirmation {
                     // MOB-1510: firmware >= 2.4.6 stamps its version into every signed PCZT, two
                     // releases before the minimum this gate enforces — an unstamped PCZT is
                     // therefore necessarily below minimum, never merely "unknown".
-                    let detectedFirmware = pcztWithSigs.keystoneFirmwareVersion()
-                    let minimumFirmware = KeystoneFirmwareVersion.minimumSupported.versionString
+                    let firmwareStamp = pcztWithSigs.keystoneFirmwareStamp()
+                    let detectedFirmware = firmwareStamp.map { KeystoneFirmwareVersion.fromStamp($0) }
+                    // Both numberings, because they differ: the device stamps its internal major,
+                    // which is 10 higher than the version shown on its own screen.
+                    let firmwareGateLog = """
+                        Keystone firmware gate: raw stamp \(firmwareStamp?.rawString ?? "absent"), \
+                        reads as \(detectedFirmware?.versionString ?? "unknown"), \
+                        minimum \(KeystoneFirmwareVersion.minimumSupported.versionString)
+                        """
                     guard let detectedFirmware, detectedFirmware >= KeystoneFirmwareVersion.minimumSupported else {
-                        LoggerProxy.warn(
-                            "Keystone firmware gate: stamp \(detectedFirmware?.versionString ?? "absent"), minimum \(minimumFirmware), blocked"
-                        )
+                        LoggerProxy.warn("\(firmwareGateLog), blocked")
                         state.detectedKeystoneFirmware = detectedFirmware
                         return .send(.keystoneFirmwareUpdateRequired)
                     }
-                    LoggerProxy.info(
-                        "Keystone firmware gate: stamp \(detectedFirmware.versionString), minimum \(minimumFirmware), allowed"
-                    )
+                    LoggerProxy.info("\(firmwareGateLog), allowed")
 
                     state.pcztWithSigs = pcztWithSigs
                     return .merge(

--- a/zodlTests/SendTests/KeystoneFirmwareCoordFlowTests.swift
+++ b/zodlTests/SendTests/KeystoneFirmwareCoordFlowTests.swift
@@ -43,10 +43,11 @@ import XCTestDynamicOverlay
         )
     }
 
-    private func signedPczt(firmware: (major: Int, minor: Int, build: Int)) -> Pczt {
+    /// `stamp` is in the wire's numbering — a device displaying 3.0.1 stamps `[13, 0, 1]`.
+    private func signedPczt(stamp: (major: Int, minor: Int, build: Int)) -> Pczt {
         var data = Data()
         data.append(contentsOf: Array("keystone:fw_version".utf8))
-        data.append(contentsOf: [0x03, UInt8(firmware.major), UInt8(firmware.minor), UInt8(firmware.build)])
+        data.append(contentsOf: [0x03, UInt8(stamp.major), UInt8(stamp.minor), UInt8(stamp.build)])
         return Pczt(data)
     }
 
@@ -146,7 +147,7 @@ import XCTestDynamicOverlay
         } operation: {
             var confirmState = SendConfirmation.State.initial
             confirmState.isKeystoneCodeFound = true
-            confirmState.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+            confirmState.detectedKeystoneFirmware = KeystoneFirmwareVersion(displayMajor: 2, minor: 4, build: 6)
 
             var initialState = SendCoordFlow.State()
             initialState.path.append(.confirmWithKeystone(confirmState))
@@ -185,7 +186,7 @@ import XCTestDynamicOverlay
         } operation: {
             var initialState = SignWithKeystoneCoordFlow.State()
             initialState.sendConfirmationState.isKeystoneCodeFound = true
-            initialState.sendConfirmationState.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+            initialState.sendConfirmationState.detectedKeystoneFirmware = KeystoneFirmwareVersion(displayMajor: 2, minor: 4, build: 6)
             initialState.path.append(.keystoneFirmwareUpdate(initialState.sendConfirmationState))
             let updateId = try #require(initialState.path.ids.last)
 
@@ -218,7 +219,7 @@ import XCTestDynamicOverlay
         } operation: {
             var confirmState = SendConfirmation.State.initial
             confirmState.isKeystoneCodeFound = true
-            confirmState.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+            confirmState.detectedKeystoneFirmware = KeystoneFirmwareVersion(displayMajor: 2, minor: 4, build: 6)
 
             var initialState = SendCoordFlow.State()
             initialState.path.append(.confirmWithKeystone(confirmState))
@@ -260,7 +261,7 @@ import XCTestDynamicOverlay
             let markCalls = LockIsolated(0)
             let store = try makeSwapAndPayStore(markCalls: markCalls)
 
-            store.send(.path(.element(id: try #require(store.state.path.ids.last), action: .scan(.foundPCZT(signedPczt(firmware: (2, 4, 6)))))))
+            store.send(.path(.element(id: try #require(store.state.path.ids.last), action: .scan(.foundPCZT(signedPczt(stamp: (12, 4, 6)))))))
 
             await waitForCoordFlowStore {
                 !store.state.path.filter { $0.is(\.keystoneFirmwareUpdate) }.isEmpty
@@ -279,7 +280,7 @@ import XCTestDynamicOverlay
             let markCalls = LockIsolated(0)
             let store = try makeSwapAndPayStore(markCalls: markCalls)
 
-            store.send(.path(.element(id: try #require(store.state.path.ids.last), action: .scan(.foundPCZT(signedPczt(firmware: (3, 0, 1)))))))
+            store.send(.path(.element(id: try #require(store.state.path.ids.last), action: .scan(.foundPCZT(signedPczt(stamp: (13, 0, 1)))))))
 
             await waitForCoordFlowStore {
                 markCalls.value == 1

--- a/zodlTests/SendTests/KeystoneFirmwareCoordFlowTests.swift
+++ b/zodlTests/SendTests/KeystoneFirmwareCoordFlowTests.swift
@@ -280,7 +280,7 @@ import XCTestDynamicOverlay
             let markCalls = LockIsolated(0)
             let store = try makeSwapAndPayStore(markCalls: markCalls)
 
-            store.send(.path(.element(id: try #require(store.state.path.ids.last), action: .scan(.foundPCZT(signedPczt(stamp: (13, 0, 1)))))))
+            store.send(.path(.element(id: try #require(store.state.path.ids.last), action: .scan(.foundPCZT(signedPczt(stamp: (13, 0, 3)))))))
 
             await waitForCoordFlowStore {
                 markCalls.value == 1

--- a/zodlTests/SendTests/KeystoneFirmwareTests.swift
+++ b/zodlTests/SendTests/KeystoneFirmwareTests.swift
@@ -2,13 +2,17 @@
 //  KeystoneFirmwareTests.swift
 //  zodlTests
 //
-//  Covers MOB-1510 (Keystone minimum-firmware check): the `Data.keystoneFirmwareVersion()`
-//  byte-scan reader, `KeystoneFirmwareVersion`'s `Comparable` conformance, and the
-//  `SendConfirmationStore` gate at `.foundPCZT` that blocks below-minimum/unstamped firmware
-//  before `createTransactionFromPCZT` ever schedules.
+//  Covers MOB-1510 (Keystone minimum-firmware check): the `Data.keystoneFirmwareStamp()`
+//  byte-scan reader, the raw-to-displayed normalization in `KeystoneFirmwareVersion.fromStamp`,
+//  `Comparable`, and the `SendConfirmationStore` gate at `.foundPCZT` that blocks
+//  below-minimum/unstamped firmware before `createTransactionFromPCZT` ever schedules.
 //
-//  The reader/Comparable suites are pure and dependency-free, so they run unserialized; see
-//  `KeystoneFirmwareGateTests` below for why the gate suite needs more than that.
+//  Stamps in these fixtures are written in the numbering the *wire* uses: a device whose screen
+//  reads 3.0.1 stamps `[13, 0, 1]`. Expected versions are written in the numbering the *screen*
+//  uses. Where the two appear side by side that is the point of the test, not a typo.
+//
+//  The reader/normalization/Comparable suites are pure and dependency-free, so they run
+//  unserialized; see `KeystoneFirmwareGateTests` below for why the gate suite needs more.
 //
 
 import Testing
@@ -17,47 +21,47 @@ import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-// MARK: - Data.keystoneFirmwareVersion() reader
+// MARK: - Data.keystoneFirmwareStamp() reader
 
-@Suite struct KeystoneFirmwareVersionReaderTests {
+@Suite struct KeystoneFirmwareStampReaderTests {
     private static let key = Array("keystone:fw_version".utf8)
 
-    @Test func stampedVersionAtMinimumParses() {
+    @Test func stampParsesAsWrittenWithoutNormalizing() {
         var data = Data([0x00, 0x01])
         data.append(contentsOf: Self.key)
-        data.append(contentsOf: [0x03, 3, 0, 1])
+        data.append(contentsOf: [0x03, 13, 0, 1])
 
-        #expect(data.keystoneFirmwareVersion() == KeystoneFirmwareVersion(major: 3, minor: 0, build: 1))
+        #expect(data.keystoneFirmwareStamp() == KeystoneFirmwareStamp(major: 13, minor: 0, build: 1))
     }
 
-    @Test func stampedVersionBelowMinimumParses() {
+    @Test func stampFromTheTwoPointXLineParses() {
         var data = Data()
         data.append(contentsOf: Self.key)
-        data.append(contentsOf: [0x03, 2, 4, 6])
+        data.append(contentsOf: [0x03, 12, 4, 6])
 
-        #expect(data.keystoneFirmwareVersion() == KeystoneFirmwareVersion(major: 2, minor: 4, build: 6))
+        #expect(data.keystoneFirmwareStamp() == KeystoneFirmwareStamp(major: 12, minor: 4, build: 6))
     }
 
     @Test func missingKeyReturnsNil() {
         let data = Data([0x00, 0x01, 0x02, 0x03, 0x04])
 
-        #expect(data.keystoneFirmwareVersion() == nil)
+        #expect(data.keystoneFirmwareStamp() == nil)
     }
 
     @Test func keyPresentButTruncatedValueReturnsNil() {
         var data = Data()
         data.append(contentsOf: Self.key)
-        data.append(contentsOf: [0x03, 3, 0]) // only 2 of the 3 version bytes
+        data.append(contentsOf: [0x03, 13, 0]) // only 2 of the 3 version bytes
 
-        #expect(data.keystoneFirmwareVersion() == nil)
+        #expect(data.keystoneFirmwareStamp() == nil)
     }
 
     @Test func keyPresentWithWrongLengthPrefixReturnsNil() {
         var data = Data()
         data.append(contentsOf: Self.key)
-        data.append(contentsOf: [0x04, 3, 0, 0]) // wrong prefix, not postcard's 0x03
+        data.append(contentsOf: [0x04, 13, 0, 0]) // wrong prefix, not postcard's 0x03
 
-        #expect(data.keystoneFirmwareVersion() == nil)
+        #expect(data.keystoneFirmwareStamp() == nil)
     }
 
     @Test func multipleOccurrencesFirstValidOneWins() {
@@ -67,22 +71,70 @@ import ComposableArchitecture
         data.append(contentsOf: [0x05, 9, 9, 9])
         // Second occurrence: valid.
         data.append(contentsOf: Self.key)
-        data.append(contentsOf: [0x03, 3, 1, 2])
+        data.append(contentsOf: [0x03, 13, 1, 2])
 
-        #expect(data.keystoneFirmwareVersion() == KeystoneFirmwareVersion(major: 3, minor: 1, build: 2))
+        #expect(data.keystoneFirmwareStamp() == KeystoneFirmwareStamp(major: 13, minor: 1, build: 2))
     }
 
     @Test func versionBytesAtVeryEndOfDataParses() {
         var data = Data([0xFF])
         data.append(contentsOf: Self.key)
-        data.append(contentsOf: [0x03, 4, 5, 6])
+        data.append(contentsOf: [0x03, 14, 5, 6])
 
         #expect(data.count == 1 + Self.key.count + 4)
-        #expect(data.keystoneFirmwareVersion() == KeystoneFirmwareVersion(major: 4, minor: 5, build: 6))
+        #expect(data.keystoneFirmwareStamp() == KeystoneFirmwareStamp(major: 14, minor: 5, build: 6))
     }
 
     @Test func emptyDataReturnsNil() {
-        #expect(Data().keystoneFirmwareVersion() == nil)
+        #expect(Data().keystoneFirmwareStamp() == nil)
+    }
+}
+
+// MARK: - KeystoneFirmwareVersion.fromStamp normalization
+
+@Suite struct KeystoneFirmwareNormalizationTests {
+    /// The defect this whole change exists for: a device displaying 3.0.1 stamps `[13, 0, 1]`,
+    /// and comparing that raw triple against a displayed-numbering minimum let it through.
+    @Test func stampedMajorIsOffsetFromTheDisplayedMajor() {
+        let stamp = KeystoneFirmwareStamp(major: 13, minor: 0, build: 1)
+
+        #expect(KeystoneFirmwareVersion.fromStamp(stamp) == KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 1))
+    }
+
+    @Test func twoPointXLineNormalizes() {
+        let stamp = KeystoneFirmwareStamp(major: 12, minor: 4, build: 6)
+
+        #expect(KeystoneFirmwareVersion.fromStamp(stamp) == KeystoneFirmwareVersion(displayMajor: 2, minor: 4, build: 6))
+    }
+
+    /// A 3.0.1 device must read as below a 3.0.3 minimum, not above it — the exact comparison
+    /// that was inverted. Written against literals so it holds whatever `minimumSupported` is.
+    @Test func threeZeroOneDeviceIsBelowThreeZeroThree() {
+        let detected = KeystoneFirmwareVersion.fromStamp(KeystoneFirmwareStamp(major: 13, minor: 0, build: 1))
+
+        #expect(detected < KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 3))
+    }
+
+    /// Guards the second arm: if Keystone ever applies the offset firmware-side, a stamp already
+    /// in displayed numbering must pass through untouched rather than underflow to -7.
+    @Test func rawMajorBelowTheOffsetIsTakenAsAlreadyNormalized() {
+        let stamp = KeystoneFirmwareStamp(major: 3, minor: 0, build: 1)
+
+        #expect(KeystoneFirmwareVersion.fromStamp(stamp) == KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 1))
+    }
+
+    @Test(arguments: [
+        (KeystoneFirmwareStamp(major: 10, minor: 0, build: 0), KeystoneFirmwareVersion(displayMajor: 0, minor: 0, build: 0)),
+        (KeystoneFirmwareStamp(major: 9, minor: 9, build: 9), KeystoneFirmwareVersion(displayMajor: 9, minor: 9, build: 9))
+    ])
+    func offsetBoundaryNormalizes(stamp: KeystoneFirmwareStamp, expected: KeystoneFirmwareVersion) {
+        #expect(KeystoneFirmwareVersion.fromStamp(stamp) == expected)
+    }
+
+    @Test func minorAndBuildAreNeverOffset() {
+        let stamp = KeystoneFirmwareStamp(major: 13, minor: 12, build: 11)
+
+        #expect(KeystoneFirmwareVersion.fromStamp(stamp) == KeystoneFirmwareVersion(displayMajor: 3, minor: 12, build: 11))
     }
 }
 
@@ -90,11 +142,11 @@ import ComposableArchitecture
 
 @Suite struct KeystoneFirmwareVersionComparableTests {
     @Test func lowerMajorIsBelowMinimum() {
-        #expect(KeystoneFirmwareVersion(major: 2, minor: 9, build: 9) < KeystoneFirmwareVersion.minimumSupported)
+        #expect(KeystoneFirmwareVersion(displayMajor: 2, minor: 9, build: 9) < KeystoneFirmwareVersion.minimumSupported)
     }
 
     @Test func minimumIsExactlyThreeZeroOne() {
-        #expect(KeystoneFirmwareVersion.minimumSupported == KeystoneFirmwareVersion(major: 3, minor: 0, build: 1))
+        #expect(KeystoneFirmwareVersion.minimumSupported == KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 1))
     }
 
     @Test func minimumIsNotBelowItself() {
@@ -102,14 +154,20 @@ import ComposableArchitecture
     }
 
     @Test func higherBuildIsAboveMinimum() {
-        #expect(KeystoneFirmwareVersion(major: 3, minor: 0, build: 2) > KeystoneFirmwareVersion.minimumSupported)
+        #expect(KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 2) > KeystoneFirmwareVersion.minimumSupported)
     }
 
     @Test func comparisonIsLexicographicOnMajorThenMinorThenBuild() {
         // A higher minor must not be shadowed by comparing major alone.
-        #expect(KeystoneFirmwareVersion(major: 2, minor: 99, build: 99) < KeystoneFirmwareVersion(major: 3, minor: 0, build: 0))
+        #expect(
+            KeystoneFirmwareVersion(displayMajor: 2, minor: 99, build: 99)
+            < KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 0)
+        )
         // A higher build must not be shadowed by comparing major/minor alone.
-        #expect(KeystoneFirmwareVersion(major: 3, minor: 0, build: 0) < KeystoneFirmwareVersion(major: 3, minor: 0, build: 1))
+        #expect(
+            KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 0)
+            < KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 1)
+        )
     }
 }
 
@@ -143,29 +201,33 @@ import ComposableArchitecture
         }
     }
 
-    private func signedPczt(firmware: (major: Int, minor: Int, build: Int)?) -> Pczt {
+    /// `stamp` is in the wire's numbering — pass what the device would actually write.
+    private func signedPczt(stamp: (major: Int, minor: Int, build: Int)?) -> Pczt {
         var data = Data()
-        if let firmware {
+        if let stamp {
             data.append(contentsOf: Array("keystone:fw_version".utf8))
-            data.append(contentsOf: [0x03, UInt8(firmware.major), UInt8(firmware.minor), UInt8(firmware.build)])
+            data.append(contentsOf: [0x03, UInt8(stamp.major), UInt8(stamp.minor), UInt8(stamp.build)])
         }
         return Pczt(data)
     }
 
-    // Below-minimum firmware in two shapes — a clearly-old version and the boundary case one build
-    // below the 3.0.1 minimum — both must still be blocked and must never schedule
-    // `createTransactionFromPCZT`.
-    @Test(arguments: [(2, 4, 6), (3, 0, 0)])
+    // Below-minimum firmware in three shapes — a clearly-old device (2.4.6), the boundary case one
+    // build below the 3.0.1 minimum (3.0.0), and a raw stamp below the offset — all must be
+    // blocked and must never schedule `createTransactionFromPCZT`.
+    @Test(arguments: [(12, 4, 6), (13, 0, 0), (2, 4, 6)])
     func belowMinimumFirmwarePresentsUpdateScreen(major: Int, minor: Int, build: Int) async {
         await withDependencies {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             let store = makeStore()
-            let pczt = signedPczt(firmware: (major, minor, build))
+            let pczt = signedPczt(stamp: (major, minor, build))
+            let expected = KeystoneFirmwareVersion.fromStamp(
+                KeystoneFirmwareStamp(major: major, minor: minor, build: build)
+            )
 
             await store.send(.foundPCZT(pczt)) {
                 $0.isKeystoneCodeFound = true
-                $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: major, minor: minor, build: build)
+                $0.detectedKeystoneFirmware = expected
             }
             await store.receive(.keystoneFirmwareUpdateRequired)
             // No further action arrives: `createTransactionFromPCZT` is never scheduled. An
@@ -177,12 +239,31 @@ import ComposableArchitecture
         }
     }
 
+    /// The screen must show the version printed on the device, not the wire's internal major.
+    @Test func detectedVersionIsReportedInTheNumberingTheDeviceDisplays() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore()
+
+            await store.send(.foundPCZT(signedPczt(stamp: (12, 4, 6)))) {
+                $0.isKeystoneCodeFound = true
+                $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(displayMajor: 2, minor: 4, build: 6)
+            }
+            await store.receive(.keystoneFirmwareUpdateRequired)
+            await store.finish()
+
+            #expect(store.state.detectedKeystoneFirmware?.versionString == "2.4.6")
+        }
+    }
+
     @Test func atMinimumFirmwareProceedsUnchanged() async {
         await withDependencies {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             let store = makeStore()
-            let pczt = signedPczt(firmware: (3, 0, 1))
+            // Device displaying 3.0.1 — exactly the minimum.
+            let pczt = signedPczt(stamp: (13, 0, 1))
 
             await store.send(.foundPCZT(pczt)) {
                 $0.isKeystoneCodeFound = true
@@ -204,7 +285,7 @@ import ComposableArchitecture
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             let store = makeStore()
-            let pczt = signedPczt(firmware: nil)
+            let pczt = signedPczt(stamp: nil)
 
             await store.send(.foundPCZT(pczt)) {
                 $0.isKeystoneCodeFound = true
@@ -222,11 +303,11 @@ import ComposableArchitecture
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             let store = makeStore()
-            let pczt = signedPczt(firmware: (2, 4, 6))
+            let pczt = signedPczt(stamp: (12, 4, 6))
 
             await store.send(.foundPCZT(pczt)) {
                 $0.isKeystoneCodeFound = true
-                $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(major: 2, minor: 4, build: 6)
+                $0.detectedKeystoneFirmware = KeystoneFirmwareVersion(displayMajor: 2, minor: 4, build: 6)
             }
             await store.receive(.keystoneFirmwareUpdateRequired)
 

--- a/zodlTests/SendTests/KeystoneFirmwareTests.swift
+++ b/zodlTests/SendTests/KeystoneFirmwareTests.swift
@@ -145,8 +145,8 @@ import ComposableArchitecture
         #expect(KeystoneFirmwareVersion(displayMajor: 2, minor: 9, build: 9) < KeystoneFirmwareVersion.minimumSupported)
     }
 
-    @Test func minimumIsExactlyThreeZeroOne() {
-        #expect(KeystoneFirmwareVersion.minimumSupported == KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 1))
+    @Test func minimumIsExactlyThreeZeroThree() {
+        #expect(KeystoneFirmwareVersion.minimumSupported == KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 3))
     }
 
     @Test func minimumIsNotBelowItself() {
@@ -154,7 +154,7 @@ import ComposableArchitecture
     }
 
     @Test func higherBuildIsAboveMinimum() {
-        #expect(KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 2) > KeystoneFirmwareVersion.minimumSupported)
+        #expect(KeystoneFirmwareVersion(displayMajor: 3, minor: 0, build: 4) > KeystoneFirmwareVersion.minimumSupported)
     }
 
     @Test func comparisonIsLexicographicOnMajorThenMinorThenBuild() {
@@ -211,10 +211,11 @@ import ComposableArchitecture
         return Pczt(data)
     }
 
-    // Below-minimum firmware in three shapes — a clearly-old device (2.4.6), the boundary case one
-    // build below the 3.0.1 minimum (3.0.0), and a raw stamp below the offset — all must be
-    // blocked and must never schedule `createTransactionFromPCZT`.
-    @Test(arguments: [(12, 4, 6), (13, 0, 0), (2, 4, 6)])
+    // Below-minimum firmware in four shapes — a clearly-old device (2.4.6), the device that
+    // exposed this defect (3.0.1), the boundary case one build below the 3.0.3 minimum (3.0.2),
+    // and a raw stamp below the offset — all must be blocked and must never schedule
+    // `createTransactionFromPCZT`.
+    @Test(arguments: [(12, 4, 6), (13, 0, 1), (13, 0, 2), (2, 4, 6)])
     func belowMinimumFirmwarePresentsUpdateScreen(major: Int, minor: Int, build: Int) async {
         await withDependencies {
             $0.defaultInMemoryStorage = InMemoryStorage()
@@ -262,8 +263,8 @@ import ComposableArchitecture
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             let store = makeStore()
-            // Device displaying 3.0.1 — exactly the minimum.
-            let pczt = signedPczt(stamp: (13, 0, 1))
+            // Device displaying 3.0.3 — exactly the minimum.
+            let pczt = signedPczt(stamp: (13, 0, 3))
 
             await store.send(.foundPCZT(pczt)) {
                 $0.isKeystoneCodeFound = true


### PR DESCRIPTION
## Summary

The Keystone minimum-firmware gate has never blocked a device that reports a version. It compares the firmware's **internal** major against a minimum written in the major the device **displays**, and the two differ by a constant 10.

Found because a Keystone displaying **3.0.1** signed and broadcast against a 3.0.3 minimum, then failed at extraction:

```
-996 ZRUST0071: Error from rust layer when calling ZcashRustBackend.extractAndStoreTxFromPCZT
Failed to extract transaction from PCZT: Pczt(Extraction(Orchard(Extract(MissingSpendAuthSig))))
```

That extraction failure is the *consequence* of the gate not firing, not a separate defect — the device should never have got that far.

## Root cause

`keystone3-firmware`'s `src/config/version.h` carries `SOFTWARE_VERSION_MAJOR` alongside `SOFTWARE_VERSION_MAJOR_OFFSET` (10), and `src/config/version.c` renders `MAJOR - OFFSET` on the device screen. The offset is 10 at every tag from 2.2.8 through 3.0.0. The PCZT stamp is generated straight from the raw macro, so a Keystone showing 3.0.1 stamps `[13, 0, 1]`.

Confirmed on a physical device, breakpoint on the gate:

```
po detectedFirmware
▿ KeystoneFirmwareVersion
  - major : 13
  - minor : 0
  - build : 1
```

`13.0.1 >= 3.0.3` is true, so the guard passed and `pcztWithSigs` was set. Since every stamping firmware (≥ 2.4.6) reports major 12 or 13, **any** minimum expressed in displayed numbering was satisfied automatically — the earlier raise from 3.0.0 to 3.0.1 could not have changed anything either. Only firmware too old to stamp at all was ever refused.

This is Keystone's contract rather than an oversight on their side: their SDK specifies the equivalent field on the batch-signing envelope as the raw triple and documents that display offsets are deliberately not applied to it.

### How it got in

#1689 read the stamp the same way, but its fixtures were raw-space throughout — `KeystoneFirmwareVersion(major: 12, minor: 4, build: 0)`, and an ordering assertion `12.4.0 < 13.0.0`. It shipped the minimum as `(0, 0, 0)` with a "skip the check entirely" branch, so a real minimum was never written and the question was never forced.

#1916/#1952 correctly removed that escape hatch and filled in a real minimum — in displayed numbering, against a raw-space reader. Nothing in the code marked which numbering the constant lived in, so writing `3` where `13` was meant looked entirely natural.

## Fix

Three commits, each written test-first and observed failing.

1. **Log what the gate reads.** No behaviour change. The gate recorded nothing about its input or its decision, which is why this survived review, a test suite and a release branch.
2. **Normalize the stamp.** `KeystoneFirmwareStamp` is what the wire carries, `KeystoneFirmwareVersion` is what the screen shows, and `fromStamp` is the only bridge. Naming the initializer `displayMajor:` suppresses the synthesized memberwise one, so a raw triple can no longer become a version without the offset being applied — the mistake above stops compiling.
3. **Minimum → 3.0.3**, since 3.0.1 produces a PCZT this app cannot extract.

A raw major below the offset is taken as already normalized, so if the firmware ever applies the offset itself this degrades to correct rather than rejecting every device.

`KeystoneFirmwareUpdateView` needed no change — the screen now reports the version as the device displays it, because the value type is display-space.

### Considered and rejected

Comparing in raw space (`minimumSupported = 13.0.3`) works today and matches the wire exactly, but leaves the maintained constant in a numbering nobody sees. The next person raising the minimum to "3.1.0" writes `3` and silently switches the gate off again — precisely what happened here.

Not anchoring the postcard `0x13` key-length prefix either: there is no observed false positive, the reader located the real entry and returned exactly what the firmware wrote, and a stricter matcher can only fail closed against valid devices — unverifiable without a physical Keystone. Left as a follow-up rather than bundled into a bug fix.

## Tests

`KeystoneFirmwareStampReaderTests` (reader returns bytes as written), `KeystoneFirmwareNormalizationTests` (the 13→3 mapping, minor/build never offset, the offset boundary at `[10,0,0]` → `0.0.0` and `[9,9,9]` → `9.9.9`, and the already-normalized arm), plus the store gate and coord-flow suites retargeted onto realistic wire stamps.

The decisive red: before the last commit, a `[13, 0, 1]` stamp still left `store.state.pcztWithSigs → 23 bytes` — the reported broadcast, reproduced as a test. It now blocks and reports `3.0.1` on screen.

## Gate

- `zodl-internal` full suite: **681 tests / 111 suites passed**, `** TEST SUCCEEDED **`. The single known issue is the pre-existing `CurrencyConversionSetupTests` Tor/swap-access expectation, untouched here.
- `zodl-testnet`: **BUILD SUCCEEDED**, 0 errors.

## Not in this PR

- **zodl-android has the same defect.** `toKeystoneFwVersion()` takes the envelope bytes verbatim and compares them against `KeystoneFirmwareVersion(3, 0, 2)`, so a device displaying 2.4.6 sends `[12, 4, 6]` and passes. Its migration gate currently blocks only devices reporting no version at all. Handed off separately.
- **The voting flow is ungated.** `VotingCoordFlowCoordinator` takes a Keystone-signed PCZT via `foundVotingDelegationPCZT` without any firmware check; it does not route through `SendConfirmation.foundPCZT`.
- **`MissingSpendAuthSig` on 3.0.1** should now be unreachable. If it reproduces on 3.0.3 or newer it is a separate defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
