### PR TITLE
Fix SwiftLint config drift after the secantTests → zodlTests rename

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,8 +6,7 @@ included:
 
 excluded:
   - xctemplates
-  - secantTests
-  - secantUITests
+  - zodlTests
 
 disabled_rules:
   - notification_center_detachment

--- a/.swiftlint_tests.yml
+++ b/.swiftlint_tests.yml
@@ -2,8 +2,7 @@
 # https://github.com/raywenderlich/swift-style-guide
 
 included:
-  - secantTests/
-  - secantUITests/
+  - zodlTests/
 
 excluded:
   - secant/
@@ -29,6 +28,8 @@ disabled_rules:
   - function_parameter_count
   - identifier_name
   - empty_parentheses_with_trailing_closure
+  - large_tuple # test helpers return grouped fixture tuples
+  - type_name # descriptive test type names run long
 
 opt_in_rules:
   - mark
@@ -46,11 +47,11 @@ opt_in_rules:
   - enum_case_associated_values_count
   - fatal_error_message
   - first_where
-  - indentation_width
+  # - indentation_width # false-positives on multiline string fixtures (JSON / expected-output literals)
   - last_where
   - legacy_random
   - literal_expression_end_indentation
-  - multiline_arguments
+  # - multiline_arguments # tests pack fixture/assertion arguments in table style
   - multiline_arguments_brackets
   - multiline_function_chains
   - multiline_literal_brackets
@@ -87,7 +88,7 @@ custom_rules:
 
   string_concatenation:
     included: ".*\\.swift"
-    excluded: ".*Test\\.swift"
+    excluded: ".*Tests?\\.swift"
     name: "String Concatenation"
     regex:  " \\+ \"|\" \\+ |\\+= \""
     message: "Please use string interpolation instead of concatenation"
@@ -95,7 +96,7 @@ custom_rules:
 
   nslog_function_usage:
     included: ".*\\.swift"
-    excluded: ".*Test\\.swift"
+    excluded: ".*Tests?\\.swift"
     name: "Swift NSLog() should not be used in App Code"
     regex: "NSLog\\("
     message: "The swift NSLog function should not be used."
@@ -134,19 +135,13 @@ identifier_name:
     - tx
     - as
 
-indentation_width:
-  indentation_width: 4
-
 line_length:
-  warning: 150
+  warning: 250
+  error: 350
   ignores_urls: true
   ignores_function_declarations: true
   ignores_comments: true
 
