### PR TITLE
Push the scheduled screen synchronously after a plan commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] The Migration Progress screen and banner now always show the engine's live state — the stale-cache layer that could show an outdated transfer/split status (or a pre-commit empty screen) while proving ran has been removed.
 - [MOB-1466] Opening the migration from the banner no longer flashes or stacks the mode-picker screen beneath the migration progress screen.
 - [MOB-1466] Swiping back off the very first screen shown when re-opening an in-progress migration now closes the migration flow, instead of leaving a blank, stuck screen with no way forward except quitting the app.
+- Confirming a migration transfer plan now lands on the scheduled screen immediately, and the Confirm button can no longer be tapped again after a successful commit.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] The Migration Progress screen and banner now always show the engine's live state — the stale-cache layer that could show an outdated transfer/split status (or a pre-commit empty screen) while proving ran has been removed.
 - [MOB-1466] Opening the migration from the banner no longer flashes or stacks the mode-picker screen beneath the migration progress screen.
 - [MOB-1466] Swiping back off the very first screen shown when re-opening an in-progress migration now closes the migration flow, instead of leaving a blank, stuck screen with no way forward except quitting the app.
-- Confirming a migration transfer plan now lands on the scheduled screen immediately, and the Confirm button can no longer be tapped again after a successful commit.
+- The Confirm button on a migration transfer plan now keeps its loading indicator up until your transfers are prepared and presigned (the first delivery kicked off), then opens the Migration Scheduled screen — one tap, no dead first tap, and the Home banner reflects the committed run when you return. The Confirm button still can no longer be tapped again after a successful commit.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -989,11 +989,14 @@ extension MigrationCoordFlow {
     /// sweep — the first-tap "nothing happens" stall, which survived the read-only-reads work
     /// precisely because those two hops are writers.
     ///
-    /// Field 2026-08-06: `.delegate(.confirmed)` itself now arrives LATER than it used to —
+    /// Field 2026-08-06: for the software `.transferPlan(.delegate(.confirmed))` caller (:196)
+    /// ONLY, `.delegate(.confirmed)` itself now arrives LATER than it used to —
     /// `MigrationTransferPlan` holds it back behind an awaited first drive (`.scheduleCommitted`),
-    /// so by the time this builder runs, that drive (at tip) has already run its course, or was
-    /// skipped mid-sync. Either way the write actor the async summary used to queue behind is
-    /// free again by the time `transferPlanPostConfirmChain` below reads the snapshot.
+    /// so by the time THAT caller reaches this builder, the drive (at tip) has already run its
+    /// course, or was skipped mid-sync. This builder has two OTHER callers that reach it WITHOUT
+    /// any awaited drive at all: the recovery refresh-stale push below (:335), and the Keystone
+    /// `planCommit` resume (`resumeCommittedMigrationChain`, :1290) — the Keystone lane's own
+    /// first-drive gap is a known limitation, flagged in the PR as not yet fixed.
     static func scheduledStateNow(
         schedule: MigrationSchedule?,
         snapshot: MigrationViewSnapshot?
@@ -1022,12 +1025,16 @@ extension MigrationCoordFlow {
             // the screen is up, its latency off the navigation path — where a post-commit
             // prove sweep can no longer hold the push hostage.
             //
-            // Field 2026-08-06: this push itself now lands AFTER the run's awaited first drive —
-            // `MigrationTransferPlan` holds `.delegate(.confirmed)` back behind its own
-            // `.scheduleCommitted` handler until that drive completes (or is skipped mid-sync), so
-            // by the time control reaches here the write actor the drive's prove sweep can hold is
-            // free again — the snapshot refresh below republishes against a free actor instead of
-            // queuing behind the very sweep this chain just ran.
+            // Field 2026-08-06: for this function's SOFTWARE caller (the `.transferPlan
+            // (.delegate(.confirmed))` case at :196) ONLY, this push now lands AFTER the run's
+            // awaited first drive — `MigrationTransferPlan` holds `.delegate(.confirmed)` back
+            // behind its own `.scheduleCommitted` handler until that drive completes (or is
+            // skipped mid-sync), so by the time control reaches here on THAT path the write actor
+            // the drive's prove sweep can hold is free again, and the snapshot refresh below
+            // republishes against a free actor. This function's OTHER caller — the Keystone
+            // `planCommit` resume (`resumeCommittedMigrationChain`, :1290) — reaches here WITHOUT
+            // any awaited drive at all; the Keystone lane's own first-drive gap is a known
+            // limitation, flagged in the PR as not yet fixed.
             state.path.append(.scheduled(Self.scheduledStateNow(
                 schedule: schedule,
                 snapshot: migrationManager.currentMigrationSnapshot(accountUUID)

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -332,9 +332,10 @@ extension MigrationCoordFlow {
                             // app would keep showing the STALE pre-refresh schedule.
                             await migrationManager.recordCommittedSchedule(account.id, schedule)
                             await migrationManager.reconcile()
-                            await send(.pushHydratedPathState(.scheduled(
-                                await scheduledState(accountUUID: account.id, schedule: schedule)
-                            )))
+                            await send(.pushHydratedPathState(.scheduled(Self.scheduledStateNow(
+                                schedule: schedule,
+                                snapshot: migrationManager.currentMigrationSnapshot(account.id)
+                            ))))
                         } catch {
                             await send(.recoveryFailed)
                         }
@@ -969,6 +970,27 @@ extension MigrationCoordFlow {
 
     // MARK: - Post-confirm (#1930 :1689)
 
+    /// Post-commit hydration WITHOUT the engine: a just-committed schedule's numbers are known
+    /// by definition (nothing sent yet; the totals are the schedule's own), and prior rounds'
+    /// moved value comes from the PUBLISHED snapshot — a synchronous read of the channel's
+    /// last value, never actor-bound. The async summary this replaces crossed the DB write
+    /// actor twice (`migrationState`'s advance-step read, `residualAfterMigration`) and queued
+    /// behind the post-commit prove sweep — the first-tap "nothing happens" stall, which
+    /// survived the read-only-reads work precisely because those two hops are writers.
+    static func scheduledStateNow(
+        schedule: MigrationSchedule?,
+        snapshot: MigrationViewSnapshot?
+    ) -> MigrationScheduled.State {
+        let newScheduleAmount = schedule?.transfers.reduce(Zatoshi.zero) { $0 + $1.amount } ?? Zatoshi.zero
+        let priorMoved = snapshot?.movedByDoneTransfers ?? Zatoshi.zero
+        return MigrationScheduled.State(
+            totalAmount: priorMoved + newScheduleAmount,
+            sentCount: 0,
+            totalCount: schedule?.transfers.count ?? (snapshot?.totalTransfers ?? 0),
+            durationHours: schedule?.estimatedDurationHours ?? 0
+        )
+    }
+
     private func transferPlanPostConfirmChain(
         variant: MigrationTransferPlan.State.Variant,
         schedule: MigrationSchedule?,
@@ -977,13 +999,18 @@ extension MigrationCoordFlow {
         let accountUUID = state.selectedWalletAccount?.id
         switch variant {
         case .scheduled, .recreated:
-            // PHASE 4 lands the notification arm exactly where #1930 ran
-            // `migrationBGScheduler.scheduleFirstWindow()`. The BG half stays gone (D2): a window
-            // can be ANNOUNCED ahead of time, never acted on in the background.
-            return .run { [migrationManager] send in
-                let scheduled = await scheduledState(accountUUID: accountUUID, schedule: schedule)
-                await send(.pushHydratedPathState(.scheduled(scheduled)))
+            // PUSH SYNCHRONOUSLY — the same shape the `.manual` arm below has always used.
+            // Everything the Scheduled screen shows is in hand (see `scheduledStateNow`);
+            // the engine work that remains (window arming, the snapshot rebuild) runs AFTER
+            // the screen is up, its latency off the navigation path — where a post-commit
+            // prove sweep can no longer hold the push hostage.
+            state.path.append(.scheduled(Self.scheduledStateNow(
+                schedule: schedule,
+                snapshot: migrationManager.currentMigrationSnapshot(accountUUID)
+            )))
+            return .run { [migrationManager] _ in
                 await migrationManager.armNextWindowNotifications(accountUUID)
+                migrationManager.refreshMigrationSnapshot(accountUUID)
             }
         case .manual:
             // The manual-delivery run's FIRST transfer — same "sent" wording as every subsequent
@@ -1244,20 +1271,6 @@ extension MigrationCoordFlow {
     }
 
     // MARK: - State hydration (#1930 :1777 / :2750 / :2837)
-
-    private func scheduledState(accountUUID: AccountUUID?, schedule: MigrationSchedule?) async -> MigrationScheduled.State {
-        let summary = await migrationManager.migrationSummary(accountUUID)
-        let newScheduleAmount = schedule?.transfers.reduce(Zatoshi.zero) { $0 + $1.amount } ?? Zatoshi.zero
-        return MigrationScheduled.State(
-            // `summary.transferred` is only nil on the no-committed-schedule fallback — impossible
-            // here, since this hydrates right after `recordCommittedSchedule` has run. `.zero` is
-            // the correct additive identity regardless.
-            totalAmount: (summary.transferred ?? Zatoshi.zero) + newScheduleAmount,
-            sentCount: summary.transfersSent,
-            totalCount: summary.transfersTotal,
-            durationHours: summary.estimatedDurationHours ?? 0
-        )
-    }
 
     /// R13 Brick 2: hydration is ONE read of ONE value. The pre-Brick-2 version fetched rows,
     /// summary and the snapshot as three separate calls at three moments — three clocks inside a

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -988,6 +988,12 @@ extension MigrationCoordFlow {
     /// advance-step read, `residualAfterMigration`) and queued behind the post-commit prove
     /// sweep — the first-tap "nothing happens" stall, which survived the read-only-reads work
     /// precisely because those two hops are writers.
+    ///
+    /// Field 2026-08-06: `.delegate(.confirmed)` itself now arrives LATER than it used to —
+    /// `MigrationTransferPlan` holds it back behind an awaited first drive (`.scheduleCommitted`),
+    /// so by the time this builder runs, that drive (at tip) has already run its course, or was
+    /// skipped mid-sync. Either way the write actor the async summary used to queue behind is
+    /// free again by the time `transferPlanPostConfirmChain` below reads the snapshot.
     static func scheduledStateNow(
         schedule: MigrationSchedule?,
         snapshot: MigrationViewSnapshot?
@@ -1015,6 +1021,13 @@ extension MigrationCoordFlow {
             // the engine work that remains (window arming, the snapshot rebuild) runs AFTER
             // the screen is up, its latency off the navigation path — where a post-commit
             // prove sweep can no longer hold the push hostage.
+            //
+            // Field 2026-08-06: this push itself now lands AFTER the run's awaited first drive —
+            // `MigrationTransferPlan` holds `.delegate(.confirmed)` back behind its own
+            // `.scheduleCommitted` handler until that drive completes (or is skipped mid-sync), so
+            // by the time control reaches here the write actor the drive's prove sweep can hold is
+            // free again — the snapshot refresh below republishes against a free actor instead of
+            // queuing behind the very sweep this chain just ran.
             state.path.append(.scheduled(Self.scheduledStateNow(
                 schedule: schedule,
                 snapshot: migrationManager.currentMigrationSnapshot(accountUUID)

--- a/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/MigrationCoordFlowCoordinator.swift
@@ -970,13 +970,24 @@ extension MigrationCoordFlow {
 
     // MARK: - Post-confirm (#1930 :1689)
 
-    /// Post-commit hydration WITHOUT the engine: a just-committed schedule's numbers are known
-    /// by definition (nothing sent yet; the totals are the schedule's own), and prior rounds'
-    /// moved value comes from the PUBLISHED snapshot — a synchronous read of the channel's
-    /// last value, never actor-bound. The async summary this replaces crossed the DB write
-    /// actor twice (`migrationState`'s advance-step read, `residualAfterMigration`) and queued
-    /// behind the post-commit prove sweep — the first-tap "nothing happens" stall, which
-    /// survived the read-only-reads work precisely because those two hops are writers.
+    /// Post-commit hydration WITHOUT the engine: a just-committed schedule's transfer count and
+    /// amount sum are known by definition (the schedule IS the plan), and both the moved value
+    /// AND the sent count fold in the PUBLISHED snapshot's cumulative totals — a synchronous read
+    /// of the channel's last value, never actor-bound.
+    ///
+    /// `sentCount` is not always 0: a fresh round-1 commit has nothing sent yet (a `nil`
+    /// snapshot folds in nothing), but the recovery refresh-stale lane re-serves the run's
+    /// STORED schedule, which can already carry transfers broadcast in an earlier round. The
+    /// snapshot's `doneTransfers`/`movedByDoneTransfers` re-materialize those via `leadingRows`
+    /// (prior `sentRecords` no longer in the current schedule) pre- or post-commit, so folding
+    /// `doneTransfers` here keeps the count on the SAME cumulative-confirmed basis `totalAmount`
+    /// already uses — a hardcoded 0 would have regressed the recovery lane's success screen to
+    /// "0 of N" for a run that had already sent several.
+    ///
+    /// The async summary this replaces crossed the DB write actor twice (`migrationState`'s
+    /// advance-step read, `residualAfterMigration`) and queued behind the post-commit prove
+    /// sweep — the first-tap "nothing happens" stall, which survived the read-only-reads work
+    /// precisely because those two hops are writers.
     static func scheduledStateNow(
         schedule: MigrationSchedule?,
         snapshot: MigrationViewSnapshot?
@@ -985,7 +996,7 @@ extension MigrationCoordFlow {
         let priorMoved = snapshot?.movedByDoneTransfers ?? Zatoshi.zero
         return MigrationScheduled.State(
             totalAmount: priorMoved + newScheduleAmount,
-            sentCount: 0,
+            sentCount: snapshot?.doneTransfers ?? 0,
             totalCount: schedule?.transfers.count ?? (snapshot?.totalTransfers ?? 0),
             durationHours: schedule?.estimatedDurationHours ?? 0
         )
@@ -1257,6 +1268,11 @@ extension MigrationCoordFlow {
     ) -> Effect<Action> {
         switch context {
         case .planCommit:
+            // The underlying `MigrationTransferPlan.State.hasConfirmed` is still `false` here —
+            // the Keystone lane deliberately never sets it (see the Store's own doc on that
+            // property) — but that's safe at this exact point: the push below covers this screen
+            // with `.scheduled`, which hides its back affordance, so the un-latched plan screen
+            // is never reachable again for `.backTapped`/`.confirmTapped` to act on.
             guard case let .transferPlan(planState) = state.path.last else { return .none }
             return transferPlanPostConfirmChain(variant: planState.variant, schedule: planState.schedule, state: &state)
 

--- a/secant/Sources/Features/Migration/MigrationCommitPipeline.swift
+++ b/secant/Sources/Features/Migration/MigrationCommitPipeline.swift
@@ -49,9 +49,15 @@
 //  commit: signs EVERYTHING of the run — every transfer AND any note-split preparation layers it
 //  needs — straight from the plan cache `schedule`'s own propose call already wrote, with NO
 //  proving and NO broadcast) -> `recordCommittedSchedule` -> `reconcile`. The first prep's actual
-//  broadcast (prove-at-broadcast, Tor, privacy buffer) happens AFTER navigation, via
-//  `MigrationCoordFlowCoordinator`'s post-confirm first-delivery kick over the existing next-due
-//  lane — see `runFirstDeliveryKick`'s doc there. NEVER add a `submitNoteSplit` OR a
+//  broadcast (prove-at-broadcast, Tor, privacy buffer) happens via the DRIVER lane
+//  (`MigrationManagerClient.advance`), never inline in this pipeline. Field 2026-08-06: for the
+//  software SCHEDULED-PLAN commit — this function, called from `MigrationTransferPlanStore` — that
+//  drive now runs UNDER the Confirm loader: `MigrationTransferPlan`'s `.scheduleCommitted` awaits
+//  `advance(.afterSync)` at tip (mid-sync it defers to the coming sync edge instead), BEFORE
+//  navigation. Root's G1 `.confirmed` case still fires afterward too, now only as an idempotent
+//  backstop for that lane — and remains the ONLY drive for the `reviewTransfer` lane
+//  (`MigrationReviewTransferStore`'s immediate-sweep commit, which never calls this function and
+//  gained no loader-side drive of its own). NEVER add a `submitNoteSplit` OR a
 //  `prepareNoteSplit` call ahead of `signAndStoreMigrationSchedule` here (MOB-1513 F1-A1): the SDK
 //  holds ONE proposal-handle slot per account (`MigrationSchedule.proposalHandle`'s doc), and ANY
 //  propose/prepare call for that account — `prepareNoteSplit` included — supersedes whatever

--- a/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledStore.swift
+++ b/secant/Sources/Features/Migration/MigrationScheduled/MigrationScheduledStore.swift
@@ -4,12 +4,15 @@
 //
 //  "Migration Scheduled" screen (MOB-1463, Figma S9 · 2630:11282). Terminal success screen shown
 //  once a scheduled migration plan has been confirmed: a summary card of what's being transferred
-//  and over how long. The coordinator's one production call site (`MigrationCoordFlowCoordinator
-//  .transferPlanPostConfirmChain`'s `.scheduled`/`.recreated` case) hydrates `totalAmount`/
-//  `sentCount`/`totalCount`/`durationHours` from the just-committed schedule plus
-//  `migrationManager.migrationSummary(accountUUID)` (MOB-1458 W-E — closes the MOB-1466 gap this
-//  screen used to carry; see that method's doc for the exact source of each field). The coordinator
-//  does consume the `doneTapped` delegate (MigrationCoordFlowCoordinator, MOB-1466).
+//  and over how long. Hydrated by `MigrationCoordFlowCoordinator.scheduledStateNow(schedule:
+//  snapshot:)` — `totalAmount`/`sentCount`/`totalCount`/`durationHours` come from the
+//  just-committed (or recovery-rebuilt) schedule's own numbers plus a SYNCHRONOUS read of the
+//  published `MigrationViewSnapshot` for cumulative moved value and sent count; the engine is
+//  never consulted on this path. Two production call sites build `.scheduled` state this way —
+//  `transferPlanPostConfirmChain`'s `.scheduled`/`.recreated` case, and the recovery
+//  refresh-stale push (MOB-1466 — closes the async-hydration stall this screen used to carry; see
+//  `scheduledStateNow`'s own doc for the exact source of each field). The coordinator does
+//  consume the `doneTapped` delegate (MigrationCoordFlowCoordinator, MOB-1466).
 //
 //  The "Dust balance remaining" card MOB-1458 (W-E, Figma 3480:7631) put below the summary rows is
 //  GONE — the component is no longer valid for this screen. `MigrationComplete`'s own dust card

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -539,6 +539,10 @@ struct MigrationTransferPlan {
                     MigrationTrace.event("CONFIRM tap ignored — a confirm leg is already in flight")
                     return .none
                 }
+                guard !state.hasConfirmed else {
+                    MigrationTrace.event("CONFIRM tap ignored — this plan is already committed")
+                    return .none
+                }
                 state.isFailurePresented = false
 
                 // MOB-1496 (R8-T1, S3): a propose failure's Retry re-proposes instead of

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -403,8 +403,9 @@ struct MigrationTransferPlan {
         case backTapped
         /// Failure sheet: dismiss (stay on screen).
         case cancelTapped
-        /// Signs and stores the active schedule (sign-only — the first prep broadcasts later, via
-        /// the coordinator's post-confirm kick; MOB-1513 B4).
+        /// Signs and stores the active schedule — sign-only (MOB-1513 B4), then (Field 2026-08-06)
+        /// `.scheduleCommitted` keeps this same loader up while it awaits the run's first drive
+        /// (prove + first broadcast, `advance(.afterSync)` at tip) before navigating — see its doc.
         case confirmTapped
         /// MOB-1458: `confirmTapped`/`retryTapped`'s device-authentication gate
         /// (`State.confirmRequiresAuthentication`) refused — authentication failed, or the user

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -26,14 +26,21 @@
 //  zero-transfer schedule regardless of why. The Keystone fork throws through instead of swallowing
 //  errors with `try?`, and an empty PCZT batch is also a failure (finding #4).
 //
-//  MOB-1513 (B4 — confirm redesign): the commit chain is SIGN-ONLY now. The MOB-1478 (W4) silent
-//  note-split broadcast that used to run under this screen's Confirm (`submitNoteSplit`: proving +
-//  inline Tor + broadcast — the multi-second confirm freeze QA hit) left the chain entirely, along
-//  with its whole R14-R17 broadcast-failure surface (`failureKind`, `broadcastFailureRouted`, the
-//  Tor off-warning alert, and the sync-server fallback actions this store carried in R9-T2) — a
+//  MOB-1513 (B4 — confirm redesign): the commit chain is SIGN-ONLY, plus (Field 2026-08-06) an
+//  AWAITED first drive under the same Confirm loader. The MOB-1478 (W4) silent note-split
+//  broadcast that used to run under this screen's Confirm (`submitNoteSplit`: proving + inline
+//  Tor + broadcast — the multi-second confirm freeze QA hit) left the chain entirely, along with
+//  its whole R14-R17 broadcast-failure surface (`failureKind`, `broadcastFailureRouted`, the Tor
+//  off-warning alert, and the sync-server fallback actions this store carried in R9-T2) — a
 //  commit failure is a plain thrown error now, presented on the existing generic Cancel/Retry
-//  sheet. The first prep broadcasts AFTER navigation, via `MigrationCoordFlowCoordinator`'s
-//  post-confirm first-delivery kick; broadcast failures surface (and retry) through the migration
+//  sheet. `commitSoftware` returning is no longer the end of the chain: `.scheduleCommitted`
+//  keeps the loader up through `migrationManager.advance(.afterSync)` (at tip; skipped mid-sync,
+//  deferring to the coming edge) before `.scheduleSigned` navigates — so the run's first
+//  preparation is prepared, presigned, and its split broadcast BEFORE this screen ever leaves,
+//  not only after, via `MigrationCoordFlowCoordinator`'s post-confirm first-delivery kick. That
+//  drive is the DRIVER's own lane (`MigrationManagerClient.advance`, the same call Root's G1 case
+//  makes) — NEVER reintroduce an inline SDK broadcast call here (no `submitNoteSplit`/
+//  `prepareNoteSplit`); broadcast failures still surface (and retry) through the migration
 //  progress machinery, never on this screen. Confirm shows a loader (`isConfirming`) and is
 //  single-flight. The Keystone fork's batch (`requestKeystoneSignature`) still proposes any
 //  preparation PCZTs first, so the whole batch (preps + all N transfers) signs in the same QR
@@ -181,28 +188,34 @@ struct MigrationTransferPlan {
         // expired-recovery lane commits one screen earlier and every `requiresSigning == false`
         // confirm routes to `.flowFinished`.)
         /// MOB-1513 (B4): true while an async confirm leg is in flight — the device-authentication
-        /// prompt itself (MOB-1458), the software commit, the Keystone PCZT-batch propose, or a
-        /// propose-failure Retry's re-propose. Drives the Confirm button's disabled+spinner state
-        /// AND the `.confirmTapped`/`.retryTapped` single-flight guard: a second tap while set is a
-        /// complete no-op, so concurrent commits (the plan-cache-overwrite race behind QA's
-        /// `MIGRATION_PLAN_STALE` error sheet) can't happen — and, MOB-1458, a second tap can't
-        /// open a second authentication prompt either, since this is set true BEFORE that prompt's
-        /// effect launches, not after.
+        /// prompt itself (MOB-1458), the software commit (through its `.scheduleCommitted` latch
+        /// and the awaited first-drive wait that follows — Field 2026-08-06), the Keystone
+        /// PCZT-batch propose, or a propose-failure Retry's re-propose. Drives the Confirm button's
+        /// disabled+spinner state AND the `.confirmTapped`/`.retryTapped` single-flight guard: a
+        /// second tap while set is a complete no-op, so concurrent commits (the plan-cache-overwrite
+        /// race behind QA's `MIGRATION_PLAN_STALE` error sheet) can't happen — and, MOB-1458, a
+        /// second tap can't open a second authentication prompt either, since this is set true
+        /// BEFORE that prompt's effect launches, not after.
         ///
         /// MOB-1458: cleared unconditionally at the top of `.confirmAuthenticated` — every intent
         /// branch that goes on to launch a further async leg (`.software`, `.keystone`) re-sets it
         /// `true` immediately after, so this is a real transition only for `.acknowledge`, which
         /// delegates `.confirmed` straight away — and by `.authenticationCancelled`. Also cleared
-        /// on every terminal outcome of those further legs: `.scheduleSigned`, `.noteSplitFailed`,
-        /// `.delegate(.keystoneSignRequested)` (so a pop-back after a rejected QR ceremony
-        /// re-enables Confirm), `.transfersProposed`, and `.transferProposalFailed`.
+        /// on every terminal outcome of those further legs: `.scheduleSigned` (Field 2026-08-06:
+        /// `.scheduleCommitted` deliberately does NOT clear it — the loader must stay up through
+        /// the first-drive wait in between), `.noteSplitFailed`, `.delegate(.keystoneSignRequested)`
+        /// (so a pop-back after a rejected QR ceremony re-enables Confirm), `.transfersProposed`,
+        /// and `.transferProposalFailed`.
         var isConfirming = false
         /// MOB-1466 (field finding O5): true once Confirm has genuinely done its job THIS visit —
-        /// the software lane's sign+store (`.scheduleSigned`) or the acknowledge-only lane's no-op
-        /// "got it" (`.confirmAuthenticated`'s `.acknowledge` branch). Deliberately NOT set by the
-        /// Keystone lane's `.delegate(.keystoneSignRequested)`: that only PROPOSES the batch (the
-        /// engine persists a run, but nothing is signed yet), and if the QR ceremony is later
-        /// rejected/abandoned the coordinator explicitly cancels that run
+        /// the software lane's sign+store, latched at `.scheduleCommitted` (Field 2026-08-06:
+        /// moved earlier, from `.scheduleSigned` — so a back-out during the first-drive wait that
+        /// follows passes the leave guard honestly, since the plan IS committed by then;
+        /// `.scheduleSigned` re-sets it to the same `true` as a belt once the drive also lands) —
+        /// or the acknowledge-only lane's no-op "got it" (`.confirmAuthenticated`'s `.acknowledge`
+        /// branch). Deliberately NOT set by the Keystone lane's `.delegate(.keystoneSignRequested)`:
+        /// that only PROPOSES the batch (the engine persists a run, but nothing is signed yet), and
+        /// if the QR ceremony is later rejected/abandoned the coordinator explicitly cancels that run
         /// (`restartCurrentMigrationStep`) — so a user who pops back down to this screen after an
         /// abandoned ceremony genuinely has nothing committed, and `.backTapped`'s guard should
         /// still apply. Read by `.backTapped` — see its doc for the full pass-through rule.
@@ -439,7 +452,16 @@ struct MigrationTransferPlan {
         /// sequence when `failureReason == .commit` (or unset), or (MOB-1496 R8-T1, S3) a fresh
         /// proposal when `failureReason == .propose`.
         case retryTapped
-        /// `signAndStoreMigrationSchedule` completed.
+        /// Field 2026-08-06: `MigrationCommitPipeline.commitSoftware` returned — the run is
+        /// committed (signed + stored + recorded + reconciled). Latches `hasConfirmed`
+        /// IMMEDIATELY (before the first drive below), so a re-tap during the drive wait is dead
+        /// and a back-out passes the leave guard honestly, then keeps `isConfirming` up while the
+        /// newborn run's first drive (prove + first broadcast) runs — see the handler's own doc
+        /// for why the drive lives here and not only in Root's G1 case.
+        case scheduleCommitted
+        /// The whole confirm chain's terminal now: `signAndStoreMigrationSchedule` completed AND
+        /// the first drive `.scheduleCommitted`'s handler awaits has either run to completion (at
+        /// tip) or was skipped (mid-sync, deferring to the coming edge).
         case scheduleSigned
         /// MOB-1458 (Task 3): the software commit's or the Keystone propose's consent echo found
         /// the displayed schedule stale (`ZcashError.migrationPlanStale`) — `refreshAfterPlanStale`
@@ -766,8 +788,43 @@ struct MigrationTransferPlan {
                 state.totalRounds = state.round != nil ? totalRounds : nil
                 return .none
 
+            case .scheduleCommitted:
+                MigrationTrace.event("CONFIRM commit COMPLETE — signed + stored; driving the first step under the loader")
+                // The latch flips HERE — at commit success, BEFORE the drive — so `.confirmTapped`'s
+                // hasConfirmed guard kills a re-tap mid-wait and `.backTapped`'s carve-out passes a
+                // back-out through (the plan IS committed; leaving forfeits nothing).
+                state.hasConfirmed = true
+                return .run { send in
+                    // Field 2026-08-06 (the "instant dismiss" regression): with the push synchronous,
+                    // the loader dropped the moment the sign-only commit landed — and the homepage
+                    // then rendered the PRE-commit snapshot for the whole prove+broadcast window,
+                    // because the post-commit republish queues behind the G1 prove sweep (its summary
+                    // join crosses the DB write actor twice: `migrationState`'s advance-step read and
+                    // `residualAfterMigration`). The field contract: ONE tap, loader up while the
+                    // run's first step is prepared, presigned and its split broadcast, THEN navigate
+                    // — by which time the write actor is free, the republish lands, and the homepage
+                    // tells the truth. Same phase token and same at-tip guard as Root's G1 drive,
+                    // which still fires on `.confirmed` after this (idempotent backstop; the
+                    // tick-loop spawn lives there). Mid-sync the drive is skipped exactly like
+                    // Root's guard skips: the coming edge owns it, and the loader covers just the
+                    // commit.
+                    if case .upToDate = sdkSynchronizer.latestState().syncStatus {
+                        // Unstructured on purpose: a back-out mid-wait pops this element and TCA
+                        // cancels this effect — the drive must survive that cancellation or the
+                        // newborn run sits undriven until the next edge/app-open (the exact wedge
+                        // G1 closed). `.value` on a non-throwing Task does not return early on
+                        // cancellation, and a cancelled effect's trailing send is a no-op — which
+                        // is exactly right, the screen is gone.
+                        let drive = Task { [migrationManager] in
+                            await migrationManager.advance(.afterSync)
+                        }
+                        _ = await drive.value
+                    }
+                    await send(.scheduleSigned)
+                }
+
             case .scheduleSigned:
-                MigrationTrace.event("CONFIRM commit COMPLETE — schedule signed + stored, delegating .confirmed")
+                MigrationTrace.event("CONFIRM chain COMPLETE — first drive done, delegating .confirmed")
                 state.isConfirming = false
                 // MOB-1466: the software lane's genuine "Confirm has done its job" moment — signed
                 // AND stored. See `State.hasConfirmed`'s doc.
@@ -833,7 +890,7 @@ struct MigrationTransferPlan {
                     derivationTool: derivationTool,
                     networkType: zcashSDKEnvironment.network().networkType
                 )
-                await send(.scheduleSigned)
+                await send(.scheduleCommitted)
             } catch ZcashError.migrationPlanStale {
                 await refreshAfterPlanStale(accountUUID: account.id, send: send)
             } catch {

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanStore.swift
@@ -790,9 +790,15 @@ struct MigrationTransferPlan {
 
             case .scheduleCommitted:
                 MigrationTrace.event("CONFIRM commit COMPLETE — signed + stored; driving the first step under the loader")
-                // The latch flips HERE — at commit success, BEFORE the drive — so `.confirmTapped`'s
-                // hasConfirmed guard kills a re-tap mid-wait and `.backTapped`'s carve-out passes a
-                // back-out through (the plan IS committed; leaving forfeits nothing).
+                // The latch flips HERE — at commit success, BEFORE the drive — not for re-tap
+                // safety (`.confirmTapped`/`.retryTapped`'s `isConfirming` guard already fires
+                // FIRST in that chain and alone kills a re-tap for this whole window, latch or no
+                // latch) but for `.backTapped`'s own guard: without moving it earlier, a back-tap
+                // during the drive wait would still read `hasConfirmed == false` and present the
+                // leave-guard sheet as though nothing were committed yet, when the plan already
+                // IS — flipping the latch here instead lets that back-out pass straight through
+                // honestly, exactly like `.backTapped`'s carve-out promises (leaving forfeits
+                // nothing).
                 state.hasConfirmed = true
                 return .run { send in
                     // Field 2026-08-06 (the "instant dismiss" regression): with the push synchronous,
@@ -870,12 +876,13 @@ struct MigrationTransferPlan {
         }
     }
 
-    /// The software commit — sign-only since MOB-1513 (B4): a success is `.scheduleSigned`, any
-    /// thrown error is the plain generic `.noteSplitFailed` (nothing was persisted — see
-    /// `MigrationCommitPipeline.commitSoftware`'s doc). No broadcast happens here any more, so
-    /// there is no failure to classify/route either. MOB-1458 (Task 3): `ZcashError
-    /// .migrationPlanStale` is caught SPECIFICALLY ahead of that generic catch — see
-    /// `refreshAfterPlanStale`'s doc.
+    /// The software commit — sign-only since MOB-1513 (B4): a success sends `.scheduleCommitted`,
+    /// which latches `hasConfirmed` and drives the newborn run's first step under the loader, then
+    /// itself sends `.scheduleSigned` once that settles. Any thrown error is the plain generic
+    /// `.noteSplitFailed` (nothing was persisted — see `MigrationCommitPipeline.commitSoftware`'s
+    /// doc). No broadcast happens here any more, so there is no failure to classify/route either.
+    /// MOB-1458 (Task 3): `ZcashError.migrationPlanStale` is caught SPECIFICALLY ahead of that
+    /// generic catch — see `refreshAfterPlanStale`'s doc.
     private func commitEffect(schedule: MigrationSchedule, account: WalletAccount, zip32AccountIndex: Zip32AccountIndex) -> Effect<Action> {
         .run { send in
             do {

--- a/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
+++ b/secant/Sources/Features/Migration/MigrationTransferPlan/MigrationTransferPlanView.swift
@@ -111,29 +111,37 @@ struct MigrationTransferPlanView: View {
                 // migration"), not `general.confirm` — "Confirm" read as acknowledge-and-leave
                 // rather than as the tap that actually starts the migration. `general.confirm`
                 // itself is untouched; other screens (e.g. `MigrationReviewTransferView`) keep it.
-                if store.isConfirming {
-                    ZashiButton(
-                        String(localizable: .migrationPlanStartCta),
-                        accessoryView:
-                            ProgressView()
-                            .progressViewStyle(
-                                CircularProgressViewStyle(
-                                    tint: Asset.Colors.secondary.color
+                // MOB-1466 (field finding O5, code review): the disabled state has to govern
+                // BOTH branches, not just the spinner one — the plain button below sends
+                // `.confirmTapped` directly, and without this it looked tappable (no dimming)
+                // during the window between a successful commit and the push landing. Hoisted
+                // onto a `Group` wrapping the if/else rather than duplicated onto each branch,
+                // so the two conditions can never drift apart again.
+                Group {
+                    if store.isConfirming {
+                        ZashiButton(
+                            String(localizable: .migrationPlanStartCta),
+                            accessoryView:
+                                ProgressView()
+                                .progressViewStyle(
+                                    CircularProgressViewStyle(
+                                        tint: Asset.Colors.secondary.color
+                                    )
                                 )
-                            )
-                    ) { }
-                    .screenHorizontalPadding()
-                    .padding(.top, 16)
-                    .padding(.bottom, 24)
-                    .disabled(store.isConfirming)
-                } else {
-                    ZashiButton(String(localizable: .migrationPlanStartCta)) {
-                        store.send(.confirmTapped)
+                        ) { }
+                        .screenHorizontalPadding()
+                        .padding(.top, 16)
+                        .padding(.bottom, 24)
+                    } else {
+                        ZashiButton(String(localizable: .migrationPlanStartCta)) {
+                            store.send(.confirmTapped)
+                        }
+                        .screenHorizontalPadding()
+                        .padding(.top, 16)
+                        .padding(.bottom, 24)
                     }
-                    .screenHorizontalPadding()
-                    .padding(.top, 16)
-                    .padding(.bottom, 24)
                 }
+                .disabled(store.isConfirming || store.hasConfirmed)
             }
             // MOB-1466 (field finding O5): intercepted — an unconfirmed plan must not be left
             // silently. See `MigrationTransferPlanStore`'s `.backTapped` doc, including its known

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -307,6 +307,13 @@ extension Root {
             // is not the state the pre-commit pass drove). Mid-sync, the guard defers to the
             // coming edge, whose own drive now also holds a fresh credit. The tick loop stays the
             // belt for everything after.
+            // Field 2026-08-06: the scheduled-plan lane now front-runs this same drive UNDER THE
+            // CONFIRM LOADER, awaited, before `.transferPlan`'s `.delegate(.confirmed)` ever fires
+            // (`MigrationTransferPlan`'s `.scheduleCommitted` — see its doc). So for that lane this
+            // call is an idempotent backstop, not the first driver — it still fires here every
+            // time, on the same phase token and the same at-tip guard, and still matters (a
+            // pop-back that raced the commit, an app relaunch mid-wait). It remains the ONLY drive
+            // for the `.reviewTransfer` lane below, which gained no loader-side drive of its own.
             case .migrationCoordFlow(.path(.element(id: _, action: .transferPlan(.delegate(.confirmed))))),
                 .migrationCoordFlow(.path(.element(id: _, action: .reviewTransfer(.delegate(.confirmed))))):
                 return .merge(

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -310,10 +310,18 @@ extension Root {
             // Field 2026-08-06: the scheduled-plan lane now front-runs this same drive UNDER THE
             // CONFIRM LOADER, awaited, before `.transferPlan`'s `.delegate(.confirmed)` ever fires
             // (`MigrationTransferPlan`'s `.scheduleCommitted` — see its doc). So for that lane this
-            // call is an idempotent backstop, not the first driver — it still fires here every
-            // time, on the same phase token and the same at-tip guard, and still matters (a
-            // pop-back that raced the commit, an app relaunch mid-wait). It remains the ONLY drive
-            // for the `.reviewTransfer` lane below, which gained no loader-side drive of its own.
+            // call is now an idempotent backstop, not the first driver — it still fires here every
+            // time, on the same phase token and the same at-tip guard, and the tick-loop spawn
+            // above still matters regardless of which lane fired it. NOT a backstop for a back-tap
+            // during the drive wait, though: that pops the path element before `.delegate(.confirmed)`
+            // can ever fire, so this case never matches on that path (TCA's `forEach` cancels the
+            // in-flight `.scheduleCommitted` effect on the pop, so its trailing
+            // `send(.scheduleSigned)` is a no-op) — that path is recovered by `flowFinished` below
+            // (fires when the coordinator closes) and, failing that, the next app-open's re-arm in
+            // `RootInitialization`, not by this case. The drive itself keeps running regardless —
+            // it's unstructured specifically so the pop's cancellation can't reach it (see
+            // `.scheduleCommitted`'s own doc). This case remains the ONLY drive for the
+            // `.reviewTransfer` lane below, which gained no loader-side drive of its own.
             case .migrationCoordFlow(.path(.element(id: _, action: .transferPlan(.delegate(.confirmed))))),
                 .migrationCoordFlow(.path(.element(id: _, action: .reviewTransfer(.delegate(.confirmed))))):
                 return .merge(

--- a/zodlTests/MigrationTests/MigrationConfirmSynchronousPushTests.swift
+++ b/zodlTests/MigrationTests/MigrationConfirmSynchronousPushTests.swift
@@ -1,0 +1,200 @@
+//
+//  MigrationConfirmSynchronousPushTests.swift
+//  zodlTests
+//
+//  FIELD BUG: the first Confirm tap on a signing transfer plan committed (signed + stored) in
+//  well under a second, then the screen sat still — the push to "Migration Scheduled" awaited
+//  `migrationSummary`, whose compute path crosses the DB write actor TWICE (`migrationState`'s
+//  advance-step read, and `residualAfterMigration`), exactly while the post-commit drive's prove
+//  sweep can hold that same actor for seconds per Halo2 chunk. The read-only-reads work never
+//  touched either of those two hops, so the stall survived that rebuild intact.
+//
+//  THE CONTRACT this suite pins: a software `.confirmed` on a signing plan pushes `.scheduled`
+//  SYNCHRONOUSLY — the path mutation happens in the reducer handling the delegate itself, built
+//  from data already in hand (the just-committed schedule's own numbers, plus a synchronous read
+//  of the published snapshot for prior rounds' moved value). The engine is never consulted on the
+//  navigation path; that is exactly the shape the `.manual` arm already used. A second contract
+//  closes the re-tap window the stall used to invite: once `hasConfirmed` is set, a further
+//  `.confirmTapped`/`.retryTapped` is a traced no-op — no auth prompt, no second commit leg.
+//
+
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct MigrationConfirmSynchronousPushTests {
+    // MARK: - Fixtures
+
+    private static let accountUUID = AccountUUID(id: [UInt8](repeating: 0x21, count: 16))
+
+    private static func account() -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: accountUUID,
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private static func transfer(id: UInt32, zatoshi: Int64) -> MigrationTransferProposal {
+        MigrationTransferProposal(
+            id: id,
+            amount: Zatoshi(zatoshi),
+            anchorHeight: BlockHeight(3_000_000),
+            nextExecutableAfterHeight: BlockHeight(3_000_100),
+            expiryHeight: BlockHeight(3_000_140)
+        )
+    }
+
+    /// Two transfers — 100_000_000 + 250_000_000 = 350_000_000 zatoshi — over an estimated 5h.
+    private static func schedule() -> MigrationSchedule {
+        MigrationSchedule(
+            transfers: [
+                transfer(id: 0, zatoshi: 100_000_000),
+                transfer(id: 1, zatoshi: 250_000_000)
+            ],
+            estimatedDurationHours: 5,
+            proposalHandle: 1,
+            preparations: []
+        )
+    }
+
+    private static func snapshot(movedByDoneTransfers: Zatoshi, totalTransfers: Int) -> MigrationViewSnapshot {
+        MigrationViewSnapshot(
+            orchardRemaining: .zero,
+            ironwoodHeld: .zero,
+            poolCorrection: MigrationDerivations.PoolTruthCorrection.none,
+            movedByDoneTransfers: movedByDoneTransfers,
+            doneTransfers: 0,
+            totalTransfers: totalTransfers,
+            transfers: [],
+            summary: MigrationSummary.zero,
+            banner: nil,
+            preparations: [],
+            planTotal: nil,
+            isTorHoldActive: false,
+            needsTorFirstRunChoice: false,
+            isSubmitting: false,
+            sessionOrdinal: 1,
+            asOfSyncedAt: nil
+        )
+    }
+
+    // MARK: - The fix
+
+    /// THE fix. A software `.confirmed` on a signing plan pushes `.scheduled` SYNCHRONOUSLY — the
+    /// path mutation happens in the reducer handling the delegate, with the state built from the
+    /// in-hand schedule + the published snapshot; no async receive precedes the push.
+    @Test func aConfirmedPlanPushesTheScheduledScreenSynchronously() async {
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        $selectedWalletAccount.withLock { $0 = nil }
+
+        var planState = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: true)
+        planState.schedule = Self.schedule()
+
+        var initialState = MigrationCoordFlow.State.initial
+        initialState.path.append(.transferPlan(planState))
+        let transferPlanID = initialState.path.ids[0]
+
+        let store = TestStore(initialState: initialState) {
+            MigrationCoordFlow()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            var client = MigrationManagerClient.noOp
+            client.currentMigrationSnapshot = { _ in nil }
+            client.armNextWindowNotifications = { _ in }
+            client.refreshMigrationSnapshot = { _ in }
+            $0.migrationManager = client
+        }
+        store.exhaustivity = .off
+
+        // No `store.receive` before this assertion — the push must already be reflected in the
+        // SAME send's resulting state, not arrive later off a queued action.
+        await store.send(
+            .path(.element(id: transferPlanID, action: .transferPlan(.delegate(.confirmed))))
+        ) {
+            $0.path.append(.scheduled(MigrationScheduled.State(
+                totalAmount: Zatoshi(350_000_000),
+                sentCount: 0,
+                totalCount: 2,
+                durationHours: 5
+            )))
+        }
+
+        // The trailing effect (window arming + snapshot refresh) is fire-and-forget — it must
+        // still be let run to completion so it doesn't leak into a later test.
+        await store.finish()
+    }
+
+    // MARK: - The builder table
+
+    /// Fresh commit, nil snapshot — schedule-only numbers; nothing has moved before this run.
+    @Test func theBuilderUsesScheduleOnlyNumbersWithoutASnapshot() {
+        let result = MigrationCoordFlow.scheduledStateNow(schedule: Self.schedule(), snapshot: nil)
+
+        #expect(result == MigrationScheduled.State(
+            totalAmount: Zatoshi(350_000_000),
+            sentCount: 0,
+            totalCount: 2,
+            durationHours: 5
+        ))
+    }
+
+    /// Multi-round: a snapshot carrying a prior round's moved value folds into `totalAmount`
+    /// alongside this round's fresh schedule sum.
+    @Test func theBuilderFoldsPriorRoundsMovedValueFromTheSnapshot() {
+        let priorRoundSnapshot = Self.snapshot(movedByDoneTransfers: Zatoshi(300_000), totalTransfers: 0)
+        let result = MigrationCoordFlow.scheduledStateNow(schedule: Self.schedule(), snapshot: priorRoundSnapshot)
+
+        #expect(result == MigrationScheduled.State(
+            totalAmount: Zatoshi(300_000) + Zatoshi(350_000_000),
+            sentCount: 0,
+            totalCount: 2,
+            durationHours: 5
+        ))
+    }
+
+    /// No fresh schedule — the snapshot's own totals stand in, and a prior round's moved value
+    /// still folds through. Never a crash, never a negative total.
+    @Test func theBuilderFallsBackToSnapshotTotalsWithoutASchedule() {
+        let noScheduleSnapshot = Self.snapshot(movedByDoneTransfers: Zatoshi(750_000), totalTransfers: 5)
+        let result = MigrationCoordFlow.scheduledStateNow(schedule: nil, snapshot: noScheduleSnapshot)
+
+        #expect(result == MigrationScheduled.State(
+            totalAmount: Zatoshi(750_000),
+            sentCount: 0,
+            totalCount: 5,
+            durationHours: 0
+        ))
+    }
+
+    // MARK: - The latch
+
+    /// The latch: once `hasConfirmed` is set, another confirmTapped is a traced no-op — no auth
+    /// prompt, no commit leg, no state change. An exhaustive `send` with no trailing closure IS
+    /// the pin: any mutation (e.g. `isConfirming` flipping true on the way into the auth gate)
+    /// fails it outright.
+    @Test func aCommittedPlanIgnoresAnotherConfirmTap() async {
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        $selectedWalletAccount.withLock { $0 = Self.account() }
+
+        var state = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: true)
+        state.schedule = Self.schedule()
+        state.hasConfirmed = true
+
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        }
+
+        await store.send(.confirmTapped)
+
+        await store.finish()
+    }
+}

--- a/zodlTests/MigrationTests/MigrationConfirmSynchronousPushTests.swift
+++ b/zodlTests/MigrationTests/MigrationConfirmSynchronousPushTests.swift
@@ -66,13 +66,25 @@ import Testing
         )
     }
 
-    private static func snapshot(movedByDoneTransfers: Zatoshi, totalTransfers: Int) -> MigrationViewSnapshot {
+    /// Five transfers of 50_000_000 each — 250_000_000 total, over an estimated 3h. Shaped like
+    /// what the recovery refresh-stale lane re-serves: the run's STORED schedule, rebuilt in
+    /// place, which can include transfers a PRIOR round already broadcast.
+    private static func recoveryRebuiltSchedule() -> MigrationSchedule {
+        MigrationSchedule(
+            transfers: (0..<5).map { transfer(id: UInt32($0), zatoshi: 50_000_000) },
+            estimatedDurationHours: 3,
+            proposalHandle: 2,
+            preparations: []
+        )
+    }
+
+    private static func snapshot(movedByDoneTransfers: Zatoshi, doneTransfers: Int = 0, totalTransfers: Int) -> MigrationViewSnapshot {
         MigrationViewSnapshot(
             orchardRemaining: .zero,
             ironwoodHeld: .zero,
             poolCorrection: MigrationDerivations.PoolTruthCorrection.none,
             movedByDoneTransfers: movedByDoneTransfers,
-            doneTransfers: 0,
+            doneTransfers: doneTransfers,
             totalTransfers: totalTransfers,
             transfers: [],
             summary: MigrationSummary.zero,
@@ -147,17 +159,34 @@ import Testing
         ))
     }
 
-    /// Multi-round: a snapshot carrying a prior round's moved value folds into `totalAmount`
-    /// alongside this round's fresh schedule sum.
-    @Test func theBuilderFoldsPriorRoundsMovedValueFromTheSnapshot() {
-        let priorRoundSnapshot = Self.snapshot(movedByDoneTransfers: Zatoshi(300_000), totalTransfers: 0)
+    /// Multi-round: a snapshot carrying a prior round's cumulative totals folds into BOTH
+    /// `totalAmount` (moved value) and `sentCount` (done transfers) alongside this round's fresh
+    /// schedule sum/count.
+    @Test func theBuilderFoldsPriorRoundsMovedValueAndSentCountFromTheSnapshot() {
+        let priorRoundSnapshot = Self.snapshot(movedByDoneTransfers: Zatoshi(300_000), doneTransfers: 4, totalTransfers: 0)
         let result = MigrationCoordFlow.scheduledStateNow(schedule: Self.schedule(), snapshot: priorRoundSnapshot)
 
         #expect(result == MigrationScheduled.State(
             totalAmount: Zatoshi(300_000) + Zatoshi(350_000_000),
-            sentCount: 0,
+            sentCount: 4,
             totalCount: 2,
             durationHours: 5
+        ))
+    }
+
+    /// The recovery refresh-stale lane's own shape: it re-serves the run's STORED schedule,
+    /// which can already include transfers a PRIOR round broadcast. `sentCount` must fold the
+    /// snapshot's cumulative `doneTransfers` here too — a hardcoded 0 would regress this lane's
+    /// success screen to "0 of 5" for a run that had already sent 3.
+    @Test func theBuilderCountsAlreadySentTransfersOnARecoveryRefresh() {
+        let recoverySnapshot = Self.snapshot(movedByDoneTransfers: Zatoshi(600_000_000), doneTransfers: 3, totalTransfers: 0)
+        let result = MigrationCoordFlow.scheduledStateNow(schedule: Self.recoveryRebuiltSchedule(), snapshot: recoverySnapshot)
+
+        #expect(result == MigrationScheduled.State(
+            totalAmount: Zatoshi(600_000_000) + Zatoshi(250_000_000),
+            sentCount: 3,
+            totalCount: 5,
+            durationHours: 3
         ))
     }
 

--- a/zodlTests/MigrationTests/MigrationConfirmSynchronousPushTests.swift
+++ b/zodlTests/MigrationTests/MigrationConfirmSynchronousPushTests.swift
@@ -17,6 +17,15 @@
 //  closes the re-tap window the stall used to invite: once `hasConfirmed` is set, a further
 //  `.confirmTapped`/`.retryTapped` is a traced no-op — no auth prompt, no second commit leg.
 //
+//  Field 2026-08-06: the chain in front of that synchronous push grew one more link. Commit
+//  success now latches `hasConfirmed` immediately, then KEEPS the Confirm loader up while the
+//  newborn run's first drive (prove + first broadcast, at tip) runs to completion — only once
+//  that drive lands (or is skipped mid-sync, deferring to the coming edge) does the chain reach
+//  `.scheduleSigned` and fire the same synchronous push above. So: commit → latch → awaited first
+//  drive under the loader → synchronous push. A back-out mid-wait passes the leave guard, same as
+//  any other already-committed visit — the plan IS committed by the time the drive starts, so
+//  leaving forfeits nothing.
+//
 
 import ComposableArchitecture
 import Foundation
@@ -97,6 +106,13 @@ import Testing
             sessionOrdinal: 1,
             asOfSyncedAt: nil
         )
+    }
+
+    private static func upToDateState() -> SynchronizerState {
+        var state = SynchronizerState.zero
+        state.syncStatus = .upToDate
+        state.latestBlockHeight = 4_200_000
+        return state
     }
 
     // MARK: - The fix
@@ -225,5 +241,87 @@ import Testing
         await store.send(.confirmTapped)
 
         await store.finish()
+    }
+
+    // MARK: - The drive under the loader
+
+    /// Field 2026-08-06: commit success latches `hasConfirmed` and KEEPS the loader up while the
+    /// newborn run's first drive (prove + first broadcast) runs to completion — only then does
+    /// `.scheduleSigned` clear the loader and delegate `.confirmed`. The advance must land at
+    /// `.afterSync`, once, before `.scheduleSigned` arrives.
+    @Test func aCommittedScheduleDrivesTheFirstStepUnderTheLoaderAtTip() async {
+        let phases = LockIsolated<[MigrationOpenPhase]>([])
+        var state = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: true)
+        state.schedule = Self.schedule()
+        state.isConfirming = true
+
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            var manager = MigrationManagerClient.noOp
+            manager.advance = { phase in
+                phases.withValue { $0.append(phase) }
+                return .proved(count: 0)
+            }
+            $0.migrationManager = manager
+            $0.sdkSynchronizer = .mocked(latestState: { Self.upToDateState() })
+        }
+
+        await store.send(.scheduleCommitted) {
+            $0.hasConfirmed = true
+        }
+        await store.receive(\.scheduleSigned) {
+            $0.isConfirming = false
+        }
+        #expect(phases.value == [MigrationOpenPhase.afterSync])
+        await store.receive(.delegate(.confirmed))
+    }
+
+    /// Mid-sync the drive is SKIPPED — same guard as Root's G1 case: the coming sync edge owns the
+    /// drive, and the loader covers just the commit. `.mocked()`'s default `latestState` is
+    /// `SynchronizerState.zero`, which is not `.upToDate`.
+    @Test func aCommittedScheduleSkipsTheDriveMidSync() async {
+        let phases = LockIsolated<[MigrationOpenPhase]>([])
+        var state = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: true)
+        state.schedule = Self.schedule()
+        state.isConfirming = true
+
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        } withDependencies: {
+            var manager = MigrationManagerClient.noOp
+            manager.advance = { phase in
+                phases.withValue { $0.append(phase) }
+                return .proved(count: 0)
+            }
+            $0.migrationManager = manager
+            $0.sdkSynchronizer = .mocked()
+        }
+
+        await store.send(.scheduleCommitted) {
+            $0.hasConfirmed = true
+        }
+        await store.receive(\.scheduleSigned) {
+            $0.isConfirming = false
+        }
+        #expect(phases.value.isEmpty)
+        await store.receive(.delegate(.confirmed))
+    }
+
+    /// A back-tap DURING the drive wait (`hasConfirmed` already latched, loader still up) passes the
+    /// leave guard silently — the plan IS committed, so there is nothing left to guard. Exhaustive
+    /// send with no state closure pins "no sheet, no mutation".
+    @Test func aBackTapDuringTheDriveWaitPassesThroughTheLeaveGuard() async {
+        var state = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: true)
+        state.schedule = Self.schedule()
+        state.isConfirming = true
+        state.hasConfirmed = true
+
+        let store = TestStore(initialState: state) {
+            MigrationTransferPlan()
+        }
+
+        await store.send(.backTapped)
+        await store.receive(.delegate(.leftWithoutConfirming))
     }
 }


### PR DESCRIPTION
Field report (2026-08-05/06): the first Confirm tap on "Confirm transfer plan" signed and
stored the whole schedule in ~0.7s — then nothing visibly happened, inviting a second tap
(a benign engine-side resume, but a re-auth and a long spinner). The push to the Scheduled
screen awaited `migrationSummary`, whose compute path crosses the DB write actor twice
(`migrationState`'s advance-step read and `residualAfterMigration`) — exactly while the
post-commit drive's prove sweep holds that actor seconds per Halo2 chunk. That is why the
stall survived the read-only-reads FFI rebuild: those two hops are writers.

Fix: the push is synchronous. A just-committed schedule's numbers are known by definition
(nothing sent; totals are its own), prior rounds' moved value reads synchronously from the
published snapshot, and the path mutation happens in the reducer — the shape the manual arm
always used. Window arming and the snapshot rebuild run after the screen is up. The recovery
refresh-stale push (same stall shape) adopts the same builder; the Keystone planCommit
resume reaches the same chain and is fixed with it. A `hasConfirmed` latch (traced reducer
guard + disabled button) closes the re-tap lane.

ZIP-318 / privacy machinery untouched: no session, gate, buffer, or broadcast-ordering
changes. Five new tests (synchronous-push pin, three builder table rows, the latch); full
zodlTests green.

Known multi-round nuance (deliberate, per the approved design): after round 2+ the scheduled
screen's transfer counts describe the just-committed round while the total amount folds
prior rounds' moved value — flagging for product eyes; round 1 is unaffected.

## Field revision (2026-08-06)

Field regression: with the push synchronous, the Confirm loader dropped the instant the
sign-only commit landed — dismissing straight to a homepage still rendering the
**pre-commit** banner. The newborn run's first drive (prove + first broadcast) was already
under way, and the post-commit snapshot republish that would correct the banner queues
behind that same drive: its summary join crosses the DB write actor twice
(`migrationState`'s advance-step read and `residualAfterMigration`), exactly while Root's G1
prove sweep holds that actor. The homepage told a stale truth for the whole
prove-and-broadcast window.

New contract: `MigrationTransferPlanStore`'s commit success now sends a new
`.scheduleCommitted` action instead of going straight to `.scheduleSigned`.
`.scheduleCommitted` latches `hasConfirmed` immediately — so a re-tap is dead and a
back-tap's leave guard passes straight through honestly, since the plan already is committed
— then, at tip only, awaits `migrationManager.advance(.afterSync)` before sending
`.scheduleSigned`. This is the same phase token and the same at-tip `.upToDate` guard Root's
G1 case already runs, on the same `.confirmed` action chain; no session, gate, buffer, or
broadcast-ordering semantics changed. `.scheduleSigned` itself is unchanged: it clears
`isConfirming` and pushes the Scheduled screen synchronously, exactly as before. Net effect:
the loader now stays up through the run's first step, so by the time the screen navigates the
write actor is free and the homepage's next republish reflects the committed run truthfully.

Back-out semantics: the drive runs inside an unstructured `Task` nested in the
`.scheduleCommitted` effect, specifically so a back-tap mid-wait — which pops the path
element and cancels the awaiting effect — cannot cancel the drive along with it; a cancelled
effect's trailing `send(.scheduleSigned)` is simply a no-op on a screen that's already gone.
That back-out path is recovered the same way an ordinary flow close already is credited:
`flowFinished`'s tick-loop respawn, and failing that, `RootInitialization`'s next app-open
re-arm — not by Root's G1 case, which never sees that path at all (the pop happens before
`.transferPlan(.delegate(.confirmed))` can ever fire).

Mid-sync commits skip the wait entirely: the `.upToDate` guard fails, `.scheduleCommitted`
sends `.scheduleSigned` immediately, and the coming sync edge — which now also holds a fresh
open-lane credit — drives the run's first step itself, the same deferral Root's own G1 guard
already uses.

Testing: three new tests in `MigrationConfirmSynchronousPushTests` (the drive-order pin at
tip, the mid-sync skip, and back-tap-during-the-wait passing the leave guard) join the file's
existing six for 9/9 green; the adjacent `MigrationLeaveGuardTests` (5/5) is unaffected. Full
suite: 1,145 tests, 0 failures, 1 pre-existing known issue (`CurrencyConversionSetupTests`,
unrelated to this change).

**Flagged, not fixed:**
- Keystone's `planCommit` resume (the QR-signing ceremony) still gets no G1-style immediate
  first drive: it bypasses `MigrationTransferPlanStore`'s reducer entirely — a
  coordinator-level `transferPlanPostConfirmChain` call, not a
  `.transferPlan(.delegate(.confirmed))` action — so neither this change nor Root's G1 case
  fires for it; it still relies on the tick loop alone to drive the run forward. Pre-existing
  gap, out of scope here.
- The recovery refresh-stale lane (`refreshStaleMigrationTransfers`) is unchanged by this
  revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
