### PR TITLE
Submit appstore builds to App Review from the release tooling (--submit-review)

### DIFF
--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -8,7 +8,9 @@ usage() {
 Usage: Scripts/release.sh --variant <v> --ref <ref> --version <X.Y.Z> --build <n> [options]
 
   --variant     internal | testnet | appstore | internal-testnet
-  --ref         branch, tag, or commit SHA to build
+  --submit-review  appstore only: submit the build to App Review after upload;
+                   without --ref, submits a build already on App Store Connect
+  --ref         branch, tag, or commit SHA to build (optional with --submit-review)
   --version     marketing version you intend to ship (X.Y.Z)
   --build       build number (integer)
   --dry-run     run all preflight checks, then stop before building
@@ -19,7 +21,7 @@ EOF
 }
 
 VARIANT="" ; REF="" ; VERSION="" ; BUILD=""
-DRY_RUN=false ; YES=false ; SKIP_TESTS=false
+DRY_RUN=false ; YES=false ; SKIP_TESTS=false ; SUBMIT_REVIEW=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -27,6 +29,7 @@ while [[ $# -gt 0 ]]; do
     --ref) REF="$2" ; shift 2 ;;
     --version) VERSION="$2" ; shift 2 ;;
     --build) BUILD="$2" ; shift 2 ;;
+    --submit-review) SUBMIT_REVIEW=true ; shift ;;
     --dry-run) DRY_RUN=true ; shift ;;
     -y|--yes) YES=true ; shift ;;
     --skip-tests) SKIP_TESTS=true ; shift ;;
@@ -35,12 +38,19 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-for pair in "variant:$VARIANT" "ref:$REF" "version:$VERSION" "build:$BUILD"; do
+for pair in "variant:$VARIANT" "version:$VERSION" "build:$BUILD"; do
   name="${pair%%:*}" ; val="${pair#*:}"
   if [[ -z "$val" ]]; then echo "error: --$name is required" >&2 ; usage >&2 ; exit 2 ; fi
 done
 
+if [[ -z "$REF" && "$SUBMIT_REVIEW" != true ]]; then
+  echo "error: --ref is required (omit it only with --submit-review)" >&2 ; usage >&2 ; exit 2
+fi
+if [[ "$SUBMIT_REVIEW" == true && "$VARIANT" != "appstore" ]]; then
+  echo "error: --submit-review requires --variant appstore" >&2 ; usage >&2 ; exit 2
+fi
+
 FASTLANE="${FASTLANE_CMD:-bundle exec fastlane}"
 exec $FASTLANE release \
   variant:"$VARIANT" ref:"$REF" version:"$VERSION" build:"$BUILD" \
-  dry_run:"$DRY_RUN" yes:"$YES" skip_tests:"$SKIP_TESTS"
+  dry_run:"$DRY_RUN" yes:"$YES" skip_tests:"$SKIP_TESTS" submit_review:"$SUBMIT_REVIEW"

--- a/Scripts/test/release_args.bats
+++ b/Scripts/test/release_args.bats
@@ -45,3 +45,34 @@ setup() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage: Scripts/release.sh"* ]]
 }
+
+@test "forwards --submit-review as submit_review:true" {
+  run "$RELEASE" --variant appstore --ref release/3.8.0 --version 3.8.0 --build 3 --submit-review
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"submit_review:true"* ]]
+}
+
+@test "--submit-review works without --ref" {
+  run "$RELEASE" --variant appstore --version 3.8.0 --build 3 --submit-review
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ref: version:3.8.0"* ]]
+  [[ "$output" == *"submit_review:true"* ]]
+}
+
+@test "missing --ref without --submit-review exits 2" {
+  run "$RELEASE" --variant appstore --version 3.8.0 --build 3
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--ref is required"* ]]
+}
+
+@test "--submit-review with non-appstore variant exits 2" {
+  run "$RELEASE" --variant internal --ref main --version 3.8.0 --build 3 --submit-review
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires --variant appstore"* ]]
+}
+
+@test "--submit-review with internal-testnet exits 2" {
+  run "$RELEASE" --variant internal-testnet --version 3.8.0 --build 3 --submit-review
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires --variant appstore"* ]]
+}

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -169,7 +169,7 @@ Submitting to App Review:
 - Writes What's New for every enabled App Store localization from `secant/Resources/WhatsNew/whatsNew*.json` in your **current checkout** (the entry matching `--version` — run `/update-whatsnew` first and commit; note this uses your local working tree, not the ref being built)
 - Attaches the requested build, replacing a wrong one
 - Submits with manual release — you still press Release in App Store Connect after approval
-- Reads back promotional text and What's New per locale from App Store Connect and warns loudly if promotional text is empty where a copy was planned (this is **non-fatal and fixable in App Store Connect without a new review** — edit the missing text directly in ASC and resubmit)
+- Reads back promotional text and What's New per locale from App Store Connect and warns loudly if promotional text is empty where a copy was planned (this is **non-fatal and fixable in App Store Connect without a new review** — edit the missing text directly in ASC and save)
 
 The submission fails if: a version is already submitted/in review (cancel in App Store Connect first), a version is approved-awaiting-release (release it first), the requested version is already live, or any enabled App Store localization lacks a What's New entry for the version.
 
@@ -213,7 +213,7 @@ Scripts/bump.sh --version <X.Y.Z> --build <n>
 | Message | Fix |
 |---|---|
 | `version … does not match project MARKETING_VERSION …` | Run `bump` first, or pass the version the project is actually at. |
-| `build N already exists` / `is lower than the latest build` | Pick a higher number — check that variant's app in App Store Connect / TestFlight. |
+| `build N already exists` / `is lower than the latest build` | Pick a higher number — check that variant's app in App Store Connect / TestFlight. With `--submit-review`, you can instead drop `--ref` to submit that already-uploaded build. |
 | `ref is not on origin` | `git push` the branch or commit first. |
 | `Could not resolve ref …` | The branch/tag/commit isn't on `origin` or locally — push or fetch it. |
 | `PartnerKeys.plist is missing or invalid` | Place a valid plist at `secant/Resources/PartnerKeys.plist` (see `Scripts/validate-partner-keys.sh`). |
@@ -223,7 +223,6 @@ Scripts/bump.sh --version <X.Y.Z> --build <n>
 | TestFlight build stuck on *Missing Compliance* | Set `ITSAppUsesNonExemptEncryption` so the build clears export compliance automatically. |
 | `build … not found on App Store Connect — pass --ref` | The build was never uploaded: add `--ref` to build it, or fix `--build`. |
 | `build … is still processing` | App Store Connect is still processing the upload — retry in a few minutes. |
-| `build … already exists … drop --ref` | You asked to build a number that's already uploaded — drop `--ref` to submit it, or pick a new `--build`. |
 | `already submitted for review` | Cancel the submission in App Store Connect, or wait for the review to finish. |
 | `approved and awaiting release` | Release the approved version in App Store Connect first. |
 | `whatsNew….json has no entry for version …` | Run `/update-whatsnew` for this version and commit the result. |

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -6,8 +6,6 @@ signing keys are stored in the repo or anywhere new**. A fail-closed *preflight*
 reconciles what you ask for against git, the project, and App Store Connect, and
 refuses to build on any mismatch.
 
-For the design rationale and the full check list see the
-[spec](superpowers/specs/2026-06-25-local-fastlane-release-automation-design.md).
 `fastlane/README.md` is the one-screen quick reference.
 
 ## How it fits together
