### PR TITLE
Adopt the SDK's batch-Prove step and advance outlook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1510] Signing with a Keystone device now requires firmware 3.0.1 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast, and the prompt reports the firmware version exactly as your Keystone displays it.
 - [MOB-1535] The "Total Balance Across Pools" breakdown now shows each pool's balance to its full precision (up to 8 decimal places) instead of flooring to 0.001 ZEC, so small amounts are no longer hidden, and the pools now appear in the order Ironwood, Orchard, Sapling, Transparent.
 - [MOB-1466] The "ready to run" step badge in the migration plan's Split Balance row now shows its step number instead of a checkmark, to avoid reading as already completed.
+- [Ironwood] Migration plan previews now show sane value breakdowns: exact funding amounts are preserved, and a split that cannot be funded reports as deferred instead of complete.
+- [Ironwood] The migration reminder is now armed from the engine's own next-work answer as well as the schedule, so the "come back" notification lands at the earliest genuinely serviceable moment — and never inside the privacy buffer for send work.
 
 ### Fixed
 - [MOB-1466] A sent migration transfer's checkmark, amount and transaction id now always land on the transfer that was actually broadcast: the app previously assumed sends happen in the plan's original row order, so once the engine (correctly) sent the earliest-scheduled transfer instead, the wrong row could show as sent — and its later confirmation could be matched against the wrong transaction.
@@ -77,6 +79,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] Opening the migration from the banner no longer flashes or stacks the mode-picker screen beneath the migration progress screen.
 - [MOB-1466] Swiping back off the very first screen shown when re-opening an in-progress migration now closes the migration flow, instead of leaving a blank, stuck screen with no way forward except quitting the app.
 - The Confirm button on a migration transfer plan now keeps its loading indicator up until your transfers are prepared and presigned (the first delivery kicked off), then opens the Migration Scheduled screen — one tap, no dead first tap, and the Home banner reflects the committed run when you return. The Confirm button still can no longer be tapped again after a successful commit.
