### PR TITLE
Dispatch the cold-start transaction fetch after accounts load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [Ironwood] The migration reminder is now armed from the engine's own next-work answer as well as the schedule, so the "come back" notification lands at the earliest genuinely serviceable moment — and never inside the privacy buffer for send work.
 
 ### Fixed
+- The transaction list no longer sits empty for tens of seconds after a cold app start while migration checks and sync startup run — loading now begins as soon as the wallet's accounts are available.
 - [MOB-1466] A sent migration transfer's checkmark, amount and transaction id now always land on the transfer that was actually broadcast: the app previously assumed sends happen in the plan's original row order, so once the engine (correctly) sent the earliest-scheduled transfer instead, the wrong row could show as sent — and its later confirmation could be matched against the wrong transaction.
 - [MOB-1466] The transaction history no longer shows up empty on a populated wallet: a database read failure could silently discard the whole list (seen in the field when every stored transaction hit a strict decode of an always-empty trust column — fixed in the SDK), and such a failure is now logged instead of vanishing without a trace.
 - [MOB-1466] The Home pool-balances sheet no longer counts scheduled migration transfers that have not mined yet: the Ironwood and Orchard cards now tell the same story as the Migration Status screen, instead of showing value as already moved hours or days early.

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -1043,14 +1043,16 @@ extension Root {
                                 await send(.initialization(.staleWalletDatabaseHealed))
                             }
 
-                            await send(.fetchTransactionsForTheSelectedAccount)
-                            /// The TCA spins an async Task in `fetchTransactionsForTheSelectedAccount` and it's needed to run
-                            /// before next code here therefore Task is asleep for 0.01s. The purpose is also to not block the main thread
-                            /// so await of mainQueue is not used.
-                            try? await Task.sleep(nanoseconds: 10_000_000)
-
                             let walletAccounts = try await sdkSynchronizer.walletAccounts()
                             await send(.initialization(.loadedWalletAccounts(walletAccounts)))
+                            // Dispatched only now that `.loadedWalletAccounts` has selected an account:
+                            // `.fetchTransactionsForTheSelectedAccount` silently no-ops without one, and on
+                            // a cold start `selectedWalletAccount` (in-memory) is nil until that selection —
+                            // dispatching any earlier is a guaranteed no-op, leaving the list empty until
+                            // the post-gate `.observeTransactions` fetch finally runs. Fire-and-forget on
+                            // purpose: the fetch races ahead on the still-quiet synchronizer while the
+                            // migration gate below does its network-bound work.
+                            await send(.fetchTransactionsForTheSelectedAccount)
                             await send(.resolveMetadataEncryptionKeys)
                             await send(.loadUserMetadata)
 