@@ -149,9 +147,31 @@ build number:
 ```
 
 `appstore` is its own App Store Connect app, so its build numbers are a separate
-sequence — start from wherever that app left off. (The build then waits for App
-Store Connect processing; submitting it for review is still done in App Store
-Connect.)
+sequence — start from wherever that app left off.
+
+#### Submitting to App Review with `--submit-review`
+
+After the build is uploaded and App Store Connect has processed it, you can submit it for review:
+
+With `--ref` (build in one go, then submit):
+```bash
+./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 1 --submit-review
+```
+
+Without `--ref` (submit an already-uploaded build):
+```bash
+./Scripts/release.sh --variant appstore --version 3.8.0 --build 1 --submit-review
+```
+
+Submitting to App Review:
+- Creates the App Store version record if missing, or adopts an existing one in an editable state (PREPARE_FOR_SUBMISSION, developer-rejected, rejected, metadata-rejected, invalid-binary), renaming it if needed
+- Copies promotional text from the live version into any localization that doesn't have one yet (manually entered text is kept, never overwritten)
+- Writes What's New for every enabled App Store localization from `secant/Resources/WhatsNew/whatsNew*.json` in your **current checkout** (the entry matching `--version` — run `/update-whatsnew` first and commit; note this uses your local working tree, not the ref being built)
+- Attaches the requested build, replacing a wrong one
+- Submits with manual release — you still press Release in App Store Connect after approval
+- Reads back promotional text and What's New per locale from App Store Connect and warns loudly if promotional text is empty where a copy was planned (this is **non-fatal and fixable in App Store Connect without a new review** — edit the missing text directly in ASC and resubmit)
+
+The submission fails if: a version is already submitted/in review (cancel in App Store Connect first), a version is approved-awaiting-release (release it first), the requested version is already live, or any enabled App Store localization lacks a What's New entry for the version.
 
 ## Always check first with `--dry-run`
 
@@ -169,17 +189,20 @@ is lower than the variant's latest on App Store Connect; the ref isn't on
 `.xcode-version`; or no distribution signing identity is present. It *warns* (but
 proceeds) on a build-number gap or an uncommitted working tree.
 
+With `--submit-review`, the dry run also verifies the build's existence and processing state on App Store Connect, the version record's state, and that every enabled App Store localization has a What's New entry for the version.
+
 ## Command reference
 
 ```
 Scripts/release.sh --variant <v> --ref <ref> --version <X.Y.Z> --build <n> [options]
-  --variant     internal | testnet | appstore | internal-testnet
-  --ref         branch, tag, or commit to build (no checkout needed)
-  --version     marketing version you intend to ship (X.Y.Z)
-  --build       build number (integer)
-  --dry-run     run checks, then stop before building
-  --yes         skip the confirmation prompt
-  --skip-tests  skip the unit-test step
+  --variant       internal | testnet | appstore | internal-testnet
+  --ref           branch, tag, or commit to build (optional with --submit-review)
+  --version       marketing version you intend to ship (X.Y.Z)
+  --build         build number (integer)
+  --dry-run       run checks, then stop before building
+  --yes           skip the confirmation prompt
+  --skip-tests    skip the unit-test step
+  --submit-review submit to App Review after upload (appstore only)
   -h, --help
 
 Scripts/bump.sh --version <X.Y.Z> --build <n>
@@ -198,6 +221,13 @@ Scripts/bump.sh --version <X.Y.Z> --build <n>
 | `no distribution signing identity` | Ensure your Apple Distribution certificate is in the keychain — the same setup that lets you Archive manually. |
 | `Run through bundler …` | Use `./Scripts/release.sh` / `./Scripts/bump.sh` (or `bundle exec fastlane …`), not bare `fastlane`. |
 | TestFlight build stuck on *Missing Compliance* | Set `ITSAppUsesNonExemptEncryption` so the build clears export compliance automatically. |
+| `build … not found on App Store Connect — pass --ref` | The build was never uploaded: add `--ref` to build it, or fix `--build`. |
+| `build … is still processing` | App Store Connect is still processing the upload — retry in a few minutes. |
+| `build … already exists … drop --ref` | You asked to build a number that's already uploaded — drop `--ref` to submit it, or pick a new `--build`. |
+| `already submitted for review` | Cancel the submission in App Store Connect, or wait for the review to finish. |
+| `approved and awaiting release` | Release the approved version in App Store Connect first. |
+| `whatsNew….json has no entry for version …` | Run `/update-whatsnew` for this version and commit the result. |
+| `version … is already live` | That version shipped — bump with `Scripts/bump.sh` and build the next one. |
 
 ## Tests and project files
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,7 +102,16 @@ lane :release do |options|
       )
       report = Zodl::Preflight.check(ctx)
       print_summary(variant, cfg, ref, sha, ctx, report)
-      UI.user_error!("Preflight failed for #{variant} — aborting.") unless report.ok?
+      unless report.ok?
+        # The duplicate-build refusal is the one failure where submit-only mode
+        # is the likely intent — the binary is already on App Store Connect —
+        # so point at it here: the submit preflight that carries this hint
+        # runs after this loop and is never reached on a failed build preflight.
+        if submit_review && report.errors.any? { |e| e.include?("already exists") }
+          UI.important("With --submit-review you can drop --ref to submit the build already on App Store Connect instead of rebuilding.")
+        end
+        UI.user_error!("Preflight failed for #{variant} — aborting.")
+      end
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,6 +12,8 @@ require_relative "lib/zodl/preflight"
 require_relative "lib/zodl/build_paths"
 require_relative "lib/zodl/local_packages"
 require_relative "lib/zodl/notify"
+require_relative "lib/zodl/whats_new"
+require_relative "lib/zodl/submit_preflight"
 
 # Refuse to run outside bundler so the pinned gem versions in Gemfile.lock are
 # always used. The Scripts/*.sh wrappers invoke `bundle exec fastlane`.
@@ -23,6 +25,7 @@ PROJECT = Zodl::BuildPaths::PROJECT
 TEST_SCHEME = "zodl-internal"        # only scheme wired to the zodlTests target
 TEST_DEVICE = "iPhone 17 Pro"
 PARTNER_KEYS_REL = "secant/Resources/PartnerKeys.plist"
+WHATS_NEW_REL = "secant/Resources/WhatsNew"
 FASTLANE_DIR = __dir__
 TEAM_ID = "RLPRR8CPQG"               # Apple Developer team (matches DEVELOPMENT_TEAM in the project)
 
@@ -47,97 +50,130 @@ XCODEBUILD_FORMATTER = "xcbeautify"
 # Don't auto-generate fastlane/README.md on every run; it is maintained by hand.
 skip_docs
 
-desc "Build, sign, and upload one or more variants. Driven by Scripts/release.sh."
+desc "Build, sign, and upload one or more variants; optionally submit to App Review. Driven by Scripts/release.sh."
 lane :release do |options|
   repo_root = run("git rev-parse --show-toplevel", must_succeed: true).strip
-  ref       = options.fetch(:ref)
-  version   = options.fetch(:version)
-  build     = Integer(options.fetch(:build))
-  dry_run   = truthy(options[:dry_run])
+  ref           = options[:ref].to_s
+  version       = options.fetch(:version)
+  build         = Integer(options.fetch(:build))
+  dry_run       = truthy(options[:dry_run])
+  submit_review = truthy(options[:submit_review])
+  building      = !ref.empty?
 
   variants = Zodl::Variants.expand(options.fetch(:variant))
   # Context for the `error` hook below, which only receives the raised exception.
   @notify_context = { variants: variants, version: version, build: build }
-
-  UI.message("Fetching latest refs from origin…")
-  # Fail closed: the preflight reconciles against origin, so a failed fetch must abort
-  # rather than silently leave the checks running on stale local refs.
-  run("git -C #{repo_root.shellescape} fetch --quiet --tags origin", must_succeed: true)
-  sha = resolve_sha(repo_root, ref)
-  branch_version = Zodl::Version.from_branch(ref)
-  project_version = marketing_version_at(repo_root, sha)
-  local_packages = local_packages_at(repo_root, sha)
+  if submit_review && variants != ["appstore"]
+    UI.user_error!("--submit-review is only supported for --variant appstore")
+  end
+  UI.user_error!("--ref is required unless --submit-review is used") if !building && !submit_review
   api_key = asc_api_key
-  # Resolve+verify the signing key path now (cwd is still the real repo), so it's
-  # an absolute path into the real fastlane dir before we chdir into the worktree.
-  auth_xcargs = asc_auth_xcargs(repo_root)
 
