### PR TITLE
[MOB-1581] Refresh the transaction list the moment a send completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1512] The "Wallet data replaced" notice now stays on screen after the healed wallet opens, instead of disappearing during the transition to the home screen.
 - [Keystone] Switching between the ZODL and Keystone accounts now always shows the selected account's transaction history — a slow in-flight refresh for the previous account can no longer overwrite it — and connecting a Keystone hardware wallet refreshes the transaction list and balance immediately.
 - [Keystone] The transaction list no longer gets stuck showing its loading placeholder when switching to an account whose transaction list turns out identical to the previous one — in practice, switching between two accounts that both have no transactions, such as right after connecting a Keystone.
+- [MOB-1581] The Activity list now shows a sent transaction immediately after sending, regardless of how the send flow is closed, instead of waiting for the next sync cycle.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -357,6 +357,21 @@ extension Root {
 
                 // MARK: - Scan Coord Flow
                 
+            // MOB-1581: a terminal send outcome that stored a transaction must refresh the shared
+            // transactions list immediately — an idle wallet emits no sync event until the next block
+            // (~75s), and not every flow exit passes a refetching Close arm (the View Transaction →
+            // detail-close exit did not). `sendFailed(_, false)` stored nothing, so it stays silent.
+            case .scanCoordFlow(.path(.element(id: _, action: .sendConfirmation(.sendDone)))),
+                    .scanCoordFlow(.path(.element(id: _, action: .sendConfirmation(.sendPartial)))),
+                    .scanCoordFlow(.path(.element(id: _, action: .sendConfirmation(.sendFailed(_, true))))),
+                    .scanCoordFlow(.path(.element(id: _, action: .requestZecConfirmation(.sendDone)))),
+                    .scanCoordFlow(.path(.element(id: _, action: .requestZecConfirmation(.sendPartial)))),
+                    .scanCoordFlow(.path(.element(id: _, action: .requestZecConfirmation(.sendFailed(_, true))))),
+                    .scanCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendDone)))),
+                    .scanCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendPartial)))),
+                    .scanCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendFailed(_, true))))):
+                return .send(.fetchTransactionsForTheSelectedAccount)
+
             case .scanCoordFlow(.scan(.cancelTapped)):
                 state.path = nil
                 return .none
@@ -365,9 +380,10 @@ extension Root {
                 state.path = nil
                 return .none
 
+            // MOB-1581: this exit previously refreshed nothing — see the send-terminal arms above.
             case .scanCoordFlow(.path(.element(id: _, action: .transactionDetails(.closeDetailTapped)))):
                 state.path = nil
-                return .none
+                return .send(.fetchTransactionsForTheSelectedAccount)
 
             case .scanCoordFlow(.path(.element(id: _, action: .sendResultSuccess(.closeTapped)))),
                     .scanCoordFlow(.path(.element(id: _, action: .sendResultFailure(.closeTapped)))),
@@ -395,18 +411,43 @@ extension Root {
                 )
 
                 // MARK: - Send Coord Flow
-                
+
+            // MOB-1581: a terminal send outcome that stored a transaction must refresh the shared
+            // transactions list immediately — an idle wallet emits no sync event until the next block
+            // (~75s), and not every flow exit passes a refetching Close arm (the View Transaction →
+            // detail-close exit did not). `sendFailed(_, false)` stored nothing, so it stays silent.
+            case .sendCoordFlow(.path(.element(id: _, action: .sendConfirmation(.sendDone)))),
+                    .sendCoordFlow(.path(.element(id: _, action: .sendConfirmation(.sendPartial)))),
+                    .sendCoordFlow(.path(.element(id: _, action: .sendConfirmation(.sendFailed(_, true))))),
+                    .sendCoordFlow(.path(.element(id: _, action: .requestZecConfirmation(.sendDone)))),
+                    .sendCoordFlow(.path(.element(id: _, action: .requestZecConfirmation(.sendPartial)))),
+                    .sendCoordFlow(.path(.element(id: _, action: .requestZecConfirmation(.sendFailed(_, true))))),
+                    .sendCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendDone)))),
+                    .sendCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendPartial)))),
+                    .sendCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendFailed(_, true))))):
+                return .send(.fetchTransactionsForTheSelectedAccount)
+
             case .sendCoordFlow(.path(.element(id: _, action: .sendResultSuccess(.closeTapped)))),
                     .sendCoordFlow(.path(.element(id: _, action: .sendResultFailure(.closeTapped)))),
                     .sendCoordFlow(.path(.element(id: _, action: .sendResultPending(.closeTapped)))):
                 state.path = nil
                 return .send(.fetchTransactionsForTheSelectedAccount)
 
