### PR TITLE
[MOB-1580] Show only the fee for a transaction sent to yourself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ directly impact users rather than highlighting other crucial architectural updat
 
 ### Added
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
-- [Ironwood] A transfer that moves funds into the Ironwood pool now shows the amount that actually moved, in both the transaction list and the transaction detail screen. Previously such a transfer displayed only its fee.
 - [Ironwood] Once ZODL sees that the Ironwood network upgrade is live on the network, it shows a short one-time screen introducing the change, with a link to a support article. It appears once per device — after you continue past it, it never comes back.
 - [MOB-1535] Tapping your balance on the home screen now opens a "Total Balance Across Pools" breakdown showing how much ZEC sits in each Zcash pool — Orchard, Sapling, Transparent and Ironwood — so you can see exactly where your funds are. When currency conversion is turned on, each pool also shows its value in your selected currency. Pools you hold nothing in are still listed, and with balances hidden every amount stays masked.
 

--- a/secant/Sources/Models/TransactionState.swift
+++ b/secant/Sources/Models/TransactionState.swift
@@ -49,14 +49,6 @@ struct TransactionState: Equatable, Identifiable {
     var hasTransparentOutputs = false
     var totalSpent: Zatoshi?
     var totalReceived: Zatoshi?
-    /// The SDK's per-transaction note counts, carried so the display amount can adopt Android's
-    /// migration-self-send fallback (see `netValue`). Default 0 for the non-SDK inits (a pending
-    /// send, a swap deposit). The swap-deposit init DOES land on the same 0/0 "note-less" shape,
-    /// but it sets `totalReceived = .zero`; `netValue`'s `totalReceived.amount > 0` guard keeps
-    /// that (and any other genuinely amount-less state) on the `zecAmount` path — only a real
-    /// migration crossing, which carries a positive `totalReceived`, takes the fallback.
-    var sentNoteCount = 0
-    var receivedNoteCount = 0
 
     var rawID: Data? = nil
     
@@ -299,17 +291,6 @@ struct TransactionState: Equatable, Identifiable {
         if isShieldingTransaction {
             return Zatoshi(totalSpent?.amount ?? 0).atLeastThreeDecimalsZashiFormatted()
         }
-        // An Orchard -> Ironwood turnstile transfer is a self-send: it collapses to a fee-only
-        // net value (`zecAmount`), which hides the real amount that crossed. Mirror Android's
-        // fallback (TransactionRepository.kt): a transaction with no counted sent OR received
-        // notes shows `totalReceived` — the true crossing amount — instead of the fee-collapsed
-        // net. Both the transaction list (TransactionRowView) and the detail screen
-        // (TransactionDetailsView) render this property, so both pick up the fallback
-        // consistently. Every other transaction kind keeps at least one note, so the guard
-        // leaves them byte-identical.
-        if sentNoteCount == 0, receivedNoteCount == 0, let totalReceived, totalReceived.amount > 0 {
-            return totalReceived.atLeastThreeDecimalsZashiFormatted()
-        }
         return zecAmount.atLeastThreeDecimalsZashiFormatted()
     }
 
@@ -418,8 +399,6 @@ extension TransactionState {
         memoCount = transaction.memoCount
         totalSpent = transaction.totalSpent
         totalReceived = transaction.totalReceived
-        sentNoteCount = transaction.sentNoteCount
-        receivedNoteCount = transaction.receivedNoteCount
 
         let isPending = isSentTransaction ? minedHeight == nil : transaction.state == .pending
         // Fallback for when the SDK's `expired_unmined` column lags (e.g. an unmined sent tx

--- a/zodlTests/ModelsTests/TransactionStateTests.swift
+++ b/zodlTests/ModelsTests/TransactionStateTests.swift
@@ -2,13 +2,15 @@
 //  TransactionStateTests.swift
 //  zodlTests
 //
-//  Covers the migration self-send display fallback on TransactionState.netValue
-//  (Models/TransactionState.swift). An Orchard -> Ironwood turnstile transfer is a self-send:
-//  its net value collapses to just the fee, so without the fallback the transaction list and
-//  detail screen would show a fee-sized amount instead of the amount that actually crossed the
-//  turnstile. When the SDK reports no counted sent or received notes, netValue falls back to
-//  totalReceived (the real crossing amount), mirroring Android's TransactionRepository. Pure
-//  model logic, no shared/global state -> no `.serialized`.
+//  Covers `TransactionState.netValue` (Models/TransactionState.swift) for self-transfers - a
+//  transaction whose sender and recipient are the same wallet. A self-transfer's SDK-reported
+//  `value` (the account's balance delta) is exactly `-fee`: the amount sent out and the amount
+//  that returns as change cancel each other out, leaving only the fee behind. `netValue`'s
+//  default path (`zecAmount`, which is just `-value` for a sent transaction) therefore already
+//  displays the fee correctly, with no special-casing required. There is deliberately no
+//  note-count-based (or otherwise conditional) fallback to a larger "amount that actually moved" -
+//  none exists, and these tests guard against one being reintroduced. Pure model logic, no
+//  shared/global state -> no `.serialized`.
 //
 
 import Testing
@@ -48,30 +50,63 @@ import Foundation
         )
     }
 