-  variants.each do |variant|
-    cfg = Zodl::Variants.config(variant)
-    UI.message("Reconciling #{variant} against git, the project, and App Store Connect…")
-    ctx = Zodl::Preflight::Context.new(
-      variant: variant,
-      requested_version: version,
-      requested_build: build,
-      project_version: project_version,
-      branch_version: branch_version,
-      latest_build: latest_build_number(api_key, cfg[:app_identifier], version),
-      ref_on_origin: ref_on_origin?(repo_root, sha),
-      dirty_tree: dirty_tree?(repo_root),
-      partner_keys_error: partner_keys_error(repo_root),
-      xcode_ok: xcode_ok?(repo_root),
-      signing_identity_ok: signing_identity_ok?,
-      local_packages: local_packages
-    )
-    report = Zodl::Preflight.check(ctx)
-    print_summary(variant, cfg, ref, sha, ctx, report)
-    UI.user_error!("Preflight failed for #{variant} — aborting.") unless report.ok?
+  sha = nil
+  if building
+    UI.message("Fetching latest refs from origin…")
+    # Fail closed: the preflight reconciles against origin, so a failed fetch must abort
+    # rather than silently leave the checks running on stale local refs.
+    run("git -C #{repo_root.shellescape} fetch --quiet --tags origin", must_succeed: true)
+    sha = resolve_sha(repo_root, ref)
+    branch_version = Zodl::Version.from_branch(ref)
+    project_version = marketing_version_at(repo_root, sha)
+    local_packages = local_packages_at(repo_root, sha)
+    # Resolve+verify the signing key path now (cwd is still the real repo), so it's
+    # an absolute path into the real fastlane dir before we chdir into the worktree.
+    auth_xcargs = asc_auth_xcargs(repo_root)
+
+    variants.each do |variant|
+      cfg = Zodl::Variants.config(variant)
+      UI.message("Reconciling #{variant} against git, the project, and App Store Connect…")
+      ctx = Zodl::Preflight::Context.new(
+        variant: variant,
+        requested_version: version,
+        requested_build: build,
+        project_version: project_version,
+        branch_version: branch_version,
+        latest_build: latest_build_number(api_key, cfg[:app_identifier], version),
+        ref_on_origin: ref_on_origin?(repo_root, sha),
+        dirty_tree: dirty_tree?(repo_root),
+        partner_keys_error: partner_keys_error(repo_root),
+        xcode_ok: xcode_ok?(repo_root),
+        signing_identity_ok: signing_identity_ok?,
+        local_packages: local_packages
+      )
+      report = Zodl::Preflight.check(ctx)
+      print_summary(variant, cfg, ref, sha, ctx, report)
+      UI.user_error!("Preflight failed for #{variant} — aborting.") unless report.ok?
+    end
+  end
+
+  submission = nil
+  if submit_review
+    UI.message("Reconciling the App Review submission against App Store Connect…")
+    submission = submit_facts(api_key, repo_root, version, build, ref_given: building)
+    print_submit_summary(submission)
+    UI.user_error!("Submit preflight failed — aborting.") unless submission[:report].ok?
   end
 
   if dry_run
     Zodl::Notify.post(event: :dry_run_ok, variants: variants, version: version, build: build)
-    UI.success("Dry run complete — preflight passed for: #{variants.join(', ')}. No build performed.")
+    checks = submit_review ? " (including App Review submission checks)" : ""
+    UI.success("Dry run complete — preflight passed for: #{variants.join(', ')}#{checks}. No build performed.")
     next
   end
 
-  UI.user_error!("Aborted.") unless truthy(options[:yes]) || UI.confirm("Proceed with the build above?")
+  prompt = if building
+             "Proceed with the build above?#{submit_review ? ' It will be submitted to App Review after upload.' : ''}"
+           else
+             "Submit the summary above to App Review?"
+           end
+  UI.user_error!("Aborted.") unless truthy(options[:yes]) || UI.confirm(prompt)
 
-  # Create/refresh the App Store distribution profiles up front, so a signing or
-  # API-permission problem fails now instead of after the ~15-minute build.
-  ensure_appstore_profiles(variants, api_key)
+  if building
+    # Create/refresh the App Store distribution profiles up front, so a signing or
+    # API-permission problem fails now instead of after the ~15-minute build.
+    ensure_appstore_profiles(variants, api_key)
 
-  # The worktree is a sibling of the repo, NOT under $TMPDIR: the project may
-  # reference local Swift packages by relative path (XCLocalSwiftPackageReference,
-  # e.g. ../ZcashLightClientKit), and only a sibling worktree resolves those to
-  # the same directories the primary checkout uses in Xcode.
-  worktree = File.join(File.dirname(repo_root), "zodl-release-#{sha[0, 8]}")
-  begin
-    UI.message("Creating a clean build worktree at #{sha[0, 8]}…")
-    run("git -C #{repo_root.shellescape} worktree add --detach #{worktree.shellescape} #{sha}", must_succeed: true)
-    FileUtils.cp(File.join(repo_root, PARTNER_KEYS_REL), File.join(worktree, PARTNER_KEYS_REL))
+    # The worktree is a sibling of the repo, NOT under $TMPDIR: the project may
+    # reference local Swift packages by relative path (XCLocalSwiftPackageReference,
+    # e.g. ../ZcashLightClientKit), and only a sibling worktree resolves those to
+    # the same directories the primary checkout uses in Xcode.
+    worktree = File.join(File.dirname(repo_root), "zodl-release-#{sha[0, 8]}")
+    begin
+      UI.message("Creating a clean build worktree at #{sha[0, 8]}…")
+      run("git -C #{repo_root.shellescape} worktree add --detach #{worktree.shellescape} #{sha}", must_succeed: true)
+      FileUtils.cp(File.join(repo_root, PARTNER_KEYS_REL), File.join(worktree, PARTNER_KEYS_REL))
 
-    Dir.chdir(worktree) do
-      # Absolute paths, anchored to the worktree: fastlane runs each action inside
-      # `Dir.chdir("..")`, which from here lands in the worktree's PARENT, so any
-      # RELATIVE path passed to run_tests/build_app would resolve there and break.
-      paths = Zodl::BuildPaths.resolve(worktree)
-      UI.message("Resolving Swift packages…")
-      run("xcodebuild -project #{PROJECT} -scheme #{TEST_SCHEME} -resolvePackageDependencies", must_succeed: true)
-      run_unit_tests(paths) unless truthy(options[:skip_tests])
-      variants.each do |variant|
-        UI.message("Building and uploading #{variant}…")
-        build_and_upload(variant, version, build, api_key, paths, auth_xcargs)
+      Dir.chdir(worktree) do
+        # Absolute paths, anchored to the worktree: fastlane runs each action inside
+        # `Dir.chdir("..")`, which from here lands in the worktree's PARENT, so any
+        # RELATIVE path passed to run_tests/build_app would resolve there and break.
+        paths = Zodl::BuildPaths.resolve(worktree)
+        UI.message("Resolving Swift packages…")
+        run("xcodebuild -project #{PROJECT} -scheme #{TEST_SCHEME} -resolvePackageDependencies", must_succeed: true)
+        run_unit_tests(paths) unless truthy(options[:skip_tests])
+        variants.each do |variant|
+          UI.message("Building and uploading #{variant}…")
+          build_and_upload(variant, version, build, api_key, paths, auth_xcargs)
+        end
       end
-    end
-  ensure
-    if File.directory?(worktree)
-      UI.message("Cleaning up the build worktree…")
-      run("git -C #{repo_root.shellescape} worktree remove --force #{worktree.shellescape}")
+    ensure
+      if File.directory?(worktree)
+        UI.message("Cleaning up the build worktree…")
+        run("git -C #{repo_root.shellescape} worktree remove --force #{worktree.shellescape}")
+      end
     end
   end
 
