### PR TITLE
Adopt the split ZODLSlipstream SDK product

### DIFF
--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -8,8 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		343DCB8E3019388D00B5E65C /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 343DCB8D3019388D00B5E65C /* ZcashLightClientKit */; };
+		A55B10005119857BEAC00001 /* ZODLSlipstream in Frameworks */ = {isa = PBXBuildFile; productRef = A55B20005119857BEAC00002 /* ZODLSlipstream */; };
 		343DCB93301938A200B5E65C /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 343DCB92301938A200B5E65C /* ZcashLightClientKit */; };
+		A55B10015119857BEAC00001 /* ZODLSlipstream in Frameworks */ = {isa = PBXBuildFile; productRef = A55B20015119857BEAC00002 /* ZODLSlipstream */; };
 		34982B6E3014A1C100FF9205 /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34982B6D3014A1C100FF9205 /* ZcashLightClientKit */; };
+		A55B10025119857BEAC00001 /* ZODLSlipstream in Frameworks */ = {isa = PBXBuildFile; productRef = A55B20025119857BEAC00002 /* ZODLSlipstream */; };
 		34AA77182F857DB300D244E2 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 34AA77172F857DB300D244E2 /* ComposableArchitecture */; };
 		34AA771A2F857DB800D244E2 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 34AA77192F857DB800D244E2 /* ComposableArchitecture */; };
 		34AA771C2F857DBB00D244E2 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 34AA771B2F857DBB00D244E2 /* ComposableArchitecture */; };
@@ -50,6 +53,7 @@
 		34B967672F8CC48B00823B20 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 34B967662F8CC48B00823B20 /* Atomics */; };
 		34B967692F8CC49100823B20 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 34B967682F8CC49100823B20 /* Atomics */; };
 		34FB884B3010911000A2F01F /* ZcashLightClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34FB884A3010911000A2F01F /* ZcashLightClientKit */; };
+		A55B10035119857BEAC00001 /* ZODLSlipstream in Frameworks */ = {isa = PBXBuildFile; productRef = A55B20035119857BEAC00002 /* ZODLSlipstream */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -147,6 +151,7 @@
 				34AA778E2F85833900D244E2 /* Lottie in Frameworks */,
 				34AA77402F8580D700D244E2 /* CasePathsCore in Frameworks */,
 				34982B6E3014A1C100FF9205 /* ZcashLightClientKit in Frameworks */,
+				A55B10025119857BEAC00001 /* ZODLSlipstream in Frameworks */,
 				34AA77A42F8583C300D244E2 /* BigDecimal in Frameworks */,
 				34AA77C02F85862200D244E2 /* UInt128 in Frameworks */,
 				34AA77782F8582AC00D244E2 /* Flexa in Frameworks */,
@@ -168,6 +173,7 @@
 				34AA778A2F85832E00D244E2 /* Lottie in Frameworks */,
 				34AA77382F8580CB00D244E2 /* CasePathsCore in Frameworks */,
 				343DCB93301938A200B5E65C /* ZcashLightClientKit in Frameworks */,
+				A55B10015119857BEAC00001 /* ZODLSlipstream in Frameworks */,
 				34AA77A02F8583BA00D244E2 /* BigDecimal in Frameworks */,
 				34AA77BC2F85861800D244E2 /* UInt128 in Frameworks */,
 				34AA77742F8582A200D244E2 /* Flexa in Frameworks */,
@@ -182,6 +188,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				343DCB8E3019388D00B5E65C /* ZcashLightClientKit in Frameworks */,
+				A55B10005119857BEAC00001 /* ZODLSlipstream in Frameworks */,
 				34AA77812F8582EB00D244E2 /* ZcashPaymentURI in Frameworks */,
 				34AA77492F85814C00D244E2 /* URLRouting in Frameworks */,
 				34AA77292F857E3400D244E2 /* XCTestDynamicOverlay in Frameworks */,
@@ -190,6 +197,7 @@
 				34AA773C2F8580D000D244E2 /* CasePathsCore in Frameworks */,
 				34AA77A22F8583BF00D244E2 /* BigDecimal in Frameworks */,
 				34FB884B3010911000A2F01F /* ZcashLightClientKit in Frameworks */,
+				A55B10035119857BEAC00001 /* ZODLSlipstream in Frameworks */,
 				34AA77BE2F85861E00D244E2 /* UInt128 in Frameworks */,
 				34AA77762F8582A700D244E2 /* Flexa in Frameworks */,
 				34AA77542F85818500D244E2 /* MnemonicSwift in Frameworks */,
@@ -301,6 +309,7 @@
 				34AA77BF2F85862200D244E2 /* UInt128 */,
 				34B967682F8CC49100823B20 /* Atomics */,
 				34982B6D3014A1C100FF9205 /* ZcashLightClientKit */,
+				A55B20025119857BEAC00002 /* ZODLSlipstream */,
 			);
 			productName = "zodl-testnet";
 			productReference = 9E41FFBB2CB2814500783CFD /* zodl-testnet.app */;
