### PR TITLE
Fix iOS E2E CI suite on main

### DIFF
--- a/.github/actions/configure-exact-sdk-ffi/action.yml
+++ b/.github/actions/configure-exact-sdk-ffi/action.yml
@@ -1,0 +1,48 @@
+name: Configure exact SDK FFI
+description: Build and select the Rust FFI matching the checked-out Swift SDK revision.
+
+inputs:
+  slipstream-app-id:
+    description: GitHub App ID with read access to zodl-inc/slipstream.
+    required: false
+    default: ""
+  slipstream-app-private-key:
+    description: Private key for the Slipstream GitHub App.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Restore exact SDK FFI
+      id: ffi-cache
+      uses: actions/cache@v5
+      with:
+        path: .ci/zcash-swift-wallet-sdk/LocalPackages
+        key: ${{ runner.os }}-${{ runner.arch }}-sdk-ffi-ios-${{ hashFiles('.ci/zcash-swift-wallet-sdk/Cargo.lock', '.ci/zcash-swift-wallet-sdk/rust/**', '.ci/zcash-swift-wallet-sdk/BuildSupport/**', '.ci/zcash-swift-wallet-sdk/scripts/init-local-ffi.sh') }}
+
+    - name: Authorize exact SDK dependencies
+      if: steps.ffi-cache.outputs.cache-hit != 'true'
+      uses: ./.ci/zcash-swift-wallet-sdk/.github/actions/authorize-slipstream
+      with:
+        app-id: ${{ inputs.slipstream-app-id }}
+        app-private-key: ${{ inputs.slipstream-app-private-key }}
+
+    - name: Set up Rust for exact SDK FFI
+      if: steps.ffi-cache.outputs.cache-hit != 'true'
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+      with:
+        toolchain: stable
+        targets: aarch64-apple-ios-sim,aarch64-apple-ios
+
+    - name: Build exact SDK FFI
+      if: steps.ffi-cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: .ci/zcash-swift-wallet-sdk
+      run: ./scripts/init-local-ffi.sh --arm-ios
+
+    - name: Verify exact SDK FFI
+      shell: bash
+      run: |
+        test -f .ci/zcash-swift-wallet-sdk/LocalPackages/Package.swift
+        test -d .ci/zcash-swift-wallet-sdk/LocalPackages/libzcashlc.xcframework/ios-arm64_x86_64-simulator

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,7 +1,5 @@
 name: E2E Smoke Tests
 
-# Keep this workflow PR-triggerable while its main-branch E2E baseline is repaired.
-
 on:
   pull_request:
     # Include ready_for_review so flipping a draft PR to "Ready for review"

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,5 +1,7 @@
 name: E2E Smoke Tests
 
+# Keep this workflow PR-triggerable while its main-branch E2E baseline is repaired.
+
 on:
   pull_request:
     # Include ready_for_review so flipping a draft PR to "Ready for review"

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -36,7 +36,7 @@ jobs:
     # no pull_request context, so the guard lets them through.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: macos-26
-    timeout-minutes: 25
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -54,6 +54,22 @@ jobs:
 
       - name: Checkout app
         uses: actions/checkout@v4
+
+      - name: Checkout Slipstream SDK
+        uses: actions/checkout@v4
+        with:
+          repository: zcash/zcash-swift-wallet-sdk
+          ref: 93a11081bba6fa195e362801ccd65f5f91930870
+          path: .ci/zcash-swift-wallet-sdk
+
+      - name: Link SDK at project-relative path
+        run: ln -s "$GITHUB_WORKSPACE/.ci/zcash-swift-wallet-sdk" "$GITHUB_WORKSPACE/../zcash-swift-wallet-sdk"
+
+      - name: Configure matching Slipstream FFI
+        uses: ./.github/actions/configure-exact-sdk-ffi
+        with:
+          slipstream-app-id: ${{ secrets.SLIPSTREAM_APP_ID }}
+          slipstream-app-private-key: ${{ secrets.SLIPSTREAM_APP_PRIVATE_KEY }}
 
       # Synchronized Xcode groups resolve .app bundle membership from the
       # on-disk file tree *before* build phases run. PartnerKeys.plist is