-  Zodl::Notify.post(event: :success, variants: variants, version: version, build: build)
-  UI.success("Done: #{variants.join(', ')} #{version} (#{build}) from #{ref} @ #{sha[0, 8]}")
+  if submit_review
+    UI.message("Submitting to App Review…")
+    submit_to_review(submission, api_key)
+    verify_submission_metadata(submission)
+  end
+
+  Zodl::Notify.post(event: submit_review ? :submit_success : :success, variants: variants, version: version, build: build)
+  done = building ? "Done: #{variants.join(', ')} #{version} (#{build}) from #{ref} @ #{sha[0, 8]}" : "Done: appstore #{version} (#{build})"
+  done += " — submitted to App Review" if submit_review
+  UI.success(done)
 end
 
 desc "Set MARKETING_VERSION and CURRENT_PROJECT_VERSION and commit. Driven by Scripts/bump.sh."
@@ -469,6 +505,192 @@ def build_and_upload(variant, version, build, api_key, paths, auth_xcargs)
   )
 
   UI.success("Uploaded #{cfg[:app_identifier]} #{version} (#{build}) to TestFlight.")
+end
+
+# --- App Review submission -----------------------------------------------
+
+# ASC version states that mean a version record is history, not in flight.
+TERMINAL_VERSION_STATES = %w[
+  READY_FOR_SALE REPLACED_WITH_NEW_VERSION REMOVED_FROM_SALE DEVELOPER_REMOVED_FROM_SALE
+].freeze
+
+# Gathers every fact the submit preflight needs from App Store Connect and the
+# repo's WhatsNew files, and precomputes the plans the submission will apply.
+# All reads — nothing here writes to App Store Connect (dry-run safe).
+def submit_facts(api_key, repo_root, version, build, ref_given:)
+  require "spaceship"
+  cfg = Zodl::Variants.config("appstore")
+  Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from(hash: api_key)
+  app = Spaceship::ConnectAPI::App.find(cfg[:app_identifier])
+  UI.user_error!("App #{cfg[:app_identifier]} not found on App Store Connect") unless app
+
+  platform = Spaceship::ConnectAPI::Platform::IOS
+  live = app.get_live_app_store_version(platform: platform)
+  inflight = inflight_app_store_version(app, live)
+  build_state = asc_build_state(app, version, build)
+  attached_build = inflight&.build&.version&.to_i
+
+  edit_locs = inflight ? inflight.get_app_store_version_localizations : []
+  live_locs = live ? live.get_app_store_version_localizations : []
+  # The in-flight version's locales are authoritative once it exists; before it
+  # exists (build path, or nothing created yet) the live version's locales are
+  # what the new record will inherit.
+  locales = (inflight ? edit_locs : live_locs).map(&:locale).sort
+  UI.user_error!("No App Store localizations found for #{cfg[:app_identifier]}") if locales.empty?
+
+  whats_new = Zodl::WhatsNew.resolve(dir: File.join(repo_root, WHATS_NEW_REL), locales: locales, version: version)
+  promo_plan = Zodl::SubmitPreflight.promotional_text_plan(
+    locales: locales,
+    edit: edit_locs.to_h { |loc| [loc.locale, loc.promotional_text] },
+    live: live_locs.to_h { |loc| [loc.locale, loc.promotional_text] }
+  )
+
+  ctx = Zodl::SubmitPreflight::Context.new(
+    variant: "appstore", requested_version: version, requested_build: build,
+    ref_given: ref_given, build_state: build_state,
+    version_state: inflight&.app_store_state, version_string: inflight&.version_string,
+    live_version: live&.version_string, whats_new_errors: whats_new.errors
+  )
+
+  {
+    app: app, cfg: cfg, version: version, build: build, ctx: ctx,
+    report: Zodl::SubmitPreflight.check(ctx),
+    whats_new: whats_new, promo_plan: promo_plan,
+    build_action: Zodl::SubmitPreflight.build_action(attached: attached_build, requested: build),
+    attached_build: attached_build
+  }
+end
+
+# The one non-live version "in flight" (ASC allows at most one), whatever its
+# state — created manually or by a previous run. nil when only live/history
+# version records exist.
+def inflight_app_store_version(app, live)
+  versions = app.get_app_store_versions(filter: { platform: Spaceship::ConnectAPI::Platform::IOS }, includes: "build")
+  versions.find do |v|
+    next false if live && v.id == live.id
+
+    !TERMINAL_VERSION_STATES.include?(v.app_store_state)
+  end
+end
+
+# TestFlight processing state of build (version, build_number) for this app:
+# :absent, :processing, :processed, or :failed.
+def asc_build_state(app, version, build_number)
+  builds = app.get_builds(
+    filter: { "preReleaseVersion.version" => version, version: build_number.to_s },
+    sort: "-uploadedDate"
+  )
+  found = builds.first
+  return :absent unless found
+
+  case found.processing_state
+  when "VALID" then :processed
+  when "PROCESSING" then :processing
+  else :failed
+  end
+end
+
+# Submits the build to App Review via deliver. The binary is already on App
+# Store Connect (uploaded by this run or a previous one), so this manages only
+# the version record, metadata, build attachment, and the submission itself.
+# automatic_release stays false — after approval the release is triggered by a
+# human in App Store Connect, mirroring the manual process.
+def submit_to_review(sub, api_key)
+  promo = sub[:promo_plan].select { |_, plan| plan[:action] == :copy }.transform_values { |plan| plan[:text] }
+  opts = {
+    api_key: api_key,
+    app_identifier: sub[:cfg][:app_identifier],
+    app_version: sub[:version],
+    build_number: sub[:build].to_s,
+    skip_binary_upload: true,
+    skip_screenshots: true,
+    release_notes: sub[:whats_new].notes,
+    submit_for_review: true,
+    automatic_release: false,
+    submission_information: { add_id_info_uses_idfa: false },
+    precheck_include_in_app_purchases: false, # the API key cannot check IAP — ZODL has none
+    force: true # non-interactive: skip deliver's HTML preview confirmation
+  }
+  opts[:promotional_text] = promo unless promo.empty?
+  upload_to_app_store(**opts)
+  UI.success("Submitted #{sub[:cfg][:app_identifier]} #{sub[:version]} (#{sub[:build]}) to App Review.")
+end
+
+# Reads back what App Store Connect now holds for the submitted version and
+# warns when promotional text is missing where a copy was planned —
+# promotional text is editable without a new review, so the warning is
+# actionable. Read-only and failure-safe: a verification hiccup never fails a
+# submission that already went through.
+def verify_submission_metadata(sub)
+  version_record = sub[:app].get_app_store_versions(
+    filter: { versionString: sub[:version], platform: Spaceship::ConnectAPI::Platform::IOS }
+  ).first
+  unless version_record
+    UI.important("Could not re-read version #{sub[:version]} from App Store Connect for verification.")
+    return
+  end
+
+  UI.message("──────── App Store Connect now has (#{sub[:version]}) ────────")
+  version_record.get_app_store_version_localizations.sort_by(&:locale).each do |loc|
+    promo = loc.promotional_text.to_s.strip
+    notes = loc.whats_new.to_s.strip
+    UI.message("  #{loc.locale}: promotional text #{promo.empty? ? '(empty)' : 'set'}, what's new #{notes.empty? ? '(EMPTY)' : 'set'}")
+    plan = sub[:promo_plan][loc.locale]
+    if promo.empty? && plan && plan[:action] != :none
+      UI.important("  warning: #{loc.locale}: promotional text is EMPTY on #{sub[:version]} — fix it in App Store Connect (editable without a new review).")
+    end
+  end
+rescue StandardError => e
+  UI.important("Verification read-back failed (#{e.message}) — check App Store Connect manually.")
+end
+
+def print_submit_summary(sub)
+  ctx = sub[:ctx]
+  UI.message("──────── submit preflight: appstore ────────")
+  UI.message("  app            #{sub[:cfg][:app_identifier]}")
+  UI.message("  version        #{sub[:version]} #{version_record_note(sub)}")
+  UI.message("  build          #{sub[:build]} (#{build_action_note(sub)})")
+  UI.message("  release mode   manual — you release in App Store Connect after approval")
+  UI.message("  live version   #{ctx.live_version || 'none'}")
+  sub[:whats_new].notes.each_key do |locale|
+    UI.message("  #{locale}  what's new: #{sub[:whats_new].sources[locale]}, promotional text: #{promo_note(sub[:promo_plan][locale])}")
+  end
+  sub[:whats_new].notes.each do |locale, text|
+    UI.message("  ── What's New (#{locale}) ──")
+    text.each_line { |line| UI.message("  │ #{line.chomp}") }
+  end
+  sub[:promo_plan].each do |locale, plan|
+    UI.message("  ── Promotional text to copy (#{locale}) ──\n  │ #{plan[:text]}") if plan[:action] == :copy
+  end
+  sub[:report].warnings.each { |w| UI.important("  warning: #{w}") }
+  sub[:report].errors.each { |e| UI.error("  error:   #{e}") }
+end
+
+def version_record_note(sub)
+  ctx = sub[:ctx]
+  if ctx.version_state.nil?
+    "— new version record will be created"
+  elsif ctx.version_string == sub[:version]
+    "— reusing the existing #{ctx.version_state} version"
+  else
+    "— renaming the existing #{ctx.version_state} version #{ctx.version_string}"
+  end
+end
+
+def build_action_note(sub)
+  case sub[:build_action]
+  when :attach then "will be attached"
+  when :keep then "already attached"
+  when :replace then "replacing attached build #{sub[:attached_build]}"
+  end
+end
+
+def promo_note(plan)
+  case plan[:action]
+  when :keep then "kept (already set on the version)"
+  when :copy then "copied from the live version"
+  when :none then "nothing to copy (not set on the live version)"
+  end
 end
 
 def print_summary(variant, cfg, ref, sha, ctx, report)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -29,11 +29,27 @@ Dry run (all checks, no build):
 
     ./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 3 --dry-run
 
