### PR TITLE
[MOB-1466] Never reveal the entry fork beneath a pushed migration re-entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] Leaving the migration plan review screen via the back button, before you've started the plan, now asks you to confirm first — "Your migration hasn't started yet. Leaving now won't schedule any transfers." — so you can't accidentally back out thinking your migration is already underway.
 - [MOB-1466] A successful migration transfer no longer wedges the wallet: the sync gate's refusal to start (part of the migration privacy protection) is now handled as the broadcast session it actually signals, instead of showing a fatal, unrecoverable initialization error.
 - [MOB-1466] The Migration Progress screen and banner now always show the engine's live state — the stale-cache layer that could show an outdated transfer/split status (or a pre-commit empty screen) while proving ran has been removed.
+- [MOB-1466] Opening the migration from the banner no longer flashes or stacks the mode-picker screen beneath the migration progress screen.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] A successful migration transfer no longer wedges the wallet: the sync gate's refusal to start (part of the migration privacy protection) is now handled as the broadcast session it actually signals, instead of showing a fatal, unrecoverable initialization error.
 - [MOB-1466] The Migration Progress screen and banner now always show the engine's live state — the stale-cache layer that could show an outdated transfer/split status (or a pre-commit empty screen) while proving ran has been removed.
 - [MOB-1466] Opening the migration from the banner no longer flashes or stacks the mode-picker screen beneath the migration progress screen.
+- [MOB-1466] Swiping back off the very first screen shown when re-opening an in-progress migration now closes the migration flow, instead of leaving a blank, stuck screen with no way forward except quitting the app.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -846,6 +846,17 @@ extension MigrationCoordFlow {
                 // Closes the flow the same way; Root routes on to Activity.
                 return .send(.flowFinished)
 
+            case .path(.popFrom(id: let id)):
+                // An interactive back-swipe off the LAST element of a re-entry stack whose fork
+                // was never revealed would land on the permanently-hidden spinner root — a
+                // dead end with no toolbar and no gestures. Leaving the flow is what the
+                // gesture meant; finish it. (A pop deeper in the stack, or any pop when the
+                // fork IS the revealed root, keeps ordinary pop semantics.) Runs BEFORE
+                // `.forEach(\.path, action: \.path)` below removes the element, so `state.path`
+                // here is still the PRE-pop stack — see `MigrationCoordFlowStore.body`.
+                guard !state.isReentryResolved && state.path.ids == [id] else { return .none }
+                return .send(.flowFinished)
+
             case .path:
                 return .none
             }

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+import SwiftUI
 import ComposableArchitecture
 @preconcurrency import ZcashLightClientKit
 