+- [Ironwood] Accepting a migration plan on a large wallet no longer stalls for tens of minutes — plan commit completes promptly.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerInterface.swift
@@ -414,14 +414,18 @@ struct MigrationManagerClient: Sendable {
     // Reconciliation. MOB-1496: async — re-reads `getMigrationState` for `stateEvents`; call sites in
     // `MigrationSendingStore`/`MigrationNoteSplitStore` (post-broadcast) join the launch/foreground
     // ones. `= { }` is a no-op default, not a test fallback (see the `recordCommittedSchedule` note).
-    /// PHASE 4 (plan D9): arms the NEXT window's two local notifications for `accountUUID` — a
-    /// `timeToSync` at (window - lead) and a `manualTransferReady` at the window itself — and
-    /// cancels them once nothing is pending. Called at COMMIT and on every reconcile, which is
-    /// what replaces #1930's background-session arming: plan D2 removed the BG lane, so a window
-    /// can only ever be announced ahead of time, never acted on in the background.
+    /// P4: arms exactly ONE generic poke for `accountUUID`, at the EARLIEST of four candidates —
+    /// the engine's own sync/prove wake-ups, the earliest still-unsent row's window (preparation
+    /// and transfer rows both), a near-term attention blocker, and the engine's own advance
+    /// outlook (one step of lookahead from the same read that drove the session) — and cancels
+    /// the account's poke once none of the four resolves to a date. Called on every driver pass
+    /// (`.beforeSync`/`.afterSync`, and a substantive `.tick`) plus COMMIT and reconcile.
     ///
-    /// Re-arming is idempotent by construction: the ids are stable per (case, account), so a
-    /// re-arm REPLACES the account's own prior pending request rather than stacking a second one.
+    /// The copy names neither an account nor a specific action: by the time the user opens, state
+    /// may have moved, so naming one would be a promise the app might not keep.
+    ///
+    /// Re-arming is idempotent by construction: the id is stable per account, so a re-arm REPLACES
+    /// the account's own prior pending request rather than stacking a second one.
     var armNextWindowNotifications: @Sendable (_ accountUUID: AccountUUID?) async -> Void = { _ in }
     var reconcile: @Sendable () async -> Void = { }
     // R8-T3 (#9): clears `accountUUID`'s (`nil` resolves the selected account) network snapshot iff

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -2048,11 +2048,12 @@ final class MigrationManagerImpl: @unchecked Sendable {
     /// the app next. Heights become dates through the measured block rate (`MigrationChainClock`),
     /// not a 75 s assumption, and are re-drawn on every call: the engine re-jitters its wake-ups per
     /// read, so this must never cache a schedule.
-    func armNextWindowNotifications(accountUUID: AccountUUID?) async {
+    func armNextWindowNotifications(accountUUID: AccountUUID?, outlook: MigrationNextWork? = nil) async {
         guard let resolvedAccountUUID = accountUUID ?? selectedWalletAccount?.id else { return }
 
         let clock = await chainClock(accountUUID: resolvedAccountUUID)
         let now = Date()
+        let gate = await sendGate()
 
         // A SYNC step: the earliest height at which the engine wants the wallet woken and proved.
         // No privacy buffer applies — a sync visit is the thing THAT buffer separates a SEND from.
@@ -2110,7 +2111,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
             // The row carries MINUTES (its displayed ETA), not a height, so the two-block slack is
             // added here rather than through `notificationDate` — same number, same reason.
             var date = now.addingTimeInterval(TimeInterval(next.forwardETAMinutes) * 60 + clock.notificationBuffer)
-            if case let MigrationSendGate.waitUntil(gateUntil) = await sendGate(), gateUntil > date {
+            if case let MigrationSendGate.waitUntil(gateUntil) = gate, gateUntil > date {
                 date = gateUntil
             }
             sendDate = date
@@ -2127,7 +2128,20 @@ final class MigrationManagerImpl: @unchecked Sendable {
         let blockerDate: Date? = stepBlockerAccounts.withLock { $0.contains(resolvedAccountUUID) }
             ? now.addingTimeInterval(60)
             : nil
-        guard let nextStepDate = [proveDate, sendDate, blockerDate].compactMap({ $0 }).min() else {
+
+        // P4 (outlook adoption, #2936): the engine's own "when is the next serviceable step"
+        // answer — one step of lookahead from the SAME advance read that drove this session's
+        // discharge (the driver passes it through; feature callers have no fresh read in hand and
+        // pass nothing — re-reading here is off the table, the advance read is a write-lane pass).
+        // Min-folded below: the outlook can only make the poke earlier, never later, and the
+        // authorities it augments — `migrationSyncWakeups`, the row windows — keep their say.
+        let outlookDate = MigrationDerivations.outlookCandidateDate(
+            outlook: outlook,
+            clock: clock,
+            now: now,
+            sendGate: gate
+        )
+        guard let nextStepDate = [proveDate, sendDate, blockerDate, outlookDate].compactMap({ $0 }).min() else {
             // Nothing left to do — retire THIS ACCOUNT's poke rather than leaving a stale one
             // armed. Scoped (audit 2026-08-03, P1): the wallet-wide sweep this used to be erased
             // the OTHER account's just-armed poke on every per-account arming pass — the
@@ -2168,6 +2182,8 @@ final class MigrationManagerImpl: @unchecked Sendable {
             source = "prove wake-up"
         } else if nextStepDate == sendDate {
             source = "send window"
+        } else if nextStepDate == outlookDate {
+            source = "engine outlook (\(outlook.map { String(describing: $0.kind) } ?? "?"))"
         } else {
             source = "attention blocker"
         }
@@ -2178,6 +2194,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
             "\(Self.logTag) notification ARMED for \(nextStepDate) (in \(inSeconds)s) — \(source)"
             + "; prove \(proveDate.map(String.init(describing:)) ?? "none")"
             + ", send \(sendDate.map(String.init(describing:)) ?? "none")"
+            + ", outlook \(outlookDate.map(String.init(describing:)) ?? "none")"
             + "; buffer \(Int(clock.notificationBuffer))s at \(Int(clock.secondsPerBlock))s/block"
         )
     }
@@ -3485,6 +3502,30 @@ enum MigrationDerivations {
         }
 
         return accountUUIDs
+    }
+
+    /// P4 (outlook adoption, #2936): the engine outlook's arming candidate — the pure half.
+    ///
+    /// Height→date through the same measured clock every other candidate uses. The KIND is
+    /// consulted for exactly one thing: a `.broadcast` outlook takes the same privacy clamp the
+    /// row-derived send window does — a poke must not invite a send the gate would refuse. Every
+    /// other kind is a sync- or user-shaped visit, which is what the buffer separates sends FROM,
+    /// so it arms unclamped. The caller min-folds the result: an outlook can only make the poke
+    /// EARLIER, never later.
+    static func outlookCandidateDate(
+        outlook: MigrationNextWork?,
+        clock: MigrationChainClock,
+        now: Date,
+        sendGate: MigrationSendGate
+    ) -> Date? {
+        guard let outlook else { return nil }
+        var date = clock.notificationDate(atHeight: outlook.height, now: now)
+        if outlook.kind == MigrationStepKind.broadcast,
+            case let MigrationSendGate.waitUntil(gateUntil) = sendGate,
+            gateUntil > date {
+            date = gateUntil
+        }
+        return date
     }
 
     /// See MOB-1466 spec, "bannerVariant derivation" table. `isIronwoodActivated` (MOB-1483) is

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -2162,10 +2162,10 @@ final class MigrationManagerImpl: @unchecked Sendable {
             Data(resolvedAccountUUID.id).hexEncodedString()
         )
 
-        // WHEN, and WHICH of the two candidates won. A poke is the one part of this lane the user
+        // WHEN, and WHICH of the four candidates won. A poke is the one part of this lane the user
         // meets while the app is closed, so "did it arm, and for when" cannot be answered by
-        // watching the app — and §7 of the scenario sheet is untestable without it. Both candidate
-        // dates are printed, not just the winner: a poke firing at the wrong moment is almost
+        // watching the app — and §7 of the scenario sheet is untestable without it. Every candidate
+        // date is printed, not just the winner: a poke firing at the wrong moment is almost
         // always the other candidate having been the one that mattered.
         // Authorization, every time. A denied/undetermined status makes every arm below a silent
         // no-op, and that is the first thing to check when a poke never arrives.
@@ -2194,6 +2194,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
             "\(Self.logTag) notification ARMED for \(nextStepDate) (in \(inSeconds)s) — \(source)"
             + "; prove \(proveDate.map(String.init(describing:)) ?? "none")"
             + ", send \(sendDate.map(String.init(describing:)) ?? "none")"
+            + ", blocker \(blockerDate.map(String.init(describing:)) ?? "none")"
             + ", outlook \(outlookDate.map(String.init(describing:)) ?? "none")"
             + "; buffer \(Int(clock.notificationBuffer))s at \(Int(clock.secondsPerBlock))s/block"
         )

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -719,7 +719,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
         let hasInvalid = await hasInvalidTask
         let hasOverdue = await hasOverdueTask
         let clock = await clockTask
-        let advanceStep = await advanceStepTask
+        let advanceStep = (await advanceStepTask)?.step
 
         let state = rawState
 
@@ -2202,7 +2202,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
         // suppresses sync for the open.
         var visit = MigrationVisit.sync
         for accountUUID in accountUUIDs {
-            let step = try? await sdkSynchronizer.migrationAdvanceStep(accountUUID)
+            let step = (try? await sdkSynchronizer.migrationAdvanceStep(accountUUID))?.step
             // THE key driver, logged verbatim. Everything this lane does follows from the engine's
             // answer here, and until 07-31 it was the one thing never written down: a run sitting at
             // 0-of-12 looked identical whether the engine was saying `prove`, `waiting`, or
@@ -2350,7 +2350,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
     /// warning naming the exact prover error — but that line goes to the Rust `tracing` → os_log
     /// bridge (subsystem `co.electriccoin.ios`, category `rust`), NOT through `LoggerProxy`, so it
     /// never reaches the stream anyone reads while testing. Field-caught 2026-08-01: a run sat at
-    /// 0-of-12 for a day with `prove sweep: proved 0` next to `advance step: prove(id: 0)` and
+    /// 0-of-12 for a day with `prove sweep: proved 0` next to `advance step: prove(transactions: …)` and
     /// nothing anywhere naming the reason.
     ///
     /// The three heights are the reading, and they separate the two candidate causes without
@@ -2531,7 +2531,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
             // estimate and answers `.nothingDue`/`.awaitingProof` honestly, so a false positive
             // here degrades to a held verdict, never a wrong send.
             let deliverableId: UInt32?
-            if case let MigrationAdvanceStep.broadcast(stepId)? = try? await sdkSynchronizer.migrationAdvanceStep(accountUUID) {
+            if case let MigrationAdvanceStep.broadcast(stepId)? = (try? await sdkSynchronizer.migrationAdvanceStep(accountUUID))?.step {
                 deliverableId = stepId
             } else if (try? await sdkSynchronizer.hasOverdueMigrationTransfers(accountUUID, true)) == true,
                 let proposal = try? await sdkSynchronizer.pendingMigrationTransferProposal(accountUUID) {
@@ -3163,7 +3163,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
     /// healthy account with no run reads a successful `nil` step and derives `.notStarted`.
     ///
     /// The `do`/`catch` is load-bearing and must not be "tidied" back into `try?`. `migrationAdvanceStep`
-    /// returns `MigrationAdvanceStep?`, and since SE-0230 `try?` FLATTENS a throwing optional call
+    /// returns `MigrationAdvance?`, and since SE-0230 `try?` FLATTENS a throwing optional call
     /// into a single optional — so `try? await …` collapses "threw" and "no run" into the same `nil`,
     /// and a `guard let … else { return nil }` on it treats a perfectly healthy no-run account as a
     /// failed read. That is exactly what happened: a freshly restored wallet has no run, so every
@@ -3172,9 +3172,9 @@ final class MigrationManagerImpl: @unchecked Sendable {
     /// `MigrationState.derive`'s documented `advanceStep == nil` arm was live-unreachable; only tests
     /// (which pass the optional directly) ever exercised it, which is why 778 of them stayed green.
     private func migrationState(accountUUID: AccountUUID) async -> MigrationState? {
-        let advanceStep: MigrationAdvanceStep?
+        let advance: MigrationAdvance?
         do {
-            advanceStep = try await sdkSynchronizer.migrationAdvanceStep(accountUUID)
+            advance = try await sdkSynchronizer.migrationAdvanceStep(accountUUID)
         } catch {
             // The read itself failed. Degrade to no state so callers keep their previous value
             // rather than flipping to `.notStarted`.
@@ -3182,7 +3182,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
             return nil
         }
         return MigrationState.derive(
-            advanceStep: advanceStep,
+            advanceStep: advance?.step,
             progress: try? await sdkSynchronizer.getMigrationProgress(accountUUID),
             statuses: (try? await sdkSynchronizer.migrationTransactionStatuses(accountUUID)) ?? [],
             hasInvalidTransfers: await hasInvalidMigrationTransfers(accountUUID: accountUUID)

--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -2015,7 +2015,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
     /// height-based due-ness at open (`executeNextPendingMigrationTransfer`'s nil return is the
     /// sole authority — matrix D7). An early poke therefore causes no broadcast, only a calm
     /// "not yet".
-    /// Arms THE notification — exactly one, wallet-wide, always.
+    /// Arms THE notification — exactly one per account, always.
     ///
     /// The migration has no background lane. Nothing happens unless the user opens Zodl, and each
     /// open is one opportunity to take ONE step: sync, or send, or split, or re-plan. Which one
@@ -2035,9 +2035,9 @@ final class MigrationManagerImpl: @unchecked Sendable {
     /// scheduled local notification cannot be conditionally withdrawn at delivery time. With one
     /// poke, armed fresh on every open, there is nothing to suppress.
     ///
-    /// Wallet-wide rather than per-account on purpose: two accounts migrating at once still means
-    /// one app to open, and a poke that named an account would have to promise which one still
-    /// needs attention by the time it fires. It cannot.
+    /// Content-generic rather than account-specific on purpose: two accounts migrating at once
+    /// still means one app to open, and a poke that named an account would have to promise which
+    /// one still needs attention by the time it fires. It cannot.
     ///
     /// P3: the poke is armed at the earliest moment the run has ANY step to take, which is not
     /// always the next transfer's window. The engine schedules its own sync/proving wake-ups
@@ -2146,7 +2146,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
             // armed. Scoped (audit 2026-08-03, P1): the wallet-wide sweep this used to be erased
             // the OTHER account's just-armed poke on every per-account arming pass — the
             // account with nothing pending wiped everything and armed nothing.
-            MigrationTrace.notificationCancelled("no prove wake-up and no unsent row")
+            MigrationTrace.notificationCancelled("no prove wake-up, no unsent row, no blocker and no outlook")
             await userNotifications.cancelMigrationNotifications(accountHex)
             return
         }
@@ -2166,7 +2166,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
         // meets while the app is closed, so "did it arm, and for when" cannot be answered by
         // watching the app — and §7 of the scenario sheet is untestable without it. Every candidate
         // date is printed, not just the winner: a poke firing at the wrong moment is almost
-        // always the other candidate having been the one that mattered.
+        // always another candidate having been the one that mattered.
         // Authorization, every time. A denied/undetermined status makes every arm below a silent
         // no-op, and that is the first thing to check when a poke never arrives.
         let authorization = await userNotifications.authorizationStatus()

--- a/secant/Sources/Dependencies/MigrationManager/MigrationStepDriver.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationStepDriver.swift
@@ -309,7 +309,10 @@ extension MigrationManagerImpl {
         // keeps arming, exactly like the two opens.
         if !isQuietTick {
             for accountUUID in accountUUIDs {
-                await armNextWindowNotifications(accountUUID: accountUUID)
+                // P4: the account's own outlook from THIS drive's read — the single engine read
+                // feeding the session decision, the discharge, the log, and now the arm.
+                let outlook = steps.first { $0.accountUUID == accountUUID }?.advance?.next
+                await armNextWindowNotifications(accountUUID: accountUUID, outlook: outlook)
             }
         }
 

--- a/secant/Sources/Dependencies/MigrationManager/MigrationStepDriver.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationStepDriver.swift
@@ -249,16 +249,16 @@ extension MigrationManagerImpl {
         // the exact flattening `MigrationManagerLiveKey`'s own state-read doc forbids. A throw is
         // recorded per-account; accounts that read cleanly still discharge, and an all-throw pass
         // surfaces as `.failed` below — substantive, event-logged, loop-surviving.
-        var steps: [(accountUUID: AccountUUID, step: MigrationAdvanceStep?)] = []
+        var steps: [(accountUUID: AccountUUID, advance: MigrationAdvance?)] = []
         // MOB-1466: buffered, not logged immediately — a `.tick`'s log LEVEL depends on the verdict
         // these reads feed into, which isn't known until `discharge` below returns. See the emission
         // loop after it.
         var stepLogLines: [String] = []
         var stepReadFailure: String?
         for accountUUID in accountUUIDs {
-            let step: MigrationAdvanceStep?
+            let advance: MigrationAdvance?
             do {
-                step = try await sdkSynchronizer.migrationAdvanceStep(accountUUID)
+                advance = try await sdkSynchronizer.migrationAdvanceStep(accountUUID)
             } catch {
                 stepReadFailure = "\(error.toZcashError())"
                 stepLogLines.append("\(Self.logTag) advance step (\(phase)): READ FAILED — \(error.toZcashError())")
@@ -267,10 +267,12 @@ extension MigrationManagerImpl {
             // THE key driver line, logged verbatim at both phases. A run sitting at 0-of-12 looks
             // identical whether the engine is saying `prove`, `waiting` or `broadcast` — this is the
             // line that tells those apart, and until 07-31 it was the one thing never written down.
-            stepLogLines.append(
-                "\(Self.logTag) advance step (\(phase)): \(step.map { String(describing: $0) } ?? "none (no run)")"
-            )
-            steps.append((accountUUID, step))
+            // The step keeps its verbatim print (grep-stable); the engine's outlook (#2936) rides as
+            // a suffix when present — advisory, consumed by the arming pass below.
+            let stepDescription = advance.map { String(describing: $0.step) } ?? "none (no run)"
+            let outlookSuffix = advance?.next.map { " — next: \($0.kind) @ \($0.height)" } ?? ""
+            stepLogLines.append("\(Self.logTag) advance step (\(phase)): \(stepDescription)\(outlookSuffix)")
+            steps.append((accountUUID, advance))
         }
 
         var verdict = await discharge(steps: steps, phase: phase)
@@ -368,13 +370,14 @@ extension MigrationManagerImpl {
     /// already priority-ordered, and ZIP 318 caps a session at one broadcast, so "first substantive"
     /// is the honest summary of what this open accomplished.
     private func discharge(
-        steps: [(accountUUID: AccountUUID, step: MigrationAdvanceStep?)],
+        steps: [(accountUUID: AccountUUID, advance: MigrationAdvance?)],
         phase: MigrationOpenPhase
     ) async -> MigrationStepVerdict {
         var fallback = MigrationStepVerdict.noRun
         var firstHeld: MigrationStepVerdict?
 
-        for (accountUUID, step) in steps {
+        for (accountUUID, advance) in steps {
+            let step = advance?.step
             // AUD-3: kind-awareness for the broadcast cells. A note-PREPARATION is ZIP-exempt from
             // the transfer-only throttles (session separation, buffer, mode belt, manual hold),
             // and the plan's `.afterSync` broadcast cell forks on it — so the kind is derived

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
@@ -54,16 +54,20 @@ struct SDKSynchronizerClient: Sendable {
     // needs — Phase 1 the banner state read, Phase 2 the two propose lanes below.
 
     /// What this account's migration needs NEXT, decided by the engine from persisted state alone —
-    /// `nil` when no run is stored. The replacement for the retired 5-case `MigrationState`: that
-    /// enum conflated "what is true" with "what to do", and every app-side consumer actually wanted
-    /// the latter.
+    /// `nil` when no run is stored. The step (``MigrationAdvance/step``) is the replacement for the
+    /// retired 5-case `MigrationState`: that enum conflated "what is true" with "what to do", and
+    /// every app-side consumer actually wanted the latter. The wrapper also carries the engine's
+    /// advisory OUTLOOK (``MigrationAdvance/next``): when, and of what kind, the migration next has
+    /// serviceable work assuming this step is executed — `nil` when nothing is height-schedulable.
+    /// One step of lookahead, superseded by the next read; consumed by the driver's arming pass and
+    /// never cached across state changes.
     ///
     /// Priority is BROADCAST > PROVE > REBUILD, and that ordering is load-bearing: ZIP 318 wants a
     /// waking session used either to sync or to broadcast, never both, so surfacing every due
     /// broadcast first is what makes a sync-free broadcast session possible. The step is memoryless
     /// about sessions — it says WHAT, the app says WHEN (which visit type). See
     /// `MigrationManagerImpl` for the app's own session policy.
-    let migrationAdvanceStep: @Sendable (AccountUUID) async throws -> MigrationAdvanceStep?
+    let migrationAdvanceStep: @Sendable (AccountUUID) async throws -> MigrationAdvance?
     /// The full scheduled-migration schedule for the account's spendable Orchard balance.
     let proposeMigrationTransfers: @Sendable (AccountUUID) async throws -> MigrationSchedule
     /// Proposes the immediate (single-transaction) migration — an ordinary send-max proposal,

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
@@ -233,7 +233,7 @@ extension SDKSynchronizerClient {
         isInitialized: @escaping @Sendable () -> Bool = { false },
     importAccount: @escaping @Sendable (String, [UInt8]?, Zip32AccountIndex?, AccountPurpose, String, String?, BlockHeight?) async throws -> AccountUUID? = { _, _, _, _, _, _, _ in nil },
         deleteAccount: @escaping @Sendable (AccountUUID) async throws -> Void = { _ in },
-        migrationAdvanceStep: @escaping @Sendable (AccountUUID) async throws -> MigrationAdvanceStep? = { _ in nil },
+        migrationAdvanceStep: @escaping @Sendable (AccountUUID) async throws -> MigrationAdvance? = { _ in nil },
         proposeMigrationTransfers: @escaping @Sendable (AccountUUID) async throws -> MigrationSchedule = { _ in throw ZcashError.synchronizerNotPrepared },
         proposeImmediateMigration: @escaping @Sendable (AccountUUID) async throws -> ImmediateMigrationProposal = { _ in throw ZcashError.synchronizerNotPrepared },
         recordImmediateMigration: @escaping @Sendable (AccountUUID, Data) async throws -> Void = { _, _ in },

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -651,8 +651,8 @@ extension Root {
                                 // the gate's false edge (the probe's work is moot once unblocked).
                                 for attempt in 0..<Root.Constants.migrationGateStopProbeAttempts {
                                     for accountUUID in stoppableCandidateUUIDs {
-                                        let step = try? await sdkSynchronizer.migrationAdvanceStep(accountUUID)
-                                        if case .broadcast = step {
+                                        let advance = try? await sdkSynchronizer.migrationAdvanceStep(accountUUID)
+                                        if case .broadcast = advance?.step {
                                             // RACE GUARD: `.cancel(id:)` is cooperative — it cannot abort the
                                             // `migrationAdvanceStep` await already in flight above, and `try?`
                                             // swallows any cancellation error that call itself might throw. Without

--- a/secant/Sources/Models/Migration/MigrationStepPlan.swift
+++ b/secant/Sources/Models/Migration/MigrationStepPlan.swift
@@ -207,18 +207,22 @@ enum MigrationStepPlan {
                 return MigrationStepAction.broadcast(id: id)
             }
 
-        case let MigrationAdvanceStep.prove(id, kind):
-            // The kind (`.transfer` vs `.preparation`) changes what happens AFTER the proof — a
-            // preparation broadcasts at the SAME wake-up, a transfer waits for its own session —
-            // so it rides the action into the driver's prove discharge. D2 (nuttycom, 2026-08-05):
-            // "there should be no second call needed — inspect the kind attribute of
-            // `Prove { id, kind }`, and if it matches Preparation then prove and broadcast." The
-            // step itself is the sanction; nothing re-asks the engine. (An earlier draft chained a
-            // `next_step` re-ask after the sweep and delivered only what it offered — one call too
-            // many, by the author's own word.)
+        case let MigrationAdvanceStep.prove(transactions):
+            // The engine offers the WHOLE provable set (#2939) — earliest-ready first, never empty
+            // (SDK contract; `transactions[0]` below leans on it, and a breached contract must
+            // crash here rather than read as "no run"). The action still carries ONE id: the HEAD,
+            // exactly the entry the old single-id step named. The discharge's sweep proves every
+            // ready row in one pass regardless; the head's id/kind only route what happens AFTER
+            // the proof — a preparation broadcasts at the SAME wake-up, a transfer waits for its
+            // own session. D2 (nuttycom, 2026-08-05): "there should be no second call needed —
+            // inspect the kind attribute of `Prove { id, kind }`, and if it matches Preparation
+            // then prove and broadcast." The step itself is the sanction; nothing re-asks the
+            // engine. (A preparation elsewhere in the batch behind a transfer head still gets
+            // PROVED by the whole-queue sweep; its broadcast follows at the edge whose step names
+            // it — nothing new to handle.)
             switch phase {
             case MigrationOpenPhase.afterSync:
-                return MigrationStepAction.prove(id: id, isPreparation: kind.isPreparation)
+                return MigrationStepAction.prove(id: transactions[0].id, isPreparation: transactions[0].kind.isPreparation)
             case MigrationOpenPhase.tick:
                 // A tick proves UNCONDITIONALLY (FIND-5, 2026-08-05). Two prior versions of this
                 // cell each starved a real session: full deferral (pre-2026-08-02) starved
@@ -232,7 +236,7 @@ enum MigrationStepPlan {
                 // mid-sync. Proving is local computation, so ZIP 318's broadcast-session
                 // separation is untouched. The one tick-side refinement lives in the driver: a
                 // sweep already adjudicated STALLED is not re-run every 30s.
-                return MigrationStepAction.prove(id: id, isPreparation: kind.isPreparation)
+                return MigrationStepAction.prove(id: transactions[0].id, isPreparation: transactions[0].kind.isPreparation)
             case MigrationOpenPhase.beforeSync:
                 // The open's own edge is moments away and must stay free to broadcast instead —
                 // deferring here is unchanged even at the tip.

--- a/zodlTests/MigrationTests/MigrationAdvanceStepBannerTests.swift
+++ b/zodlTests/MigrationTests/MigrationAdvanceStepBannerTests.swift
@@ -192,7 +192,7 @@ import ZcashLightClientKit
     /// The precedence that A28 made reachable. The engine can still report a perfectly live
     /// `.waiting` for a run whose funding notes were spent elsewhere — it has no way to know until
     /// the app's invalidation sweep tells it — so a live-looking step must not mask a dead run.
-    @Test(arguments: [MigrationAdvanceStep.waiting, .prove(id: 1, kind: .transfer(crossing: 0)), .broadcast(id: 1)])
+    @Test(arguments: [MigrationAdvanceStep.waiting, .prove(transactions: [MigrationProveTarget(id: 1, kind: .transfer(crossing: 0))]), .broadcast(id: 1)])
     func invalidationOutranksALiveStep(step: MigrationAdvanceStep) {
         #expect(Self.banner(advanceStep: step, hasInvalid: true) == .updatePlan)
     }
@@ -206,7 +206,10 @@ import ZcashLightClientKit
     /// counts idle (`.idleCounts`), never the notify line (`.idle` is termination-only,
     /// store-entered) and never a numberless progress claim.
     @Test func aProveStepWithoutInFlightRowsReadsAsIdle() {
-        let variant = Self.banner(advanceStep: .prove(id: 1, kind: .transfer(crossing: 0)), progress: Self.progress())
+        let variant = Self.banner(
+            advanceStep: .prove(transactions: [MigrationProveTarget(id: 1, kind: .transfer(crossing: 0))]),
+            progress: Self.progress()
+        )
         #expect(variant == .idleCounts(done: 0, total: 0))
     }
 
@@ -226,7 +229,7 @@ import ZcashLightClientKit
         ]
         let rows = [MigrationTransferRow(id: "10", index: 0, amount: nil, status: .pending, hoursFromNow: 6)]
         let variant = Self.banner(
-            advanceStep: .prove(id: 2, kind: .preparation(layer: 1, index: 0)),
+            advanceStep: .prove(transactions: [MigrationProveTarget(id: 2, kind: .preparation(layer: 1, index: 0))]),
             progress: Self.progress(),
             statuses: statuses,
             transferRows: rows
@@ -274,8 +277,8 @@ import ZcashLightClientKit
     /// Every advance step the engine can report produces SOME user-visible answer — none of them
     /// falls into a hole that renders nothing while a run is live.
     @Test(arguments: [
-        MigrationAdvanceStep.prove(id: 1, kind: .transfer(crossing: 0)),
-        .prove(id: 1, kind: .preparation(layer: 0, index: 0)),
+        MigrationAdvanceStep.prove(transactions: [MigrationProveTarget(id: 1, kind: .transfer(crossing: 0))]),
+        .prove(transactions: [MigrationProveTarget(id: 1, kind: .preparation(layer: 0, index: 0))]),
         .broadcast(id: 1),
         .rebuild(id: 1),
         .waiting,

--- a/zodlTests/MigrationTests/MigrationBannerEntryTests.swift
+++ b/zodlTests/MigrationTests/MigrationBannerEntryTests.swift
@@ -77,7 +77,7 @@ import ComposableArchitecture
     /// `advanceStep` says otherwise, no migration run at all.
     private static func bannerVariant(
         balance: Zatoshi,
-        advanceStep: @escaping @Sendable (AccountUUID) async throws -> MigrationAdvanceStep? = { _ in nil },
+        advanceStep: @escaping @Sendable (AccountUUID) async throws -> MigrationAdvance? = { _ in nil },
         state: @escaping @Sendable () -> SynchronizerState = { syncedState() }
     ) async -> MigrationBannerVariant? {
         await withDependencies {

--- a/zodlTests/MigrationTests/MigrationSendGateAndArmingTests.swift
+++ b/zodlTests/MigrationTests/MigrationSendGateAndArmingTests.swift
@@ -201,4 +201,85 @@ import ZcashLightClientKit
 
         #expect(Self.nextBroadcast(preparations: preparations, transfers: transfers) == nil)
     }
+
+    // MARK: - P4: the engine outlook's arming candidate (pure half)
+
+    /// A `.prove` outlook is a sync visit — the buffer separates sends FROM syncs, so no clamp
+    /// applies even while the gate is closed.
+    @Test func aProveOutlookArmsUnclampedInsideTheBuffer() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let date = MigrationDerivations.outlookCandidateDate(
+            outlook: MigrationNextWork(height: 3_000_010, kind: .prove),
+            clock: Self.clock,
+            now: now,
+            sendGate: .waitUntil(now.addingTimeInterval(100_000))
+        )
+        #expect(date == Self.clock.notificationDate(atHeight: 3_000_010, now: now))
+    }
+
+    /// A `.broadcast` outlook inside the buffer is clamped to the gate's expiry — the poke must
+    /// not invite a send the gate would refuse.
+    @Test func aBroadcastOutlookInsideTheBufferClampsToTheGate() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let unclamped = Self.clock.notificationDate(atHeight: 3_000_001, now: now)
+        let gateUntil = unclamped.addingTimeInterval(500)
+        let date = MigrationDerivations.outlookCandidateDate(
+            outlook: MigrationNextWork(height: 3_000_001, kind: .broadcast),
+            clock: Self.clock,
+            now: now,
+            sendGate: .waitUntil(gateUntil)
+        )
+        #expect(date == gateUntil)
+    }
+
+    /// A gate that expires before the window changes nothing — the clamp is a max, not an add.
+    @Test func aBroadcastOutlookPastTheGatesExpiryIsUnclamped() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let window = Self.clock.notificationDate(atHeight: 3_000_100, now: now)
+        let date = MigrationDerivations.outlookCandidateDate(
+            outlook: MigrationNextWork(height: 3_000_100, kind: .broadcast),
+            clock: Self.clock,
+            now: now,
+            sendGate: .waitUntil(now.addingTimeInterval(1))
+        )
+        #expect(date == window)
+    }
+
+    /// An open gate arms the broadcast outlook at its own window.
+    @Test func aBroadcastOutlookWithAnOpenGateArmsAtItsWindow() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let date = MigrationDerivations.outlookCandidateDate(
+            outlook: MigrationNextWork(height: 3_000_050, kind: .broadcast),
+            clock: Self.clock,
+            now: now,
+            sendGate: .allowed
+        )
+        #expect(date == Self.clock.notificationDate(atHeight: 3_000_050, now: now))
+    }
+
+    /// `.rebuild`/`.replan` are user-shaped visits: plain candidates, no clamp.
+    @Test func userShapedOutlookKindsArmUnclamped() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        for kind in [MigrationStepKind.rebuild, MigrationStepKind.replan] {
+            let date = MigrationDerivations.outlookCandidateDate(
+                outlook: MigrationNextWork(height: 3_000_020, kind: kind),
+                clock: Self.clock,
+                now: now,
+                sendGate: .waitUntil(now.addingTimeInterval(100_000))
+            )
+            #expect(date == Self.clock.notificationDate(atHeight: 3_000_020, now: now))
+        }
+    }
+
+    /// No outlook, no candidate — the arm's other three candidates decide alone.
+    @Test func aNilOutlookContributesNoCandidate() {
+        #expect(
+            MigrationDerivations.outlookCandidateDate(
+                outlook: nil,
+                clock: Self.clock,
+                now: Date(timeIntervalSince1970: 1_000_000),
+                sendGate: .allowed
+            ) == nil
+        )
+    }
 }

--- a/zodlTests/MigrationTests/MigrationSplitOverdueRouteTests.swift
+++ b/zodlTests/MigrationTests/MigrationSplitOverdueRouteTests.swift
@@ -138,7 +138,7 @@ import ZcashLightClientKit
         let route = Self.route(
             state: .inProgress(Self.progress()),
             hasOverdue: true,
-            advanceStep: .prove(id: 3, kind: .transfer(crossing: 0))
+            advanceStep: .prove(transactions: [MigrationProveTarget(id: 3, kind: .transfer(crossing: 0))])
         )
 
         #expect(route != .statusResume)
@@ -202,7 +202,7 @@ import ZcashLightClientKit
         let route = Self.route(
             state: .inProgress(Self.progress()),
             hasOverdue: true,
-            advanceStep: .prove(id: 1, kind: .transfer(crossing: 0))
+            advanceStep: .prove(transactions: [MigrationProveTarget(id: 1, kind: .transfer(crossing: 0))])
         )
         #expect(route == .statusProgress)
     }

--- a/zodlTests/MigrationTests/MigrationStepPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationStepPlanTests.swift
@@ -64,7 +64,7 @@ import ZcashLightClientKit
     /// The mirror: proving needs the commitment tree at the tip, so it only happens after a sync —
     /// and never in a broadcast session, where it would force that session onto the wire.
     @Test func proveIsOfferedOnlyAfterSync() {
-        let step = MigrationAdvanceStep.prove(id: 1, kind: .transfer(crossing: 0))
+        let step = MigrationAdvanceStep.prove(transactions: [MigrationProveTarget(id: 1, kind: .transfer(crossing: 0))])
 
         #expect(MigrationStepPlan.action(for: step, phase: .afterSync) == .prove(id: 1, isPreparation: false))
         #expect(MigrationStepPlan.action(for: step, phase: .beforeSync) == .nothing(.wrongPhase))
@@ -75,11 +75,34 @@ import ZcashLightClientKit
     /// a preparation's same-pass broadcast in the discharge — not a statuses re-read, and never a
     /// `next_step` re-ask.
     @Test func bothProveKindsProveButTheActionCarriesTheKind() {
-        let preparation = MigrationAdvanceStep.prove(id: 9, kind: .preparation(layer: 0, index: 0))
-        let transfer = MigrationAdvanceStep.prove(id: 9, kind: .transfer(crossing: 0))
+        let preparation = MigrationAdvanceStep.prove(transactions: [MigrationProveTarget(id: 9, kind: .preparation(layer: 0, index: 0))])
+        let transfer = MigrationAdvanceStep.prove(transactions: [MigrationProveTarget(id: 9, kind: .transfer(crossing: 0))])
 
         #expect(MigrationStepPlan.action(for: preparation, phase: .afterSync) == .prove(id: 9, isPreparation: true))
         #expect(MigrationStepPlan.action(for: transfer, phase: .afterSync) == .prove(id: 9, isPreparation: false))
+    }
+
+    /// #2939 batch step: the action takes the HEAD — the earliest-ready entry, exactly what the
+    /// old single-id step carried. A preparation later in the batch changes nothing here: the
+    /// sweep proves the whole queue regardless, and the head's kind is what routes the
+    /// after-proof step.
+    @Test func aBatchProveActsOnItsHeadEntry() {
+        let step = MigrationAdvanceStep.prove(transactions: [
+            MigrationProveTarget(id: 4, kind: .transfer(crossing: 0)),
+            MigrationProveTarget(id: 9, kind: .preparation(layer: 0, index: 0))
+        ])
+        #expect(MigrationStepPlan.action(for: step, phase: .afterSync) == .prove(id: 4, isPreparation: false))
+        #expect(MigrationStepPlan.action(for: step, phase: .tick) == .prove(id: 4, isPreparation: false))
+    }
+
+    /// The mirror order: a preparation head keeps its same-wake-up broadcast routing even with a
+    /// transfer queued behind it.
+    @Test func aPreparationHeadKeepsItsSameWakeupRouting() {
+        let step = MigrationAdvanceStep.prove(transactions: [
+            MigrationProveTarget(id: 2, kind: .preparation(layer: 1, index: 0)),
+            MigrationProveTarget(id: 7, kind: .transfer(crossing: 0))
+        ])
+        #expect(MigrationStepPlan.action(for: step, phase: .afterSync) == .prove(id: 2, isPreparation: true))
     }
 
     // MARK: - The quiet answers
@@ -129,8 +152,8 @@ import ZcashLightClientKit
     /// sweep is safe on any schedule — the tick obeys it, full stop. This test is the
     /// anti-regression pin for BOTH failure modes.
     @Test func tickProvesUnconditionally() {
-        let transfer = MigrationAdvanceStep.prove(id: 1, kind: .transfer(crossing: 0))
-        let preparation = MigrationAdvanceStep.prove(id: 1, kind: .preparation(layer: 0, index: 0))
+        let transfer = MigrationAdvanceStep.prove(transactions: [MigrationProveTarget(id: 1, kind: .transfer(crossing: 0))])
+        let preparation = MigrationAdvanceStep.prove(transactions: [MigrationProveTarget(id: 1, kind: .preparation(layer: 0, index: 0))])
 
         #expect(MigrationStepPlan.action(for: transfer, phase: .tick) == .prove(id: 1, isPreparation: false))
         #expect(MigrationStepPlan.action(for: preparation, phase: .tick) == .prove(id: 1, isPreparation: true))
@@ -140,7 +163,7 @@ import ZcashLightClientKit
     /// prove (its own edge is moments away, and the open must stay free to broadcast instead),
     /// and rebuild/attention keep their edge anchoring untouched.
     @Test func tickProveLeavesEveryOtherCellAlone() {
-        let transfer = MigrationAdvanceStep.prove(id: 1, kind: .transfer(crossing: 0))
+        let transfer = MigrationAdvanceStep.prove(transactions: [MigrationProveTarget(id: 1, kind: .transfer(crossing: 0))])
 
         #expect(MigrationStepPlan.action(for: transfer, phase: .beforeSync) == .nothing(.wrongPhase))
         #expect(MigrationStepPlan.action(for: .rebuild(id: 7), phase: .tick) == .nothing(.wrongPhase))
@@ -168,8 +191,8 @@ import ZcashLightClientKit
     @Test func everyStepIsActionableAtSomePhase() {
         let everyStep: [MigrationAdvanceStep] = [
             .broadcast(id: 1),
-            .prove(id: 1, kind: .transfer(crossing: 0)),
-            .prove(id: 1, kind: .preparation(layer: 0, index: 0)),
+            .prove(transactions: [MigrationProveTarget(id: 1, kind: .transfer(crossing: 0))]),
+            .prove(transactions: [MigrationProveTarget(id: 1, kind: .preparation(layer: 0, index: 0))]),
             .rebuild(id: 1),
             .requiresAttention(id: 1),
             .waiting,
@@ -201,7 +224,7 @@ import ZcashLightClientKit
     /// `nil` entries (an account with no run, or a read that failed) do not vote.
     @Test func accountsWithNoRunDoNotVote() {
         #expect(!MigrationStepPlan.isBroadcastSession(steps: [nil, nil]))
-        #expect(!MigrationStepPlan.isBroadcastSession(steps: [nil, .prove(id: 1, kind: .preparation(layer: 0, index: 0))]))
+        #expect(!MigrationStepPlan.isBroadcastSession(steps: [nil, .prove(transactions: [MigrationProveTarget(id: 1, kind: .preparation(layer: 0, index: 0))])]))
     }
 
     /// The session decision must agree with `MigrationVisit`, which Root still asks separately
@@ -213,7 +236,7 @@ import ZcashLightClientKit
             [nil],
             [.waiting],
             [.broadcast(id: 1)],
-            [.prove(id: 1, kind: .preparation(layer: 0, index: 0)), .broadcast(id: 2)],
+            [.prove(transactions: [MigrationProveTarget(id: 1, kind: .preparation(layer: 0, index: 0))]), .broadcast(id: 2)],
             [.rebuild(id: 1), .requiresAttention(id: 2)]
         ]
 

--- a/zodlTests/MigrationTests/MigrationStepPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationStepPlanTests.swift
@@ -224,7 +224,12 @@ import ZcashLightClientKit
     /// `nil` entries (an account with no run, or a read that failed) do not vote.
     @Test func accountsWithNoRunDoNotVote() {
         #expect(!MigrationStepPlan.isBroadcastSession(steps: [nil, nil]))
-        #expect(!MigrationStepPlan.isBroadcastSession(steps: [nil, .prove(transactions: [MigrationProveTarget(id: 1, kind: .preparation(layer: 0, index: 0))])]))
+        #expect(!MigrationStepPlan.isBroadcastSession(
+            steps: [
+                nil,
+                .prove(transactions: [MigrationProveTarget(id: 1, kind: .preparation(layer: 0, index: 0))])
+            ]
+        ))
     }
 
     /// The session decision must agree with `MigrationVisit`, which Root still asks separately

--- a/zodlTests/MigrationTests/MigrationTickDriverTests.swift
+++ b/zodlTests/MigrationTests/MigrationTickDriverTests.swift
@@ -1182,6 +1182,7 @@ import ComposableArchitecture
         } operation: {
             let manager = MigrationManagerImpl(
                 gateStorage: Self.freshGateStorage(mode: .privateScheduled),
+                scheduleStorage: Self.freshScheduleStorage(),
                 sessionOrdinalProvider: { 1 }
             )
             return await manager.advance(phase: .afterSync)

--- a/zodlTests/MigrationTests/MigrationTickDriverTests.swift
+++ b/zodlTests/MigrationTests/MigrationTickDriverTests.swift
@@ -139,7 +139,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 9) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
                     return .executed(.success(txId: "should-never-run"))
@@ -165,7 +165,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 9) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
                     return .executed(.success(txId: "abcd"))
@@ -199,7 +199,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .waiting },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
                 executeNextPendingMigrationTransfer: { _, _, useEstimatedTip in
                     submissionCalls.withValue { $0 += 1 }
                     estFlagsSeen.withValue { $0.append(useEstimatedTip) }
@@ -249,7 +249,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .waiting },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
                     return .executed(.success(txId: "must-not-run"))
@@ -301,7 +301,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 9) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
                 migrationTransactionStatuses: { _ in [Self.preparationStatus(id: 9)] },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
@@ -332,7 +332,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 9) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
                 migrationTransactionStatuses: { _ in [] },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
@@ -364,7 +364,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 9) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
                 migrationTransactionStatuses: { _ in [Self.preparationStatus(id: 9)] },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
@@ -394,7 +394,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 9) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
                 migrationTransactionStatuses: { _ in [] },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
@@ -428,7 +428,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 9) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
                 migrationTransactionStatuses: { _ in [Self.preparationStatus(id: 9)] },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
@@ -471,9 +471,11 @@ import ComposableArchitecture
                 // no read of its own beyond the first; the statuses-empty pin below is what
                 // catches a smuggled-back decision re-ask.)
                 migrationAdvanceStep: { _ in
-                    if submissionCalls.value > 0 { return .waiting }
+                    if submissionCalls.value > 0 { return MigrationAdvance(step: .waiting, next: nil) }
                     let read = stepReads.withValue { $0 += 1; return $0 }
-                    return read == 1 ? .prove(id: 2, kind: .preparation(layer: 1, index: 0)) : .broadcast(id: 2)
+                    return read == 1
+                        ? MigrationAdvance(step: .prove(transactions: [MigrationProveTarget(id: 2, kind: .preparation(layer: 1, index: 0))]), next: nil)
+                        : MigrationAdvance(step: .broadcast(id: 2), next: nil)
                 },
                 // EMPTY on purpose — the old chain's `preparationTransactionIds.contains(id)`
                 // cross-check would break here; the step's kind must be the only authority.
@@ -514,7 +516,9 @@ import ComposableArchitecture
                 isSyncing: { false },
                 migrationAdvanceStep: { _ in
                     let read = stepReads.withValue { $0 += 1; return $0 }
-                    return read == 1 ? .prove(id: 4, kind: .transfer(crossing: 0)) : .broadcast(id: 4)
+                    return read == 1
+                        ? MigrationAdvance(step: .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 0))]), next: nil)
+                        : MigrationAdvance(step: .broadcast(id: 4), next: nil)
                 },
                 migrationTransactionStatuses: { _ in [] },
                 executeNextPendingMigrationTransfer: { _, _, _ in
@@ -554,7 +558,9 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.atTipState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .prove(id: 4, kind: .transfer(crossing: 0)) },
+                migrationAdvanceStep: { _ in
+                    MigrationAdvance(step: .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 0))]), next: nil)
+                },
                 finalizeReadyMigrationTransfers: { _ in
                     sweepCalls.withValue { $0 += 1 }
                     return 1
@@ -582,7 +588,9 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .prove(id: 4, kind: .transfer(crossing: 0)) },
+                migrationAdvanceStep: { _ in
+                    MigrationAdvance(step: .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 0))]), next: nil)
+                },
                 finalizeReadyMigrationTransfers: { _ in
                     sweepCalls.withValue { $0 += 1 }
                     return 1
@@ -614,7 +622,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .waiting },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
                 executeNextPendingMigrationTransfer: { _, _, useEstimatedTip in
                     submissionCalls.withValue { $0 += 1 }
                     #expect(useEstimatedTip, "the submit stays the est-aware single authority")
@@ -653,7 +661,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .waiting },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
                 executeNextPendingMigrationTransfer: { _, _, _ in
                     submissionCalls.withValue { $0 += 1 }
                     return .executed(.success(txId: "must-not-run"))
@@ -717,7 +725,9 @@ import ComposableArchitecture
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
                 migrationAdvanceStep: { accountUUID in
-                    accountUUID == Self.secondAccountUUID ? .broadcast(id: 7) : .broadcast(id: 1)
+                    accountUUID == Self.secondAccountUUID
+                        ? MigrationAdvance(step: .broadcast(id: 7), next: nil)
+                        : MigrationAdvance(step: .broadcast(id: 1), next: nil)
                 },
                 executeNextPendingMigrationTransfer: { accountUUID, _, _ in
                     submittedFor.withValue { $0.append(accountUUID) }
@@ -747,7 +757,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 9) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
                 executeNextPendingMigrationTransfer: { _, _, _ in .nothingDue }
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
@@ -776,7 +786,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.atTipState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .requiresAttention(id: 2) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .requiresAttention(id: 2), next: nil) },
                 migrationTransactionStatuses: { _ in [] }
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
@@ -854,7 +864,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.atTipState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .waiting },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
                 migrationTransactionStatuses: { _ in [] }
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
@@ -896,7 +906,7 @@ import ComposableArchitecture
                 isSyncing: { false },
                 migrationAdvanceStep: { _ in
                     engineReadCount.withValue { $0 += 1 }
-                    return .broadcast(id: 1)
+                    return MigrationAdvance(step: .broadcast(id: 1), next: nil)
                 },
                 migrationPrivacySyncBufferDuration: { 600 }
             )
@@ -934,7 +944,7 @@ import ComposableArchitecture
                     while !releaseFirstRead.value {
                         try? await Task.sleep(nanoseconds: 5_000_000)
                     }
-                    return .waiting
+                    return MigrationAdvance(step: .waiting, next: nil)
                 }
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
@@ -981,7 +991,7 @@ import ComposableArchitecture
                             try? await Task.sleep(nanoseconds: 5_000_000)
                         }
                     }