+Build, upload, and submit to App Review in one go (`appstore` only):
+
+    ./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 3 --submit-review
+
+Submit a build that is already on App Store Connect (omit `--ref`):
+
+    ./Scripts/release.sh --variant appstore --version 3.8.0 --build 3 --submit-review
+
+Submitting creates (or adopts) the App Store version record, copies promotional
+text from the live version into any localization that doesn't have one yet,
+writes What's New for every enabled localization from
+`secant/Resources/WhatsNew/whatsNew*.json` (the entry matching `--version`),
+attaches the build (replacing a wrong one), and submits with manual release —
+you still press Release in App Store Connect after approval. It refuses to run
+when a version is already in review or approved-but-unreleased.
+
 Bump the marketing version + build (the deliberate version-change step, run in `main`):
 
     ./Scripts/bump.sh --version 3.8.0 --build 1
 
-Other flags: `-y` / `--yes` (skip confirmation), `--skip-tests`, `--help`.
+Other flags: `-y` / `--yes` (skip confirmation), `--skip-tests`, `--submit-review` (`appstore` only), `--help`.
 
 ## What it checks before building
 

--- a/fastlane/lib/zodl/notify.rb
+++ b/fastlane/lib/zodl/notify.rb
@@ -24,7 +24,7 @@ module Zodl
     # Builds the notification fields for `event`. Pure (no I/O), so the wording
     # and sound selection are unit-testable.
     #
-    #   event   :success | :dry_run_ok | :failure
+    #   event   :success | :submit_success | :dry_run_ok | :failure
     #   reason  failure detail (only its first line is shown); used by :failure
     #
     # Returns { title:, subtitle:, message:, sound: }.
@@ -33,6 +33,8 @@ module Zodl
       case event
       when :success
         { title: "ZODL release ✅", subtitle: subtitle, message: "Uploaded to TestFlight", sound: SUCCESS_SOUND }
+      when :submit_success
+        { title: "ZODL release ✅", subtitle: subtitle, message: "Submitted to App Review", sound: SUCCESS_SOUND }
       when :dry_run_ok
         { title: "ZODL dry run ✅", subtitle: subtitle, message: "Preflight passed", sound: SUCCESS_SOUND }
       when :failure

--- a/fastlane/lib/zodl/submit_preflight.rb
+++ b/fastlane/lib/zodl/submit_preflight.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "zodl/version"
+
+module Zodl
+  # Pure reconciliation for an App Review submission. No I/O — the Fastfile
+  # gathers facts from App Store Connect and passes them in, mirroring
+  # Zodl::Preflight. Encodes the convergence rules for a version that may have
+  # been created (and partially prepared) by hand in App Store Connect.
+  class SubmitPreflight
+    # States in which App Store Connect lets us edit metadata and (re)submit.
+    EDITABLE_STATES = %w[
+      PREPARE_FOR_SUBMISSION DEVELOPER_REJECTED REJECTED METADATA_REJECTED INVALID_BINARY
+    ].freeze
+    # Already in the review pipeline — submitting again must be resolved by a
+    # human in App Store Connect (cancel or wait), never automatically.
+    IN_REVIEW_STATES = %w[WAITING_FOR_REVIEW IN_REVIEW READY_FOR_REVIEW].freeze
+    # Approved but not yet released; ASC allows only one version in flight, so
+    # the pending version blocks preparing the next one.
+    PENDING_RELEASE_STATES = %w[PENDING_DEVELOPER_RELEASE PENDING_APPLE_RELEASE].freeze
+
+    Context = Struct.new(
+      :variant,            # must be "appstore"
+      :requested_version,  # "X.Y.Z"
+      :requested_build,    # Integer
+      :ref_given,          # true on the build-and-submit path
+      :build_state,        # :absent | :processing | :processed | :failed
+      :version_state,      # appStoreState of the one in-flight version, or nil
+      :version_string,     # version string of that in-flight version, or nil
+      :live_version,       # version string of the live version, or nil
+      :whats_new_errors,   # Zodl::WhatsNew::Result#errors
+      keyword_init: true
+    )
+
+    Report = Struct.new(:errors, :warnings) do
+      def ok?
+        errors.empty?
+      end
+    end
+
+    def self.check(ctx)
+      errors = []
+      warnings = []
+
+      errors << "--submit-review is only supported for the appstore variant (got '#{ctx.variant}')" unless ctx.variant == "appstore"
+      errors << "version '#{ctx.requested_version}' is not in X.Y.Z form" unless Zodl::Version.valid?(ctx.requested_version)
+
+      check_build(ctx, errors)
+      check_version_state(ctx, errors, warnings)
+      errors.concat(ctx.whats_new_errors || [])
+
+      Report.new(errors, warnings)
+    end
+
+    # How the requested build relates to the in-flight version's attached build:
+    #   :attach — nothing attached yet, :keep — the right build is already
+    #   attached, :replace — a different build is attached and gets swapped out.
+    def self.build_action(attached:, requested:)
+      return :attach if attached.nil?
+
+      attached.to_i == requested.to_i ? :keep : :replace
+    end
+
+    # Per-locale promotional-text convergence: keep a manually entered text,
+    # fill an empty one from the live version, note when there is nothing to
+    # copy from. Returns {locale => {action: :keep|:copy|:none, text: ...}}.
+    def self.promotional_text_plan(locales:, edit:, live:)
+      locales.to_h do |locale|
+        edit_text = presence((edit || {})[locale])
+        live_text = presence((live || {})[locale])
+        if edit_text
+          [locale, { action: :keep, text: edit_text }]
+        elsif live_text
+          [locale, { action: :copy, text: live_text }]
+        else
+          [locale, { action: :none, text: nil }]
+        end
+      end
+    end
+
+    class << self
+      private
+
+      def presence(text)
+        value = text.to_s.strip
+        value.empty? ? nil : value
+      end
+
+      def check_build(ctx, errors)
+        if ctx.ref_given
+          unless ctx.build_state == :absent
+            errors << "build #{ctx.requested_build} already exists on App Store Connect — drop --ref to submit the existing build, or pick a new --build to rebuild"
+          end
+          return
+        end
+
+        case ctx.build_state
+        when :processed then nil
+        when :absent
+          errors << "build #{ctx.requested_build} for #{ctx.requested_version} not found on App Store Connect — pass --ref to build and upload it first"
+        when :processing
+          errors << "build #{ctx.requested_build} is still processing on App Store Connect — retry in a few minutes"
+        when :failed
+          errors << "build #{ctx.requested_build} failed processing on App Store Connect — upload a new build with a new --build number"
+        else
+          errors << "unknown build state #{ctx.build_state.inspect} for build #{ctx.requested_build}"
+        end
+      end
+
+      def check_version_state(ctx, errors, warnings)
+        if ctx.live_version && ctx.live_version == ctx.requested_version
+          errors << "version #{ctx.requested_version} is already live on the App Store"
+          return
+        end
+
+        state = ctx.version_state
+        return if state.nil? # no in-flight version — deliver will create one
+
+        if EDITABLE_STATES.include?(state)
+          if ctx.version_string && ctx.version_string != ctx.requested_version
+            warnings << "App Store Connect has version #{ctx.version_string} in #{state} — it will be renamed to #{ctx.requested_version}"
+          end
+        elsif IN_REVIEW_STATES.include?(state)
+          errors << "version #{ctx.version_string} is already submitted for review (#{state}) — cancel the submission in App Store Connect first"
+        elsif PENDING_RELEASE_STATES.include?(state)
+          errors << "version #{ctx.version_string} is approved and awaiting release (#{state}) — release it in App Store Connect first"
+        else
+          errors << "version #{ctx.version_string} is in state #{state} — resolve it in App Store Connect first"
+        end
+      end
+    end
+  end
+end