-multiline_arguments:
-  first_argument_location: next_line
-  only_enforce_after_first_closure_on_first_line: true
-  
 private_over_fileprivate:
   validate_extensions: true
 

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletCoordFlowTests.swift
@@ -23,7 +23,6 @@ import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
 
 @Suite(.serialized) @MainActor struct AddKeystoneHWWalletCoordFlowTests {
-
     // MARK: - accountImportFailed from keystoneDeviceReady
 
     @Test func accountImportFailedShowsFailureSheet() async {

--- a/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
+++ b/zodlTests/AddKeystoneHWWalletTests/AddKeystoneHWWalletTests.swift
@@ -19,7 +19,7 @@ import ComposableArchitecture
 
     @Test func hexStringToBytesParsesValidEvenLengthHex() {
         #expect(AddKeystoneHWWallet.hexStringToBytes("00ff10") == [0x00, 0xff, 0x10])
-        #expect(AddKeystoneHWWallet.hexStringToBytes("") == [])
+        #expect(AddKeystoneHWWallet.hexStringToBytes("")?.isEmpty == true)
     }
 
     @Test func hexStringToBytesRejectsOddLengthAndInvalidCharacters() {

--- a/zodlTests/CurrencyConversionTests/CurrencyConversionTests.swift
+++ b/zodlTests/CurrencyConversionTests/CurrencyConversionTests.swift
@@ -9,9 +9,7 @@ import XCTest
 @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-
 class CurrencyConversionTests: XCTestCase {
-
     func testInitRoundsRatioToSixDecimals() {
         let conversion = CurrencyConversion(.usd, ratio: 1.123456789, timestamp: 0)
 

--- a/zodlTests/MigrationTests/MigrationAdvanceStepBannerTests.swift
+++ b/zodlTests/MigrationTests/MigrationAdvanceStepBannerTests.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 import Testing
-@_spi(Testing) import ZcashLightClientKit
+@_spi(Testing)
+import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite struct MigrationAdvanceStepBannerTests {

--- a/zodlTests/MigrationTests/MigrationBannerNamesTests.swift
+++ b/zodlTests/MigrationTests/MigrationBannerNamesTests.swift
@@ -33,7 +33,7 @@ import Testing
 @testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite struct MigrationBannerNamesTests {
+@Suite enum MigrationBannerNamesTests {
     private static func progress(completed: Int, total: Int) -> MigrationProgress {
         MigrationProgress(
             completedTransfers: completed,

--- a/zodlTests/MigrationTests/MigrationCancelledRunStateTests.swift
+++ b/zodlTests/MigrationTests/MigrationCancelledRunStateTests.swift
@@ -22,7 +22,8 @@
 
 import Foundation
 import Testing
-@_spi(Testing) import ZcashLightClientKit
+@_spi(Testing)
+import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite struct MigrationCancelledRunStateTests {

--- a/zodlTests/MigrationTests/MigrationConfirmSynchronousPushTests.swift
+++ b/zodlTests/MigrationTests/MigrationConfirmSynchronousPushTests.swift
@@ -119,7 +119,7 @@ import Testing
     /// path mutation happens in the reducer handling the delegate, with the state built from the
     /// in-hand schedule + the published snapshot; no async receive precedes the push.
     @Test func aConfirmedPlanPushesTheScheduledScreenSynchronously() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = nil }
 
         var planState = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: true)
@@ -225,7 +225,7 @@ import Testing
     /// the pin: any mutation (e.g. `isConfirming` flipping true on the way into the auth gate)
     /// fails it outright.
     @Test func aCommittedPlanIgnoresAnotherConfirmTap() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         var state = MigrationTransferPlan.State(variant: .scheduled, requiresSigning: true)

--- a/zodlTests/MigrationTests/MigrationCoordFlowKeystoneScheduleStoreTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowKeystoneScheduleStoreTests.swift
@@ -95,7 +95,7 @@ import Testing
     /// The P1 pin: both halves store, split positionally, and the committed schedule records —
     /// no deferral, no drop.
     @Test func lastRoundStoresBothHalvesAndRecordsTheSchedule() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         let storedPreps = LockIsolated<[MigrationSignedTransferPczt]>([])
@@ -135,13 +135,10 @@ import Testing
             )
         )
 
-        await store.receive(
-            { action in
-                guard case .keystoneSigningSubmitted = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .keystoneSigningSubmitted = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(storedPreps.value.map(\.id) == [0], "the preparation half stores by position")
         #expect(storedSchedule.value.map(\.id) == [4], "the schedule half stores by position — the audit's dropped payload")
@@ -156,7 +153,7 @@ import Testing
     /// The honest-failure twin: a schedule-store failure abandons the ceremony (run cancelled,
     /// nothing resumes) rather than landing on "Migration Scheduled" with half a batch stored.
     @Test func scheduleStoreFailureAbandonsInsteadOfResuming() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         let recordedSchedules = LockIsolated<Int>(0)
@@ -192,13 +189,10 @@ import Testing
             )
         )
 
-        await store.receive(
-            { action in
-                guard case .keystoneScanAbandoned = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .keystoneScanAbandoned = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(recordedSchedules.value == 0, "a failed store must never record the schedule as committed")
 

--- a/zodlTests/MigrationTests/MigrationImmediateRetryLaneTests.swift
+++ b/zodlTests/MigrationTests/MigrationImmediateRetryLaneTests.swift
@@ -87,7 +87,7 @@ import Testing
     /// THE PRIMARY PATH, unchanged: the Review element survived the pop, so its own commit-failure
     /// sheet is armed IN PLACE and nothing is pushed. Retry there re-runs the ceremony.
     @Test func aSurvivingReviewIsArmedInPlace() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         let store = Self.coordinatorStore(bottom: .reviewTransfer(MigrationReviewTransfer.State(mode: .immediate)))
@@ -109,7 +109,7 @@ import Testing
     /// carrying the same commit-failure sheet — NOT a Sending screen. This is the whole regression:
     /// the Sending screen it used to push had no proposal, so its Retry drove the scheduled lane.
     @Test func aLostReviewPushesAFreshImmediateReviewNotSending() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         let store = Self.coordinatorStore(bottom: .transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
@@ -137,7 +137,7 @@ import Testing
     /// The tombstone check is untouched by the fix: a ceremony the user already abandoned drops the
     /// late failure silently rather than pushing anything at all.
     @Test func anAbandonedCeremonyDropsTheLateFailure() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         var state = Self.makeState(bottom: .transferPlan(MigrationTransferPlan.State(variant: .scheduled)))
@@ -167,7 +167,7 @@ import Testing
     /// counted rather than left unimplemented, so a reintroduced drive fails loudly here instead of
     /// silently working.
     @Test func retryOnAProposallessSendingScreenNeverConsultsTheDrive() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         let cranks = LockIsolated<Int>(0)

--- a/zodlTests/MigrationTests/MigrationReplanRoutingTests.swift
+++ b/zodlTests/MigrationTests/MigrationReplanRoutingTests.swift
@@ -22,7 +22,8 @@
 
 import Foundation
 import Testing
-@_spi(Testing) import ZcashLightClientKit
+@_spi(Testing)
+import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite struct MigrationReplanRoutingTests {
@@ -235,5 +236,4 @@ import Testing
         #expect(MigrationEngineAnswer(step: .replan) == .replan)
         #expect(MigrationEngineAnswer(step: .reevaluate) == .reevaluate)
     }
-
 }

--- a/zodlTests/MigrationTests/MigrationRestartTests.swift
+++ b/zodlTests/MigrationTests/MigrationRestartTests.swift
@@ -57,7 +57,7 @@ import ComposableArchitecture
     /// the write has to land BEFORE `MigrationRestart.State()` reads it, or `TestStore` snapshots a
     /// nil account and reports the arrival as an unasserted state change on the first `send`.
     @MainActor private static func presentedState() -> MigrationRestart.State {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         var state = MigrationRestart.State()
@@ -185,7 +185,7 @@ import ComposableArchitecture
     /// and the pool header read (R13's one-derivation rule), so this screen cannot quote a count or
     /// a balance that contradicts them.
     @MainActor @Test func numbersComeFromTheSnapshot() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = Self.account() }
 
         // The Figma's own numbers: 7 of 11 migrated, 3.070 ZEC left.
@@ -225,7 +225,7 @@ import ComposableArchitecture
     /// No selected account ⇒ no engine call is addressable, so the CTA is inert rather than
     /// throwing into the failure path. `isRestartPossible` is what disables Next in the view.
     @MainActor @Test func noAccountMakesTheFlowInert() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         $selectedWalletAccount.withLock { $0 = nil }
 
         var state = MigrationRestart.State()

--- a/zodlTests/MigrationTests/MigrationSnapshotFreshnessTests.swift
+++ b/zodlTests/MigrationTests/MigrationSnapshotFreshnessTests.swift
@@ -51,7 +51,7 @@ import ComposableArchitecture
     /// Installs `accountUUID` as the sole candidate — selected AND the whole wallet-account list —
     /// mirrors the retired warm-up suite's `installCandidateAccount()`.
     private static func installCandidateAccount() {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         @Shared(.inMemory(.walletAccounts)) var walletAccounts: [WalletAccount] = []
         $selectedWalletAccount.withLock { $0 = Self.account() }
         $walletAccounts.withLock { $0 = [Self.account()] }

--- a/zodlTests/MigrationTests/MigrationSplitOverdueRouteTests.swift
+++ b/zodlTests/MigrationTests/MigrationSplitOverdueRouteTests.swift
@@ -24,7 +24,8 @@
 //
 
 import Testing
-@_spi(Testing) import ZcashLightClientKit
+@_spi(Testing)
+import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite struct MigrationSplitOverdueRouteTests {

--- a/zodlTests/MigrationTests/MigrationStepPlanTests.swift
+++ b/zodlTests/MigrationTests/MigrationStepPlanTests.swift
@@ -18,7 +18,8 @@
 //
 
 import Testing
-@_spi(Testing) import ZcashLightClientKit
+@_spi(Testing)
+import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite struct MigrationStepPlanTests {

--- a/zodlTests/MigrationTests/MigrationTickDriverTests.swift
+++ b/zodlTests/MigrationTests/MigrationTickDriverTests.swift
@@ -24,7 +24,8 @@
 
 import Foundation
 import Testing
-@_spi(Testing) @testable @preconcurrency import ZcashLightClientKit
+@_spi(Testing)
+@testable @preconcurrency import ZcashLightClientKit
 import ComposableArchitecture
 @testable import zodl_internal
 
@@ -75,7 +76,7 @@ import ComposableArchitecture
     /// via the same shared in-memory keys `MigrationManagerImpl.advance` reads. Every test calls
     /// this first; `.serialized` (above) is what makes doing so from several tests safe.
     private static func installCandidateAccount() {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         @Shared(.inMemory(.walletAccounts)) var walletAccounts: [WalletAccount] = []
         $selectedWalletAccount.withLock { $0 = Self.account() }
         $walletAccounts.withLock { $0 = [Self.account()] }
@@ -960,7 +961,7 @@ import ComposableArchitecture
     /// with its own due transfer. The first hold used to end the discharge loop — account B's
     /// delivery never ran, on every tick, for as long as A stayed due.
     @Test func aHeldAccountDoesNotStarveTheNextAccountsDelivery() async {
-        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount?
         @Shared(.inMemory(.walletAccounts)) var walletAccounts: [WalletAccount] = []
         $selectedWalletAccount.withLock { $0 = Self.account() }
         $walletAccounts.withLock { $0 = [Self.account(), Self.secondAccount()] }

--- a/zodlTests/MigrationTests/MigrationVisitTests.swift
+++ b/zodlTests/MigrationTests/MigrationVisitTests.swift
@@ -13,7 +13,8 @@
 //
 
 import Testing
-@_spi(Testing) import ZcashLightClientKit
+@_spi(Testing)
+import ZcashLightClientKit
 @testable import zodl_internal
 
 @Suite struct MigrationVisitTests {

--- a/zodlTests/UserMetadataTests/UMSerializationTests.swift
+++ b/zodlTests/UserMetadataTests/UMSerializationTests.swift
@@ -72,7 +72,7 @@ import ComposableArchitecture
     @Test func v2ToLatestClearsFromAssetWhenProviderIsZec() {
         let v2 = makeV2(provider: SwapConstants.zecAssetIdOnNear, totalFees: 0, lastUsed: [], swapsLastUpdated: 0)
         let swap = UserMetadata.v2ToLatest(v2).accountMetadata.swaps.swapIds.first
-        #expect(swap?.fromAsset == "")
+        #expect(swap?.fromAsset.isEmpty == true)
         #expect(swap?.toAsset == SwapConstants.zecAssetIdOnNear)
     }
 

--- a/zodlTests/UtilTests/ArrayChunkedTests.swift
+++ b/zodlTests/UtilTests/ArrayChunkedTests.swift
@@ -22,7 +22,7 @@ import Testing
     }
 
     @Test func chunkedEmptyArrayReturnsEmpty() {
-        #expect([Int]().chunked(into: 3) == [])
+        #expect([Int]().chunked(into: 3).isEmpty)
     }
 
     @Test func removingDuplicatesKeepsFirstOccurrencePreservingOrder() {
@@ -39,7 +39,8 @@ import Testing
     }
 
     @Test func removingDuplicatesOnEmptyReturnsEmpty() {
-        #expect([Item]().removingDuplicates().isEmpty)
+        let empty: [Item] = []
+        #expect(empty.removingDuplicates().isEmpty)
     }
 }
 

--- a/zodlTests/UtilTests/RootInitializeSDKColdStartFetchTests.swift
+++ b/zodlTests/UtilTests/RootInitializeSDKColdStartFetchTests.swift
@@ -141,13 +141,10 @@ import Testing
         // exhaustivity off, earlier received actions (`.loadedWalletAccounts` included, in the
         // fixed ordering) are still processed while being skipped, so the state read below sees
         // exactly what the fetch's reducer guard saw.
-        await store.receive(
-            { action in
-                guard case .fetchTransactionsForTheSelectedAccount = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .fetchTransactionsForTheSelectedAccount = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(
             store.state.selectedWalletAccount != nil,
@@ -156,13 +153,10 @@ import Testing
 
         // And the dispatch must be EFFECTIVE: the fetch effect reaches getAllTransactions with
         // the selected account (the guard's early `.none` return would never get here).
-        await store.receive(
-            { action in
-                guard case .fetchedTransactions = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .fetchedTransactions = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(
             fetchedAccountIds.value.first == RootInitializeSDKColdStartFetchTests.seedDerivedAccount.id,

--- a/zodlTests/UtilTests/RootInitializeSDKHealTests.swift
+++ b/zodlTests/UtilTests/RootInitializeSDKHealTests.swift
@@ -237,13 +237,10 @@ extension Root.State: @retroactive Equatable {
 
         await store.send(.initialization(.initializeSDK(.existingWallet)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isRestoringWallet = true
             state.$walletStatus.withLock { $0 = .restoring }
             state.isStaleWalletHealedAlertPending = true
@@ -266,13 +263,10 @@ extension Root.State: @retroactive Equatable {
         // never naturally sent here. Drive it explicitly to exercise the deferred-presentation wiring.
         await store.send(.destination(.updateDestination(.home)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isStaleWalletHealedAlertPending = false
             state.alert = AlertState.staleWalletDatabaseHealed()
         }
@@ -299,13 +293,10 @@ extension Root.State: @retroactive Equatable {
 
         await store.send(.initialization(.initializeSDK(.existingWallet)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isRestoringWallet = true
             state.$walletStatus.withLock { $0 = .restoring }
             state.isStaleWalletHealedAlertPending = true
@@ -350,13 +341,10 @@ extension Root.State: @retroactive Equatable {
 
         await store.send(.initialization(.initializeSDK(.existingWallet)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isRestoringWallet = true
             state.$walletStatus.withLock { $0 = .restoring }
             state.isStaleWalletHealedAlertPending = true
@@ -398,13 +386,10 @@ extension Root.State: @retroactive Equatable {
 
         await store.send(.initialization(.initializeSDK(.existingWallet)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.initializationSuccessfullyDone) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.initializationSuccessfullyDone) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(!calls.value.contains("wipe"), "no heal must occur when the seed is already relevant")
         #expect(store.state.alert == nil, "no heal alert should be shown")
@@ -429,13 +414,10 @@ extension Root.State: @retroactive Equatable {
 
         await store.send(.initialization(.initializeSDK(.existingWallet)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.staleWalletDatabaseHealed) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isRestoringWallet = true
             state.$walletStatus.withLock { $0 = .restoring }
             state.isStaleWalletHealedAlertPending = true
@@ -484,13 +466,10 @@ extension Root.State: @retroactive Equatable {
 
         await store.send(.initialization(.initializeSDK(.existingWallet)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.checkWalletInitialization) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.checkWalletInitialization) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         let recordedCalls = calls.value
         let wipeIndex = try #require(recordedCalls.firstIndex(of: "wipe"))
@@ -513,13 +492,10 @@ extension Root.State: @retroactive Equatable {
 
         await store.send(.destination(.updateDestination(.home)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isStaleWalletHealedAlertPending = false
             state.alert = AlertState.staleWalletDatabaseHealed()
         }
@@ -576,13 +552,10 @@ extension Root.State: @retroactive Equatable {
         // `.presentStaleWalletHealedAlert` re-checks the destination at delivery time and,
         // finding it's no longer `.home`, bails out without presenting the alert or clearing
         // the pending flag.
-        await store.receive(
-            { action in
-                guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
         #expect(store.state.alert == nil, "must not present over a screen other than home")
         #expect(store.state.isStaleWalletHealedAlertPending, "the flag must survive a delivery that lands off-home")
 
@@ -590,13 +563,10 @@ extension Root.State: @retroactive Equatable {
         await store.send(.destination(.updateDestination(.home)))
         await testQueue.advance(by: .seconds(0.5))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isStaleWalletHealedAlertPending = false
             state.alert = AlertState.staleWalletDatabaseHealed()
         }
@@ -631,13 +601,10 @@ extension Root.State: @retroactive Equatable {
 
         await store.send(.onboarding(.newWalletSuccessfulyCreated))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isStaleWalletHealedAlertPending = false
             state.alert = AlertState.staleWalletDatabaseHealed()
         }
@@ -677,13 +644,10 @@ extension Root.State: @retroactive Equatable {
             state.isStaleWalletHealedAlertPending = true
         }
 
-        await store.receive(
-            { action in
-                guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        ) { state in
+        await store.receive({ action in
+            guard case .initialization(.presentStaleWalletHealedAlert) = action else { return false }
+            return true
+        }, timeout: .seconds(5)) { state in
             state.isStaleWalletHealedAlertPending = false
             state.alert = AlertState.staleWalletDatabaseHealed()
         }

--- a/zodlTests/UtilTests/RootMigrationGateRefusalTests.swift
+++ b/zodlTests/UtilTests/RootMigrationGateRefusalTests.swift
@@ -193,13 +193,10 @@ import Testing
 
         // Mutually exclusive with `.initializationFailed` — both are the ONLY two outcomes of the
         // same do/catch, so successfully receiving this one also proves the other was never sent.
-        await store.receive(
-            { action in
-                guard case .initialization(.initializationSuccessfullyDone) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.initializationSuccessfullyDone) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(
             advanceCalls(calls) >= 2,
@@ -219,13 +216,10 @@ import Testing
 
         await store.send(.initialization(.initializeSDK(.existingWallet)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.initializationFailed) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.initializationFailed) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(advanceCalls(calls) == 1, "a non-gate error must not be treated as a broadcast session — only the pre-start call")
         #expect(store.state.appInitializationState == .failed)
@@ -256,13 +250,10 @@ import Testing
             state.lastMigrationSyncGateBlocked = false
         }
 
-        await store.receive(
-            { action in
-                guard case .initialization(.retryStart) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.retryStart) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         // Audit 2026-08-03 (#12): the arming flag is consumed by `.retryStart` PAST its guards,
         // no longer by the gate-resume reducer — clearing before the guards meant a disk-space or
@@ -290,13 +281,10 @@ import Testing
             state.lastMigrationSyncGateBlocked = false
         }
 
-        await store.receive(
-            { action in
-                guard case .initialization(.retryStart) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.retryStart) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(
             store.state.syncDeferredByMigrationGate,
@@ -315,21 +303,15 @@ import Testing
 
         await store.send(.initialization(.retryStart))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.registerForSynchronizersUpdate) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.registerForSynchronizersUpdate) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.synchronizerStartFailed) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.synchronizerStartFailed) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(store.state.didScheduleStartFailureRetry, "the failure must arm its one-shot delayed retry")
 
@@ -351,13 +333,10 @@ import Testing
 
         await store.send(.initialization(.initializeSDK(.existingWallet)))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.initializationSuccessfullyDone) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.initializationSuccessfullyDone) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(store.state.syncDeferredByMigrationGate, "the refusal itself must arm the deferred-start flag")
 
@@ -367,13 +346,10 @@ import Testing
 
         await store.send(.migrationSyncGateChanged(false))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.retryStart) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.retryStart) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         // (#12) Cleared by `.retryStart` past its guards, not by the gate-resume reducer.
         #expect(!store.state.syncDeferredByMigrationGate, "retryStart consumed the flag the refusal armed")
@@ -392,13 +368,10 @@ import Testing
         // Mutually exclusive with `.synchronizerStartFailed` — both are the ONLY two outcomes of
         // the same do/catch, so successfully receiving this one also proves the other was never
         // sent.
-        await store.receive(
-            { action in
-                guard case .initialization(.registerForSynchronizersUpdate) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.registerForSynchronizersUpdate) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(
             advanceCalls(calls) >= 2,
@@ -416,13 +389,10 @@ import Testing
 
         await store.send(.initialization(.retryStart))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.synchronizerStartFailed) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.synchronizerStartFailed) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(advanceCalls(calls) == 1, "a non-gate error must not be treated as a broadcast session — only the pre-start call")
 
@@ -456,17 +426,14 @@ import Testing
 
         await store.send(.initialization(.retryStart))
 
-        await store.receive(
-            { action in
-                if case .initialization(.registerForSynchronizersUpdate) = action {
-                    Issue.record("a broadcast-only pass re-registered the streams — the ~10 Hz spin is back")
-                    return true
-                }
-                guard case .refreshAutomaticServer = action else { return false }
+        await store.receive({ action in
+            if case .initialization(.registerForSynchronizersUpdate) = action {
+                Issue.record("a broadcast-only pass re-registered the streams — the ~10 Hz spin is back")
                 return true
-            },
-            timeout: .seconds(5)
-        )
+            }
+            guard case .refreshAutomaticServer = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         await drain(store)
     }
@@ -480,13 +447,10 @@ import Testing
 
         await store.send(.initialization(.retryStart))
 
-        await store.receive(
-            { action in
-                guard case .initialization(.registerForSynchronizersUpdate) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.registerForSynchronizersUpdate) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         await drain(store)
     }

--- a/zodlTests/UtilTests/RootMigrationGateStopOnBlockTests.swift
+++ b/zodlTests/UtilTests/RootMigrationGateStopOnBlockTests.swift
@@ -54,7 +54,8 @@
 import ComposableArchitecture
 import Foundation
 import Testing
-@_spi(Testing) @testable @preconcurrency import ZcashLightClientKit
+@_spi(Testing)
+@testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
 // Serialized: resets the process-global `@Shared(.inMemory(.migrationStoppedSyncForBroadcast))`
@@ -179,7 +180,7 @@ import Testing
     /// Resets the shared resume flag the production stop sets — process-global, so each test
     /// starts from a known false.
     private func resetSharedResumeFlag() {
-        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
+        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast = false
         $migrationStoppedSyncForBroadcast.withLock { $0 = false }
     }
 
@@ -221,7 +222,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
-            mode: MigrationMode.privateScheduled,            advanceStep: { _ in
+            mode: MigrationMode.privateScheduled, advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             },
@@ -241,7 +242,7 @@ import Testing
         // this test for the wrong reason.
         #expect(stepReads.value >= 1, "the stop must be attributed through the probe's own migrationAdvanceStep read, not fired unconditionally")
         #expect(stopCalls.value == 1, "a tick-deliverable candidate's .broadcast step must stop sync")
-        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
+        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast = false
         #expect(migrationStoppedSyncForBroadcast == true, "the stop must go through stopStartedSyncForMigrationGate, arming the resume half")
 
         await teardown(store)
@@ -258,7 +259,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
-            mode: MigrationMode.privateScheduled,            advanceStep: { _ in
+            mode: MigrationMode.privateScheduled, advanceStep: { _ in
                 let callNumber = stepReads.withValue { value -> Int in
                     value += 1
                     return value
@@ -297,7 +298,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
-            mode: MigrationMode.privateScheduled,            advanceStep: { _ in
+            mode: MigrationMode.privateScheduled, advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
                 return MigrationAdvance(step: .waiting, next: nil)
             },
@@ -324,7 +325,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
-            mode: MigrationMode.privateScheduled,            advanceStep: { _ in
+            mode: MigrationMode.privateScheduled, advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
                 return MigrationAdvance(step: .waiting, next: nil)
             },
@@ -369,7 +370,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
-            mode: MigrationMode.privateScheduled,            advanceStep: { _ in
+            mode: MigrationMode.privateScheduled, advanceStep: { _ in
                 await withCheckedContinuation { continuation in
                     stepContinuation.setValue(continuation)
                 }
@@ -411,7 +412,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
-            mode: MigrationMode.immediate,            advanceStep: { accountUUID in
+            mode: MigrationMode.immediate, advanceStep: { accountUUID in
                 queriedAccountUUIDs.withValue { $0.append(accountUUID) }
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             },
@@ -442,7 +443,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
-            mode: MigrationMode.immediate,            advanceStep: { _ in
+            mode: MigrationMode.immediate, advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             }
@@ -516,7 +517,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.stopped,
-            mode: MigrationMode.privateScheduled,            advanceStep: { _ in
+            mode: MigrationMode.privateScheduled, advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             },
@@ -534,7 +535,7 @@ import Testing
         // mocked `stop()` closure this suite spies on. `stopCalls` staying 0 is therefore the
         // B12 contract, not a probe failure.
         #expect(stopCalls.value == 0, "a stopped engine has nothing to stop — the helper's own guard no-ops before calling stop()")
-        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
+        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast = false
         #expect(!migrationStoppedSyncForBroadcast, "never arm the resume flag for a sync nobody paused")
 
         await teardown(store)
@@ -552,7 +553,7 @@ import Testing
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
-            mode: MigrationMode.privateScheduled,            advanceStep: { _ in
+            mode: MigrationMode.privateScheduled, advanceStep: { _ in
                 stepReads.withValue { $0 += 1 }
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             },

--- a/zodlTests/UtilTests/RootMigrationTickLoopTests.swift
+++ b/zodlTests/UtilTests/RootMigrationTickLoopTests.swift
@@ -413,20 +413,17 @@ import Testing
         let testClock = TestClock()
         let store = makeStore(spy: spy, testClock: testClock, lastMigrationSyncGateBlocked: true)
 
-        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
+        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast = false
         $migrationStoppedSyncForBroadcast.withLock { $0 = true }
 
         await store.send(.migrationSyncGateChanged(false)) { state in
             state.lastMigrationSyncGateBlocked = false
         }
 
-        await store.receive(
-            { action in
-                guard case .initialization(.retryStart) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.retryStart) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         #expect(!migrationStoppedSyncForBroadcast, "the resume must clear the flag it consumed")
 
@@ -451,7 +448,7 @@ import Testing
         let testClock = TestClock()
         let store = makeStore(spy: spy, testClock: testClock)
 
-        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
+        @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast = false
         $migrationStoppedSyncForBroadcast.withLock { $0 = false }
 
         await store.send(.initialization(.initializationSuccessfullyDone))
@@ -467,13 +464,10 @@ import Testing
             state.syncDeferredByMigrationGate = false
         }
 
-        await store.receive(
-            { action in
-                guard case .initialization(.retryStart) = action else { return false }
-                return true
-            },
-            timeout: .seconds(5)
-        )
+        await store.receive({ action in
+            guard case .initialization(.retryStart) = action else { return false }
+            return true
+        }, timeout: .seconds(5))
 
         // Parked-debt pin (2026-08-03), same rationale as (a) above: exactly one resume open.
         await waitUntil { spy.nonTickCalls >= 1 }

--- a/zodlTests/UtilTests/SerializerTests.swift
+++ b/zodlTests/UtilTests/SerializerTests.swift
@@ -23,8 +23,8 @@ import Foundation
     }
 
     @Test func emptyStringRoundTrip() {
-        #expect(Serializer.stringToBytes("") == [])
-        #expect(Serializer.bytesToString([]) == "")
+        #expect(Serializer.stringToBytes("").isEmpty)
+        #expect(Serializer.bytesToString([])?.isEmpty == true)
     }
 
     @Test func bytesToStringReturnsNilForInvalidUTF8() {


### PR DESCRIPTION
## Summary

The secantTests → zodlTests rename left the SwiftLint configs pointing at directories that no longer exist, so `.swiftlint_tests.yml` linted **zero files** — nothing under `zodlTests/` was covered by any config. SwiftLint 0.50.3 filters even explicitly-passed paths through `included:`, so with the stale globs `swiftlint lint --config .swiftlint_tests.yml zodlTests/` reports "No lintable files found". Found during CHP Task 8L, where linting zodlTests produced no signal.

Two commits, reviewable separately:

1. **Config** — `included:` → `zodlTests/` (no UI-tests successor target exists), stale `excluded:` entries dropped from the app config, and in-config baselines for the rules the newly-visible 170 files show tests were never written against: `line_length` 250/350 (long fixture lines), `multiline_arguments` / `large_tuple` / `type_name` off (assertion tables, grouped fixture tuples, descriptive test names), `indentation_width` off (all 8 hits are false-positives inside multiline string fixtures — six 2-space JSON literals, two exact-match expected-output blocks whose indentation *is* the asserted content), and the custom-rule excluded regex now matches `*Tests.swift` (plural) as intended, resolving 5 `string_concatenation` errors the rule was designed not to raise in test files.
2. **Mechanical fixes** for everything else that surfaced (152 violations, 7 serious): autocorrect (`opening_brace`, `comma`, `redundant_optional_initialization`, `redundant_type_annotation`, `vertical_whitespace`) plus small hand fixes — attributes onto their own lines (8), `.isEmpty` over empty-literal comparisons (5, truth-table equivalent), one static-only struct → enum, one explicit empty-array annotation, and a whitespace-only bracket reflow where the opening_brace fix exposed `multiline_arguments_brackets` conflicts (30 sites).

No app-code changes; CHANGELOG untouched (not user-visible). Fixture/expected-output string literals are byte-untouched.

## Testing

- `swiftlint lint --config .swiftlint_tests.yml`: **0 violations, 0 serious in 170 files**, zero configuration warnings (before: 0 files linted).
- All 24 edited test files pass `swiftc -parse`; the optional `@Shared` form without `= nil` matches existing app usage (e.g. `MigrationEntryStore.swift:27`).
- Full unit-test suite runs in this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)