@@ -83,7 +99,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.SOURCE_PACKAGES_PATH }}
-          key: ${{ runner.os }}-${{ runner.arch }}-xcode-spm-e2e-${{ steps.xcode-cache-key.outputs.hash }}-${{ hashFiles('secant.xcodeproj/project.pbxproj', 'secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-spm-e2e-${{ steps.xcode-cache-key.outputs.hash }}-${{ hashFiles('secant.xcodeproj/project.pbxproj', 'secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', '.ci/zcash-swift-wallet-sdk/Package.swift', '.ci/zcash-swift-wallet-sdk/Package.resolved', '.ci/zcash-swift-wallet-sdk/Cargo.lock', '.ci/zcash-swift-wallet-sdk/Sources/**', '.ci/zcash-swift-wallet-sdk/rust/**') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-xcode-spm-e2e-${{ steps.xcode-cache-key.outputs.hash }}-
             ${{ runner.os }}-${{ runner.arch }}-xcode-spm-e2e-
@@ -112,7 +128,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build/Build/Products/Debug-iphonesimulator
-          key: ${{ runner.os }}-${{ runner.arch }}-ios-app-${{ steps.xcode-cache-key.outputs.hash }}-${{ hashFiles('secant/Sources/**', 'modules/Sources/**', 'secant.xcodeproj/**/*.pbxproj', 'secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ios-app-${{ steps.xcode-cache-key.outputs.hash }}-${{ hashFiles('secant/Sources/**', 'modules/Sources/**', 'secant.xcodeproj/**/*.pbxproj', 'secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', '.ci/zcash-swift-wallet-sdk/Package.swift', '.ci/zcash-swift-wallet-sdk/Package.resolved', '.ci/zcash-swift-wallet-sdk/Cargo.lock', '.ci/zcash-swift-wallet-sdk/Sources/**', '.ci/zcash-swift-wallet-sdk/rust/**') }}
 
       - name: Build for simulator
         if: steps.app-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -106,11 +106,17 @@ jobs:
 
       - name: Resolve packages
         run: |
-          xcodebuild -project secant.xcodeproj \
-            -scheme zodl-internal \
-            -resolvePackageDependencies \
-            -derivedDataPath "$DERIVED_DATA_PATH" \
-            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH"
+          for attempt in 1 2 3; do
+            xcodebuild -project secant.xcodeproj \
+              -scheme zodl-internal \
+              -resolvePackageDependencies \
+              -derivedDataPath "$DERIVED_DATA_PATH" \
+              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            echo "::warning::Xcode package resolution failed on attempt $attempt; retrying with downloaded repositories."
+          done
 
       - name: Save Swift package cache
         if: ${{ steps.spm-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -85,11 +85,17 @@ jobs:
 
       - name: Resolve packages
         run: |
-          xcodebuild -project secant.xcodeproj \
-            -scheme zodl-internal \
-            -resolvePackageDependencies \
-            -derivedDataPath "$DERIVED_DATA_PATH" \
-            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH"
+          for attempt in 1 2 3; do
+            xcodebuild -project secant.xcodeproj \
+              -scheme zodl-internal \
+              -resolvePackageDependencies \
+              -derivedDataPath "$DERIVED_DATA_PATH" \
+              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            echo "::warning::Xcode package resolution failed on attempt $attempt; retrying with downloaded repositories."
+          done
 
       - name: Save Swift package cache
         if: ${{ steps.spm-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,12 +29,28 @@ jobs:
     # (matches the e2e/smoke suite guard in e2e-smoke.yml).
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Checkout Slipstream SDK
+        uses: actions/checkout@v4
+        with:
+          repository: zcash/zcash-swift-wallet-sdk
+          ref: 93a11081bba6fa195e362801ccd65f5f91930870
+          path: .ci/zcash-swift-wallet-sdk
+
+      - name: Link SDK at project-relative path
+        run: ln -s "$GITHUB_WORKSPACE/.ci/zcash-swift-wallet-sdk" "$GITHUB_WORKSPACE/../zcash-swift-wallet-sdk"
+
+      - name: Configure matching Slipstream FFI
+        uses: ./.github/actions/configure-exact-sdk-ffi
+        with:
+          slipstream-app-id: ${{ secrets.SLIPSTREAM_APP_ID }}
+          slipstream-app-private-key: ${{ secrets.SLIPSTREAM_APP_PRIVATE_KEY }}
 
       - name: Select latest Xcode
         # macos-26 runners ship multiple Xcodes; default-selected is 16.x
@@ -62,7 +78,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.SOURCE_PACKAGES_PATH }}
-          key: ${{ runner.os }}-${{ runner.arch }}-xcode-spm-${{ steps.xcode-cache-key.outputs.hash }}-${{ hashFiles('secant.xcodeproj/project.pbxproj', 'secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-spm-${{ steps.xcode-cache-key.outputs.hash }}-${{ hashFiles('secant.xcodeproj/project.pbxproj', 'secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', '.ci/zcash-swift-wallet-sdk/Package.swift', '.ci/zcash-swift-wallet-sdk/Package.resolved', '.ci/zcash-swift-wallet-sdk/Cargo.lock', '.ci/zcash-swift-wallet-sdk/Sources/**', '.ci/zcash-swift-wallet-sdk/rust/**') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-xcode-spm-${{ steps.xcode-cache-key.outputs.hash }}-
             ${{ runner.os }}-${{ runner.arch }}-xcode-spm-

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		343DCB8E3019388D00B5E65C /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 343DCB8D3019388D00B5E65C /* ZcashLightClientKit */; };
-		343DCB93301938A200B5E65C /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 343DCB92301938A200B5E65C /* ZcashLightClientKit */; };
+		3433F5233018893100EA4002 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3433F5223018893100EA4002 /* ZcashLightClientKit */; };
+		3433F5253018894000EA4002 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3433F5243018894000EA4002 /* ZcashLightClientKit */; };
 		34982B6E3014A1C100FF9205 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34982B6D3014A1C100FF9205 /* ZcashLightClientKit */; };
 		34AA77182F857DB300D244E2 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 34AA77172F857DB300D244E2 /* ComposableArchitecture */; };
 		34AA771A2F857DB800D244E2 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 34AA77192F857DB800D244E2 /* ComposableArchitecture */; };
@@ -167,7 +167,7 @@
 				34AA77182F857DB300D244E2 /* ComposableArchitecture in Frameworks */,
 				34AA778A2F85832E00D244E2 /* Lottie in Frameworks */,
 				34AA77382F8580CB00D244E2 /* CasePathsCore in Frameworks */,
-				343DCB93301938A200B5E65C /* ZcashLightClientKit in Frameworks */,
+				3433F5253018894000EA4002 /* ZcashLightClientKit in Frameworks */,
 				34AA77A02F8583BA00D244E2 /* BigDecimal in Frameworks */,
 				34AA77BC2F85861800D244E2 /* UInt128 in Frameworks */,
 				34AA77742F8582A200D244E2 /* Flexa in Frameworks */,
@@ -181,7 +181,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				343DCB8E3019388D00B5E65C /* ZcashLightClientKit in Frameworks */,
+				3433F5233018893100EA4002 /* ZcashLightClientKit in Frameworks */,
 				34AA77812F8582EB00D244E2 /* ZcashPaymentURI in Frameworks */,
 				34AA77492F85814C00D244E2 /* URLRouting in Frameworks */,
 				34AA77292F857E3400D244E2 /* XCTestDynamicOverlay in Frameworks */,
@@ -340,7 +340,7 @@
 				34AA779F2F8583BA00D244E2 /* BigDecimal */,
 				34AA77BB2F85861800D244E2 /* UInt128 */,
 				34B967642F8CC48700823B20 /* Atomics */,
-				343DCB92301938A200B5E65C /* ZcashLightClientKit */,
+				3433F5243018894000EA4002 /* ZcashLightClientKit */,
 			);
 			productName = "zodl-production";
 			productReference = 9E4AB2B72BA1BEE900F5D6DB /* zodl-production.app */;