--- a/fastlane/lib/zodl/whats_new.rb
+++ b/fastlane/lib/zodl/whats_new.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Zodl
+  # Maps App Store Connect locales to the repo's whatsNew*.json files, finds the
+  # release entry for a version, and renders the App Store "What's New" text.
+  #
+  # File reading + transformation only, no network: the Fastfile passes in the
+  # WhatsNew directory and the locales it fetched from App Store Connect.
+  #
+  # Rendering must stay byte-identical to the `appstore` command of the
+  # /update-whatsnew helper script (whatsnew.py): section title line, one
+  # "* "-prefixed line per bullet, sections separated by one blank line.
+  module WhatsNew
+    Result = Struct.new(:notes, :sources, :errors) do
+      def ok?
+        errors.empty?
+      end
+    end
+
+    module_function
+
+    # whatsNew.json for English, whatsNew_<lang>.json for every other language —
+    # the same language→file rule the /update-whatsnew skill documents. The
+    # language is the part of the locale before the first dash (es-ES → es).
+    def basename_for_locale(locale)
+      lang = locale.to_s.split("-").first.to_s.downcase
+      lang == "en" ? "whatsNew.json" : "whatsNew_#{lang}.json"
+    end
+
+    # The release entry for `version` anywhere in the file's releases array —
+    # not just the newest entry, so a re-submission after the next version was
+    # already prepended still finds its notes.
+    #
+    # File.read pins the read to UTF-8 regardless of the process's default
+    # external encoding: fastlane/CI often runs with no LANG/LC_ALL set, which
+    # makes Ruby default to US-ASCII and raises Encoding::InvalidByteSequenceError
+    # on the real whatsNew files' em dashes and accents (e.g. "Añadido:") — a
+    # crash `resolve`'s `rescue JSON::ParserError` cannot catch.
+    def entry_for_version(file, version)
+      parsed = JSON.parse(File.read(file, encoding: Encoding::UTF_8))
+      # A syntactically valid but structurally wrong file (e.g. a bare JSON
+      # array) would otherwise blow up inside #fetch with a raw TypeError that
+      # `resolve` can't turn into a useful per-locale message.
+      raise TypeError, "top-level JSON value is #{parsed.class}, not an object" unless parsed.is_a?(Hash)
+
+      parsed.fetch("releases", []).find { |entry| entry["version"] == version }
+    end
+
+    def render(entry)
+      entry.fetch("sections", []).map do |section|
+        ([section.fetch("title")] + section.fetch("bulletpoints", []).map { |bp| "* #{bp}" }).join("\n")
+      end.join("\n\n")
+    end
+
+    # Resolves every locale to its rendered App Store text. Problems (missing
+    # file, missing entry, unparseable JSON) are collected per locale so the
+    # preflight can show all of them at once instead of one per run.
+    def resolve(dir:, locales:, version:)
+      result = Result.new({}, {}, [])
+      locales.each do |locale|
+        basename = basename_for_locale(locale)
+        file = File.join(dir, basename)
+        unless File.file?(file)
+          result.errors << "locale #{locale}: #{basename} not found in #{dir}"
+          next
+        end
+        begin
+          entry = entry_for_version(file, version)
+        rescue JSON::ParserError => e
+          result.errors << "locale #{locale}: #{basename} is not valid JSON (#{e.message})"
+          next
+        rescue TypeError => e
+          result.errors << "locale #{locale}: #{basename} #{e.message}"
+          next
+        end
+        if entry.nil?
+          result.errors << "locale #{locale}: #{basename} has no entry for version #{version}"
+          next
+        end
+        result.notes[locale] = render(entry)
+        result.sources[locale] = basename
+      end
+      result
+    end
+  end
+end

--- a/fastlane/spec/notify_test.rb
+++ b/fastlane/spec/notify_test.rb
@@ -36,6 +36,14 @@ class ZodlNotifyTest < Minitest::Test
     assert_equal "Ping", fields[:sound]
   end
 