--- a/zodlTests/UtilTests/RootInitializeSDKColdStartFetchTests.swift
+++ b/zodlTests/UtilTests/RootInitializeSDKColdStartFetchTests.swift
@@ -1,0 +1,174 @@
+//
+//  RootInitializeSDKColdStartFetchTests.swift
+//  zodlTests
+//
+//  Cold-start ordering pin for `.initialization(.initializeSDK)`'s first transaction fetch
+//  (Features/Root/RootInitialization.swift).
+//
+//  THE BUG this pins: `.fetchTransactionsForTheSelectedAccount` silently no-ops when
+//  `selectedWalletAccount` is nil (RootTransactions.swift's guard), and that shared value is
+//  `.inMemory` — nil on every cold launch until `.loadedWalletAccounts` selects the Zashi
+//  account. The init effect used to dispatch the fetch BEFORE loading wallet accounts, so the
+//  dispatch was a guaranteed no-op and the first effective fetch waited for the post-gate
+//  `.observeTransactions` subscription — behind the whole migration gate (and, on send-visit
+//  opens, a 10-20s no-sync delivery session). The list sat empty the whole time.
+//
+//  The pin: by the time the init effect's fetch dispatch is processed, an account IS selected
+//  (so the guard passes), and the fetch effect reaches `getAllTransactions` with that account.
+//
+//  `extension Root.State: @retroactive Equatable` already exists, module-wide, at
+//  RootInitializeSDKHealTests.swift — this file must NOT redeclare it (duplicate-conformance
+//  compile error; see that file's header).
+//
+
+@preconcurrency import Combine
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// Serialized per repo convention for suites driving `.initializeSDK` through a real TestStore —
+// see RootInitializeSDKHealTests's identical `@Suite(.serialized)` rationale.
+@Suite(.serialized) @MainActor struct RootInitializeSDKColdStartFetchTests {
+    private static let seedDerivedAccount = WalletAccount(
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: "Zashi",
+            keySource: "zashi",
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    )
+
+    private static let seededWallet = StoredWallet.placeholder
+
+    private func makeStore(
+        fetchedAccountIds: LockIsolated<[AccountUUID?]>
+    ) -> TestStore<Root.State, Root.Action> {
+        let initialState = Root.State(
+            destinationState: Root.DestinationState(internalDestination: .welcome),
+            exportLogsState: ExportLogs.State(),
+            onboardingState: RestoreWalletCoordFlow.State(),
+            phraseDisplayState: RecoveryPhraseDisplay.State(),
+            walletConfig: .initial,
+            welcomeState: Welcome.State()
+        )
+
+        let seedDerivedAccount = RootInitializeSDKColdStartFetchTests.seedDerivedAccount
+
+        let store = TestStore(
+            initialState: initialState
+        ) {
+            Root()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            $0.continuousClock = TestClock()
+
+            $0.exchangeRate = .noOp
+            $0.autolockHandler = .noOp
+            $0.shieldingProcessor = ShieldingProcessorClient(
+                observe: { Empty().eraseToAnyPublisher() },
+                shieldFunds: { }
+            )
+
+            $0.mnemonic = .noOp
+            $0.databaseFiles = .noOp
+
+            let seededWallet = RootInitializeSDKColdStartFetchTests.seededWallet
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportWallet = { seededWallet }
+
+            $0.flexaHandler = .noOp
+            $0.flexaHandler.signOut = { }
+
+            $0.userStoredPreferences.removeAll = { }
+            $0.readTransactionsStorage = .noOp
+
+            $0.userDefaults.objectForKey = { _ in nil }
+            $0.userDefaults.remove = { _ in }
+            $0.userDefaults.setValue = { _, _ in }
+
+            $0.addressBook.allLocalContacts = { _ in (AddressBookContacts.empty, .notAttempted) }
+
+            $0.userMetadataProvider.load = { _ in }
+            // `.fetchedTransactions` resolves swaps unconditionally before its unchanged-list
+            // early-out — this suite (unlike the siblings, which drain before any fetch
+            // completes) waits for that reducer to run, so the member must be stubbed.
+            $0.userMetadataProvider.allSwaps = { [] }
+
+            $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+
+            $0.migrationManager.visitKind = { .sync }
+            $0.migrationManager.advance = { _ in .broadcast(id: 1) }
+
+            $0.sdkSynchronizer = .mocked(
+                stateStream: { Empty().eraseToAnyPublisher() },
+                prepareWith: { _, _, _, _ in .success },
+                start: { _ in },
+                getAllTransactions: { accountUUID in
+                    fetchedAccountIds.withValue { $0.append(accountUUID) }
+                    return []
+                },
+                isSeedRelevantToAnyDerivedAccount: { _ in true },
+                walletAccounts: { [seedDerivedAccount] }
+            )
+        }
+        store.exhaustivity = .off
+        return store
+    }
+
+    /// Same rationale as RootInitializeSDKHealTests.drain: let the `.initializeSDK` cascade
+    /// settle without asserting on it, then silence the store's bookkeeping.
+    private func drain(_ store: TestStore<Root.State, Root.Action>) async {
+        await store.send(.cancelAllRunningEffects)
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+    }
+
+    // MARK: - Cold launch: the init effect's fetch dispatch must land AFTER account selection
+
+    @Test func coldStartFetchDispatchLandsAfterAccountSelection() async throws {
+        let fetchedAccountIds = LockIsolated<[AccountUUID?]>([])
+        let store = makeStore(fetchedAccountIds: fetchedAccountIds)
+
+        await store.send(.initialization(.initializeSDK(.existingWallet)))
+
+        // The FIRST `.fetchTransactionsForTheSelectedAccount` the store receives is the init
+        // effect's own dispatch — nothing else dispatches it this early on a cold start. With
+        // exhaustivity off, earlier received actions (`.loadedWalletAccounts` included, in the
+        // fixed ordering) are still processed while being skipped, so the state read below sees
+        // exactly what the fetch's reducer guard saw.
+        await store.receive(
+            { action in
+                guard case .fetchTransactionsForTheSelectedAccount = action else { return false }
+                return true
+            },
+            timeout: .seconds(5)
+        )
+
+        #expect(
+            store.state.selectedWalletAccount != nil,
+            "the init effect's fetch dispatch must be processed only after `.loadedWalletAccounts` selected an account — with a nil account the dispatch is a silent no-op and the list stays empty until the post-gate refetch"
+        )
+
+        // And the dispatch must be EFFECTIVE: the fetch effect reaches getAllTransactions with
+        // the selected account (the guard's early `.none` return would never get here).
+        await store.receive(
+            { action in
+                guard case .fetchedTransactions = action else { return false }
+                return true
+            },
+            timeout: .seconds(5)
+        )
+
+        #expect(
+            fetchedAccountIds.value.first == RootInitializeSDKColdStartFetchTests.seedDerivedAccount.id,
+            "the first getAllTransactions call must query the account `.loadedWalletAccounts` selected"
+        )
+
+        await drain(store)
+    }
+}