@@ -341,6 +350,7 @@
 				34AA77BB2F85861800D244E2 /* UInt128 */,
 				34B967642F8CC48700823B20 /* Atomics */,
 				343DCB92301938A200B5E65C /* ZcashLightClientKit */,
+				A55B20015119857BEAC00002 /* ZODLSlipstream */,
 			);
 			productName = "zodl-production";
 			productReference = 9E4AB2B72BA1BEE900F5D6DB /* zodl-production.app */;
@@ -381,7 +391,9 @@
 				34AA77BD2F85861E00D244E2 /* UInt128 */,
 				34B967662F8CC48B00823B20 /* Atomics */,
 				34FB884A3010911000A2F01F /* ZcashLightClientKit */,
+				A55B20035119857BEAC00002 /* ZODLSlipstream */,
 				343DCB8D3019388D00B5E65C /* ZcashLightClientKit */,
+				A55B20005119857BEAC00002 /* ZODLSlipstream */,
 			);
 			productName = "zodl-internal";
 			productReference = 9E5AB4822C94777800065483 /* zodl-internal.app */;
@@ -1429,14 +1441,28 @@
 			package = 3453893B300A5646008677A8 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */;
 			productName = ZcashLightClientKit;
 		};
+		A55B20005119857BEAC00002 /* ZODLSlipstream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3453893B300A5646008677A8 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */;
+			productName = ZODLSlipstream;
+		};
 		343DCB92301938A200B5E65C /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3453893B300A5646008677A8 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */;
 			productName = ZcashLightClientKit;
 		};
+		A55B20015119857BEAC00002 /* ZODLSlipstream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3453893B300A5646008677A8 /* XCLocalSwiftPackageReference "../zcash-swift-wallet-sdk" */;
+			productName = ZODLSlipstream;
+		};
 		34982B6D3014A1C100FF9205 /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ZcashLightClientKit;
+		};
+		A55B20025119857BEAC00002 /* ZODLSlipstream */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ZODLSlipstream;
 		};
 		34AA77172F857DB300D244E2 /* ComposableArchitecture */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1651,6 +1677,10 @@
 		34FB884A3010911000A2F01F /* ZcashLightClientKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ZcashLightClientKit;
+		};
+		A55B20035119857BEAC00002 /* ZODLSlipstream */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ZODLSlipstream;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -10,6 +10,7 @@ import Foundation
 import ComposableArchitecture
 import os
 @preconcurrency import ZcashLightClientKit
+@preconcurrency import ZODLSlipstream
 @preconcurrency import KeystoneSDK
 
 private let slipstreamLogger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "co.ecc.zashi", category: "slipstream")


### PR DESCRIPTION
## What

Companion to [zcash-swift-wallet-sdk#1964](https://github.com/zcash/zcash-swift-wallet-sdk/pull/1964), which moves `SlipstreamSynchronizer` out of `ZcashLightClientKit` into an opt-in `ZODLSlipstream` product so the default SDK artifact ships MIT-clean (no AGPL code).

App-side adoption is deliberately minimal:

- All four targets (`zodl-production`, `zodl-internal`, `zodl-testnet`, `zodlTests`) gain the `ZODLSlipstream` product dependency through the existing local package reference to `../zcash-swift-wallet-sdk`.
- `SDKSynchronizerLive.swift` — the one file that constructs `SlipstreamSynchronizer` — adds `@preconcurrency import ZODLSlipstream`. No other source changes; the `useSlipstreamSynchronizer` runtime flag and everything around it is untouched.

## Verification

Against the SDK vendoring branch in variant mode (`Scripts/init-local-ffi.sh --slipstream`; ios-sim FFI slice rebuilt through the new feature-gated pipeline with the unifdef-specialized superset header):

- `zodl-internal` builds clean for the iPhone 17 Pro simulator.
- Full test suite on this branch as rebased onto `main`: **1,225 tests executed, 0 failures** (`Test-zodl-internal-2026.08.14_20-26-16` xcresult: Passed).

## Notes

- Based on `main`.
- Until the SDK's first dual release (2.9.0 / 2.9.0-zodl-slipstream) publishes the variant artifact, building requires the local SDK checkout in variant mode; after that, ZODL's own builds pin `exact: "X.Y.Z-zodl-slipstream"` (first-party App Store distribution is covered by Znewco's own AGPL §7 permission — see the SDK's `Sources/ZODLSlipstream/NOTICE.md`).

🤖 Drafted and opened by [Claude Code](https://claude.com/claude-code) on @pacu's behalf.

https://claude.ai/code/session_01AkdBfgXpNvWmnNQXWjfA9G