-                    return .waiting
+                    return MigrationAdvance(step: .waiting, next: nil)
                 }
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
@@ -1036,7 +1046,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .waiting },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
                 migrationSyncWakeups: { _ in
                     armingProbeCalls.withValue { $0 += 1 }
                     return []
@@ -1070,7 +1080,7 @@ import ComposableArchitecture
             $0.sdkSynchronizer = .mocked(
                 latestState: { Self.activatedState() },
                 isSyncing: { false },
-                migrationAdvanceStep: { _ in .broadcast(id: 3) },
+                migrationAdvanceStep: { _ in MigrationAdvance(step: .broadcast(id: 3), next: nil) },
                 executeNextPendingMigrationTransfer: { _, _, _ in .executed(.success(txId: "abcd")) }
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }

--- a/zodlTests/MigrationTests/MigrationTickDriverTests.swift
+++ b/zodlTests/MigrationTests/MigrationTickDriverTests.swift
@@ -81,6 +81,38 @@ import ComposableArchitecture
         $walletAccounts.withLock { $0 = [Self.account()] }
     }
 
+    /// A single pending `.transfer` row at `scheduledHeight` — proved, not yet on the wire — the
+    /// minimal fixture `armNextWindowNotifications`'s row-derived send-window candidate needs.
+    /// Mirrors `MigrationSendGateAndArmingTests.status(...)`'s shape; this suite only ever needs
+    /// this one kind/state combination, so the fuller helper's extra parameters are inlined away.
+    private static func pendingTransferStatus(scheduledHeight: BlockHeight) -> MigrationTransactionStatus {
+        MigrationTransactionStatus(
+            id: 1,
+            kind: .transfer(crossing: 0),
+            state: .proved,
+            scheduledHeight: scheduledHeight,
+            expiryHeight: nil,
+            isReady: false,
+            nextAction: nil,
+            blockedOn: nil,
+            dependsOn: [],
+            anchorBoundaryHeight: nil
+        )
+    }
+
+    /// A freshly-scoped, isolated schedule storage (own `UserDefaults` suite, never `.standard`) —
+    /// `MigrationManagerImpl`'s own default (`MigrationScheduleStorage()`) falls back to `.standard`,
+    /// which PERSISTS on a simulator across separate `xcodebuild test` invocations. The P4 fold
+    /// tests below need `committedSchedule(for: accountUUID) == nil` (so `migrationTransfers`' W1
+    /// statuses-only fallback derives the fabricated row) — a fact `.standard` cannot guarantee once
+    /// any other suite has ever committed a schedule for this file's hardcoded `accountUUID` on this
+    /// same simulator. Mirrors `freshGateStorage` right below.
+    private static func freshScheduleStorage() -> MigrationScheduleStorage {
+        let suiteName = "MigrationTickDriverTests.\(UUID().uuidString)"
+        // swiftlint:disable:next force_unwrapping
+        return MigrationScheduleStorage(userDefaults: UserDefaults(suiteName: suiteName)!)
+    }
+
     /// A freshly-scoped, isolated gate storage (own `UserDefaults` suite, never `.standard`) with
     /// `accountUUID`'s mode pre-set — mirrors `MigrationSendGateAndArmingTests`'s `storage()` helper.
     private static func freshGateStorage(mode: MigrationMode) -> MigrationGateStorage {
@@ -474,7 +506,10 @@ import ComposableArchitecture
                     if submissionCalls.value > 0 { return MigrationAdvance(step: .waiting, next: nil) }
                     let read = stepReads.withValue { $0 += 1; return $0 }
                     return read == 1
-                        ? MigrationAdvance(step: .prove(transactions: [MigrationProveTarget(id: 2, kind: .preparation(layer: 1, index: 0))]), next: nil)
+                        ? MigrationAdvance(
+                            step: .prove(transactions: [MigrationProveTarget(id: 2, kind: .preparation(layer: 1, index: 0))]),
+                            next: nil
+                        )
                         : MigrationAdvance(step: .broadcast(id: 2), next: nil)
                 },
                 // EMPTY on purpose — the old chain's `preparationTransactionIds.contains(id)`
