### PR TITLE
[MOB-1585] Explain the temporarily unavailable balance after sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1512] The "Wallet data replaced" notice now stays on screen after the healed wallet opens, instead of disappearing during the transition to the home screen.
 - [Keystone] Switching between the ZODL and Keystone accounts now always shows the selected account's transaction history — a slow in-flight refresh for the previous account can no longer overwrite it — and connecting a Keystone hardware wallet refreshes the transaction list and balance immediately.
 - [Keystone] The transaction list no longer gets stuck showing its loading placeholder when switching to an account whose transaction list turns out identical to the previous one — in practice, switching between two accounts that both have no transactions, such as right after connecting a Keystone.
+- [MOB-1585] Explain why the balance is temporarily not spendable after sending (new "Updating Balance" banner) instead of showing a bare zero.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -420,7 +420,14 @@ struct SmartBanner {
 
                         if state.priorityContent == .priority5 {
                             if !isShieldedBalancePending {
-                                return .send(.closeAndCleanupBanner)
+                                // Mirrors priority7's own close pattern below: recovering while
+                                // the banner's help sheet is open must dismiss that sheet too, or
+                                // the user is left staring at an almost-empty sheet (priority5's
+                                // helpSheetContent() default is EmptyView).
+                                return .merge(
+                                    .send(.closeAndCleanupBanner),
+                                    .send(.closeSheetTapped)
+                                )
                             }
                         } else if isShieldedBalancePending && !isSyncing
                             && (state.priorityContent?.rawValue ?? Int.max) > State.PriorityContent.priority5.rawValue {

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -243,6 +243,10 @@ struct SmartBanner {
                 
             case .walletAccountChanged:
                 state.remindMeShieldedPhaseCounter = 0
+                // Stale per-account reading: the previous account's spendable balance must not
+                // leak into `areFundsSpendable` between the switch and the new account's first
+                // `synchronizerStateChanged` tick.
+                state.spendableBalance = Zatoshi(0)
                 return .run { send in
                     await send(.closeBanner(true), animation: .easeInOut(duration: Constants.easeInOutDuration))
                     try? await mainQueue.sleep(for: .seconds(1))
@@ -409,6 +413,20 @@ struct SmartBanner {
                     }
                     
                     if let account = state.selectedWalletAccount, let accountBalance = latestState.data.accountsBalances[account.id] {
+                        // Shielded spendable reads 0 while shielded total > 0: inputs are
+                        // pending-spent (e.g. right after a send) and/or change is awaiting
+                        // confirmations. Pool-agnostic accessors only — never hand-sum pools.
+                        let isShieldedBalancePending = accountBalance.shieldedSpendableValue.amount == 0 && accountBalance.shieldedTotal().amount > 0
+
+                        if state.priorityContent == .priority5 {
+                            if !isShieldedBalancePending {
+                                return .send(.closeAndCleanupBanner)
+                            }
+                        } else if isShieldedBalancePending && !isSyncing
+                            && (state.priorityContent?.rawValue ?? Int.max) > State.PriorityContent.priority5.rawValue {
+                            return .send(.triggerPriority(.priority5))
+                        }
+
                         if state.priorityContent == .priority7 {
                             if accountBalance.unshielded > zcashSDKEnvironment.shieldingThreshold() {
                                 return .send(.transparentBalanceUpdated(accountBalance.unshielded))
@@ -472,7 +490,17 @@ struct SmartBanner {
 
                 // updating balance
             case .evaluatePriority5:
-                return .send(.evaluatePriority6)
+                guard let account = state.selectedWalletAccount else {
+                    return .send(.evaluatePriority6)
+                }
+                return .run { send in
+                    if let accountBalance = try? await sdkSynchronizer.getAccountsBalances()[account.id],
+                       accountBalance.shieldedSpendableValue.amount == 0 && accountBalance.shieldedTotal().amount > 0 {
+                        await send(.triggerPriority(.priority5))
+                    } else {
+                        await send(.evaluatePriority6)
+                    }
+                }
 
                 // wallet backup
             case .evaluatePriority6:

--- a/zodlTests/SmartBannerTests/SmartBannerUpdatingBalanceTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerUpdatingBalanceTests.swift
@@ -189,6 +189,33 @@ import Testing
         }
     }
 
+    /// Mirrors priority7's own close pattern (`.merge(.send(.closeAndCleanupBanner),
+    /// .send(.closeSheetTapped))`): recovering while the banner's help sheet is open must dismiss
+    /// that sheet too, or the user is left staring at an almost-empty sheet (priority5's
+    /// `helpSheetContent()` default is `EmptyView`) they have to swipe away by hand.
+    @Test func balanceRecoveryDismissesAnOpenHelpSheetToo() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(modify: { state in
+                state.priorityContent = .priority5
+                state.priorityContentRequested = .priority5
+                state.isOpen = true
+                state.isSmartBannerSheetPresented = true
+            })
+
+            await store.send(.synchronizerStateChanged(Self.tick(.upToDate, balance: Self.healthyBalance)))
+            await store.receive(\.closeAndCleanupBanner)
+            await store.receive(\.closeSheetTapped)
+            await store.receive(\.closeBanner)
+            await store.receive(\.openBannerRequest)
+
+            #expect(store.state.priorityContent == nil)
+            #expect(store.state.isOpen == false)
+            #expect(store.state.isSmartBannerSheetPresented == false)
+        }
+    }
+
     // MARK: - 6. Still-pending balance keeps the banner open, no duplicate trigger
 
     @Test func stillPendingBalanceKeepsPriority5BannerOpen() async {

--- a/zodlTests/SmartBannerTests/SmartBannerUpdatingBalanceTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerUpdatingBalanceTests.swift
@@ -1,0 +1,308 @@
+//
+//  SmartBannerUpdatingBalanceTests.swift
+//  zodlTests
+//
+//  Covers the priority5 "Updating Balance" banner (MOB-1585): after a send, the shielded
+//  spendable balance can legitimately read 0 while the shielded total stays > 0 (inputs
+//  pending-spent, change awaiting confirmations). This exercises the trigger/close wiring in
+//  `.synchronizerStateChanged`, the `evaluatePriority5` cascade fallback, and the
+//  `.walletAccountChanged` balance reset (Features/SmartBanner/SmartBannerStore.swift).
+//
+
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// Serialized: drives `SmartBanner.State`'s `@Shared(.inMemory(.selectedWalletAccount))` state,
+// process-global storage. Each test additionally scopes a fresh `InMemoryStorage()` via
+// `withDependencies` so parallel suites can't clobber that shared state either — the same
+// belt-and-suspenders approach used by SmartBannerTests.swift's Ironwood-balance test.
+@Suite(.serialized) @MainActor struct SmartBannerUpdatingBalanceTests {
+    private static let account = WalletAccount(
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x05, count: 16)),
+            name: "Zodl",
+            keySource: nil,
+            seedFingerprint: nil,
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    )
+
+    /// Spendable 0, change pending confirmation > 0 — the post-send state this feature exists to
+    /// surface: shielded total > 0 (inputs pending-spent, change awaiting confirmations) but none
+    /// of it is spendable yet.
+    private static let pendingBalance = AccountBalance(
+        saplingBalance: PoolBalance(
+            spendableValue: Zatoshi(0),
+            changePendingConfirmation: Zatoshi(50_000),
+            valuePendingSpendability: Zatoshi(0)
+        ),
+        orchardBalance: .zero,
+        unshielded: Zatoshi(0)
+    )
+
+    /// Spendable > 0 — the balance has recovered.
+    private static let healthyBalance = AccountBalance(
+        saplingBalance: PoolBalance(spendableValue: Zatoshi(100_000), changePendingConfirmation: .zero, valuePendingSpendability: .zero),
+        orchardBalance: .zero,
+        unshielded: Zatoshi(0)
+    )
+
+    /// All-transparent wallet: shielded spendable AND shielded total are both zero, so the zero
+    /// spendable reading is simply reality (no shielded funds at all), not a pending-confirmation
+    /// artifact. That state belongs to priority7 (shielding), not priority5. `unshielded` is kept
+    /// below the (test default 100_000) shielding threshold so it doesn't also trigger priority7.
+    private static let transparentOnlyBalance = AccountBalance(
+        saplingBalance: .zero,
+        orchardBalance: .zero,
+        unshielded: Zatoshi(1_000)
+    )
+
+    private static func tick(_ status: SyncStatus, balance: AccountBalance) -> RedactableSynchronizerState {
+        var state = SynchronizerState.zero
+        state.syncStatus = status
+        state.accountsBalances = [account.id: balance]
+        return state.redacted
+    }
+
+    private func makeStore(
+        configureDependencies: (inout DependencyValues) -> Void = { _ in },
+        modify: (inout SmartBanner.State) -> Void = { _ in }
+    ) -> TestStore<SmartBanner.State, SmartBanner.Action> {
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = Self.account }
+        modify(&state)
+
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            configureDependencies(&$0)
+        }
+        store.exhaustivity = .off
+        return store
+    }
+
+    // MARK: - 1. Trigger on a non-syncing tick with no banner open
+
+    @Test func pendingBalanceOnUpToDateTickTriggersPriority5AndOpensBanner() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore()
+
+            await store.send(.synchronizerStateChanged(Self.tick(.upToDate, balance: Self.pendingBalance)))
+            await store.receive(\.triggerPriority, .priority5)
+            await store.receive(\.openBannerRequest)
+            await store.receive(\.openBanner)
+
+            #expect(store.state.priorityContent == .priority5)
+            #expect(store.state.isOpen)
+        }
+    }
+
+    // MARK: - 2. No trigger while syncing
+
+    /// Non-syncing ticks own the priority5 trigger; a `.syncing` tick must defer to whichever
+    /// restoring/syncing banner (priority3/4) owns the display during an active sync.
+    @Test func pendingBalanceOnSyncingTickDoesNotTrigger() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore()
+
+            await store.send(.synchronizerStateChanged(Self.tick(.syncing(0.5, false), balance: Self.pendingBalance)))
+
+            #expect(store.state.priorityContentRequested == nil)
+            #expect(store.state.priorityContent == nil)
+        }
+    }
+
+    // MARK: - 3. No trigger while a higher-priority banner is showing
+
+    /// A generic sync error (rather than `.upToDate`) reaches the shared balance-check block
+    /// without being intercepted by `.upToDate`'s own unconditional close of priority3/45/4 — so
+    /// this actually exercises the rawValue guard on the trigger, not that unrelated early return.
+    /// `lastKnownErrorMessage` is pre-matched to the tick's own message so the reducer's
+    /// different-error check (which would otherwise trigger priority2 first) is a no-op. (`.stopped`
+    /// is avoided here: the SDK's hand-written `SyncStatus.==` has no `.stopped` case and falls to
+    /// `default: false`, so `.stopped` never equals itself — it would spuriously fail TestStore's
+    /// own state-diffing regardless of this test's own assertions.)
+    @Test func pendingBalanceDoesNotOverrideRestoringBanner() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let genericError = SyncStatus.error(ZcashError.compactBlockProcessorCritical)
+            let store = makeStore(modify: { state in
+                state.priorityContent = .priority3
+                state.priorityContentRequested = .priority3
+                state.lastKnownErrorMessage = SyncStatusSnapshot.snapshotFor(state: genericError).message
+            })
+
+            await store.send(.synchronizerStateChanged(Self.tick(genericError, balance: Self.pendingBalance)))
+
+            #expect(store.state.priorityContentRequested == .priority3)
+            #expect(store.state.priorityContent == .priority3)
+        }
+    }
+
+    // MARK: - 4. No trigger for healthy or all-transparent balances
+
+    @Test func healthyOrTransparentOnlyBalanceDoesNotTrigger() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let healthyStore = makeStore()
+            await healthyStore.send(.synchronizerStateChanged(Self.tick(.upToDate, balance: Self.healthyBalance)))
+            #expect(healthyStore.state.priorityContentRequested == nil)
+
+            let transparentStore = makeStore()
+            await transparentStore.send(.synchronizerStateChanged(Self.tick(.upToDate, balance: Self.transparentOnlyBalance)))
+            #expect(transparentStore.state.priorityContentRequested == nil)
+        }
+    }
+
+    // MARK: - 5. Recovery closes and cleans up the banner
+
+    @Test func balanceRecoveryClosesAndCleansUpPriority5Banner() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(modify: { state in
+                state.priorityContent = .priority5
+                state.priorityContentRequested = .priority5
+                state.isOpen = true
+            })
+
+            await store.send(.synchronizerStateChanged(Self.tick(.upToDate, balance: Self.healthyBalance)))
+            await store.receive(\.closeAndCleanupBanner)
+            await store.receive(\.closeBanner)
+            await store.receive(\.openBannerRequest)
+
+            #expect(store.state.priorityContent == nil)
+            #expect(store.state.priorityContentRequested == nil)
+            #expect(store.state.isOpen == false)
+        }
+    }
+
+    // MARK: - 6. Still-pending balance keeps the banner open, no duplicate trigger
+
+    @Test func stillPendingBalanceKeepsPriority5BannerOpen() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(modify: { state in
+                state.priorityContent = .priority5
+                state.priorityContentRequested = .priority5
+                state.isOpen = true
+            })
+
+            await store.send(.synchronizerStateChanged(Self.tick(.upToDate, balance: Self.pendingBalance)))
+
+            #expect(store.state.priorityContent == .priority5)
+            #expect(store.state.priorityContentRequested == .priority5)
+            #expect(store.state.isOpen)
+        }
+    }
+
+    // MARK: - 7. Replaces a lower-priority banner
+
+    @Test func pendingBalanceReplacesShieldingBanner() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(modify: { state in
+                state.priorityContent = .priority7
+                state.priorityContentRequested = .priority7
+                state.isOpen = true
+            })
+
+            await store.send(.synchronizerStateChanged(Self.tick(.upToDate, balance: Self.pendingBalance)))
+            await store.receive(\.triggerPriority, .priority5)
+            // `openBannerRequest` finds a lower-priority banner already open, so it closes it
+            // first (`closeBanner`) and re-runs `openBannerRequest` before it can actually swap in
+            // priority5 — see SmartBannerStore.swift's `openBannerRequest`/`closeBanner` pair.
+            await store.receive(\.openBannerRequest)
+            await store.receive(\.closeBanner)
+            await store.receive(\.openBannerRequest)
+            await store.receive(\.openBanner)
+
+            #expect(store.state.priorityContent == .priority5)
+            #expect(store.state.isOpen)
+        }
+    }
+
+    // MARK: - 8. Account switch resets the stale per-account balance
+
+    @Test func walletAccountChangedResetsSpendableBalance() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = SmartBanner.State()
+            state.spendableBalance = Zatoshi(50_000)
+            state.remindMeShieldedPhaseCounter = 2
+            // No account selected: the ladder walk this action re-runs (`.evaluatePriority1` ->
+            // ... -> `.evaluatePriority7`) then short-circuits at each account-dependent guard
+            // without touching any other dependency, so nothing else needs stubbing here.
+            state.$selectedWalletAccount.withLock { $0 = nil }
+
+            let store = TestStore(initialState: state) {
+                SmartBanner()
+            } withDependencies: {
+                $0.mainQueue = .immediate
+            }
+            store.exhaustivity = .off
+
+            await store.send(.walletAccountChanged) {
+                $0.remindMeShieldedPhaseCounter = 0
+                $0.spendableBalance = Zatoshi(0)
+            }
+        }
+    }
+
+    // MARK: - 9. evaluatePriority5 cascade
+
+    @Test func evaluatePriority5TriggersOnPendingBalanceFromTheSDK() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            // Captured into locals before crossing into the `@Sendable` closure below: `account`/
+            // `pendingBalance` are `@MainActor`-isolated statics (members of this `@MainActor`
+            // suite), and `getAccountsBalances`'s closure type isn't actor-isolated.
+            let account = Self.account
+            let pendingBalance = Self.pendingBalance
+            // `walletStorage` is stubbed defensively: against the unfixed reducer this cascades
+            // into `.evaluatePriority7`, which reads `walletStorage.exportShieldingReminder`.
+            let store = makeStore(configureDependencies: {
+                $0.sdkSynchronizer = .mocked(getAccountsBalances: { [account.id: pendingBalance] })
+                $0.walletStorage = .noOp
+            })
+
+            await store.send(.evaluatePriority5)
+            await store.receive(\.triggerPriority, .priority5)
+        }
+    }
+
+    @Test func evaluatePriority5FallsThroughToPriority6OnHealthyBalanceFromTheSDK() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let account = Self.account
+            let healthyBalance = Self.healthyBalance
+            // `walletStorage` is stubbed because a healthy balance means this doesn't stop at
+            // `.evaluatePriority6` — the ladder walk continues into `.evaluatePriority7` in the
+            // background, which reads `walletStorage.exportShieldingReminder`.
+            let store = makeStore(configureDependencies: {
+                $0.sdkSynchronizer = .mocked(getAccountsBalances: { [account.id: healthyBalance] })
+                $0.walletStorage = .noOp
+            })
+
+            await store.send(.evaluatePriority5)
+            await store.receive(\.evaluatePriority6)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes MOB-1585: after sending, the shielded spendable balance can legitimately read 0 while shielded funds exist (inputs are pending-spent and change waits for confirmations; brief chain-tip refresh windows have the same effect) — and the app showed a bare zero or spinner with no explanation.