@@ -51,22 +52,20 @@ extension MigrationCoordFlow {
                 // Armed unconditionally: the flow is on screen whether this open is fresh or a
                 // re-entry mid-stack; disarmed at `flowFinished`/`switchServerRequested`.
                 migrationManager.setMigrationFlowPresented(state.selectedWalletAccount?.id, true)
-                // A screen is already on the stack, so nothing is about to be decided and the root
-                // must not stay hidden behind a resolution that will never run — see
-                // `State.isReentryResolved`.
-                guard state.path.isEmpty else {
-                    state.isReentryResolved = true
-                    return .none
-                }
+                // A screen is already on the stack: routing already ran (or the stack was
+                // hydrated) and the root's visibility is whatever that resolution chose. The
+                // old force-reveal here re-revealed the fork beneath a pushed re-entry stack.
+                guard state.path.isEmpty else { return .none }
                 return .run { [accountUUID = state.selectedWalletAccount?.id] send in
                     let pathState = await reentryPathState(accountUUID: accountUUID)
-                    // PUSH first, reveal second — and the push does BOTH in one mutation. The
-                    // previous ordering (reveal, then push) was two separate sends, so SwiftUI could
-                    // render between them: root revealed, path still empty, fork on screen. Exactly
-                    // the flash this was meant to remove, just narrower. `nil` means the fork IS the
-                    // destination, and only then is a bare reveal correct.
+                    // The fork reveals ONLY when routing chose it (`nil` — the fork IS the
+                    // destination). A pushed destination leaves the root hidden forever, and
+                    // the push lands without an animation frame so the destination appears
+                    // directly instead of sliding over the hidden root.
                     if let pathState {
-                        await send(.pushHydratedPathState(pathState))
+                        var transaction = Transaction()
+                        transaction.disablesAnimations = true
+                        await send(.pushHydratedPathState(pathState), transaction: transaction)
                     } else {
                         await send(.reentryResolved)
                     }
@@ -99,10 +98,11 @@ extension MigrationCoordFlow {
                 return .none
 
             case .pushHydratedPathState(let pathState):
-                // Both in ONE mutation, so no render can catch the root revealed with an empty
-                // path — which is the state that shows the fork. See `State.isReentryResolved`.
+                // Append WITHOUT revealing the root: the fork renders only when routing chose
+                // it (`.reentryResolved`), so a pushed re-entry destination sits over the
+                // neutral, permanently-hidden spinner — never over a tappable fork offering a
+                // choice the committed run already made.
                 state.path.append(pathState)
-                state.isReentryResolved = true
                 return .none
 
             case .pushHydratedStatus(let statusState):

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowStore.swift
@@ -113,17 +113,25 @@ struct MigrationCoordFlow {
     struct State: Equatable {
         var path = StackState<Path.State>()
         var entryState = MigrationEntry.State()
-        /// Whether re-entry routing has finished deciding which screen this flow opens on.
+        /// Whether re-entry routing chose the fork itself as the destination — the ONLY condition
+        /// under which the flow root reveals.
         ///
         /// Entry is the flow's ROOT screen, so it renders the instant the flow opens, while the real
         /// destination is only APPENDED once `reentryPathState`'s async reads resolve. On a committed
-        /// run that means the fork — "migrate privately, or manually?" — flashes up before the status
-        /// screen replaces it, which is what a tester saw on 07-31. Worse than untidy: the fork
-        /// offers a CHOICE a committed run has already made, and a fast tap on it starts a second
-        /// flow over a live one.
+        /// run that means the fork — "migrate privately, or manually?" — flashed up before the status
+        /// screen replaced it, which is what a tester saw on 07-31: the fork offers a CHOICE a
+        /// committed run has already made, and a fast tap on it starts a second flow over a live one.
         ///
-        /// So the root renders nothing until this is true. The wait is identical either way; this
-        /// only stops the app asserting something it has not established yet.
+        /// FIELD BUG (2026-08-06): merely holding the root back until "routing has decided" was not
+        /// enough — `pushHydratedPathState` used to reveal AND push in the same mutation, so a
+        /// resolved PUSH destination still satisfied this flag, and the fork became the push
+        /// animation's own visible base layer, staying beneath the destination for the stack's whole
+        /// life.
+        ///
+        /// So: revealed IFF routing chose the fork (`reentryPathState` returning `nil` — the fork IS
+        /// the destination). A resolved push destination never sets this — the root stays hidden for
+        /// that stack's entire life, and the pushed screen renders over a neutral, permanently-hidden
+        /// root instead of a tappable fork.
         var isReentryResolved = false
         /// The lane the user picked at the fork. Held here so a later hop in the same run doesn't
         /// need to re-read it. #1930 also persisted it via `migrationManager.setMigrationMode`;
@@ -208,6 +216,7 @@ struct MigrationCoordFlow {
         case path(StackActionOf<Path>)
         /// Pushes a path state that had to be hydrated asynchronously first (the network snapshot
         /// must exist before anything downstream reads it), so the push itself stays synchronous.
+        /// Appends without revealing the root — see `State.isReentryResolved`.
         case pushHydratedPathState(Path.State)
         /// Re-entry routing has decided — reveal the flow root. See `State.isReentryResolved`.
         case reentryResolved

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowView.swift
@@ -23,7 +23,8 @@ struct MigrationCoordFlowView: View {
     var body: some View {
         WithPerceptionTracking {
             NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-                // Held blank until re-entry routing has decided (`State.isReentryResolved`). Entry is
+                // Held blank unless re-entry routing chose the fork — a pushed destination keeps
+                // this root hidden for the flow's whole life (`State.isReentryResolved`). Entry is
                 // this stack's ROOT, so rendering it eagerly flashed the "privately or manually?"
                 // fork on every committed run — offering a choice already made, and tappable while
                 // it showed. The pause is the same wait either way; it just no longer asserts a

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -1696,10 +1696,11 @@ extension Root {
 
     // MARK: - PHASE 7: opening the migration flow from OUTSIDE it
 
-    /// The single entry point for every Root-side site that opens (or re-opens) the migration flow:
-    /// the banner tap and the notification tap. Both replace `migrationCoordFlowState` wholesale, so
-    /// both must run the same defensive teardown first — hence one helper rather than two inline
-    /// resets that can drift.
+    /// The single entry point for opening (or re-opening) the migration flow. Currently reached
+    /// from one Root-side site — the banner tap (notification taps land on Home now, not here) —
+    /// but kept as its own helper rather than inlined at the call site: replacing
+    /// `migrationCoordFlowState` wholesale must always run the same defensive teardown first, and a
+    /// second call site would otherwise risk drifting from it.
     func openMigrationCoordFlow(state: inout Root.State) -> Effect<Root.Action> {
         let cancelEffect = cancelAbandonedKeystoneMigrationRun(state: state)
         state.migrationCoordFlowState = MigrationCoordFlow.State.initial

--- a/zodlTests/MigrationTests/MigrationCoordFlowReentryRevealTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowReentryRevealTests.swift
@@ -1,0 +1,105 @@
+//
+//  MigrationCoordFlowReentryRevealTests.swift
+//  zodlTests
+//
+//  FIELD BUG (2026-08-06): a re-entry with a committed run that resolves to a PUSH destination
+//  (e.g. the status screen) showed the entry fork — "migrate privately, or manually?" — as the
+//  visible base layer beneath the pushed screen, permanently: `pushHydratedPathState` used to
+//  append the path element AND set `isReentryResolved = true` in the SAME mutation, so the root's
+//  reveal condition was satisfied with the destination merely stacked on top of it. Reachable from
+//  the banner: tap it, and the fork sat there under whatever the (fast) SDK reads resolved to.
+//
+//  THE CONTRACT this suite pins: the fork reveals IFF routing itself chose it as the destination
+//  (`reentryRoute()` resolving to `.entry`, i.e. `reentryPathState` returning `nil`). A resolved
+//  PUSH destination must never flip `isReentryResolved` — the root stays hidden for that stack's
+//  whole life, so a pushed screen always renders over a neutral, permanently-hidden root rather
+//  than a tappable fork offering a choice the committed run already made.
+//
+
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct MigrationCoordFlowReentryRevealTests {
+    /// Re-entry that resolves to a PUSH destination: the element is appended and the fork stays
+    /// hidden — `isReentryResolved` remains false, permanently.
+    @Test func aPushDestinationKeepsTheForkHidden() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State.initial) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            // `statusProgressState` reads this off the sdkSynchronizer for the footer's minutes
+            // copy — `.mock` answers every member benignly (0 duration included), unlike the
+            // dependency's own `testValue`, which is `unimplemented` here.
+            $0.sdkSynchronizer = .mock
+            var client = MigrationManagerClient.noOp
+            client.reentryRoute = { .statusProgress }
+            $0.migrationManager = client
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushHydratedPathState, timeout: .seconds(5))
+
+        #expect(store.state.path.count == 1, "a resolved push destination must land exactly one path element")
+        guard case .status(_)? = store.state.path.last else {
+            Issue.record("expected the push to land a .status element, got \(String(describing: store.state.path.last))")
+            return
+        }
+        #expect(!store.state.isReentryResolved, "a pushed re-entry destination must keep the fork hidden — it never reveals")
+
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+    }
+
+    /// Re-entry that resolves to the FORK (route .entry): no push, and the fork reveals via
+    /// .reentryResolved.
+    @Test func aForkDestinationRevealsWithoutPushing() async {
+        let store = TestStore(initialState: MigrationCoordFlow.State.initial) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            var client = MigrationManagerClient.noOp
+            client.reentryRoute = { .entry }
+            $0.migrationManager = client
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.reentryResolved, timeout: .seconds(5))
+
+        #expect(store.state.path.isEmpty, "the fork IS the destination — nothing should be pushed")
+        #expect(store.state.isReentryResolved, "routing chose the fork, so it must reveal")
+
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+    }
+
+    /// A re-appear with a non-empty path leaves the flag untouched (both prior values) — the
+    /// old branch force-flipped it true, which re-revealed the fork beneath a pushed stack.
+    @Test func aReappearWithANonEmptyPathLeavesTheFlagAlone() async {
+        var pathPresentState = MigrationCoordFlow.State.initial
+        pathPresentState.path.append(.status(MigrationStatus.State(presentation: .resume)))
+
+        // Prior == false: the regression case. The old branch force-flipped this to true, which
+        // is exactly the re-reveal this suite exists to forbid — an exhaustive send with no
+        // trailing closure asserts NO state change at all.
+        var hiddenPriorState = pathPresentState
+        hiddenPriorState.isReentryResolved = false
+        let hiddenPriorStore = TestStore(initialState: hiddenPriorState) {
+            MigrationCoordFlow()
+        }
+        await hiddenPriorStore.send(.onAppear)
+
+        // Prior == true: pinned too, so a future change can't silently start flipping it false
+        // on a re-appear either.
+        var revealedPriorState = pathPresentState
+        revealedPriorState.isReentryResolved = true
+        let revealedPriorStore = TestStore(initialState: revealedPriorState) {
+            MigrationCoordFlow()
+        }
+        await revealedPriorStore.send(.onAppear)
+    }
+}

--- a/zodlTests/MigrationTests/MigrationCoordFlowReentryRevealTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowReentryRevealTests.swift
@@ -102,4 +102,57 @@ import Testing
         }
         await revealedPriorStore.send(.onAppear)
     }
+
+    /// FIELD BUG (2026-08-06, whole-branch review): with the reveal gated off, a pushed re-entry
+    /// stack is exactly one element over a permanently-hidden spinner root. An interactive
+    /// back-swipe (live in this app despite hidden back buttons — see
+    /// `MigrationTransferPlanStore.backTapped`'s own KNOWN LIMITATION, and the scan-ceremony
+    /// tombstones this same coordinator already carries for it) pops that element down to an
+    /// empty path with nothing to land on. Leaving the flow is what the gesture meant, so the
+    /// coordinator finishes it instead. The counterpart guards ordinary navigation: once the fork
+    /// IS the revealed root, popping back onto it is just an ordinary pop.
+    @Test func aBackSwipeThatEmptiesAnUnrevealedStackFinishesTheFlow() async {
+        // Re-entry push, reusing test 1's setup: the fork never reveals, so the pushed element is
+        // the whole stack.
+        let store = TestStore(initialState: MigrationCoordFlow.State.initial) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            $0.sdkSynchronizer = .mock
+            var client = MigrationManagerClient.noOp
+            client.reentryRoute = { .statusProgress }
+            $0.migrationManager = client
+        }
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.pushHydratedPathState, timeout: .seconds(5))
+
+        guard let pushedId = store.state.path.ids.first else {
+            Issue.record("expected a pushed path element to pop")
+            return
+        }
+
+        await store.send(.path(.popFrom(id: pushedId)))
+        await store.receive(\.flowFinished, timeout: .seconds(5))
+
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+
+        // Counterpart guard: the fork IS the revealed root, with something pushed over it via
+        // ordinary navigation — popping back onto an already-revealed root must stay an ordinary
+        // pop. Exhaustive store: no `.flowFinished` may be produced, and the only expected state
+        // change is the pop itself.
+        var forkOriginState = MigrationCoordFlow.State.initial
+        forkOriginState.path.append(.status(MigrationStatus.State(presentation: .resume)))
+        forkOriginState.isReentryResolved = true
+        let poppedId = forkOriginState.path.ids[0]
+
+        let forkOriginStore = TestStore(initialState: forkOriginState) {
+            MigrationCoordFlow()
+        }
+        await forkOriginStore.send(.path(.popFrom(id: poppedId))) {
+            $0.path.removeAll()
+        }
+    }
 }


### PR DESCRIPTION
Field report (2026-08-06): tapping "More" on the migration SmartBanner showed the
mode-picker fork at the bottom with the progress screen stacking above it. The flow's
NavigationStack root is the fork; a committed-run re-entry pushes its destination over it,
and the reveal was fused into the push mutation — so the fork was the push animation's
visible base layer and stayed beneath the destination. Millisecond route resolution (the
read-only SDK reads) made the composition visible where seconds of spinner used to mask it.

Fix: the fork's reveal is gated on routing actually choosing it. A pushed destination
appends over the permanently-hidden neutral root through a disabled-animation transaction
(appears directly, no slide-over); only the `.entry` route reveals the fork; the re-appear
branch stops force-revealing. Every pushed flow-root screen closes instead of popping
(`isFlowRoot`), so the hidden root has no reachable exposure — and any accidental exposure
is now a spinner, not a tappable choice the committed run already made.

Three TestStore pins cover the contract (push keeps the fork hidden; fork route reveals
without pushing; re-appear leaves the flag alone). Full zodlTests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