### PR DESCRIPTION
## Summary

On a cold launch, the homepage transaction list sat empty until the whole migration gate block (and on send-visit opens, the 10-20s no-sync delivery session) had finished — tens of seconds on wallets with a live migration run.

Root cause: the `initializeSDK` effect dispatched `.fetchTransactionsForTheSelectedAccount` **before** loading wallet accounts, but `selectedWalletAccount` is in-memory shared state — nil on every cold launch until `.loadedWalletAccounts` selects the Zashi account — so the action's guard silently dropped the dispatch (and the 0.01s sleep next to it waited for a fetch task that never started). The first fetch that could actually run was `.observeTransactions`' subscribe-time dispatch, which only happens after `visitKind()` / `advance(.beforeSync)` / `start()`.

The fix moves the dispatch below the account load, making it effective, and deletes the dead sleep. It stays fire-and-forget, so the migration gate's own ordering and timing are untouched — the fetch simply races ahead on the still-quiet synchronizer while the gate does its network-bound work.

## Changes

- `RootInitialization.swift`: reorder inside the `initializeSDK` effect — `walletAccounts()` + `.loadedWalletAccounts` first, then the fetch dispatch; dead sleep removed. The gate block is byte-identical.
- New `RootInitializeSDKColdStartFetchTests` (serialized, Swift Testing): pins that the init effect's fetch dispatch is processed only after an account is selected, and that it reaches `getAllTransactions` with that account.
- CHANGELOG entry under Unreleased/Fixed.

## Testing

- New suite: red before the reorder (dispatch processed with nil account), green after.
- Sibling suites driving the same paths (gate refusal, single-flight, heal, account-switch, send-completion, migration rows): pass — 45 tests in 7 suites.
- Full zodl-internal suite on iPhone 17 simulator: pass — 1085 tests in 162 suites, zero failures; the one pre-existing known-issue annotation in `CurrencyConversionSetupTests` excepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)