@@ -1104,9 +1139,20 @@ import ComposableArchitecture
 
     /// P4: the outlook is a real arming candidate — a `.waiting` run with no wake-up, no pending
     /// row and no blocker would retire the poke today; the outlook arms it instead.
+    ///
+    /// Pinned to the outlook's OWN window, not merely "some concrete date": `.mocked`'s default
+    /// `estimatedMigrationChainTip` is `{ 0 }`, which makes `MigrationChainClock.secondsUntil`
+    /// degenerate to 0 for EVERY height (`tip > 0` fails), so an unstubbed clock would arm at
+    /// `now + notificationBuffer` regardless of the outlook height — a tautology this test used to
+    /// pass by accident. Stubbing the tip to `Self.tip` (the same fixture `atTipState()` already
+    /// reports) makes the clock real, so the assertion below can only pass if the height is honored.
     @Test func anOutlookArmsThePokeWhereTodayWouldRetireIt() async {
         Self.installCandidateAccount()
         let scheduled = LockIsolated<[(MigrationNotification, Date?)]>([])
+        let secondsPerBlock = MigrationChainClock.targetSecondsPerBlock
+        let notificationBuffer = max(2 * secondsPerBlock, 150)
+        let outlookHeight = Self.tip + 200
+        let beforeDrive = Date()
 
         _ = await withDependencies {
             $0.sdkSynchronizer = .mocked(
@@ -1115,11 +1161,13 @@ import ComposableArchitecture
                 migrationAdvanceStep: { _ in
                     MigrationAdvance(
                         step: .waiting,
-                        next: MigrationNextWork(height: Self.activationHeight + 200, kind: .prove)
+                        next: MigrationNextWork(height: outlookHeight, kind: .prove)
                     )
                 },
                 migrationTransactionStatuses: { _ in [] },
-                migrationSyncWakeups: { _ in [] }
+                migrationSyncWakeups: { _ in [] },
+                estimatedMigrationChainTip: { Self.tip },
+                estimatedMigrationSecondsPerBlock: { secondsPerBlock }
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
             $0.userNotifications = UserNotificationsClient(
@@ -1140,7 +1188,20 @@ import ComposableArchitecture
         }
 
         #expect(!scheduled.value.isEmpty, "the outlook must arm the poke a candidate-less arm would retire")
-        #expect(scheduled.value.first?.1 != nil, "armed at a concrete date, not a placeholder")
+        let armedDate = scheduled.value.first?.1
+        #expect(armedDate != nil, "armed at a concrete date, not a placeholder")
+
+        // 200 blocks out at the measured rate, plus the two-block notification slack — the
+        // outlook's own window (`MigrationChainClock.notificationDate`), not the buffer-only floor
+        // a degenerate clock would produce. `beforeDrive` predates the arm's own `Date()`, so the
+        // true offset from it is always >= `expectedOffset`; the ±60s band absorbs execution slack.
+        let expectedOffset = 200 * secondsPerBlock + notificationBuffer
+        let lowerBound = beforeDrive.addingTimeInterval(expectedOffset - 60)
+        let upperBound = beforeDrive.addingTimeInterval(expectedOffset + 60)
+        if let armedDate {
+            #expect(armedDate >= lowerBound, "armed date must not be earlier than the outlook's window")
+            #expect(armedDate <= upperBound, "armed date must not default to the notificationBuffer-only floor")
+        }
     }
 
     /// P4: the outlook is advisory — it feeds arming only, never the verdict. Same drive as the
@@ -1159,7 +1220,11 @@ import ComposableArchitecture
                     )
                 },
                 migrationTransactionStatuses: { _ in [] },
