### PR TITLE
[MOB-1593] Drop empty text memos from transaction detail messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [Keystone] Switching between the ZODL and Keystone accounts now always shows the selected account's transaction history — a slow in-flight refresh for the previous account can no longer overwrite it — and connecting a Keystone hardware wallet refreshes the transaction list and balance immediately.
 - [Keystone] The transaction list no longer gets stuck showing its loading placeholder when switching to an account whose transaction list turns out identical to the previous one — in practice, switching between two accounts that both have no transactions, such as right after connecting a Keystone.
 - [MOB-1581] The Activity list now shows a sent transaction immediately after sending, regardless of how the send flow is closed, instead of waiting for the next sync cycle.
+- [MOB-1593] Transaction detail no longer shows an extra, empty message bubble on sent transactions, and "Send again" prefills the actual message text again.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
+++ b/secant/Sources/Features/TransactionDetails/TransactionDetailsStore.swift
@@ -420,7 +420,7 @@ struct TransactionDetails {
             case .memosLoaded(let memos):
                 state.areMessagesResolved = true
                 state.$transactionMemos.withLock {
-                    $0[state.transaction.id] = memos.compactMap { $0.toString() }
+                    $0[state.transaction.id] = memos.compactMap { $0.toString() }.filter { !$0.isEmpty }
                 }
                 state.messageStates = state.memos.map {
                     $0.count < State.Constants.messageExpandThreshold ? .short : .longCollapsed

--- a/zodlTests/TransactionDetailsTests/TransactionDetailsMemosTests.swift
+++ b/zodlTests/TransactionDetailsTests/TransactionDetailsMemosTests.swift
@@ -1,0 +1,38 @@
+//
+//  TransactionDetailsMemosTests.swift
+//  zodlTests
+//
+//  Covers MOB-1593: post-NU6.3 transactions can contain fabricated zero-value outputs
+//  whose on-chain memo is 512 bytes of 0x00. Per ZIP-302 the Zcash Swift SDK parses that
+//  as a *text* memo whose string is "" (not nil), so `.memosLoaded` must drop exactly-empty
+//  memo strings — otherwise the app shows an extra, empty "Message" bubble
+//  (Features/TransactionDetails/TransactionDetailsStore.swift).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct TransactionDetailsMemosTests {
+    @Test @MainActor func memosLoadedDropsEmptyTextMemos() async throws {
+        // Pins the ZIP-302 premise: an all-zero 512-byte memo parses as a text memo
+        // whose string is "" — not nil. If this ever stops holding, the rest of this
+        // test no longer exercises the bug it's meant to guard against.
+        let allZeroMemo = try Memo(bytes: [UInt8](repeating: 0, count: 512))
+        let allZeroMemoString = try #require(allZeroMemo.toString())
+        #expect(allZeroMemoString.isEmpty)
+
+        let transaction = TransactionState.placeholder(uuid: "tx-id")
+        let store = TestStore(initialState: TransactionDetails.State(transaction: transaction)) {
+            TransactionDetails()
+        }
+
+        await store.send(.memosLoaded([allZeroMemo, try Memo(string: "Testing"), Memo.empty])) { state in
+            state.areMessagesResolved = true
+            state.$transactionMemos.withLock { $0[transaction.id] = ["Testing"] }
+            state.messageStates = [.short]
+        }
+    }
+}


### PR DESCRIPTION
Closes MOB-1593.

## What & why

Transaction detail showed an extra, **empty** Message bubble above the real message on sent transactions (and "Send again" silently prefilled that empty artifact instead of the actual message).

Root cause: post-NU6.3, a send that spends Orchard notes builds an Orchard V3 bundle in which every real spend is paired with a fabricated zero-value output back to the spent note's own address, and that fabricated output's on-chain memo field is all-zero bytes. Per ZIP-302, all-zero memo bytes decode as a *text* memo whose string is empty — only 0xF6-prefixed bytes decode as the canonical "no memo" — so the SDK correctly reports `""` for it, and the app rendered that as a message bubble. The artifact is permanently on-chain for affected transactions, so display filtering in the app is the fix that also repairs history.

## How

`TransactionDetails` `.memosLoaded` now drops exactly-empty memo strings when storing resolved memos (`.filter { !$0.isEmpty }`). Whitespace-only memos are deliberately kept — they are legitimate on-chain content; the fabricated-output artifact is exactly the empty string. The single storage point also feeds the "Send again" prefill, so both symptoms are fixed together.

## Testing

- New Swift Testing `TestStore` test (`TransactionDetailsMemosTests`) written first (TDD): feeds `.memosLoaded` an all-zero 512-byte memo, a real "Testing" memo, and `Memo.empty`; expects only `["Testing"]` stored with one `.short` message state. It also pins the ZIP-302 premise that all-zero bytes parse to an empty text memo.
- Full `zodlTests` suite: 680 tests in 112 suites, all passing.

## Notes for reviewers

- Android likely renders the same artifact (same SDK data); worth checking there too.
- Longer-term, the fabricated outputs could carry the canonical 0xF6 empty memo at the protocol-construction layer, which would stop creating the artifact for future transactions — the app-side filter remains necessary for already-mined history regardless.

---
This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)