### PR TITLE
Warn on the send confirmation screen when a send must spend Orchard funds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
 - [Ironwood] Once ZODL sees that the Ironwood network upgrade is live on the network, it shows a short one-time screen introducing the change, with a link to a support article. It appears once per device — after you continue past it, it never comes back.
 - [MOB-1535] Tapping your balance on the home screen now opens a "Total Balance Across Pools" breakdown showing how much ZEC sits in each Zcash pool — Orchard, Sapling, Transparent and Ironwood — so you can see exactly where your funds are. When currency conversion is turned on, each pool also shows its value in your selected currency. Pools you hold nothing in are still listed, and with balances hidden every amount stays masked.
-- Warn before confirming a send that has to spend Orchard funds: the confirmation screen now shows a sheet recommending migration first, with the option to continue or cancel.
+- [Ironwood] Warn before confirming a send that has to spend Orchard funds: the confirmation screen now shows a sheet recommending migration first, with the option to continue or cancel.
 
 ### Changed
 - [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
 - [Ironwood] Once ZODL sees that the Ironwood network upgrade is live on the network, it shows a short one-time screen introducing the change, with a link to a support article. It appears once per device — after you continue past it, it never comes back.
 - [MOB-1535] Tapping your balance on the home screen now opens a "Total Balance Across Pools" breakdown showing how much ZEC sits in each Zcash pool — Orchard, Sapling, Transparent and Ironwood — so you can see exactly where your funds are. When currency conversion is turned on, each pool also shows its value in your selected currency. Pools you hold nothing in are still listed, and with balances hidden every amount stays masked.
+- Warn before confirming a send that has to spend Orchard funds: the confirmation screen now shows a sheet recommending migration first, with the option to continue or cancel.
 
 ### Changed
 - [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3433F5233018893100EA4002 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3433F5223018893100EA4002 /* ZcashLightClientKit */; };
-		3433F5253018894000EA4002 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3433F5243018894000EA4002 /* ZcashLightClientKit */; };
 		34982B6E3014A1C100FF9205 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34982B6D3014A1C100FF9205 /* ZcashLightClientKit */; };
 		34AA77182F857DB300D244E2 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 34AA77172F857DB300D244E2 /* ComposableArchitecture */; };
 		34AA771A2F857DB800D244E2 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 34AA77192F857DB800D244E2 /* ComposableArchitecture */; };
@@ -49,6 +47,8 @@
 		34B967652F8CC48700823B20 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 34B967642F8CC48700823B20 /* Atomics */; };
 		34B967672F8CC48B00823B20 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 34B967662F8CC48B00823B20 /* Atomics */; };
 		34B967692F8CC49100823B20 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 34B967682F8CC49100823B20 /* Atomics */; };
+		34C6EB08301CAE0900336D75 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34C6EB07301CAE0900336D75 /* ZcashLightClientKit */; };
+		34C6EB0A301CAE1100336D75 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34C6EB09301CAE1100336D75 /* ZcashLightClientKit */; };
 		34FB884B3010911000A2F01F /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34FB884A3010911000A2F01F /* ZcashLightClientKit */; };
 /* End PBXBuildFile section */
 
@@ -167,7 +167,7 @@
 				34AA77182F857DB300D244E2 /* ComposableArchitecture in Frameworks */,
 				34AA778A2F85832E00D244E2 /* Lottie in Frameworks */,
 				34AA77382F8580CB00D244E2 /* CasePathsCore in Frameworks */,
-				3433F5253018894000EA4002 /* ZcashLightClientKit in Frameworks */,
+				34C6EB0A301CAE1100336D75 /* ZcashLightClientKit in Frameworks */,
 				34AA77A02F8583BA00D244E2 /* BigDecimal in Frameworks */,
 				34AA77BC2F85861800D244E2 /* UInt128 in Frameworks */,
 				34AA77742F8582A200D244E2 /* Flexa in Frameworks */,
@@ -181,7 +181,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3433F5233018893100EA4002 /* ZcashLightClientKit in Frameworks */,
+				34C6EB08301CAE0900336D75 /* ZcashLightClientKit in Frameworks */,
 				34AA77812F8582EB00D244E2 /* ZcashPaymentURI in Frameworks */,
 				34AA77492F85814C00D244E2 /* URLRouting in Frameworks */,
 				34AA77292F857E3400D244E2 /* XCTestDynamicOverlay in Frameworks */,
@@ -340,7 +340,7 @@
 				34AA779F2F8583BA00D244E2 /* BigDecimal */,
 				34AA77BB2F85861800D244E2 /* UInt128 */,
 				34B967642F8CC48700823B20 /* Atomics */,
-				3433F5243018894000EA4002 /* ZcashLightClientKit */,
+				34C6EB09301CAE1100336D75 /* ZcashLightClientKit */,
 			);
 			productName = "zodl-production";
 			productReference = 9E4AB2B72BA1BEE900F5D6DB /* zodl-production.app */;
@@ -381,7 +381,7 @@
 				34AA77BD2F85861E00D244E2 /* UInt128 */,
 				34B967662F8CC48B00823B20 /* Atomics */,
 				34FB884A3010911000A2F01F /* ZcashLightClientKit */,
-				3433F5223018893100EA4002 /* ZcashLightClientKit */,
+				34C6EB07301CAE0900336D75 /* ZcashLightClientKit */,
 			);
 			productName = "zodl-internal";
 			productReference = 9E5AB4822C94777800065483 /* zodl-internal.app */;