-                migrationSyncWakeups: { _ in [] }
+                migrationSyncWakeups: { _ in [] },
+                // Height-blindness is harmless here — this test pins the VERDICT, not the armed
+                // date — but stubbed anyway for consistency with the sibling test above, which
+                // does depend on it (see that test's doc for why `.mocked`'s default degrades it).
+                estimatedMigrationChainTip: { Self.tip }
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
             Self.stubUserNotifications(&$0)
@@ -1177,5 +1242,133 @@ import ComposableArchitecture
         // dispatch that could otherwise redirect `.waiting` only fires for `.beforeSync`/`.tick`, so
         // `.afterSync` has no path off `.idle` for this step to begin with.
         #expect(verdict == .idle, "an advisory outlook must not hold or otherwise change the verdict")
+    }
+
+    // MARK: - P4: the outlook joins the min-fold, in both directions
+
+    /// P4: the fold's other half — finding-1's sibling test above only pins the outlook WINNING
+    /// (no row, no wake-up, nothing else armed). That leaves the min-fold itself unpinned: a row
+    /// already gives the arm a real send window, and a far-future outlook must not override it.
+    @Test func anOutlookLaterThanTheRowWindowLeavesTheArmedDateAlone() async {
+        Self.installCandidateAccount()
+        let scheduled = LockIsolated<[(MigrationNotification, Date?)]>([])
+        let secondsPerBlock = MigrationChainClock.targetSecondsPerBlock
+        let notificationBuffer = max(2 * secondsPerBlock, 150)
+        let rowHeight = Self.tip + 400
+        let outlookHeight = Self.tip + 100_000
+        let beforeDrive = Date()
+
+        _ = await withDependencies {
+            $0.sdkSynchronizer = .mocked(
+                latestState: { Self.atTipState() },
+                isSyncing: { false },
+                migrationAdvanceStep: { _ in
+                    MigrationAdvance(step: .waiting, next: MigrationNextWork(height: outlookHeight, kind: .prove))
+                },
+                migrationTransactionStatuses: { _ in [Self.pendingTransferStatus(scheduledHeight: rowHeight)] },
+                migrationSyncWakeups: { _ in [] },
+                estimatedMigrationChainTip: { Self.tip },
+                estimatedMigrationSecondsPerBlock: { secondsPerBlock }
+            )
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
+            $0.userNotifications = UserNotificationsClient(
+                authorizationStatus: { .authorized },
+                requestAuthorization: { true },
+                scheduleMigrationNotification: { notification, date, _ in
+                    scheduled.withValue { $0.append((notification, date)) }
+                },
+                cancelMigrationNotifications: { _ in },
+                clearDeliveredMigrationNotifications: { }
+            )
+        } operation: {
+            let manager = MigrationManagerImpl(
+                gateStorage: Self.freshGateStorage(mode: .privateScheduled),
+                scheduleStorage: Self.freshScheduleStorage(),
+                sessionOrdinalProvider: { 1 }
+            )
+            return await manager.advance(phase: .afterSync)
+        }
+
+        let armedDate = scheduled.value.first?.1
+        #expect(armedDate != nil, "the row's own send window must still arm a poke")
+
+        // The row's window: 400 blocks out at the measured rate, run through the row derivation's
+        // MINUTES rounding (`MigrationETA.minutesFromNow`) then back to seconds by the arm — a
+        // clean 400 * 75s = 30000s = 500 minutes, so no rounding slop enters — plus the two-block
+        // notification slack. The outlook sits ~86 days further out (100,000 blocks) and, if the
+        // fold were broken (e.g. folding on the OUTLOOK unconditionally), would pull the armed
+        // date out to roughly `beforeDrive + 7,500,150s` — far outside this band.
+        let rowExpectedOffset = 500.0 * 60 + notificationBuffer
+        let lowerBound = beforeDrive.addingTimeInterval(rowExpectedOffset - 60)
+        let upperBound = beforeDrive.addingTimeInterval(rowExpectedOffset + 60)
+        if let armedDate {
+            #expect(armedDate >= lowerBound, "armed date must not be earlier than the row's own window")
+            #expect(armedDate <= upperBound, "a later outlook must not pull the armed date away from the row")
+        }
+    }
+
+    /// P4: the fold's WINNING direction for a row-bearing run — `outlookCandidateDate`'s own doc
+    /// promises the outlook "can only make the poke EARLIER, never later"; this is that promise
+    /// exercised through the full arm, not just the pure helper `MigrationSendGateAndArmingTests`
+    /// already pins.
+    @Test func anOutlookEarlierThanTheRowWindowWins() async {
+        Self.installCandidateAccount()
+        let scheduled = LockIsolated<[(MigrationNotification, Date?)]>([])
+        let secondsPerBlock = MigrationChainClock.targetSecondsPerBlock
+        let notificationBuffer = max(2 * secondsPerBlock, 150)
+        let rowHeight = Self.tip + 400
+        let outlookHeight = Self.tip + 10
+        let beforeDrive = Date()
+
+        _ = await withDependencies {
+            $0.sdkSynchronizer = .mocked(
+                latestState: { Self.atTipState() },
+                isSyncing: { false },
+                migrationAdvanceStep: { _ in
+                    MigrationAdvance(step: .waiting, next: MigrationNextWork(height: outlookHeight, kind: .prove))
+                },
+                migrationTransactionStatuses: { _ in [Self.pendingTransferStatus(scheduledHeight: rowHeight)] },
+                migrationSyncWakeups: { _ in [] },
+                estimatedMigrationChainTip: { Self.tip },
+                estimatedMigrationSecondsPerBlock: { secondsPerBlock }
+            )
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
+            $0.userNotifications = UserNotificationsClient(
+                authorizationStatus: { .authorized },
+                requestAuthorization: { true },
+                scheduleMigrationNotification: { notification, date, _ in
+                    scheduled.withValue { $0.append((notification, date)) }
+                },
+                cancelMigrationNotifications: { _ in },
+                clearDeliveredMigrationNotifications: { }
+            )
+        } operation: {
+            let manager = MigrationManagerImpl(
+                gateStorage: Self.freshGateStorage(mode: .privateScheduled),
+                scheduleStorage: Self.freshScheduleStorage(),
+                sessionOrdinalProvider: { 1 }
+            )
+            return await manager.advance(phase: .afterSync)
+        }
+
+        let armedDate = scheduled.value.first?.1
+        #expect(armedDate != nil, "the outlook must still arm a poke")
+
+        // The outlook's window: 10 blocks out — far sooner than the row's 400-block window. Two
+        // independent checks: the armed date lands in the OUTLOOK's own band, and it is strictly
+        // below the ROW window's band floor — the fold picked the earlier candidate, not merely
+        // "a" concrete date that happens to be less than the row's (which a bug clamping to some
+        // other unrelated earlier value could also satisfy).
+        let outlookExpectedOffset = 10 * secondsPerBlock + notificationBuffer
+        let outlookLowerBound = beforeDrive.addingTimeInterval(outlookExpectedOffset - 60)
+        let outlookUpperBound = beforeDrive.addingTimeInterval(outlookExpectedOffset + 60)
+        let rowExpectedOffset = 500.0 * 60 + notificationBuffer
+        let rowLowerBound = beforeDrive.addingTimeInterval(rowExpectedOffset - 60)
+
+        if let armedDate {
+            #expect(armedDate >= outlookLowerBound, "armed date must not be earlier than the outlook's own window")
+            #expect(armedDate <= outlookUpperBound, "armed date must land at the outlook's window, not the row's")
+            #expect(armedDate < rowLowerBound, "the earlier outlook must win the fold over the later row window")
+        }
     }
 }

