### PR TITLE
Bump json gem to 2.21.2 (Dependabot alert #11, GHSA-9hj4-r449-hfvc)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.21.1)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)


### PR DESCRIPTION
Fixes [Dependabot alert #11](https://github.com/zodl-inc/zodl-ios/security/dependabot/11): CVE-2026-71847 / [GHSA-9hj4-r449-hfvc](https://github.com/advisories/GHSA-9hj4-r449-hfvc), a heap use-after-free in the `json` C extension's `JSON::ResumableParser#partial_value` (severity: low, DoS only).

`json` is a transitive dependency of fastlane (constraint `< 3.0.0`) in `Gemfile.lock`, so this is a tooling-only bump with no app impact — hence no CHANGELOG entry. The lockfile pin was updated directly (2.21.1 → 2.21.2, the first patched version and current latest on RubyGems); no other lockfile entries change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)