### PR TITLE
[MOB-1535] Show pool balances at full precision, reordered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Changed
 - [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.
 - [MOB-1510] Signing with a Keystone device now requires firmware 3.0.3 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast, and the prompt reports the firmware version exactly as your Keystone displays it.
+- [MOB-1510] Signing with a Keystone device now requires firmware 3.0.1 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast.
+- [MOB-1535] The "Total Balance Across Pools" breakdown now shows each pool's balance to its full precision (up to 8 decimal places) instead of flooring to 0.001 ZEC, so small amounts are no longer hidden, and the pools now appear in the order Ironwood, Orchard, Sapling, Transparent.
 
 ### Fixed
 - [Ironwood] The automatic recovery from another wallet's leftover data (see MOB-1512 below) keeps working with the updated Zcash SDK. The SDK now reports that mismatch as an error rather than a status, so ZODL maps it back onto the same recovery and the wallet still heals itself instead of stopping on an initialization error.

--- a/secant/Sources/Features/Home/PoolBalancesSheet.swift
+++ b/secant/Sources/Features/Home/PoolBalancesSheet.swift
@@ -32,14 +32,14 @@ extension HomeView {
                 .padding(.bottom, 8)
 
                 HStack(spacing: 8) {
+                    poolCard(title: String(localizable: .poolBalancesIronwood), balance: store.walletBalancesState.ironwoodPoolBalance)
                     poolCard(title: String(localizable: .poolBalancesOrchard), balance: store.walletBalancesState.orchardPoolBalance)
-                    poolCard(title: String(localizable: .poolBalancesSapling), balance: store.walletBalancesState.saplingPoolBalance)
                 }
                 .padding(.bottom, 8)
 
                 HStack(spacing: 8) {
+                    poolCard(title: String(localizable: .poolBalancesSapling), balance: store.walletBalancesState.saplingPoolBalance)
                     poolCard(title: String(localizable: .poolBalancesTransparent), balance: store.walletBalancesState.transparentPoolBalance)
-                    poolCard(title: String(localizable: .poolBalancesIronwood), balance: store.walletBalancesState.ironwoodPoolBalance)
                 }
                 .padding(.bottom, 32)
 
@@ -57,21 +57,23 @@ extension HomeView {
                 .zFont(.medium, size: 14, style: Design.Text.tertiary)
                 .padding(.bottom, 4)
 
-            if dimmedToken {
-                HStack(spacing: 4) {
-                    // .abbreviated matches the home screen's balance label: floored to 0.001 ZEC,
-                    // always three fraction digits.
-                    ZatoshiText(balance, .abbreviated)
-                        .zFont(.semiBold, size: 16, style: Design.Text.primary)
+            HStack(spacing: 4) {
+                // .expanded keeps every zatoshi visible: first three fraction digits at full size,
+                // remaining five smaller.
+                ZatoshiRepresentationView(
+                    balance: balance,
+                    fontName: FontFamily.Inter.semiBold.name,
+                    mostSignificantFontSize: 16,
+                    leastSignificantFontSize: 12,
+                    format: .expanded,
+                    couldBeHidden: true
+                )
+                .zForegroundColor(Design.Text.primary)
 
-                    if !isSensitiveContentHidden {
-                        Text(tokenName)
-                            .zFont(.semiBold, size: 16, style: Design.Text.tertiary)
-                    }
+                if !isSensitiveContentHidden {
+                    Text(tokenName)
+                        .zFont(.semiBold, size: 16, style: dimmedToken ? Design.Text.tertiary : Design.Text.primary)
                 }
-            } else {
-                ZatoshiText(balance, .abbreviated, tokenName)
-                    .zFont(.semiBold, size: 16, style: Design.Text.primary)
             }
 
             if store.walletBalancesState.isFiatAvailable {

--- a/zodlTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationTests.swift
+++ b/zodlTests/ZatoshiStringRepresentation/ZatoshiStringRepresentationTests.swift
@@ -55,6 +55,11 @@ private let enUSZatoshiSamples: [ZatoshiStringRepresentationTests.Sample] = [
     ZatoshiStringRepresentationTests.Sample(zatoshi: 99_000, prefix: .none, format: .expanded, most: "0.000", least: "99"),
     ZatoshiStringRepresentationTests.Sample(zatoshi: 100_000, prefix: .none, format: .expanded, most: "0.001", least: ""),
     ZatoshiStringRepresentationTests.Sample(zatoshi: 25_793_456, prefix: .none, format: .expanded, most: "0.257", least: "93456"),
+    // Dust guarantee: pool-balances sheet must show amounts down to a single zatoshi, so
+    // `.expanded` must never drop a digit, even when the least-significant tail is all zeros.
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 1, prefix: .none, format: .expanded, most: "0.000", least: "00001"),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 14_090_955, prefix: .none, format: .expanded, most: "0.140", least: "90955"),
+    ZatoshiStringRepresentationTests.Sample(zatoshi: 14_000_000, prefix: .none, format: .expanded, most: "0.140", least: ""),
     // Prefix Plus — Abbreviated
     ZatoshiStringRepresentationTests.Sample(zatoshi: 0, prefix: .plus, format: .abbreviated, most: "+0.000", least: ""),
     ZatoshiStringRepresentationTests.Sample(zatoshi: 99_000, prefix: .plus, format: .abbreviated, most: "+0.000...", least: ""),


### PR DESCRIPTION
Two follow-ups from Neal on the shipped **Total Balance Across Pools** sheet.

## 1. Full precision

The sheet floored every amount to 0.001 ZEC, so dust was invisible — the one thing a user checking whether they are fully out of Orchard most wants to see. Android already shows all eight fraction digits.

Switched to the `.expanded` format via `ZatoshiRepresentationView`, the component the Send screen already uses for exactly this treatment: the first three fraction digits at full size (16pt), the remaining five smaller (12pt).

| | Before | After |
| --- | --- | --- |
| `0.14090955` | `0.140 ZEC` | `0.140`<sub>`90955`</sub> ` ZEC` |
| `0.00000001` | `0.000 ZEC` | `0.000`<sub>`00001`</sub> ` ZEC` |
| `0.14` | `0.140 ZEC` | `0.140 ZEC` (tail trimmed, not padded) |

This also removes a rounding artefact: each pool used to be floored independently, so the four cards could add up to as much as 0.003 ZEC less than the Total they sit under. They now sum to it exactly.

Deliberately **no** `lineLimit`/`minimumScaleFactor` — those were removed in d7da55a6 because they made one card render its whole contents at 0.7 scale while its neighbour stayed full size. The two-tier sizing is what keeps the string narrow instead.

## 2. Pool order

Now **Ironwood, Orchard, Sapling, Transparent** (was Orchard, Sapling, Transparent, Ironwood).

## Notes

- `ZatoshiRepresentationView` takes no postfix, so the token name became a sibling `Text`. That collapses `poolCard`'s two branches into one — they only differed in the token's colour, which is preserved (tertiary on the Total card, primary on the pool cards).
- Hidden-balance behaviour is unchanged: every value still masks to `-----` with the token suppressed.
- No new strings, colours, or assets — design system reuse only.

## Verification

- ✅ `xcodebuild build -scheme zodl-internal -skipMacroValidation` — **BUILD SUCCEEDED**.
- ✅ Three characterization samples added to `ZatoshiStringRepresentationTests`, pinning the dust guarantee (1 zatoshi, the 0.14090955 case from the report, and an all-zero tail).
- ⚠️ **The full test suite did not run.** `xcodebuild test` fails to compile the test target on `RootTransactionsAccountSwitchTests.swift:333/338/512/516` — `ambiguous use of 'shieldedSpendableValue'`, which is declared both in `secant/Sources/Utils/AccountBalanceExtensions.swift` and now by the SDK, and collides only under the test target's dual `@testable import`. That file is untouched by this PR and the app target compiles clean, but I did not get to confirm the failure also reproduces on `release/3.8.0` before this was pushed. **Worth confirming — it blocks the whole suite, not just these tests.**
- ⚠️ Not verified in the simulator. Layout is unconfirmed on-device, in particular how a balance ≥ ~100 ZEC behaves on a half-width card (expected to wrap rather than truncate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)