--- a/zodlTests/MigrationTests/MigrationTickDriverTests.swift
+++ b/zodlTests/MigrationTests/MigrationTickDriverTests.swift
@@ -1099,4 +1099,83 @@ import ComposableArchitecture
             cancellable.cancel()
         }
     }
+
+    // MARK: - P4: the engine outlook arms the poke (driver pass-through)
+
+    /// P4: the outlook is a real arming candidate — a `.waiting` run with no wake-up, no pending
+    /// row and no blocker would retire the poke today; the outlook arms it instead.
+    @Test func anOutlookArmsThePokeWhereTodayWouldRetireIt() async {
+        Self.installCandidateAccount()
+        let scheduled = LockIsolated<[(MigrationNotification, Date?)]>([])
+
+        _ = await withDependencies {
+            $0.sdkSynchronizer = .mocked(
+                latestState: { Self.atTipState() },
+                isSyncing: { false },
+                migrationAdvanceStep: { _ in
+                    MigrationAdvance(
+                        step: .waiting,
+                        next: MigrationNextWork(height: Self.activationHeight + 200, kind: .prove)
+                    )
+                },
+                migrationTransactionStatuses: { _ in [] },
+                migrationSyncWakeups: { _ in [] }
+            )
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
+            $0.userNotifications = UserNotificationsClient(
+                authorizationStatus: { .authorized },
+                requestAuthorization: { true },
+                scheduleMigrationNotification: { notification, date, _ in
+                    scheduled.withValue { $0.append((notification, date)) }
+                },
+                cancelMigrationNotifications: { _ in },
+                clearDeliveredMigrationNotifications: { }
+            )
+        } operation: {
+            let manager = MigrationManagerImpl(
+                gateStorage: Self.freshGateStorage(mode: .privateScheduled),
+                sessionOrdinalProvider: { 1 }
+            )
+            return await manager.advance(phase: .afterSync)
+        }
+
+        #expect(!scheduled.value.isEmpty, "the outlook must arm the poke a candidate-less arm would retire")
+        #expect(scheduled.value.first?.1 != nil, "armed at a concrete date, not a placeholder")
+    }
+
+    /// P4: the outlook is advisory — it feeds arming only, never the verdict. Same drive as the
+    /// plain `.waiting` cases, now with an outlook riding along.
+    @Test func anOutlookPerturbsNoVerdict() async {
+        Self.installCandidateAccount()
+
+        let verdict = await withDependencies {
+            $0.sdkSynchronizer = .mocked(
+                latestState: { Self.atTipState() },
+                isSyncing: { false },
+                migrationAdvanceStep: { _ in
+                    MigrationAdvance(
+                        step: .waiting,
+                        next: MigrationNextWork(height: Self.activationHeight + 200, kind: .broadcast)
+                    )
+                },
+                migrationTransactionStatuses: { _ in [] },
+                migrationSyncWakeups: { _ in [] }
+            )
+            $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
+            Self.stubUserNotifications(&$0)
+        } operation: {
+            let manager = MigrationManagerImpl(
+                gateStorage: Self.freshGateStorage(mode: .privateScheduled),
+                sessionOrdinalProvider: { 1 }
+            )
+            return await manager.advance(phase: .afterSync)
+        }
+
+        // Pinned to the exact verdict `beforeSyncDuringAnInFlightAdvanceWaitsThenRuns` asserts for
+        // the identical step/phase pair (`.waiting` @ `.afterSync`): `MigrationStepAction.armWakeups`
+        // discharges to `.idle` unconditionally (`MigrationStepDriver.execute`) — the one-clock
+        // dispatch that could otherwise redirect `.waiting` only fires for `.beforeSync`/`.tick`, so
+        // `.afterSync` has no path off `.idle` for this step to begin with.
+        #expect(verdict == .idle, "an advisory outlook must not hold or otherwise change the verdict")
+    }
 }