+  def test_payload_submit_success_uses_ping_and_app_review_message
+    fields = Zodl::Notify.payload(event: :submit_success, variants: ["appstore"], version: "3.8.0", build: 5)
+    assert_equal "ZODL release ✅", fields[:title]
+    assert_equal "appstore 3.8.0 (5)", fields[:subtitle]
+    assert_equal "Submitted to App Review", fields[:message]
+    assert_equal "Ping", fields[:sound]
+  end
+
   def test_payload_failure_uses_basso_and_first_line_of_reason
     fields = Zodl::Notify.payload(
       event: :failure, variants: ["appstore"], version: "3.8.0", build: 3,
@@ -95,6 +103,16 @@ class ZodlNotifyTest < Minitest::Test
     assert result
     assert_equal "ZODL release ✅", captured[:title]
     assert_equal "Ping", captured[:sound]
+  end
+
+  def test_post_submit_success_invokes_runner_with_correct_payload
+    captured = nil
+    result = Zodl::Notify.post(
+      event: :submit_success, variants: ["appstore"], version: "3.8.0", build: 5,
+      runner: ->(fields) { captured = fields }
+    )
+    assert result
+    assert_equal "Submitted to App Review", captured[:message]
   end
 
   def test_post_skips_delivery_when_disabled

--- a/fastlane/spec/submit_preflight_test.rb
+++ b/fastlane/spec/submit_preflight_test.rb
@@ -1,0 +1,130 @@
+require "minitest/autorun"
+require "zodl/submit_preflight"
+
+class ZodlSubmitPreflightTest < Minitest::Test
+  def facts(**overrides)
+    base = {
+      variant: "appstore", requested_version: "3.8.0", requested_build: 5,
+      ref_given: false, build_state: :processed, version_state: nil,
+      version_string: nil, live_version: "3.7.4", whats_new_errors: []
+    }
+    Zodl::SubmitPreflight::Context.new(**base.merge(overrides))
+  end
+
+  def test_clean_submit_only_context_passes
+    report = Zodl::SubmitPreflight.check(facts)
+    assert report.ok?, report.errors.join("; ")
+    assert_empty report.warnings
+  end
+
+  def test_clean_build_path_context_passes
+    report = Zodl::SubmitPreflight.check(facts(ref_given: true, build_state: :absent))
+    assert report.ok?, report.errors.join("; ")
+  end
+
+  def test_non_appstore_variant_blocks
+    report = Zodl::SubmitPreflight.check(facts(variant: "internal"))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("only supported for the appstore variant") })
+  end
+
+  def test_malformed_version_blocks
+    report = Zodl::SubmitPreflight.check(facts(requested_version: "3.8"))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("X.Y.Z") })
+  end
+
+  def test_ref_given_with_existing_build_blocks
+    report = Zodl::SubmitPreflight.check(facts(ref_given: true, build_state: :processed))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("already exists") })
+    assert(report.errors.any? { |e| e.include?("drop --ref") })
+  end
+
+  def test_missing_build_without_ref_blocks
+    report = Zodl::SubmitPreflight.check(facts(ref_given: false, build_state: :absent))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("not found") })
+    assert(report.errors.any? { |e| e.include?("pass --ref") })
+  end
+
+  def test_processing_build_blocks
+    report = Zodl::SubmitPreflight.check(facts(ref_given: false, build_state: :processing))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("still processing") })
+  end
+
+  def test_failed_build_blocks
+    report = Zodl::SubmitPreflight.check(facts(ref_given: false, build_state: :failed))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("failed processing") })
+  end
+
+  def test_editable_state_with_matching_version_passes
+    %w[PREPARE_FOR_SUBMISSION DEVELOPER_REJECTED].each do |state|
+      report = Zodl::SubmitPreflight.check(facts(version_state: state, version_string: "3.8.0"))
+      assert report.ok?, "#{state}: #{report.errors.join('; ')}"
+      assert_empty report.warnings, state
+    end
+  end
+
+  def test_editable_state_with_different_version_warns_about_rename
+    report = Zodl::SubmitPreflight.check(facts(version_state: "PREPARE_FOR_SUBMISSION", version_string: "3.9.0"))
+    assert report.ok?, report.errors.join("; ")
+    assert(report.warnings.any? { |w| w.include?("renamed to 3.8.0") })
+  end
+
+  def test_in_review_state_blocks
+    %w[WAITING_FOR_REVIEW IN_REVIEW READY_FOR_REVIEW].each do |state|
+      report = Zodl::SubmitPreflight.check(facts(version_state: state, version_string: "3.8.0"))
+      refute report.ok?, state
+      assert(report.errors.any? { |e| e.include?("already submitted for review") }, state)
+      assert(report.errors.any? { |e| e.include?("cancel") }, state)
+    end
+  end
+
+  def test_pending_developer_release_blocks
+    report = Zodl::SubmitPreflight.check(facts(version_state: "PENDING_DEVELOPER_RELEASE", version_string: "3.7.5"))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("awaiting release") })
+  end
+
+  def test_unknown_version_state_fails_closed
+    report = Zodl::SubmitPreflight.check(facts(version_state: "WAITING_FOR_EXPORT_COMPLIANCE"))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("resolve it in App Store Connect") })
+  end
+
+  def test_already_live_version_blocks
+    report = Zodl::SubmitPreflight.check(facts(live_version: "3.8.0"))
+    refute report.ok?
+    assert(report.errors.any? { |e| e.include?("already live") })
+  end
+
+  def test_whats_new_errors_are_propagated
+    report = Zodl::SubmitPreflight.check(facts(whats_new_errors: ["locale es-ES: boom"]))
+    refute report.ok?
+    assert_includes report.errors, "locale es-ES: boom"
+  end
+
+  def test_build_action
+    assert_equal :attach, Zodl::SubmitPreflight.build_action(attached: nil, requested: 5)
+    assert_equal :keep, Zodl::SubmitPreflight.build_action(attached: 5, requested: 5)
+    assert_equal :replace, Zodl::SubmitPreflight.build_action(attached: 4, requested: 5)
+    assert_equal :keep, Zodl::SubmitPreflight.build_action(attached: "5", requested: 5)
+  end
+
+  def test_promotional_text_plan
+    plan = Zodl::SubmitPreflight.promotional_text_plan(
+      locales: %w[en-US es-ES de-DE fr-FR ja],
+      edit: { "en-US" => "New edit text", "es-ES" => "", "de-DE" => "", "fr-FR" => "   " },
+      live: { "en-US" => "Old live text", "es-ES" => "Live only", "de-DE" => "", "fr-FR" => "Live for fr" }
+    )
+
+    assert_equal({ action: :keep, text: "New edit text" }, plan["en-US"])
+    assert_equal({ action: :copy, text: "Live only" }, plan["es-ES"])
+    assert_equal({ action: :none, text: nil }, plan["de-DE"])
+    assert_equal({ action: :copy, text: "Live for fr" }, plan["fr-FR"])
+    assert_equal({ action: :none, text: nil }, plan["ja"])
+  end
+end