+            // MOB-1581: this exit previously refreshed nothing — see the send-terminal arms above.
             case .sendCoordFlow(.path(.element(id: _, action: .transactionDetails(.closeDetailTapped)))):
                 state.path = nil
-                return .none
+                return .send(.fetchTransactionsForTheSelectedAccount)
 
                 // MARK: - Sign with Keystone Coord Flow
+
+            // MOB-1581: a terminal send outcome that stored a transaction must refresh the shared
+            // transactions list immediately — an idle wallet emits no sync event until the next block
+            // (~75s), and not every flow exit passes a refetching Close arm (the View Transaction →
+            // detail-close exit did not). `sendFailed(_, false)` stored nothing, so it stays silent.
+            case .signWithKeystoneCoordFlow(.sendConfirmation(.sendDone)),
+                    .signWithKeystoneCoordFlow(.sendConfirmation(.sendPartial)),
+                    .signWithKeystoneCoordFlow(.sendConfirmation(.sendFailed(_, true))):
+                return .send(.fetchTransactionsForTheSelectedAccount)
 
             case .signWithKeystoneCoordFlow(.path(.element(id: _, action: .sendResultSuccess(.closeTapped)))),
                     .signWithKeystoneCoordFlow(.path(.element(id: _, action: .sendResultFailure(.closeTapped)))),
@@ -414,9 +455,10 @@ extension Root {
                 state.signWithKeystoneCoordFlowBinding = false
                 return .send(.fetchTransactionsForTheSelectedAccount)
 
+            // MOB-1581: this exit previously refreshed nothing — see the send-terminal arms above.
             case .signWithKeystoneCoordFlow(.path(.element(id: _, action: .transactionDetails(.closeDetailTapped)))):
                 state.signWithKeystoneCoordFlowBinding = false
-                return .none
+                return .send(.fetchTransactionsForTheSelectedAccount)
 
                 // MARK: - Tor Setup
                 
@@ -425,6 +467,18 @@ extension Root {
                 return .send(.home(.smartBanner(.closeAndCleanupBanner)))
 
                 // MARK: - Swap and Pay Coord Flow
+
+            // MOB-1581: a terminal send outcome that stored a transaction must refresh the shared
+            // transactions list immediately — an idle wallet emits no sync event until the next block
+            // (~75s), and not every flow exit passes a refetching Close arm (the View Transaction →
+            // detail-close exit did not). `sendFailed(_, false)` stored nothing, so it stays silent.
+            case .swapAndPayCoordFlow(.sendDone),
+                    .swapAndPayCoordFlow(.sendPartial),
+                    .swapAndPayCoordFlow(.sendFailed(_, true)),
+                    .swapAndPayCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendDone)))),
+                    .swapAndPayCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendPartial)))),
+                    .swapAndPayCoordFlow(.path(.element(id: _, action: .confirmWithKeystone(.sendFailed(_, true))))):
+                return .send(.fetchTransactionsForTheSelectedAccount)
 
             case .swapAndPayCoordFlow(.path(.element(id: _, action: .swapToZecSummary(.sentTheFundsButtonTapped)))):
                 state.path = nil