--- a/zodlTests/MigrationTests/MigrationVisitTests.swift
+++ b/zodlTests/MigrationTests/MigrationVisitTests.swift
@@ -39,14 +39,14 @@ import ZcashLightClientKit
     @Test func provingATransferIsASyncVisit() {
         // Proving is sync-BOUND: it resolves anchors and witnesses from the synced tree, so this
         // session must sync. Its broadcast comes later, in its own session.
-        #expect(MigrationVisit.decide(advanceSteps: [.prove(id: 1, kind: Self.transferKind)]) == .sync)
+        #expect(MigrationVisit.decide(advanceSteps: [.prove(transactions: [MigrationProveTarget(id: 1, kind: Self.transferKind)])]) == .sync)
     }
 
     /// The documented exception: a preparation is proved AND broadcast at the same wake-up, because
     /// it anchors to a fresh checkpoint at the tip like an ordinary transaction. It must not
     /// suppress sync.
     @Test func provingAPreparationIsStillASyncVisit() {
-        #expect(MigrationVisit.decide(advanceSteps: [.prove(id: 1, kind: Self.preparationKind)]) == .sync)
+        #expect(MigrationVisit.decide(advanceSteps: [.prove(transactions: [MigrationProveTarget(id: 1, kind: Self.preparationKind)])]) == .sync)
     }
 
     @Test(arguments: [MigrationAdvanceStep.waiting, .complete, .rebuild(id: 2)])

--- a/zodlTests/UtilTests/RootMigrationGateStopOnBlockTests.swift
+++ b/zodlTests/UtilTests/RootMigrationGateStopOnBlockTests.swift
@@ -108,7 +108,7 @@ import Testing
         syncStatus: SyncStatus,
         mode: MigrationMode?,
         isManualDelivery: Bool,