--- a/fastlane/spec/whats_new_test.rb
+++ b/fastlane/spec/whats_new_test.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "json"
+require "tmpdir"
+require "zodl/whats_new"
+
+class ZodlWhatsNewTest < Minitest::Test
+  def test_basename_for_locale
+    assert_equal "whatsNew.json", Zodl::WhatsNew.basename_for_locale("en-US")
+    assert_equal "whatsNew.json", Zodl::WhatsNew.basename_for_locale("en-GB")
+    assert_equal "whatsNew_es.json", Zodl::WhatsNew.basename_for_locale("es-ES")
+    assert_equal "whatsNew_es.json", Zodl::WhatsNew.basename_for_locale("es-MX")
+    assert_equal "whatsNew_pt.json", Zodl::WhatsNew.basename_for_locale("pt-BR")
+    assert_equal "whatsNew_zh.json", Zodl::WhatsNew.basename_for_locale("zh-Hans")
+  end
+
+  # Three entries, requested version in the middle — proves the lookup is by
+  # `version` field, not by array position.
+  def releases_fixture
+    {
+      "releases" => [
+        { "version" => "3.8.0", "date" => "25-07-2026", "timestamp" => 1, "sections" => [] },
+        { "version" => "3.7.4", "date" => "22-07-2026", "timestamp" => 2, "sections" => [] },
+        { "version" => "3.7.3", "date" => "11-07-2026", "timestamp" => 3, "sections" => [] }
+      ]
+    }
+  end
+
+  def test_entry_for_version_finds_entry_that_is_not_first
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, "whatsNew.json")
+      File.write(file, JSON.generate(releases_fixture))
+
+      entry = Zodl::WhatsNew.entry_for_version(file, "3.7.4")
+
+      refute_nil entry
+      assert_equal "3.7.4", entry["version"]
+    end
+  end
+
+  def test_entry_for_version_returns_nil_for_missing_version
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, "whatsNew.json")
+      File.write(file, JSON.generate(releases_fixture))
+
+      assert_nil Zodl::WhatsNew.entry_for_version(file, "9.9.9")
+    end
+  end
+
+  # A syntactically valid file whose top level isn't a JSON object (e.g. a bare
+  # array) used to blow up inside Hash#fetch/Array#fetch with a raw TypeError.
+  # entry_for_version now validates the top-level shape itself and raises a
+  # TypeError with a message resolve can turn into a normal collected error.
+  def test_entry_for_version_raises_for_non_object_json
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, "whatsNew.json")
+      File.write(file, JSON.generate(["not", "an", "object"]))
+
+      error = assert_raises(TypeError) { Zodl::WhatsNew.entry_for_version(file, "3.8.0") }
+      assert_includes error.message, "not an object"
+    end
+  end
+
+  def test_render_exact_output_for_two_sections
+    entry = {
+      "sections" => [
+        { "title" => "Added:", "bulletpoints" => ["First.", "Second."] },
+        { "title" => "Fixed:", "bulletpoints" => ["Third."] }
+      ]
+    }
+
+    assert_equal "Added:\n* First.\n* Second.\n\nFixed:\n* Third.", Zodl::WhatsNew.render(entry)
+  end
+
+  def write_whats_new(dir, basename, version:, sections:)
+    payload = { "releases" => [{ "version" => version, "date" => "01-01-2026", "timestamp" => 1, "sections" => sections }] }
+    File.write(File.join(dir, basename), JSON.generate(payload))
+  end
+
+  def test_resolve_happy_path
+    Dir.mktmpdir do |dir|
+      sections = [{ "title" => "Added:", "bulletpoints" => ["Thing."] }]
+      write_whats_new(dir, "whatsNew.json", version: "3.8.0", sections: sections)
+      write_whats_new(dir, "whatsNew_es.json", version: "3.8.0", sections: sections)
+
+      result = Zodl::WhatsNew.resolve(dir: dir, locales: ["en-US", "es-ES"], version: "3.8.0")
+
+      assert result.ok?, result.errors.join("; ")
+      assert_equal "Added:\n* Thing.", result.notes["en-US"]
+      assert_equal "Added:\n* Thing.", result.notes["es-ES"]
+      assert_equal "whatsNew.json", result.sources["en-US"]
+      assert_equal "whatsNew_es.json", result.sources["es-ES"]
+    end
+  end
+
+  def test_resolve_collects_every_error
+    Dir.mktmpdir do |dir|
+      # en-US: whatsNew.json is simply absent from the directory.
+      # es-ES: file present, but has no entry for the requested version.
+      write_whats_new(dir, "whatsNew_es.json", version: "1.0.0", sections: [{ "title" => "Added:", "bulletpoints" => ["Thing."] }])
+      # pt-BR: file present, but is not valid JSON.
+      File.write(File.join(dir, "whatsNew_pt.json"), "{ not json")
+
+      result = Zodl::WhatsNew.resolve(dir: dir, locales: ["en-US", "es-ES", "pt-BR"], version: "3.8.0")
+
+      refute result.ok?
+      assert_equal 3, result.errors.length
+      assert(result.errors.any? { |e| e.include?("whatsNew.json") && e.include?("en-US") })
+      assert(result.errors.any? { |e| e.include?("has no entry for version") })
+      assert(result.errors.any? { |e| e.include?("not valid JSON") })
+    end
+  end
+
+  # Integration-level counterpart to test_entry_for_version_raises_for_non_object_json:
+  # resolve's own doc comment promises every problem is collected, not raised.
+  def test_resolve_collects_error_for_non_object_json
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "whatsNew.json"), JSON.generate(["not", "an", "object"]))
+
+      result = Zodl::WhatsNew.resolve(dir: dir, locales: ["en-US"], version: "3.8.0")
+
+      refute result.ok?
+      assert(result.errors.any? { |e| e.include?("whatsNew.json") && e.include?("not an object") })
+    end
+  end
+
+  # Real whatsNew files contain non-ASCII (em dashes, accents, "Añadido:"). A
+  # shell with no LANG/LC_ALL set — routine for fastlane/CI — makes Ruby's
+  # Encoding.default_external US-ASCII, and File.read without an explicit
+  # encoding used to make entry_for_version raise Encoding::InvalidByteSequenceError,
+  # which escaped resolve's `rescue JSON::ParserError` as an uncaught crash.
+  #
+  # Reproduced via a CHILD ruby process with LANG/LC_ALL/LC_CTYPE removed,
+  # rather than mutating this process's global Encoding.default_external —
+  # that would leak into every other test in this file.
+  def test_resolve_reads_non_ascii_content_without_a_utf8_process_locale
+    Dir.mktmpdir do |dir|
+      sections = [{ "title" => "Añadido:", "bulletpoints" => ["Cosa nueva — con guión largo."] }]
+      write_whats_new(dir, "whatsNew_es.json", version: "3.8.0", sections: sections)
+
+      lib_dir = File.expand_path("../lib", __dir__)
+      # Single-quoted heredoc: its #{...} belong to the CHILD script and must
+      # stay literal here, evaluated only once the child requires this source.
+      child_script = <<~'RUBY_SCRIPT'
+        require "zodl/whats_new"
+        begin
+          result = Zodl::WhatsNew.resolve(dir: ARGV[0], locales: ["es-ES"], version: "3.8.0")
+          if result.ok?
+            print "OK:#{result.notes["es-ES"]}"
+          else
+            print "ERR:#{result.errors.join("|")}"
+          end
+        rescue => e
+          print "CRASH:#{e.class}:#{e.message}"
+        end
+      RUBY_SCRIPT
+      no_locale_env = { "LANG" => nil, "LC_ALL" => nil, "LC_CTYPE" => nil }
+      out = IO.popen(no_locale_env, ["ruby", "-I#{lib_dir}", "-e", child_script, dir],
+                      external_encoding: Encoding::UTF_8, &:read)
+
+      assert_equal "OK:Añadido:\n* Cosa nueva — con guión largo.", out
+    end
+  end
+
+  def test_render_matches_python_renderer
+    script = File.expand_path("../../.claude/skills/update-whatsnew/scripts/whatsnew.py", __dir__)
+    skip "python3 not available" unless system("python3 -c 1 >/dev/null 2>&1")
+    entry = {
+      "version" => "9.9.9", "date" => "01-01-2026", "timestamp" => 1,
+      "sections" => [
+        { "title" => "Added:", "bulletpoints" => ["One with 'quotes' and accents áé.", "Two."] },
+        { "title" => "Fixed:", "bulletpoints" => ["Three."] }
+      ]
+    }
+    Dir.mktmpdir do |dir|
+      payload = File.join(dir, "payload.json")
+      File.write(payload, JSON.generate(entry))
+      # external_encoding pins the read to UTF-8 regardless of the invoking shell's
+      # locale (python3 always emits UTF-8 here) — without it, a shell with no
+      # LANG/LC_ALL set tags the bytes US-ASCII and the comparison fails spuriously.
+      python = IO.popen(["python3", script, "appstore", "--payload", payload], external_encoding: Encoding::UTF_8, &:read)
+      assert_equal python, "#{Zodl::WhatsNew.render(entry)}\n" # print adds the trailing newline
+    end
+  end
+end


### PR DESCRIPTION
# Description

`Scripts/release.sh` gains `--submit-review` (appstore variant only): submit a build to App Review with no manual App Store Connect work. `--ref` becomes the "build it" signal — with it, the existing pipeline (preflight → tests → build → upload) runs and then submits; without it, a build already on App Store Connect is submitted as-is.

What submitting does:

- Creates the App Store version record, or **adopts one created manually** in any editable state (prepare-for-submission, developer-rejected, rejected, metadata-rejected, invalid-binary), renaming it if the version string differs (warned in the summary).
- **Copies promotional text from the live version** into any localization where it is empty — App Store Connect does not carry this field over to new versions, unlike the rest of the metadata. Manually entered promotional text is always kept, never overwritten.
- Writes **What's New** for every enabled App Store localization from the current checkout's `secant/Resources/WhatsNew/whatsNew*.json` (entry matching `--version`; locales are enumerated live from App Store Connect and mapped by language prefix, so en-US/es-ES/es-MX resolve to `whatsNew.json` + `whatsNew_es.json`).
- Attaches the requested build — keeping a correct one already attached, replacing a wrong one.
- Submits with **manual release** (you still press Release after approval), no IDFA, precheck without IAP.
- Errors out (fail-closed) when a version is already in review or approved-awaiting-release, when the requested version is already live, when the build is missing or still processing, or when any enabled locale lacks a What's New entry.
- After submitting, reads back promotional text / What's New per locale and warns loudly if promotional text is missing where a copy was planned (fixable in ASC without a new review).

`--dry-run` covers all of the submission checks read-only; `--yes` also skips the submit confirmation. Failure/success macOS notifications cover the submit path.

Implementation: pure decision logic in `fastlane/lib/zodl/whats_new.rb` and `fastlane/lib/zodl/submit_preflight.rb` (minitest-covered, mirroring the existing preflight pattern — 82 runs / 198 assertions green), wrapper arg surface bats-covered (10/10), Spaceship fact-gathering + a single `deliver` call in the `Fastfile`. The What's New renderer is parity-tested against the `/update-whatsnew` helper's output. Verified end-to-end with a read-only `--dry-run` against the real App Store Connect app (locale enumeration, build/version state detection, and correct refusal all confirmed live). The actual submission write path can only be exercised at the next real release.

Docs: `fastlane/README.md` and `docs/release-automation.md` document both usages, the convergence behavior, and new troubleshooting rows. No CHANGELOG entry — release tooling, not a user-facing app change.