@@ -452,9 +506,10 @@ extension Root {
                 state.path = nil
                 return .send(.fetchTransactionsForTheSelectedAccount)
 
+            // MOB-1581: this exit previously refreshed nothing — see the send-terminal arms above.
             case .swapAndPayCoordFlow(.path(.element(id: _, action: .transactionDetails(.closeDetailTapped)))):
                 state.path = nil
-                return .none
+                return .send(.fetchTransactionsForTheSelectedAccount)
 
                 // MARK: - Transactions Coord Flow
                 

--- a/zodlTests/RootTransactionsTests/RootSendCompletionRefreshTests.swift
+++ b/zodlTests/RootTransactionsTests/RootSendCompletionRefreshTests.swift
@@ -1,0 +1,440 @@
+//
+//  RootSendCompletionRefreshTests.swift
+//  zodlTests
+//
+//  MOB-1581: the Activity list only refreshed on sync events and on the send flows' result-screen
+//  Close buttons -- never at the moment a send reaches a terminal outcome, and never on the View
+//  Transaction -> transaction detail -> close exit. An idle wallet emits no sync event until the
+//  next block (~75s), so a just-sent transaction (already stored in the local DB at creation time)
+//  could stay invisible in Activity for over a minute. The fix dispatches
+//  `.fetchTransactionsForTheSelectedAccount` (a) the moment `sendDone` / `sendPartial` /
+//  `sendFailed(_, true)` fires on any send-capable element, and (b) on every flow's
+//  `transactionDetails(.closeDetailTapped)` arm. `sendFailed(_, false)` stored nothing, so it must
+//  stay silent -- the one negative test below covers that.
+//
+//  Mirrors `RootTransactionsTests/RootTransactionsAccountSwitchTests.swift`'s established pattern:
+//  a plain `Store` (not `TestStore`) driven with `LockIsolated` spies and polling, plus its own
+//  file-private `baseNoOpDependencies` baseline and `.serialized` (Root.State touches the
+//  process-global `@Shared(.inMemory(...))` keys).
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct RootSendCompletionRefreshTests {
+    private static func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    // MARK: - Send Coord Flow -- send-terminal outcomes
+
+    @Test func sendDoneInSendFlowRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 80)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.sendCoordFlowState.path.append(.sendConfirmation(SendConfirmation.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.sendCoordFlowState.path.ids.first)
+        store.send(.sendCoordFlow(.path(.element(id: elementId, action: .sendConfirmation(.sendDone)))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    @Test func requestZecSendDoneInSendFlowRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 81)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.sendCoordFlowState.path.append(.requestZecConfirmation(SendConfirmation.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.sendCoordFlowState.path.ids.first)
+        store.send(.sendCoordFlow(.path(.element(id: elementId, action: .requestZecConfirmation(.sendDone)))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    @Test func sendFailedWithStoredTransactionRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 82)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.sendCoordFlowState.path.append(.sendConfirmation(SendConfirmation.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.sendCoordFlowState.path.ids.first)
+        store.send(.sendCoordFlow(.path(.element(id: elementId, action: .sendConfirmation(.sendFailed(nil, true))))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    /// The negative case: `sendFailed(_, false)` means nothing was ever stored in the local DB, so
+    /// there is nothing new for the Activity list to show -- no refetch must fire.
+    @Test func sendFailedWithoutStoredTransactionDoesNotRefetch() async throws {
+        let account = Self.walletAccount(idByte: 83)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.sendCoordFlowState.path.append(.sendConfirmation(SendConfirmation.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.sendCoordFlowState.path.ids.first)
+        store.send(.sendCoordFlow(.path(.element(id: elementId, action: .sendConfirmation(.sendFailed(nil, false))))))
+
+        // No polling helper here on purpose -- there is nothing to wait FOR. Give a wrongly-firing
+        // refetch a brief moment to land, then confirm nothing did.
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        #expect(fetchedAccounts.value.isEmpty)
+    }
+
+    @Test func sendPartialInSendFlowRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 84)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.sendCoordFlowState.path.append(.sendConfirmation(SendConfirmation.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.sendCoordFlowState.path.ids.first)
+        store.send(.sendCoordFlow(.path(.element(id: elementId, action: .sendConfirmation(.sendPartial([], []))))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    // MARK: - Scan Coord Flow
+
+    @Test func scanFlowSendDoneRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 85)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.scanCoordFlowState.path.append(.sendConfirmation(SendConfirmation.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.scanCoordFlowState.path.ids.first)
+        store.send(.scanCoordFlow(.path(.element(id: elementId, action: .sendConfirmation(.sendDone)))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    // MARK: - Sign with Keystone Coord Flow
+
+    /// `SignWithKeystoneCoordFlow`'s send confirmation is a DIRECT child action
+    /// (`.signWithKeystoneCoordFlow(.sendConfirmation(...))`), not a path element -- no element id
+    /// to look up, unlike every other flow tested in this file.
+    @Test func keystoneSignFlowSendDoneRefetchesTransactions() async {
+        let account = Self.walletAccount(idByte: 86)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        store.send(.signWithKeystoneCoordFlow(.sendConfirmation(.sendDone)))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    // MARK: - Swap and Pay Coord Flow
+
+    /// The Swap flow runs its own send with FLOW-LEVEL actions (`.swapAndPayCoordFlow(.sendDone)`),
+    /// not a path element -- distinct from its Keystone path below.
+    @Test func swapFlowOwnSendDoneRefetchesTransactions() async {
+        let account = Self.walletAccount(idByte: 87)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        store.send(.swapAndPayCoordFlow(.sendDone))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    @Test func swapFlowKeystoneSendDoneRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 88)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.swapAndPayCoordFlowState.path.append(.confirmWithKeystone(SendConfirmation.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.swapAndPayCoordFlowState.path.ids.first)
+        store.send(.swapAndPayCoordFlow(.path(.element(id: elementId, action: .confirmWithKeystone(.sendDone)))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    // MARK: - Transaction-detail close arms
+    //
+    // MOB-1581's second gap: closing the transaction detail screen reached via View Transaction
+    // (from any of the four send-capable flows) previously refreshed nothing at all.
+
+    @Test func detailCloseInSendFlowRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 89)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.sendCoordFlowState.path.append(.transactionDetails(TransactionDetails.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.sendCoordFlowState.path.ids.first)
+        store.send(.sendCoordFlow(.path(.element(id: elementId, action: .transactionDetails(.closeDetailTapped)))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    @Test func detailCloseInScanFlowRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 90)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.scanCoordFlowState.path.append(.transactionDetails(TransactionDetails.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.scanCoordFlowState.path.ids.first)
+        store.send(.scanCoordFlow(.path(.element(id: elementId, action: .transactionDetails(.closeDetailTapped)))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    /// Unlike the other three flows, this arm also flips `state.signWithKeystoneCoordFlowBinding`
+    /// back to `false` -- that mutation is pre-existing behavior and not this test's concern; only
+    /// the refetch is asserted here.
+    @Test func detailCloseInKeystoneSignFlowRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 91)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.signWithKeystoneCoordFlowState.path.append(.transactionDetails(TransactionDetails.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.signWithKeystoneCoordFlowState.path.ids.first)
+        store.send(.signWithKeystoneCoordFlow(.path(.element(id: elementId, action: .transactionDetails(.closeDetailTapped)))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+
+    @Test func detailCloseInSwapFlowRefetchesTransactions() async throws {
+        let account = Self.walletAccount(idByte: 92)
+        let fetchedAccounts = LockIsolated<[AccountUUID?]>([])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.swapAndPayCoordFlowState.path.append(.transactionDetails(TransactionDetails.State.initial))
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                fetchedAccounts.withValue { $0.append(accountUUID) }
+                return []
+            }
+        }
+
+        let elementId = try #require(store.state.swapAndPayCoordFlowState.path.ids.first)
+        store.send(.swapAndPayCoordFlow(.path(.element(id: elementId, action: .transactionDetails(.closeDetailTapped)))))
+
+        await waitForRefetch { fetchedAccounts.value.contains(account.id) }
+
+        #expect(fetchedAccounts.value.contains(account.id))
+    }
+}
+
+/// Shared no-op dependency baseline for every test in this file. Kept as a private, file-scoped
+/// helper rather than something shared globally, the same way
+/// `RootTransactionsTests/RootTransactionsAccountSwitchTests.swift` keeps its own private
+/// `baseNoOpDependencies` local to that file.
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    // Every positive test in this file dispatches an action that reaches `SendConfirmation`'s real
+    // reducer (`.sendDone` / `.sendFailed` / `.sendPartial` all funnel into `.updateResult`, which
+    // calls `audioServices.systemSoundVibrate()`) -- `AudioServicesClient` has no `testValue`, so
+    // without this override every such test fails on "no test implementation" instead of on the
+    // refetch assertion. Same override already used for the same reason in
+    // `SendTests/MultiServerSubmitRoutingTests.swift` and `ScanTests/ScanCoordFlowZip321Tests.swift`.
+    values.audioServices = AudioServicesClient(systemSoundVibrate: { })
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mainQueue = .immediate
+    values.mnemonic = .mock
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.load = { _ in }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}
+
+@MainActor
+private func waitForRefetch(
+    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(condition(), "Timed out waiting for the send-completion transactions refetch", sourceLocation: sourceLocation)
+}


### PR DESCRIPTION
## Problem

After sending, the "Sending" row could take over a minute to appear in the Activity list (MOB-1581, reported on 3.8.0 (9)).

The transaction is provably in the local database the moment creation succeeds — the SDK's create path even reads it back through the same connection the Activity list queries. The data was never late; the refresh was:

- The Activity list refetches only on sync events, on `.upToDate` transitions, and on the send flows' result-screen **Close** buttons.
- Leaving the success screen via **View Transaction** and then closing the transaction detail refreshed **nothing** (those arms only cleared navigation state).
- An idle, fully-synced wallet emits no sync event until the next block (~75 s average) — so with the wrong exit path, the row stayed invisible until the next block's sync cycle. Activation-day sync/mempool congestion stretches that further.

(The wrong amount shown while pending is a separate issue, tracked and fixed under MOB-1580. The Jul 25 reports of the same symptom on internal builds had a different, already-fixed cause — the fetch-starvation regression addressed on `release/3.8.0`.)

## Fix

`Root` now dispatches `.fetchTransactionsForTheSelectedAccount`:

1. **The moment a send reaches a terminal outcome that stored a transaction** — `sendDone`, `sendPartial`, and `sendFailed` with the txid present in the DB — across all four send-capable flows (Send, Scan, Sign with Keystone, Swap & Pay), including the Keystone `confirmWithKeystone` path elements and the Swap flow's own flow-level send actions. `sendFailed` with nothing stored stays silent.
2. **On those flows' `transactionDetails(.closeDetailTapped)` arms** (the View Transaction exit), which previously returned `.none`.

Concurrent fetches are safe by design: the fetch effect deliberately has no `cancelInFlight` (see the starvation comment in `RootTransactions.swift`), and the `.fetchedTransactions` provenance guard drops wrong-account payloads.

## Tests

New `RootSendCompletionRefreshTests` (13 tests, Swift Testing, serialized, plain-`Store` + `LockIsolated` spy pattern per `RootTransactionsAccountSwitchTests`). TDD: all 12 positive tests failed before the source change; all 13 pass after. Full `zodl-internal` suite: **692 tests in 112 suites passed** (1 pre-existing known issue, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)