-        advanceStep: @escaping @Sendable (AccountUUID) async throws -> MigrationAdvanceStep?,
+        advanceStep: @escaping @Sendable (AccountUUID) async throws -> MigrationAdvance?,
         tickInterval: Swift.Duration = .seconds(30),
         lastMigrationSyncGateBlocked: Bool = false,
         testClock: TestClock<Swift.Duration>? = nil,
@@ -227,7 +227,7 @@ import Testing
             isManualDelivery: false,
             advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
-                return MigrationAdvanceStep.broadcast(id: 9)
+                return MigrationAdvance(step: .broadcast(id: 9), next: nil)
             },
             // A stop-eligible candidate now also merges in `migrationTickLoopEffect`'s re-spawn
             // (Fix 1a), which reaches for `continuousClock` the instant it spawns — a `TestClock`
@@ -269,7 +269,9 @@ import Testing
                     value += 1
                     return value
                 }
-                return callNumber == 1 ? MigrationAdvanceStep.waiting : MigrationAdvanceStep.broadcast(id: 9)
+                return callNumber == 1
+                    ? MigrationAdvance(step: .waiting, next: nil)
+                    : MigrationAdvance(step: .broadcast(id: 9), next: nil)
             },
             testClock: testClock
         )
@@ -305,7 +307,7 @@ import Testing
             isManualDelivery: false,
             advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
-                return MigrationAdvanceStep.waiting
+                return MigrationAdvance(step: .waiting, next: nil)
             },
             testClock: testClock
         )
@@ -334,7 +336,7 @@ import Testing
             isManualDelivery: false,
             advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
-                return MigrationAdvanceStep.waiting
+                return MigrationAdvance(step: .waiting, next: nil)
             },
             testClock: testClock
         )
@@ -373,7 +375,7 @@ import Testing
         resetSharedResumeFlag()
         let stopCalls = LockIsolated(0)
         let testClock = TestClock()
-        let stepContinuation = LockIsolated<CheckedContinuation<MigrationAdvanceStep?, Never>?>(nil)
+        let stepContinuation = LockIsolated<CheckedContinuation<MigrationAdvance?, Never>?>(nil)
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
@@ -396,7 +398,7 @@ import Testing
 
         // Release the "late" read now — it resumes with a genuine `.broadcast`, same as if the
         // engine had proved the transfer moments after the edge had already cleared.
-        stepContinuation.value?.resume(returning: MigrationAdvanceStep.broadcast(id: 9))
+        stepContinuation.value?.resume(returning: MigrationAdvance(step: .broadcast(id: 9), next: nil))
 
         try? await Task.sleep(nanoseconds: 150_000_000)
 
@@ -425,7 +427,7 @@ import Testing
             isManualDelivery: false,
             advanceStep: { accountUUID in
                 queriedAccountUUIDs.withValue { $0.append(accountUUID) }
-                return MigrationAdvanceStep.broadcast(id: 9)
+                return MigrationAdvance(step: .broadcast(id: 9), next: nil)
             },
             testClock: TestClock(),
             secondCandidateMode: MigrationMode.privateScheduled
@@ -458,7 +460,7 @@ import Testing
             isManualDelivery: false,
             advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
-                return MigrationAdvanceStep.broadcast(id: 9)
+                return MigrationAdvance(step: .broadcast(id: 9), next: nil)
             }
         )
 
@@ -484,7 +486,7 @@ import Testing
             isManualDelivery: true,
             advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
-                return MigrationAdvanceStep.broadcast(id: 9)
+                return MigrationAdvance(step: .broadcast(id: 9), next: nil)
             }
         )
 
@@ -509,7 +511,7 @@ import Testing
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,
             isManualDelivery: false,
-            advanceStep: { _ in MigrationAdvanceStep.broadcast(id: 9) },
+            advanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
             // See `probeStopsWhenADeliverableCandidateStepIsBroadcast`'s identical note — a
             // stop-eligible candidate merges in the tick-loop re-spawn, which needs a `TestClock`.
             testClock: TestClock()
@@ -534,7 +536,7 @@ import Testing
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,
             isManualDelivery: false,
-            advanceStep: { _ in MigrationAdvanceStep.broadcast(id: 9) },
+            advanceStep: { _ in MigrationAdvance(step: .broadcast(id: 9), next: nil) },
             lastMigrationSyncGateBlocked: true
         )
 
@@ -562,7 +564,7 @@ import Testing
             isManualDelivery: false,
             advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
-                return MigrationAdvanceStep.broadcast(id: 9)
+                return MigrationAdvance(step: .broadcast(id: 9), next: nil)
             },
             // See `probeStopsWhenADeliverableCandidateStepIsBroadcast`'s identical note — the
             // candidate is eligible (mode/delivery, not syncStatus, gates the tick-loop merge), so
@@ -600,7 +602,7 @@ import Testing
             isManualDelivery: false,
             advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
-                return MigrationAdvanceStep.broadcast(id: 9)
+                return MigrationAdvance(step: .broadcast(id: 9), next: nil)
             },
             tickInterval: Swift.Duration.zero
         )
@@ -629,7 +631,7 @@ import Testing
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,
             isManualDelivery: false,
-            advanceStep: { _ in MigrationAdvanceStep.waiting },
+            advanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
             testClock: testClock
         )
         store.dependencies.migrationManager.advance = { phase in
@@ -659,7 +661,7 @@ import Testing
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,
             isManualDelivery: false,
-            advanceStep: { _ in MigrationAdvanceStep.waiting },
+            advanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
             testClock: testClock
         )
         store.dependencies.migrationManager.advance = { phase in
@@ -689,7 +691,7 @@ import Testing
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,
             isManualDelivery: false,
-            advanceStep: { _ in MigrationAdvanceStep.waiting },
+            advanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
             testClock: testClock
         )
         store.dependencies.migrationManager.clearProvisionalNetworkSnapshot = { accountUUID in
@@ -721,7 +723,7 @@ import Testing
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,
             isManualDelivery: false,
-            advanceStep: { _ in MigrationAdvanceStep.waiting },
+            advanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
             testClock: testClock
         )
         store.dependencies.migrationManager.advance = { phase in
@@ -753,7 +755,7 @@ import Testing
             syncStatus: SyncStatus.syncing(0.5, false),
             mode: MigrationMode.privateScheduled,
             isManualDelivery: false,
-            advanceStep: { _ in MigrationAdvanceStep.waiting },
+            advanceStep: { _ in MigrationAdvance(step: .waiting, next: nil) },
             testClock: testClock
         )
         store.dependencies.migrationManager.advance = { phase in


### PR DESCRIPTION
# Adopt the SDK's batch-Prove step and advance outlook

Adopts zcash-swift-wallet-sdk PR #1953 (`michal/librustzcash-batch-prove-outlook-rewire`, librustzcash pin `4d654982`) — two breaking API changes plus one new behavior.

## Part 1 — API adoption (behavior-preserving)

- `migrationAdvanceStep(accountUUID:)` now returns `MigrationAdvance?` (the step to perform now + the engine's advisory `next` outlook). Every consumer unwraps `.step` at the read; the step driver's per-account array carries the whole wrapper so ONE engine read keeps feeding the session decision, the discharge, the key step log line (now suffixed `— next: <kind> @ <height>` when an outlook is present), and the arming pass.
- `MigrationAdvanceStep.prove` now carries the whole provable batch (`[MigrationProveTarget]`, earliest-ready first, SDK-guaranteed never empty). The decision table acts on the batch HEAD — exactly the entry the old single-id step named; the prove discharge was already whole-queue, so behavior is unchanged.

## Part 2 — Outlook-armed reminder (new behavior)

The engine's outlook ("when does the migration next have serviceable work, and of what kind") becomes a **fourth arming candidate** for the migration reminder, alongside the sync wake-ups, the earliest unsent row's window, and the attention blocker — via a new pure `MigrationDerivations.outlookCandidateDate`, min-folded so the poke can only get **earlier or equal, never later**.

Privacy rules, verified unchanged end-to-end:

| Rule | Status |
|---|---|
| ZIP 318 session separation (sync XOR broadcast) | Enforced at open time by the fresh `visitKind` read, the phase table, and the submit lane's dueness re-check — all untouched. |
| Send-after-sync privacy buffer | A `.broadcast`-kind outlook is clamped past the send gate's `waitUntil` (same clamp the row-derived send window takes); non-broadcast kinds arm unclamped. The gate still enforces at discharge regardless of poke timing. |
| One step per open | Untouched — candidates arm for the earliest single next step. |
| One generic poke naming no action | Untouched — no notification payload or copy change; the outlook kind influences the clamp only. |
| No extra engine reads | The outlook rides the drive's own advance read into the arm as a parameter; `migrationAdvanceStep` call-site count is unchanged branch-wide. |

The ARMED trace now prints all four candidate dates and an `engine outlook (<kind>)` source when the outlook wins.

## Tests

- Full `zodlTests` suite on the branch rebased onto current `migration/rebuild`: **1283 passing, 0 failed** (1 pre-existing expected failure). The rebase carries the ratified-idle re-pin forward: `aProveStepWithoutInFlightRowsReadsAsIdle` keeps its base semantics (`.idle`) under the batch prove constructor.
- New: two head-of-batch decision-table pins (mixed batches, both orders); six pure clamp tests (`.prove`/`.broadcast`/`.rebuild`/`.replan` × gate open/closed/expired); integration drives pinning that an outlook arms the poke where today's arm would retire it, that the armed date tracks the outlook's actual window, that the min-fold keeps an earlier row window authoritative over a later outlook (and vice versa), and that the outlook never changes a drive verdict.

## Notes for reviewers / QA

- **Companion SDK:** builds against the sibling local package `../zcash-swift-wallet-sdk` on the PR #1953 branch; after moving it, rebuild the FFI slices (`Scripts/rebuild-local-ffi.sh ios-sim` / `ios-device`).
- **Headline manual QA item (from the SDK handoff):** plan-accept on the large testnet wallet — previously stalled ~25 min in commit/signing; should now complete promptly (two independent snapshot fixes, one upstream, one in the SDK's own adapter).
- Plan previews' value breakdowns change upstream (exact funding preserved; unfundable split reports as **deferral**, not completion) — expected-value fixtures/screenshots may need refreshing.
- Fewer schedule re-spreads after short sessions; proofs offered on the shared 10-block reorg-stability gate — no app change, listed for awareness.
- The key step log line (`advance step (<phase>): …`) now prints the outlook suffix — useful when watching a drive cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