-    /// The SDK-backed init must carry the transaction's note counts onto the state rather than
-    /// leaving them at their struct defaults. `sentNoteCount` and `receivedNoteCount` are given
-    /// distinct, non-default values here, so deleting either wiring line in
-    /// `TransactionState.init(transaction:)` (`sentNoteCount = transaction.sentNoteCount` /
-    /// `receivedNoteCount = transaction.receivedNoteCount`) makes the corresponding property fall
-    /// back to 0 and fails this test - unlike asserting against 0, which those defaults would
-    /// satisfy whether or not the wiring exists.
-    @Test func noteCountsAreWiredFromSDKTransaction() {
+    /// A self-transfer just after it's created: the SDK already counts a sent note (the payment
+    /// output) and a received note (the change), so `sentNoteCount`/`receivedNoteCount` are both
+    /// 1. The balance delta (`value`) is `-10_000`, exactly `-fee`, so `zecAmount` is `10_000` and
+    /// `netValue` must show that fee - not `totalReceived`, which stands in here for an unrelated,
+    /// much larger figure that must NOT leak into the display.
+    @Test func selfSendDisplaysTheFee() {
         let state = TransactionState(
             transaction: overview(
-                sentNoteCount: 3,
-                receivedNoteCount: 2,
-                value: Zatoshi(25_000_000)
+                sentNoteCount: 1,
+                receivedNoteCount: 1,
+                value: Zatoshi(-10_000),
+                totalReceived: Zatoshi(16_464_726)
             )
         )
 
-        #expect(state.sentNoteCount == 3)
-        #expect(state.receivedNoteCount == 2)
+        #expect(state.netValue == Zatoshi(10_000).atLeastThreeDecimalsZashiFormatted())
+        #expect(state.netValue != Zatoshi(16_464_726).atLeastThreeDecimalsZashiFormatted())
     }
 
-    /// The migration shape: a self-send whose net value collapses to the fee, with no counted
-    /// sent or received notes but a real `totalReceived`. netValue must show the crossing amount
-    /// (`totalReceived`), not the misleading fee-collapsed net (`zecAmount`).
-    @Test func migrationSelfSendWithNoNotesDisplaysTotalReceived() {
+    /// Guards the reported "value grew after confirmation" symptom: before the device scans the
+    /// block that mines a self-transfer, the SDK counts a sent and a received note
+    /// (`sentNoteCount`/`receivedNoteCount` = 1/1); once scanned, it reclassifies the payment
+    /// output as change and reports no counted notes at all (0/0). Both states share the same
+    /// `value` (`-10_000`, i.e. `-fee`) and the same `totalReceived`. Since `netValue` no longer
+    /// branches on note counts, both states must show the identical fee-sized amount - the display
+    /// must never change (let alone grow to `totalReceived`) as the transaction gets confirmed.
+    @Test func selfSendDisplaysTheSameFeeBeforeAndAfterScanning() {
+        let beforeScanning = TransactionState(
+            transaction: overview(
+                sentNoteCount: 1,
+                receivedNoteCount: 1,
+                value: Zatoshi(-10_000),
+                totalReceived: Zatoshi(16_464_726)
+            )
+        )
+        let afterScanning = TransactionState(
+            transaction: overview(
+                sentNoteCount: 0,
+                receivedNoteCount: 0,
+                value: Zatoshi(-10_000),
+                totalReceived: Zatoshi(16_464_726)
+            )
+        )
+
+        #expect(beforeScanning.netValue == afterScanning.netValue)
+        #expect(beforeScanning.netValue == Zatoshi(10_000).atLeastThreeDecimalsZashiFormatted())
+        #expect(afterScanning.netValue == Zatoshi(10_000).atLeastThreeDecimalsZashiFormatted())
+        #expect(beforeScanning.netValue != Zatoshi(16_464_726).atLeastThreeDecimalsZashiFormatted())
+        #expect(afterScanning.netValue != Zatoshi(16_464_726).atLeastThreeDecimalsZashiFormatted())
+    }
+
+    /// The Orchard -> Ironwood turnstile migration shape: a self-transfer with no counted sent or
+    /// received notes (0/0) and a large `totalReceived` left over from the now-deleted fallback.
+    /// `netValue` must still show only the fee (`10_000`), since a migration crossing is a
+    /// self-transfer like any other - its balance delta is `-fee`, and no fallback remains to
+    /// substitute `totalReceived` for it.
+    @Test func ironwoodMigrationDisplaysTheFee() {
         let state = TransactionState(
             transaction: overview(
                 sentNoteCount: 0,
@@ -81,14 +116,31 @@ import Foundation
             )
         )
 
-        #expect(state.netValue == Zatoshi(25_000_000).atLeastThreeDecimalsZashiFormatted())
+        #expect(state.netValue == Zatoshi(10_000).atLeastThreeDecimalsZashiFormatted())
+        #expect(state.netValue != Zatoshi(25_000_000).atLeastThreeDecimalsZashiFormatted())
     }
 
-    /// A shielding transaction keeps the `totalSpent` path even with 0/0 note counts: that
-    /// branch has priority and must be checked before the note-count fallback. `totalReceived`
-    /// is deliberately a different value, so an ordering bug (fallback checked first) would be
-    /// caught by the assertion below.
-    @Test func shieldingTransactionKeepsTotalSpentPathEvenWithNoNotes() {
+    /// An ordinary send to someone else: the balance delta is the sent amount plus the fee
+    /// (`-25_010_000`), so `netValue` must show the full `25_010_000` - the amount the recipient
+    /// gets plus the fee the sender paid - regardless of the unrelated `totalReceived` (change)
+    /// also present on the transaction.
+    @Test func ordinarySendDisplaysAmountPlusFee() {
+        let state = TransactionState(
+            transaction: overview(
+                sentNoteCount: 1,
+                receivedNoteCount: 0,
+                value: Zatoshi(-25_010_000),
+                totalReceived: Zatoshi(5_000)
+            )
+        )
+
+        #expect(state.netValue == Zatoshi(25_010_000).atLeastThreeDecimalsZashiFormatted())
+    }
+
+    /// A shielding transaction (transparent -> shielded) keeps its own `totalSpent`-based display
+    /// even with no counted sent or received notes: the `isShieldingTransaction` branch is checked
+    /// before the default path in `netValue`, so it must win regardless of note counts.
+    @Test func shieldingTransactionDisplaysTotalSpent() {
         let state = TransactionState(
             transaction: overview(
                 isShielding: true,
@@ -104,67 +156,10 @@ import Foundation
         #expect(state.netValue == Zatoshi(1_000_000).atLeastThreeDecimalsZashiFormatted())
     }
 
-    /// Guard hardening: a note-less (0/0) shape whose `totalReceived` is `.zero` — the same shape
-    /// the swap-deposit initialiser produces — must stay on the `zecAmount` path rather than
-    /// misreport a zero crossing amount. `zecAmount` is deliberately non-zero here, so a guard
-    /// that checks presence alone (not `> 0`) would return the zero `totalReceived` instead and
-    /// be caught by the assertion below.
-    @Test func noteslessStateWithZeroTotalReceivedKeepsZecAmountPath() {
-        let state = TransactionState(
-            transaction: overview(
-                sentNoteCount: 0,
-                receivedNoteCount: 0,
-                value: Zatoshi(-10_000),
-                totalReceived: .zero
-            )
-        )
-
-        #expect(state.netValue == state.zecAmount.atLeastThreeDecimalsZashiFormatted())
-    }
-
-    /// The non-SDK initialisers (a pending send, a swap deposit) never touch the note-count
-    /// fields, so they must default to 0 and keep compiling unchanged. Both produce a 0/0
-    /// "note-less" shape too; the pending send has no `totalReceived` at all and the swap deposit
-    /// sets it to `.zero`, so both correctly stay on the `zecAmount` path.
-    @Test func nonSDKInitsDefaultNoteCountsToZeroAndKeepZecAmountPath() {
-        let pendingSend = TransactionState(pendingSendId: "pending-send", zecAmount: Zatoshi(15_000_000))
-        #expect(pendingSend.sentNoteCount == 0)
-        #expect(pendingSend.receivedNoteCount == 0)
-        #expect(pendingSend.netValue == Zatoshi(15_000_000).atLeastThreeDecimalsZashiFormatted())
-
-        let swapDeposit = TransactionState(
-            depositAddress: "t1SwapDepositAddress",
-            timestamp: 1_699_290_621,
-            swapStatus: .pending
-        )
-        #expect(swapDeposit.sentNoteCount == 0)
-        #expect(swapDeposit.receivedNoteCount == 0)
-        #expect(swapDeposit.totalReceived == .zero)
-        #expect(swapDeposit.netValue == Zatoshi.zero.atLeastThreeDecimalsZashiFormatted())
-    }
-
-    /// An ordinary send keeps at least one sent note, so the fallback must not apply, even when
-    /// `totalReceived` (change) is present — the display stays the fee-collapsed net
-    /// (`zecAmount`). `totalReceived` is deliberately different from `zecAmount`, so a broken
-    /// `sentNoteCount` wiring (SDK -> TransactionState) would be caught here.
-    @Test func ordinarySendWithNotesIsUnchanged() {
-        let state = TransactionState(
-            transaction: overview(
-                sentNoteCount: 1,
-                receivedNoteCount: 0,
-                value: Zatoshi(-25_010_000),
-                totalReceived: Zatoshi(5_000)
-            )
-        )
-
-        #expect(state.sentNoteCount == 1)
-        #expect(state.netValue == Zatoshi(25_010_000).atLeastThreeDecimalsZashiFormatted())
-    }
-
-    /// Mirror case: an ordinary receive keeps at least one received note, so the fallback must
-    /// not apply either. `totalReceived` is deliberately different from `zecAmount`, so a broken
-    /// `receivedNoteCount` wiring would be caught here.
-    @Test func ordinaryReceiveWithNotesIsUnchanged() {
+    /// An ordinary receive: the balance delta is the full amount received (`25_000_000`), so
+    /// `netValue` must show that amount, not the unrelated `totalReceived` figure also present on
+    /// the transaction.
+    @Test func ordinaryReceiveIsUnchanged() {
         let state = TransactionState(
             transaction: overview(
                 sentNoteCount: 0,
@@ -174,7 +169,23 @@ import Foundation
             )
         )
 
-        #expect(state.receivedNoteCount == 1)
         #expect(state.netValue == Zatoshi(25_000_000).atLeastThreeDecimalsZashiFormatted())
+    }
+
+    /// The non-SDK initialisers - a pending send and a swap deposit - never go through
+    /// `init(transaction:)`, so they're unaffected by this change. A pending send's `netValue` is
+    /// simply its `zecAmount`. A swap deposit has no funds attributed to it yet (`totalReceived`
+    /// is `.zero`), so its `netValue` is `Zatoshi.zero`, formatted like any other amount.
+    @Test func nonSDKInitsAreUnchanged() {
+        let pendingSend = TransactionState(pendingSendId: "pending-send", zecAmount: Zatoshi(15_000_000))
+        #expect(pendingSend.netValue == Zatoshi(15_000_000).atLeastThreeDecimalsZashiFormatted())
+
+        let swapDeposit = TransactionState(
+            depositAddress: "t1SwapDepositAddress",
+            timestamp: 1_699_290_621,
+            swapStatus: .pending
+        )
+        #expect(swapDeposit.totalReceived == .zero)
+        #expect(swapDeposit.netValue == Zatoshi.zero.atLeastThreeDecimalsZashiFormatted())
     }
 }


### PR DESCRIPTION
A transaction the user sends to themselves — a manual send to one's own address, or an Orchard → Ironwood migration crossing — now displays the network fee, on every device and at every point in the transaction's life.

## The change is a deletion

`zecAmount` is the account balance delta. Every output of a self-transfer returns to the account, so the delta is exactly `-fee` and the default path already displays the fee. No self-transfer concept is needed.

The only thing preventing it was the note-count fallback added for the Ironwood migration display, which substituted `totalReceived` whenever the SDK reported no counted sent or received notes.

## Why that condition could not work

- `sent_note_count` counts rows in the SDK's `sent_notes` table, which only exists on the device that **created** the transaction — and its CTE further excludes sent notes whose output was recorded as change.
- `received_note_count` excludes change.
- Scanning marks a self-send's payment output as change (upstream's comment names "notes sent from one account to itself" as an intended case), and the DB upsert ratchets the flag upward.

So both counts are device-dependent *and* time-dependent. The same self-transfer reads 1/1 before its block is scanned and 0/0 afterwards — which is why the displayed value grew once the transaction confirmed, and why a second device disagreed with the sending one.

## Scope

| Shape | Device / timing | Before | After |
|---|---|---|---|
| Manual self-send | sending device, pre-scan | fee | fee |
| Manual self-send | after scan, or 2nd device | payment + change | **fee** |
| Ironwood migration | any | crossing amount | **fee** |
| Ordinary send | sending device, pre-scan | amount + fee | amount + fee |
| Ordinary send | after scan, or 2nd device | change | amount + fee |
| Receive, shielding, swaps, pending send, swap deposit | any | — | unchanged |

The ordinary-send rows are corrections of the same defect, not new behaviour — one condition produced both wrong numbers and nothing within it distinguished the shapes.

`sentNoteCount` / `receivedNoteCount` are removed from the model with the condition, since nothing else read them. The CHANGELOG entry promising that an Ironwood transfer shows the amount that moved is removed along with the behaviour it described; no new entry is added, as the fallback never reached a finalized release.

## Verification

Full `zodlTests` target: 679 tests in 111 suites pass. Written test-first — `ironwoodMigrationDisplaysTheFee` and `selfSendDisplaysTheSameFeeBeforeAndAfterScanning` both failed against the old code before the deletion.

The previous implementation of this branch is preserved at `michal/MOB-1580-self-transfer-display-value-superseded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)