@@ -427,7 +427,7 @@
 				34AA77B52F85848A00D244E2 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */,
 				34AA77B62F85860300D244E2 /* XCRemoteSwiftPackageReference "UInt128" */,
 				34B9675A2F8CC47200823B20 /* XCRemoteSwiftPackageReference "swift-atomics" */,
-				3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */,
+				34C6EB06301CAE0800336D75 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */,
 			);
 			productRefGroup = 0D4E7A0626B364170058B01E /* Products */;
 			projectDirPath = "";
@@ -1298,15 +1298,14 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/zcash/zcash-swift-wallet-sdk.git";
-			requirement = {
-				kind = exactVersion;
-				version = "2.8.0-rc.1";
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		34C6EB06301CAE0800336D75 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../zcash-swift-wallet-sdk";
 		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCRemoteSwiftPackageReference section */
 		34AA77122F857DA300D244E2 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture";
@@ -1416,16 +1415,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3433F5223018893100EA4002 /* ZcashLightClientKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */;
-			productName = ZcashLightClientKit;
-		};
-		3433F5243018894000EA4002 /* ZcashLightClientKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */;
-			productName = ZcashLightClientKit;
-		};
 		34982B6D3014A1C100FF9205 /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ZcashLightClientKit;
@@ -1639,6 +1628,15 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 34B9675A2F8CC47200823B20 /* XCRemoteSwiftPackageReference "swift-atomics" */;
 			productName = Atomics;
+		};
+		34C6EB07301CAE0900336D75 /* ZcashLightClientKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ZcashLightClientKit;
+		};
+		34C6EB09301CAE1100336D75 /* ZcashLightClientKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 34C6EB06301CAE0800336D75 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */;
+			productName = ZcashLightClientKit;
 		};
 		34FB884A3010911000A2F01F /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4c7373c5f3adfdcdcd7de6ca0dbccee8a5285b0fea671ef4c1ad7b8ee13a0c03",
+  "originHash" : "e9ee1eee75be980eb7e5c2cfd98c919295ec44a8cdab428b94f159ccaad47bde",
   "pins" : [
     {
       "identity" : "base32",
@@ -485,15 +485,6 @@
       "state" : {
         "revision" : "798053ba8a2d80560b5e3f4899a8b35ac0c348bb",
         "version" : "1.0.1"
-      }
-    },
-    {
-      "identity" : "zcash-swift-wallet-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/zcash/zcash-swift-wallet-sdk.git",
-      "state" : {
-        "revision" : "64e1d590a9f6113ff6ac56ffb3dab32bde5997dc",
-        "version" : "2.8.0-rc.1"
       }
     }
   ],

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -13955,6 +13955,39 @@
         }
       }
     },