The SmartBanner already shipped a complete "Updating Balance... / Waiting for last transaction to process" banner (priority5) for exactly this state — content view, help sheet, localized strings — but its trigger was never wired: the evaluation step skipped straight past it. This PR wires it up:

- **Trigger** when the selected account has shielded funds but zero shielded spendable (pool-agnostic accessors; transparent-only wallets are excluded — that state belongs to the shielding banner), evaluated both from the synchronizer state stream (non-syncing ticks only, so the restoring/syncing banners keep precedence) and from the priority-evaluation cascade with a fresh balance fetch.
- **Auto-close** the moment spendable recovers, also dismissing the banner's help sheet if it is open. Deliberately not closed by sync completion — pending change survives an up-to-date sync.
- **Account switches** reset the stale per-account spendable balance before the cascade re-evaluates.

## Testing

- New Swift Testing suite `SmartBannerUpdatingBalanceTests` (11 tests, TDD): trigger on pending balances, no trigger on syncing ticks / under higher-priority banners / for healthy or transparent-only wallets, close + help-sheet dismissal on recovery, no churn while pending persists, replacement of the lower-priority shielding banner, account-switch reset, and both cascade branches.
- Full `zodlTests` suite green via `xcodebuild` (scheme `zodl-internal`): `** TEST SUCCEEDED **`, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)