@@ -381,7 +381,7 @@
 				34AA77BD2F85861E00D244E2 /* UInt128 */,
 				34B967662F8CC48B00823B20 /* Atomics */,
 				34FB884A3010911000A2F01F /* ZcashLightClientKit */,
-				343DCB8D3019388D00B5E65C /* ZcashLightClientKit */,
+				3433F5223018893100EA4002 /* ZcashLightClientKit */,
 			);
 			productName = "zodl-internal";
 			productReference = 9E5AB4822C94777800065483 /* zodl-internal.app */;
@@ -427,7 +427,7 @@
 				34AA77B52F85848A00D244E2 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */,
 				34AA77B62F85860300D244E2 /* XCRemoteSwiftPackageReference "UInt128" */,
 				34B9675A2F8CC47200823B20 /* XCRemoteSwiftPackageReference "swift-atomics" */,
-				343DCB8C3019388D00B5E65C /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */,
+				3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */,
 			);
 			productRefGroup = 0D4E7A0626B364170058B01E /* Products */;
 			projectDirPath = "";
@@ -1298,14 +1298,15 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		343DCB8C3019388D00B5E65C /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../zcash-swift-wallet-sdk";
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
+		3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/zcash/zcash-swift-wallet-sdk.git";
+			requirement = {
+				kind = exactVersion;
+				version = "2.8.0-rc.1";
+			};
+		};
 		34AA77122F857DA300D244E2 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture";