+    "sheet.orchardSpend.continue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue anyway"
+          }
+        }
+      }
+    },
+    "sheet.orchardSpend.msg" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We recommend migrating your funds first to avoid leaking the transaction amount on-chain."
+          }
+        }
+      }
+    },
+    "sheet.orchardSpend.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This send requires spending Orchard funds"
+          }
+        }
+      }
+    },
     "sheet.syncTimeout.desc" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -492,6 +492,10 @@ extension ScanCoordFlow {
                 let _ = state.path.removeLast()
                 return .none
 
+            case .path(.element(id: _, action: .requestZecConfirmation(.cancelTapped))):
+                let _ = state.path.removeLast()
+                return .none
+
             case .path(.element(id: _, action: .sendConfirmation(.sendRequested))):
                 for element in state.path {
                     if case .sendConfirmation(let sendConfirmationState) = element {

--- a/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/ScanCoordFlowCoordinator.swift
@@ -171,7 +171,15 @@ extension ScanCoordFlow {
 
                 // MARK: - Request ZEC Confirmation
                 
-            case .path(.element(id: _, action: .requestZecConfirmation(.goBackTappedFromRequestZec))):
+            // Cancel from the Orchard-spend warning sheet must land exactly where the screen's own
+            // back button does — sharing this case (rather than a separate single `popLast()`) is
+            // what guarantees that when the path is [sendForm, scan, requestZecConfirmation] (the
+            // send form's own Scan button resolving to a full payment request; see
+            // `.scan(.foundRequestZec(.request))` below, which pushes `requestZecConfirmation`
+            // without popping `.scan`), cancel walks back to `sendForm` instead of stranding the
+            // user on the stale scan/camera screen.
+            case .path(.element(id: _, action: .requestZecConfirmation(.goBackTappedFromRequestZec))),
+                    .path(.element(id: _, action: .requestZecConfirmation(.cancelTapped))):
                 for (id, element) in zip(state.path.ids, state.path) {
                     if element.is(\.sendForm) {
                         state.path.pop(to: id)
@@ -489,10 +497,6 @@ extension ScanCoordFlow {
                 // MARK: - Send Confirmation
                 
             case .path(.element(id: _, action: .sendConfirmation(.cancelTapped))):
-                let _ = state.path.removeLast()
-                return .none
-
-            case .path(.element(id: _, action: .requestZecConfirmation(.cancelTapped))):
                 let _ = state.path.removeLast()
                 return .none
 

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
@@ -163,7 +163,13 @@ extension SendCoordFlow {
 
                 // MARK: - Request ZEC Confirmation
                 
-            case .path(.element(id: _, action: .requestZecConfirmation(.goBackTappedFromRequestZec))):
+            // Share this case with the screen's own back button rather than a separate single
+            // `popLast()`, so cancel from the Orchard-spend warning sheet can never diverge from
+            // whatever "go back" already does here — see the identical reasoning in
+            // ScanCoordFlowCoordinator, where diverging bodies actually did strand the user on a
+            // stale scan screen.
+            case .path(.element(id: _, action: .requestZecConfirmation(.goBackTappedFromRequestZec))),
+                    .path(.element(id: _, action: .requestZecConfirmation(.cancelTapped))):
                 state.path.removeAll()
                 return .none
 
@@ -276,10 +282,6 @@ extension SendCoordFlow {
                 // MARK: - Send Confirmation
 
             case .path(.element(id: _, action: .sendConfirmation(.cancelTapped))):
-                let _ = state.path.popLast()
-                return .none
-
-            case .path(.element(id: _, action: .requestZecConfirmation(.cancelTapped))):
                 let _ = state.path.popLast()
                 return .none
 

--- a/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SendCoordFlowCoordinator.swift
@@ -279,6 +279,10 @@ extension SendCoordFlow {
                 let _ = state.path.popLast()
                 return .none
 
+            case .path(.element(id: _, action: .requestZecConfirmation(.cancelTapped))):
+                let _ = state.path.popLast()
+                return .none
+
             case .path(.element(id: _, action: .sendConfirmation(.sendRequested))):
                 for element in state.path {
                     if case .sendConfirmation(let sendConfirmationState) = element {

--- a/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SignWithKeystoneCoordFlowCoordinator.swift
@@ -30,6 +30,13 @@ extension SignWithKeystoneCoordFlow {
                 state.path.append(.scan(scanState))
                 return .none
 
+            // No `.confirmWithKeystone` element to pop back to — this coordinator's root screen
+            // already is it — so mirror `.keystoneFirmwareUpdateCloseTapped` below and clear the
+            // internal path directly.
+            case .sendConfirmation(.cancelTapped):
+                state.path.removeAll()
+                return .none
+
             case .sendConfirmation(.updateResult(let result)):
                 switch result {
                 case .failure:

--- a/secant/Sources/Features/SendConfirmation/OrchardSpendWarningSheet.swift
+++ b/secant/Sources/Features/SendConfirmation/OrchardSpendWarningSheet.swift
@@ -1,0 +1,77 @@
+//
+//  OrchardSpendWarningSheet.swift
+//  Zashi
+//
+//  Created by Claude Fable 5 on 31-07-2026.
+//
+
+import SwiftUI
+
+struct OrchardSpendWarningSheetModifier: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+
+    @Binding var isPresented: Bool
+    let onContinue: () -> Void
+    let onCancel: () -> Void
+    let onDismiss: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .zashiSheet(isPresented: $isPresented, onDismiss: onDismiss) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Asset.Assets.infoOutline.image
+                        .zImage(size: 20, style: Design.Utility.ErrorRed._500)
+                        .background {
+                            Circle()
+                                .fill(Design.Utility.ErrorRed._50.color(colorScheme))
+                                .frame(width: 44, height: 44)
+                        }
+                        .padding(.top, 48)
+                        .padding(.leading, 12)
+
+                    Text(localizable: .sheetOrchardSpendTitle)
+                        .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                        .padding(.top, 24)
+                        .padding(.bottom, 12)
+
+                    Text(localizable: .sheetOrchardSpendMsg)
+                        .zFont(size: 14, style: Design.Text.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.leading)
+                        .lineSpacing(2)
+                        .padding(.bottom, 32)
+
+                    ZashiButton(
+                        String(localizable: .sheetOrchardSpendContinue),
+                        type: .destructive1
+                    ) {
+                        onContinue()
+                    }
+                    .padding(.bottom, 12)
+
+                    ZashiButton(String(localizable: .generalCancel)) {
+                        onCancel()
+                    }
+                    .padding(.bottom, Design.Spacing.sheetBottomSpace)
+                }
+            }
+    }
+}
+
+extension View {
+    func orchardSpendWarningSheet(
+        isPresented: Binding<Bool>,
+        onContinue: @escaping () -> Void,
+        onCancel: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            OrchardSpendWarningSheetModifier(
+                isPresented: isPresented,
+                onContinue: onContinue,
+                onCancel: onCancel,
+                onDismiss: onDismiss
+            )
+        )
+    }
+}

--- a/secant/Sources/Features/SendConfirmation/OrchardSpendWarningSheet.swift
+++ b/secant/Sources/Features/SendConfirmation/OrchardSpendWarningSheet.swift
@@ -31,6 +31,7 @@ struct OrchardSpendWarningSheetModifier: ViewModifier {
 
                     Text(localizable: .sheetOrchardSpendTitle)
                         .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                        .fixedSize(horizontal: false, vertical: true)
                         .padding(.top, 24)
                         .padding(.bottom, 12)
 

--- a/secant/Sources/Features/SendConfirmation/RequestPaymentConfirmationView.swift
+++ b/secant/Sources/Features/SendConfirmation/RequestPaymentConfirmationView.swift
@@ -239,7 +239,10 @@ struct RequestPaymentConfirmationView: View {
                 onCancel: { store.send(.orchardWarningCancelTapped) },
                 onDismiss: { store.send(.orchardWarningDismissed) }
             )
-            .onAppear { store.send(.onAppear) }
+            .onAppear {
+                store.send(.onAppear)
+                store.send(.confirmationScreenAppeared)
+            }
             .screenTitle(String(localizable: .sendRequestPaymentTitle).uppercased())
             .zashiBack(store.isSending) {
                 store.send(.goBackTappedFromRequestZec)

--- a/secant/Sources/Features/SendConfirmation/RequestPaymentConfirmationView.swift
+++ b/secant/Sources/Features/SendConfirmation/RequestPaymentConfirmationView.swift
@@ -233,6 +233,12 @@ struct RequestPaymentConfirmationView: View {
                     }
                 }
             }
+            .orchardSpendWarningSheet(
+                isPresented: $store.isOrchardWarningPresented,
+                onContinue: { store.send(.orchardWarningContinueTapped) },
+                onCancel: { store.send(.orchardWarningCancelTapped) },
+                onDismiss: { store.send(.orchardWarningDismissed) }
+            )
             .onAppear { store.send(.onAppear) }
             .screenTitle(String(localizable: .sendRequestPaymentTitle).uppercased())
             .zashiBack(store.isSending) {

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -53,18 +53,21 @@ struct SendConfirmation {
         var feeRequired: Zatoshi
         var isAddressExpanded = false
         var isKeystoneCodeFound = false
+        var isOrchardWarningPresented = false
         var isQRCodeEnlarged = false
         var isSending = false
         var isShielding = false
         var isTransparentAddress = false
         var message: String
         var messageToBeShared: String?
+        var orchardWarningShown = false
         var partialFailureTxIds: [String] = []
         var partialFailureStatuses: [String] = []
         var pczt: Pczt?
         var pcztForUI: Pczt?
         var pcztWithProofs: Pczt?
         var pcztWithSigs: Pczt?
+        var pendingCancelFromOrchardWarning = false
         var pendingDescription: String?
         var proposal: Proposal?
         var randomSuccessIconIndex = 0
@@ -146,6 +149,9 @@ struct SendConfirmation {
         case getSignatureTapped
         case goBackTappedFromRequestZec
         case onAppear
+        case orchardWarningCancelTapped
+        case orchardWarningContinueTapped
+        case orchardWarningDismissed
         case rejectRequestCanceled
         case rejectRequested
         case rejectTapped
@@ -233,6 +239,10 @@ struct SendConfirmation {
                         break
                     }
                 }
+                if state.proposal?.spendsLegacyOrchardFunds == true && !state.orchardWarningShown {
+                    state.isOrchardWarningPresented = true
+                    state.orchardWarningShown = true
+                }
                 return .none
 
             case .alert(.presented(let action)):
@@ -260,6 +270,25 @@ struct SendConfirmation {
                 return .none
 
             case .cancelTapped:
+                return .none
+
+            case .orchardWarningCancelTapped:
+                state.isOrchardWarningPresented = false
+                state.pendingCancelFromOrchardWarning = true
+                return .none
+
+            case .orchardWarningContinueTapped:
+                state.isOrchardWarningPresented = false
+                return .none
+
+            case .orchardWarningDismissed:
+                // Pop-back must happen only after the sheet finished dismissing (this action is
+                // sent from the sheet's `onDismiss`), otherwise SwiftUI would pop a screen that
+                // still presents a sheet.
+                if state.pendingCancelFromOrchardWarning {
+                    state.pendingCancelFromOrchardWarning = false
+                    return .send(.cancelTapped)
+                }
                 return .none
 
             case .viewTransactionTapped:

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -144,6 +144,7 @@ struct SendConfirmation {
         case binding(BindingAction<SendConfirmation.State>)
         case cancelTapped
         case closeTapped
+        case confirmationScreenAppeared
         case confirmWithKeystoneTapped
         case enlargeQRCodeTapped
         case getSignatureTapped
@@ -239,6 +240,13 @@ struct SendConfirmation {
                         break
                     }
                 }
+                return .none
+
+            case .confirmationScreenAppeared:
+                // Deliberately separate from `.onAppear`: this reducer is also shared by screens
+                // that never attach the warning sheet (e.g. the SwapAndPay flow pushing
+                // `confirmWithKeystone` with a fresh state), which must never trip or burn this
+                // one-shot latch just because `.onAppear` fired.
                 if state.proposal?.spendsLegacyOrchardFunds == true && !state.orchardWarningShown {
                     state.isOrchardWarningPresented = true
                     state.orchardWarningShown = true

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationView.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationView.swift
@@ -188,6 +188,12 @@ struct SendConfirmationView: View {
                     }
                 }
             }
+            .orchardSpendWarningSheet(
+                isPresented: $store.isOrchardWarningPresented,
+                onContinue: { store.send(.orchardWarningContinueTapped) },
+                onCancel: { store.send(.orchardWarningCancelTapped) },
+                onDismiss: { store.send(.orchardWarningDismissed) }
+            )
             .onAppear { store.send(.onAppear) }
             .screenTitle(
                 store.selectedWalletAccount?.vendor == .keystone

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationView.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationView.swift
@@ -194,7 +194,10 @@ struct SendConfirmationView: View {
                 onCancel: { store.send(.orchardWarningCancelTapped) },
                 onDismiss: { store.send(.orchardWarningDismissed) }
             )
-            .onAppear { store.send(.onAppear) }
+            .onAppear {
+                store.send(.onAppear)
+                store.send(.confirmationScreenAppeared)
+            }
             .screenTitle(
                 store.selectedWalletAccount?.vendor == .keystone
                 ? String(localizable: .sendReview)

--- a/zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift
+++ b/zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift
@@ -51,9 +51,15 @@ import ZcashPaymentURI
         )
     }
 
-    private func makeStore(proposeCalls: LockIsolated<[Recipient]>) -> StoreOf<ScanCoordFlow> {
-        let initialState = ScanCoordFlow.State()
+    private func makeStore(
+        proposeCalls: LockIsolated<[Recipient]>,
+        initialPath: [ScanCoordFlow.Path.State] = []
+    ) -> StoreOf<ScanCoordFlow> {
+        var initialState = ScanCoordFlow.State()
         initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+        for element in initialPath {
+            initialState.path.append(element)
+        }
 
         return Store(initialState: initialState) {
             ScanCoordFlow()
@@ -153,6 +159,55 @@ import ZcashPaymentURI
             #expect(store.state.memo == nil)
             // ...and it must never have proposed a transfer for the multi-recipient request.
             #expect(proposeCalls.withValue { $0.count == 1 })
+        }
+    }
+
+    /// Fix-round regression (code review, not ZIP-321): cancelling the Orchard-spend warning sheet
+    /// sends `.requestZecConfirmation(.cancelTapped)`, which must pop back to `sendForm` exactly
+    /// like the screen's own back button (`.goBackTappedFromRequestZec`) — even when a stale `.scan`
+    /// element is still sitting on the path underneath `requestZecConfirmation`. That shape is
+    /// reproduced here: the send form's own Scan button pushes a second `.scan` on top of an
+    /// existing `.sendForm`, and resolving that scan to a full payment request pushes
+    /// `requestZecConfirmation` without first popping `.scan` (`.proposalResolvedExistingSendForm`)
+    /// — so a naive single `popLast()` on cancel would strand the user on the stale scan/camera
+    /// screen instead of the send form.
+    @Test func cancelFromRequestZecConfirmationPopsPastStaleScanToSendForm() async throws {
+        let payment = try makePayment(amount: 0.001)
+        let singleRequest = PaymentRequest(singlePayment: payment)
+        let proposeCalls = LockIsolated<[Recipient]>([])
+
+        try await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(
+                proposeCalls: proposeCalls,
+                initialPath: [.sendForm(SendForm.State.initial), .scan(Scan.State.initial)]
+            )
+
+            store.send(.getProposal(singleRequest))
+
+            // Confirms the bug's precondition actually reproduces: `requestZecConfirmation` lands
+            // on top of a path that still has the stale `.scan` on it, both above `sendForm`.
+            await waitForScanStore {
+                store.state.path.count == 3
+            }
+            let requestZecId = try #require(store.state.path.ids.last)
+            #expect(store.state.path[id: requestZecId]?.is(\.requestZecConfirmation) == true)
+
+            // The pop itself is verified below; the known issue documents a pre-existing
+            // composition wart rather than a defect of the cancel wiring: `coordinatorReduce()`
+            // sits BEFORE the path `forEach` in the flow's `body`, so any handler that pops in
+            // response to a path-element action (this one, and equally the screen's own
+            // `.goBackTappedFromRequestZec` back button) removes the element before its child
+            // reducer runs, and TCA reports "received an action for a missing element".
+            withKnownIssue {
+                store.send(.path(.element(id: requestZecId, action: .requestZecConfirmation(.cancelTapped))))
+            }
+
+            await waitForScanStore {
+                store.state.path.count == 1
+            }
+            #expect(store.state.path.last?.is(\.sendForm) == true)
         }
     }
 }

--- a/zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift
+++ b/zodlTests/ScanTests/ScanCoordFlowZip321Tests.swift
@@ -162,15 +162,14 @@ import ZcashPaymentURI
         }
     }
 
-    /// Fix-round regression (code review, not ZIP-321): cancelling the Orchard-spend warning sheet
-    /// sends `.requestZecConfirmation(.cancelTapped)`, which must pop back to `sendForm` exactly
-    /// like the screen's own back button (`.goBackTappedFromRequestZec`) — even when a stale `.scan`
-    /// element is still sitting on the path underneath `requestZecConfirmation`. That shape is
-    /// reproduced here: the send form's own Scan button pushes a second `.scan` on top of an
-    /// existing `.sendForm`, and resolving that scan to a full payment request pushes
-    /// `requestZecConfirmation` without first popping `.scan` (`.proposalResolvedExistingSendForm`)
-    /// — so a naive single `popLast()` on cancel would strand the user on the stale scan/camera
-    /// screen instead of the send form.
+    /// Cancelling the Orchard-spend warning sheet sends `.requestZecConfirmation(.cancelTapped)`,
+    /// which must pop back to `sendForm` exactly like the screen's own back button
+    /// (`.goBackTappedFromRequestZec`) — even when a stale `.scan` element is still sitting on the
+    /// path underneath `requestZecConfirmation`. That shape is reproduced here: the send form's
+    /// own Scan button pushes a second `.scan` on top of an existing `.sendForm`, and resolving
+    /// that scan to a full payment request pushes `requestZecConfirmation` without first popping
+    /// `.scan` (`.proposalResolvedExistingSendForm`) — so a naive single `popLast()` on cancel
+    /// would strand the user on the stale scan/camera screen instead of the send form.
     @Test func cancelFromRequestZecConfirmationPopsPastStaleScanToSendForm() async throws {
         let payment = try makePayment(amount: 0.001)
         let singleRequest = PaymentRequest(singlePayment: payment)
@@ -200,7 +199,7 @@ import ZcashPaymentURI
             // response to a path-element action (this one, and equally the screen's own
             // `.goBackTappedFromRequestZec` back button) removes the element before its child
             // reducer runs, and TCA reports "received an action for a missing element".
-            withKnownIssue {
+            withKnownIssue("pre-existing: coordinatorReduce() runs before .forEach, so the pop precedes the child reducer") {
                 store.send(.path(.element(id: requestZecId, action: .requestZecConfirmation(.cancelTapped))))
             }
 

--- a/zodlTests/SendTests/SendConfirmationOrchardWarningTests.swift
+++ b/zodlTests/SendTests/SendConfirmationOrchardWarningTests.swift
@@ -3,12 +3,14 @@
 //  zodlTests
 //
 //  Covers the Orchard-spend warning bottom sheet shown on the send confirmation screen when the
-//  payment proposal spends legacy Orchard funds (Figma node 5139-23856): the `.onAppear`
-//  presentation gate, the one-shot `orchardWarningShown` flag that keeps it from re-presenting
-//  (SignWithKeystoneView shares this reducer and re-fires `.onAppear`), and the two-step cancel
-//  flow. Cancel must only turn into `.cancelTapped` once the sheet has actually finished
-//  dismissing (`.orchardWarningDismissed`, sent from the sheet's `onDismiss`) — otherwise SwiftUI
-//  would pop a screen that still presents a sheet.
+//  payment proposal spends legacy Orchard funds: the `.confirmationScreenAppeared` presentation
+//  gate (deliberately separate from `.onAppear`, so screens that share this reducer but never send
+//  `.confirmationScreenAppeared` — e.g. the SwapAndPay flow pushing `confirmWithKeystone` with a
+//  fresh state — can never trip or burn the one-shot latch), the `orchardWarningShown` flag that
+//  keeps it from re-presenting on a pop-return, and the two-step cancel flow. Cancel must only turn
+//  into `.cancelTapped` once the sheet has actually finished dismissing (`.orchardWarningDismissed`,
+//  sent from the sheet's `onDismiss`) — otherwise SwiftUI would pop a screen that still presents a
+//  sheet.
 //
 
 import Testing
@@ -37,15 +39,12 @@ import ComposableArchitecture
     private func makeStore(_ state: SendConfirmation.State) -> TestStore<SendConfirmation.State, SendConfirmation.Action> {
         TestStore(initialState: state) {
             SendConfirmation()
-        } withDependencies: {
-            $0.derivationTool = .liveValue
-            $0.zcashSDKEnvironment = .testnet
         }
     }
 
-    // MARK: - .onAppear presentation gate
+    // MARK: - .confirmationScreenAppeared presentation gate
 
-    @Test func onAppearPresentsWarningWhenProposalSpendsLegacyOrchardFunds() async {
+    @Test func confirmationScreenAppearedPresentsWarningWhenProposalSpendsLegacyOrchardFunds() async {
         await withDependencies {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
@@ -53,7 +52,7 @@ import ComposableArchitecture
             let store = makeStore(makeState(proposal: proposal))
             store.exhaustivity = .off
 
-            await store.send(.onAppear)
+            await store.send(.confirmationScreenAppeared)
             await store.finish()
             await store.skipReceivedActions(strict: false)
 
@@ -62,11 +61,75 @@ import ComposableArchitecture
         }
     }
 
-    @Test func onAppearDoesNotPresentWarningWhenProposalDoesNotSpendLegacyOrchardFunds() async {
+    @Test func confirmationScreenAppearedDoesNotPresentWarningWhenProposalDoesNotSpendLegacyOrchardFunds() async {
         await withDependencies {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             let proposal = Proposal.testOnlyFakeProposal(totalFee: 0)
+            let store = makeStore(makeState(proposal: proposal))
+            store.exhaustivity = .off
+
+            await store.send(.confirmationScreenAppeared)
+            await store.finish()
+            await store.skipReceivedActions(strict: false)
+
+            #expect(!store.state.isOrchardWarningPresented)
+            #expect(!store.state.orchardWarningShown)
+        }
+    }
+
+    @Test func confirmationScreenAppearedDoesNotPresentWarningWhenProposalIsNil() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(makeState(proposal: nil))
+            store.exhaustivity = .off
+
+            await store.send(.confirmationScreenAppeared)
+            await store.finish()
+            await store.skipReceivedActions(strict: false)
+
+            #expect(!store.state.isOrchardWarningPresented)
+            #expect(!store.state.orchardWarningShown)
+        }
+    }
+
+    @Test func confirmationScreenAppearedDoesNotRepresentWarningOnceAlreadyShown() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
+            var initialState = makeState(proposal: proposal)
+            // Simulates returning to this screen a second time (e.g. after pushing into
+            // confirmWithKeystone and coming back), which re-fires `.confirmationScreenAppeared`,
+            // once the warning already ran its course.
+            initialState.orchardWarningShown = true
+            initialState.isOrchardWarningPresented = false
+
+            let store = makeStore(initialState)
+            store.exhaustivity = .off
+
+            await store.send(.confirmationScreenAppeared)
+            await store.finish()
+            await store.skipReceivedActions(strict: false)
+
+            #expect(!store.state.isOrchardWarningPresented)
+            #expect(store.state.orchardWarningShown)
+        }
+    }
+
+    // MARK: - .onAppear no longer gates the warning
+
+    @Test func onAppearAloneNeverPresentsWarningEvenWithOrchardSpendingProposal() async {
+        // Regression coverage: before the gate moved to a dedicated action, `.onAppear` alone
+        // would present the warning. Screens that only ever send `.onAppear` (none currently do,
+        // but nothing stops a future one) must never see it fire.
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+            $0.derivationTool = .liveValue
+            $0.zcashSDKEnvironment = .testnet
+        } operation: {
+            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
             let store = makeStore(makeState(proposal: proposal))
             store.exhaustivity = .off
 
@@ -76,45 +139,6 @@ import ComposableArchitecture
 
             #expect(!store.state.isOrchardWarningPresented)
             #expect(!store.state.orchardWarningShown)
-        }
-    }
-
-    @Test func onAppearDoesNotPresentWarningWhenProposalIsNil() async {
-        await withDependencies {
-            $0.defaultInMemoryStorage = InMemoryStorage()
-        } operation: {
-            let store = makeStore(makeState(proposal: nil))
-            store.exhaustivity = .off
-
-            await store.send(.onAppear)
-            await store.finish()
-            await store.skipReceivedActions(strict: false)
-
-            #expect(!store.state.isOrchardWarningPresented)
-            #expect(!store.state.orchardWarningShown)
-        }
-    }
-
-    @Test func onAppearDoesNotRepresentWarningOnceAlreadyShown() async {
-        await withDependencies {
-            $0.defaultInMemoryStorage = InMemoryStorage()
-        } operation: {
-            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
-            var initialState = makeState(proposal: proposal)
-            // Simulates returning to this reducer's `.onAppear` a second time (e.g. after pushing
-            // into `confirmWithKeystone` and coming back) once the warning already ran its course.
-            initialState.orchardWarningShown = true
-            initialState.isOrchardWarningPresented = false
-
-            let store = makeStore(initialState)
-            store.exhaustivity = .off
-
-            await store.send(.onAppear)
-            await store.finish()
-            await store.skipReceivedActions(strict: false)
-
-            #expect(!store.state.isOrchardWarningPresented)
-            #expect(store.state.orchardWarningShown)
         }
     }
 

--- a/zodlTests/SendTests/SendConfirmationOrchardWarningTests.swift
+++ b/zodlTests/SendTests/SendConfirmationOrchardWarningTests.swift
@@ -1,0 +1,188 @@
+//
+//  SendConfirmationOrchardWarningTests.swift
+//  zodlTests
+//
+//  Covers the Orchard-spend warning bottom sheet shown on the send confirmation screen when the
+//  payment proposal spends legacy Orchard funds (Figma node 5139-23856): the `.onAppear`
+//  presentation gate, the one-shot `orchardWarningShown` flag that keeps it from re-presenting
+//  (SignWithKeystoneView shares this reducer and re-fires `.onAppear`), and the two-step cancel
+//  flow. Cancel must only turn into `.cancelTapped` once the sheet has actually finished
+//  dismissing (`.orchardWarningDismissed`, sent from the sheet's `onDismiss`) — otherwise SwiftUI
+//  would pop a screen that still presents a sheet.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// `SendConfirmation.State` carries `@Shared(.inMemory(...))` process-global storage (address book
+// contacts, feature flags, wallet accounts). `.serialized` only orders this suite's own tests — it
+// does NOT prevent other suites from running in parallel with it — so each test also binds a fresh
+// in-memory store via `withDependencies { $0.defaultInMemoryStorage = InMemoryStorage() }`, which is
+// what actually isolates this suite from cross-suite races on that storage. Same idiom as
+// `KeystoneFirmwareTests.swift`'s `KeystoneFirmwareGateTests`.
+@Suite(.serialized) @MainActor struct SendConfirmationOrchardWarningTests {
+    private func makeState(proposal: Proposal?) -> SendConfirmation.State {
+        SendConfirmation.State(
+            address: "ztestaddr",
+            amount: Zatoshi(100_000),
+            feeRequired: Zatoshi(10_000),
+            message: "",
+            proposal: proposal
+        )
+    }
+
+    private func makeStore(_ state: SendConfirmation.State) -> TestStore<SendConfirmation.State, SendConfirmation.Action> {
+        TestStore(initialState: state) {
+            SendConfirmation()
+        } withDependencies: {
+            $0.derivationTool = .liveValue
+            $0.zcashSDKEnvironment = .testnet
+        }
+    }
+
+    // MARK: - .onAppear presentation gate
+
+    @Test func onAppearPresentsWarningWhenProposalSpendsLegacyOrchardFunds() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
+            let store = makeStore(makeState(proposal: proposal))
+            store.exhaustivity = .off
+
+            await store.send(.onAppear)
+            await store.finish()
+            await store.skipReceivedActions(strict: false)
+
+            #expect(store.state.isOrchardWarningPresented)
+            #expect(store.state.orchardWarningShown)
+        }
+    }
+
+    @Test func onAppearDoesNotPresentWarningWhenProposalDoesNotSpendLegacyOrchardFunds() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0)
+            let store = makeStore(makeState(proposal: proposal))
+            store.exhaustivity = .off
+
+            await store.send(.onAppear)
+            await store.finish()
+            await store.skipReceivedActions(strict: false)
+
+            #expect(!store.state.isOrchardWarningPresented)
+            #expect(!store.state.orchardWarningShown)
+        }
+    }
+
+    @Test func onAppearDoesNotPresentWarningWhenProposalIsNil() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = makeStore(makeState(proposal: nil))
+            store.exhaustivity = .off
+
+            await store.send(.onAppear)
+            await store.finish()
+            await store.skipReceivedActions(strict: false)
+
+            #expect(!store.state.isOrchardWarningPresented)
+            #expect(!store.state.orchardWarningShown)
+        }
+    }
+
+    @Test func onAppearDoesNotRepresentWarningOnceAlreadyShown() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
+            var initialState = makeState(proposal: proposal)
+            // Simulates returning to this reducer's `.onAppear` a second time (e.g. after pushing
+            // into `confirmWithKeystone` and coming back) once the warning already ran its course.
+            initialState.orchardWarningShown = true
+            initialState.isOrchardWarningPresented = false
+
+            let store = makeStore(initialState)
+            store.exhaustivity = .off
+
+            await store.send(.onAppear)
+            await store.finish()
+            await store.skipReceivedActions(strict: false)
+
+            #expect(!store.state.isOrchardWarningPresented)
+            #expect(store.state.orchardWarningShown)
+        }
+    }
+
+    // MARK: - Continue anyway
+
+    @Test func continueTappedHidesSheetWithNoFollowUpActions() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
+            var initialState = makeState(proposal: proposal)
+            initialState.isOrchardWarningPresented = true
+            initialState.orchardWarningShown = true
+
+            let store = makeStore(initialState)
+
+            await store.send(.orchardWarningContinueTapped) {
+                $0.isOrchardWarningPresented = false
+            }
+            // Exhaustive TestStore: reaching `finish()` cleanly with no `.receive` call IS the
+            // "no follow-up actions" assertion — an unreceived action would fail here instead.
+            await store.finish()
+        }
+    }
+
+    // MARK: - Cancel
+
+    @Test func cancelTappedThenDismissedSendsCancelTapped() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
+            var initialState = makeState(proposal: proposal)
+            initialState.isOrchardWarningPresented = true
+            initialState.orchardWarningShown = true
+
+            let store = makeStore(initialState)
+
+            await store.send(.orchardWarningCancelTapped) {
+                $0.isOrchardWarningPresented = false
+                $0.pendingCancelFromOrchardWarning = true
+            }
+            // Only once the sheet has actually finished dismissing does cancel turn into
+            // `.cancelTapped` — never directly from `.orchardWarningCancelTapped`.
+            await store.send(.orchardWarningDismissed) {
+                $0.pendingCancelFromOrchardWarning = false
+            }
+            await store.receive(.cancelTapped)
+            await store.finish()
+        }
+    }
+
+    @Test func dismissedWithoutPendingCancelSendsNoActions() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
+            var initialState = makeState(proposal: proposal)
+            // Swipe-down dismissal with no pending cancel (e.g. after "Continue anyway" already
+            // hid the sheet) behaves like "Continue anyway": the user stays, no navigation.
+            initialState.isOrchardWarningPresented = false
+            initialState.orchardWarningShown = true
+            initialState.pendingCancelFromOrchardWarning = false
+
+            let store = makeStore(initialState)
+
+            await store.send(.orchardWarningDismissed)
+            await store.finish()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When the send confirmation (review) screen appears and the payment proposal spends legacy Orchard funds, the app now shows a warning bottom sheet ([design](https://www.figma.com/design/1aeq8gleYh9Yr1l33TwELR/PR-App-Designs-Q3--26?node-id=5139-23856&m=dev)): *"This send requires spending Orchard funds — We recommend migrating your funds first to avoid leaking the transaction amount on-chain."*

- **Continue anyway** (outline destructive) dismisses the sheet; the user stays on the confirmation screen. Swipe-down behaves the same.
- **Cancel** (primary) dismisses the sheet and then navigates back to the send form — the pop is deferred until the sheet's real `onDismiss`, and the cancel action shares the exact case of each coordinator's existing back-button handling so the two can never diverge (in the scan flow that means popping past a stale `.scan` element back to the form).
- Shown once per confirmation-screen instance, on both `SendConfirmationView` and `RequestPaymentConfirmationView`, driven by a dedicated `confirmationScreenAppeared` action so screens that share the reducer without attaching the sheet (e.g. the SwapAndPay Keystone path) can never trip or burn the one-shot latch.

Detection reads the actual proposal via the new SDK API `Proposal.spendsLegacyOrchardFunds` — no balance heuristics.

## SDK dependency (temporary)

The first commit switches the project to the local sibling `zcash-swift-wallet-sdk` package (per agreement) because the required SDK API is not in the pinned `2.8.0-rc.1`. Building this branch therefore requires a sibling checkout of the SDK branch `michal/proposal-spends-orchard-funds` (SDK PR: https://github.com/zcash/zcash-swift-wallet-sdk/pull/1926). The pin should be restored to an exact version once the next SDK RC tag containing the API exists.

## Testing

- New `SendConfirmationOrchardWarningTests` (Swift Testing, TestStore): presentation for orchard/non-orchard/nil proposals, the one-shot latch, continue vs. cancel vs. bare-dismissal semantics, and a regression test that the shared `.onAppear` alone never presents.
- New regression test in `ScanCoordFlowZip321Tests`: cancelling from the request-payment confirmation pops past a stale scan screen back to the send form (documents the pre-existing `coordinatorReduce()`-before-`forEach` TCA warning via `withKnownIssue`).
- Full `zodl-internal` suite: 702 tests in 114 suites, 0 failures.

No linked issue by agreement for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