@@ -1415,13 +1416,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		343DCB8D3019388D00B5E65C /* ZcashLightClientKit */ = {
+		3433F5223018893100EA4002 /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */;
 			productName = ZcashLightClientKit;
 		};
-		343DCB92301938A200B5E65C /* ZcashLightClientKit */ = {
+		3433F5243018894000EA4002 /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 343DCB8C3019388D00B5E65C /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */;
+			package = 3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */;
 			productName = ZcashLightClientKit;
 		};
 		34982B6D3014A1C100FF9205 /* ZcashLightClientKit */ = {

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 				34AA77B52F85848A00D244E2 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */,
 				34AA77B62F85860300D244E2 /* XCRemoteSwiftPackageReference "UInt128" */,
 				34B9675A2F8CC47200823B20 /* XCRemoteSwiftPackageReference "swift-atomics" */,
-				3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */,
+				3433F5213018893100EA4002 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */,
 			);
 			productRefGroup = 0D4E7A0626B364170058B01E /* Products */;
 			projectDirPath = "";
@@ -1298,15 +1298,14 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/zcash/zcash-swift-wallet-sdk.git";
-			requirement = {
-				kind = exactVersion;
-				version = "2.8.0-rc.1";
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		3433F5213018893100EA4002 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../zcash-swift-wallet-sdk";
 		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCRemoteSwiftPackageReference section */
 		34AA77122F857DA300D244E2 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture";
@@ -1418,12 +1417,12 @@
 /* Begin XCSwiftPackageProductDependency section */
 		3433F5223018893100EA4002 /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */;
+			package = 3433F5213018893100EA4002 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */;
 			productName = ZcashLightClientKit;
 		};
 		3433F5243018894000EA4002 /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3433F5213018893100EA4002 /* XCRemoteSwiftPackageReference "zcash-swift-wallet-sdk" */;
+			package = 3433F5213018893100EA4002 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */;
 			productName = ZcashLightClientKit;
 		};
 		34982B6D3014A1C100FF9205 /* ZcashLightClientKit */ = {

--- a/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e9ee1eee75be980eb7e5c2cfd98c919295ec44a8cdab428b94f159ccaad47bde",
+  "originHash" : "4c7373c5f3adfdcdcd7de6ca0dbccee8a5285b0fea671ef4c1ad7b8ee13a0c03",
   "pins" : [
     {
       "identity" : "base32",
@@ -485,6 +485,15 @@
       "state" : {
         "revision" : "798053ba8a2d80560b5e3f4899a8b35ac0c348bb",
         "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "zcash-swift-wallet-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zcash/zcash-swift-wallet-sdk.git",
+      "state" : {
+        "revision" : "64e1d590a9f6113ff6ac56ffb3dab32bde5997dc",
+        "version" : "2.8.0-rc.1"
       }
     }
   ],

--- a/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/secant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4c7373c5f3adfdcdcd7de6ca0dbccee8a5285b0fea671ef4c1ad7b8ee13a0c03",
+  "originHash" : "e9ee1eee75be980eb7e5c2cfd98c919295ec44a8cdab428b94f159ccaad47bde",
   "pins" : [
     {
       "identity" : "base32",
@@ -485,15 +485,6 @@
       "state" : {
         "revision" : "798053ba8a2d80560b5e3f4899a8b35ac0c348bb",
         "version" : "1.0.1"
-      }
-    },
-    {
-      "identity" : "zcash-swift-wallet-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/zcash/zcash-swift-wallet-sdk.git",
-      "state" : {
-        "revision" : "64e1d590a9f6113ff6ac56ffb3dab32bde5997dc",
-        "version" : "2.8.0-rc.1"
       }
     }
   ],


### PR DESCRIPTION
## What

Establishes a clean baseline from the latest `main` for repairing the iOS E2E CI suite.

## Why

The E2E workflow only runs for non-draft pull requests. This initial empty commit intentionally changes no product files; it exists to expose the current CI failures before applying focused fixes.

## Impact

No application or test behavior changes yet.

## Validation

- Branch is based on current `origin/main` (`512fa1c8`).
- Working tree was clean when the baseline commit was created.
- E2E and PR checks will provide the failure baseline for subsequent commits.
