### PR TITLE
[MOB-1678] Migrate voting to the v1.3.0 chain: zcash_voting 3.0.0-rc.3, poly-aware PIR, auth v2

### DIFF
--- a/secant/Sources/Dependencies/VotingAPIClient/RoundAuthenticator.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/RoundAuthenticator.swift
@@ -7,7 +7,8 @@ enum RoundAuthStatus: Equatable, Sendable {
     case authenticated
     /// The chain reported a round id that is absent from the signed dynamic registry.
     case missingRound
-    /// The registry entry uses a future auth schema this wallet does not understand.
+    /// The registry entry uses an auth schema this wallet does not accept —
+    /// either the retired v1 or a future version.
     case unknownAuthVersion
     /// The entry is malformed or none of its signatures validate against bundled keys.
     case invalidSignatures
@@ -16,28 +17,52 @@ enum RoundAuthStatus: Equatable, Sendable {
 }
 
 enum RoundAuthenticator {
-    static let authVersionV1 = 1
+    /// The only accepted dynamic-config round-auth version.
+    ///
+    /// Policy decision (MOB-1678, `zcash_voting` 3.0 bump): v1 entries — signatures over
+    /// the raw 32-byte `ea_pk` only — are rejected outright, matching the crate's verifier
+    /// (`config::verify_round_entry` requires `ROUND_AUTH_VERSION_V2`). Accepting v1 would
+    /// let us vote on a round whose attestation does not pin the round id or the PIR layout
+    /// we will query with. Deliberate and overturnable: if a rollout window ever requires
+    /// dual-accept, record the deviation in CHP.md and sunset it.
+    static let authVersionV2 = 2
+
+    /// ASCII domain separation tag for the v2 signing payload (33 bytes).
+    private static let domainTagV2 = Data("zcash-shielded-vote:round-auth:v2".utf8)
 
     /// Authenticate one chain-sourced round against the dynamic config registry.
     ///
-    /// For `auth_version: 1`, the admin signature covers only the raw 32-byte
-    /// `ea_pk`. After verifying that signature against a key from the bundled
-    /// static config, the wallet still checks that the chain response carries
-    /// exactly the same `ea_pk`; this is the chain-binding step that catches a
-    /// stale or hostile vote server response.
+    /// For `auth_version: 2`, the admin signature covers the fixed-width payload built by
+    /// `signingPayloadV2` — domain tag, round id, `ea_pk`, and the config's full PIR
+    /// layout. `pirLayout` MUST be the top-level `pir_layout` of the **same** dynamic
+    /// config `rounds` came from: the signature binds them, so a config mixing layouts and
+    /// rounds from different generations fails here by construction. After verifying the
+    /// signature against a key from the bundled static config, the wallet still checks
+    /// that the chain response carries exactly the same `ea_pk`; this chain-binding step
+    /// catches a stale or hostile vote server response and is not subsumed by v2.
     static func authenticate(
         chainEaPK: Data,
         roundIdHex: String,
         rounds: [String: VotingServiceConfig.RoundEntry],
-        trustedKeys: [StaticVotingConfig.TrustedKey]
+        trustedKeys: [StaticVotingConfig.TrustedKey],
+        pirLayout: VotingServiceConfig.PirLayout
     ) -> RoundAuthStatus {
         guard let entry = rounds[roundIdHex] else {
             return .missingRound
         }
-        guard entry.authVersion == authVersionV1 else {
+        guard entry.authVersion == authVersionV2 else {
             return .unknownAuthVersion
         }
-        guard entry.eaPk.count == 32, !entry.signatures.isEmpty, verifyEntrySignatures(entry: entry, trustedKeys: trustedKeys) else {
+        guard
+            entry.eaPk.count == 32,
+            !entry.signatures.isEmpty,
+            verifyEntrySignatures(
+                entry: entry,
+                roundIdHex: roundIdHex,
+                pirLayout: pirLayout,
+                trustedKeys: trustedKeys
+            )
+        else {
             return .invalidSignatures
         }
         guard chainEaPK == entry.eaPk else {
@@ -46,17 +71,22 @@ enum RoundAuthenticator {
         return .authenticated
     }
 
-    /// Return true when at least one entry signature validates.
+    /// Return true when at least one entry signature validates over the v2 payload.
     ///
     /// The dynamic config names a trusted admin key by `key_id`; it does not
     /// inline public keys. This function resolves `key_id` into the static
-    /// config, requires matching algorithms, and verifies the signature over
-    /// the v1 payload: `entry.eaPk` bytes exactly as decoded from base64.
+    /// config, requires matching algorithms, and verifies the ed25519 signature
+    /// over `signingPayloadV2(roundIdHex:eaPk:pirLayout:)`.
     static func verifyEntrySignatures(
         entry: VotingServiceConfig.RoundEntry,
+        roundIdHex: String,
+        pirLayout: VotingServiceConfig.PirLayout,
         trustedKeys: [StaticVotingConfig.TrustedKey]
     ) -> Bool {
-        guard entry.authVersion == authVersionV1, entry.eaPk.count == 32, !entry.signatures.isEmpty else {
+        guard entry.authVersion == authVersionV2, !entry.signatures.isEmpty else {
+            return false
+        }
+        guard let payload = signingPayloadV2(roundIdHex: roundIdHex, eaPk: entry.eaPk, pirLayout: pirLayout) else {
             return false
         }
 
@@ -69,13 +99,45 @@ enum RoundAuthenticator {
                   signature.alg == trustedKey.alg,
                   signature.sig.count == 64,
                   let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: trustedKey.pubkey),
-                  publicKey.isValidSignature(signature.sig, for: entry.eaPk)
+                  publicKey.isValidSignature(signature.sig, for: payload)
             else {
                 continue
             }
             return true
         }
         return false
+    }
+
+    /// Canonical round-auth v2 bytes, mirroring `zcash_voting::round_auth::RoundAuthPayloadV2`:
+    ///
+    /// `"zcash-shielded-vote:round-auth:v2" (33B) || round_id (32B) || ea_pk (32B)
+    ///   || pir_depth || tier0_layers || tier1_layers || poly_len` (each u32 little-endian).
+    ///
+    /// Returns nil — the entry can never authenticate — when the round id does not
+    /// strict-hex-decode to exactly 32 bytes (crate parity: an undecodable id is skipped
+    /// defensively), when `ea_pk` is not 32 bytes, or when the config predates
+    /// `pir_layout.poly_len` (a pre-3.0 config cannot have produced a v2 attestation).
+    static func signingPayloadV2(
+        roundIdHex: String,
+        eaPk: Data,
+        pirLayout: VotingServiceConfig.PirLayout
+    ) -> Data? {
+        guard
+            let roundId = strictHexData(roundIdHex),
+            roundId.count == 32,
+            eaPk.count == 32,
+            let polyLen = pirLayout.polyLen
+        else {
+            return nil
+        }
+
+        var payload = domainTagV2
+        payload.append(roundId)
+        payload.append(eaPk)
+        for value in [pirLayout.pirDepth, pirLayout.tier0Layers, pirLayout.tier1Layers, polyLen] {
+            withUnsafeBytes(of: value.littleEndian) { payload.append(contentsOf: $0) }
+        }
+        return payload
     }
 }
 #endif

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientInterface.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientInterface.swift
@@ -69,9 +69,11 @@ struct VotingAPIClient {
     var submitDelegation: @Sendable (_ registration: DelegationRegistration) async throws -> TxResult
     var submitVoteCommitment: @Sendable (_ bundle: VoteCommitmentBundle, _ signature: CastVoteSignature) async throws -> TxResult
     /// Distribute shares across the provided active-submission vote server set.
+    /// The round id travels inside each payload's crate wire JSON (`vote_round_id`,
+    /// carried by `VoteShareWire` since zcash_voting 3.0.0-rc.3), so no separate
+    /// round id parameter exists here.
     var delegateShares: @Sendable (
         _ payloads: [SharePayload],
-        _ roundIdHex: String,
         _ proposalId: UInt32,
         _ serverURLs: [String]
     ) async throws -> ShareDelegationResult
@@ -79,7 +81,7 @@ struct VotingAPIClient {
     var fetchShareStatus: @Sendable (_ helperBaseURL: String, _ roundIdHex: String, _ nullifierHex: String) async throws -> ShareConfirmationResult
     /// Resubmit a single share to configured vote servers, preferring URLs that have not already accepted it.
     /// Returns the list of server URLs that accepted the share (empty if all failed).
-    var resubmitShare: @Sendable (_ payload: SharePayload, _ roundIdHex: String, _ excludeURLs: [String]) async throws -> [String]
+    var resubmitShare: @Sendable (_ payload: SharePayload, _ excludeURLs: [String]) async throws -> [String]
     var fetchProposalTally: @Sendable (_ roundId: Data, _ proposalId: UInt32) async throws -> TallyResult
     /// Query the Cosmos SDK TX endpoint for a confirmed transaction and its ABCI events.
     /// Returns nil if the TX is not yet in a block (404 or network error).

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
@@ -374,6 +374,10 @@ private func postServerJSON(_ serverURL: String, _ path: String, body: [String: 
 typealias SharePost = @Sendable (_ serverURL: String, _ body: [String: Any]) async throws -> Void
 typealias ShareTargetSelector = @Sendable (_ serverURLs: [String], _ targetCount: Int) -> [String]
 
+/// Shares per vote commitment, mirroring `zcash_voting`'s `VOTE_COMMITMENT_SHARE_COUNT`.
+/// Drives the initial-target spread in `delegateSharePayloads`.
+let voteCommitmentShareCount = 16
+
 /// Strictly decodes a hex string to `Data`: the input must have even length and every
 /// 2-character pair must be a valid hex byte, or this returns `nil`. Unlike `dataFromHex`
 /// above — which silently drops any pair that fails to parse, the exact lenient-decoder
@@ -460,13 +464,52 @@ func delegateSharePayloads(
     var lastError: Error?
     var results: [DelegatedShareInfo] = []
 
+    // A full commitment's 16 share payloads each carry that share's `primary_blind`
+    // in the clear next to the whole `share_comms` vector, so a helper holding every
+    // share holds every blind against every commitment and can solve back to the
+    // voter's exact balance. `zcash_voting` 3.0.0 closes this inside its own planner
+    // (`select_batch_share_submission_targets`) by dropping the server at index
+    // `share_index % 16` from that share's initial targets, which leaves every helper
+    // provably short of at least one share. ZODL drives its own fan-out rather than
+    // calling that planner, so the same rule is applied here, under the crate's own
+    // gate: a complete 16-share commitment across more than one helper. Single-share
+    // (last-moment) sends and partial recovery resubmits carry fewer payloads and are
+    // excluded, exactly as `!single_share && share_count == VOTE_COMMITMENT_SHARE_COUNT`
+    // excludes them upstream.
+    let spreadInitialTargets = payloads.count == voteCommitmentShareCount && availableServers.count > 1
+
     for (shareOffset, payload) in payloads.enumerated() {
         let targetCount = max(1, (availableServers.count + 1) / 2)
         var acceptedServers: [String] = []
         var triedServers = Set<String>()
+        // The guarantee is scoped to initial submission only. Once a target has failed
+        // and we are backfilling, the omitted helper becomes eligible again — losing a
+        // share entirely is worse than one helper holding a complete set, and the crate
+        // scopes its own guarantee the same way.
+        var isInitialAttempt = true
 
         while acceptedServers.count < targetCount {
-            let candidates = availableServers.filter { !triedServers.contains($0) }
+            var candidates = availableServers.filter { !triedServers.contains($0) }
+            if isInitialAttempt && spreadInitialTargets {
+                let spread = candidates.filter { candidate in
+                    // Indexed against the CONFIGURED list, never `availableServers`:
+                    // failed helpers are pruned from the working set mid-commitment, and
+                    // indexing that shrinking list would slide a helper into a departed
+                    // peer's slot. A helper whose omitted share moves backwards past the
+                    // share being sent never comes due again and can take the whole
+                    // remainder of the commitment — the exact correlation this prevents.
+                    // The crate has no such problem: it plans against a fixed slice.
+                    guard let position = initialServerURLs.firstIndex(of: candidate) else { return true }
+                    return position % voteCommitmentShareCount != Int(payload.shareIndex)
+                }
+                // Never let the omission starve a share: ceil(n/2) targets are always
+                // available after dropping at most one helper, but fail open rather
+                // than drop the share if that ever stops holding.
+                if !spread.isEmpty {
+                    candidates = spread
+                }
+            }
+            isInitialAttempt = false
             guard !candidates.isEmpty else { break }
 
             let needed = max(1, targetCount - acceptedServers.count)

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
@@ -378,8 +378,9 @@ typealias ShareTargetSelector = @Sendable (_ serverURLs: [String], _ targetCount
 /// 2-character pair must be a valid hex byte, or this returns `nil`. Unlike `dataFromHex`
 /// above — which silently drops any pair that fails to parse, the exact lenient-decoder
 /// pattern behind campaign finding #3 — any deviation here fails the whole decode instead
-/// of yielding a truncated or garbage result.
-private func strictHexData(_ hex: String) -> Data? {
+/// of yielding a truncated or garbage result. Internal (not private) because
+/// `RoundAuthenticator.signingPayloadV2` decodes round ids with the same strictness.
+func strictHexData(_ hex: String) -> Data? {
     guard hex.count % 2 == 0 else { return nil }
     var data = Data()
     var idx = hex.startIndex
@@ -768,11 +769,14 @@ private func authenticateVotingSession(_ session: VotingSession) async throws ->
     }
 
     let roundIdHex = hexString(from: session.voteRoundId)
+    // `rounds` and `pirLayout` intentionally come from the same stored dynamic config:
+    // the v2 attestation signs the round id together with that config's PIR layout.
     let status = RoundAuthenticator.authenticate(
         chainEaPK: session.eaPK,
         roundIdHex: roundIdHex,
         rounds: configuration.serviceConfig.rounds,
-        trustedKeys: configuration.staticConfig.trustedKeys
+        trustedKeys: configuration.staticConfig.trustedKeys,
+        pirLayout: configuration.serviceConfig.pirLayout
     )
     guard status == .authenticated else {
         LoggerProxy.error(
@@ -802,13 +806,20 @@ private func authenticatedVotingSessions(from rounds: [[String: Any]]) async thr
 ///
 /// Round authentication is intentionally per-round: one broken historical
 /// signature must hide only that round, while still allowing other active
-/// or finalized rounds to render.
+/// or finalized rounds to render. Verification is v2 (MOB-1678): each signature
+/// covers the round id and this config's own top-level `pir_layout`, so entries
+/// signed for another round id or another layout generation drop here.
 func serviceConfigRetainingRoundsWithValidSignatures(
     _ config: VotingServiceConfig,
     trustedKeys: [StaticVotingConfig.TrustedKey]
 ) -> VotingServiceConfig {
-    let authenticatedRounds = config.rounds.filter { _, entry in
-        RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: trustedKeys)
+    let authenticatedRounds = config.rounds.filter { roundIdHex, entry in
+        RoundAuthenticator.verifyEntrySignatures(
+            entry: entry,
+            roundIdHex: roundIdHex,
+            pirLayout: config.pirLayout,
+            trustedKeys: trustedKeys
+        )
     }
     return VotingServiceConfig(
         configVersion: config.configVersion,

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
@@ -378,8 +378,9 @@ typealias ShareTargetSelector = @Sendable (_ serverURLs: [String], _ targetCount
 /// 2-character pair must be a valid hex byte, or this returns `nil`. Unlike `dataFromHex`
 /// above — which silently drops any pair that fails to parse, the exact lenient-decoder
 /// pattern behind campaign finding #3 — any deviation here fails the whole decode instead
-/// of yielding a truncated or garbage result. Internal (not private) because
-/// `RoundAuthenticator.signingPayloadV2` decodes round ids with the same strictness.
+/// of yielding a truncated or garbage result. Internal (not private) for its sole
+/// remaining caller, `RoundAuthenticator.signingPayloadV2`, which decodes round ids
+/// with this strictness for auth v2 signing.
 func strictHexData(_ hex: String) -> Data? {
     guard hex.count % 2 == 0 else { return nil }
     var data = Data()
@@ -397,28 +398,19 @@ func strictHexData(_ hex: String) -> Data? {
     return data
 }
 
-/// rc.5's `VoteShareWire` (the crate's wire DTO for one share) does not carry a
-/// `vote_round_id` field at all — only its siblings `DelegationSubmissionWire` and
-/// `VoteCommitmentWire` do. The `/shielded-vote/v1/shares` server nonetheless requires the
-/// field (HTTP 400 `vote_round_id: expected 32 bytes, got 0` otherwise), so this injects it
-/// app-side from `roundIdHex`. Measured server contract: the shares endpoint hex-decodes
-/// `vote_round_id` (unlike the delegate-vote and cast-vote endpoints, which accept base64
-/// for the same field name — asymmetry confirmed live 2026-08-12), so this sends the
-/// validated 64-char hex string verbatim, not base64. Candidate for removal once the
-/// crate's `VoteShareWire` carries the field itself.
-func sharePostBody(
-    for payload: SharePayload,
-    roundIdHex: String
-) -> [String: Any] {
+/// The share POST body is the crate's wire JSON verbatim. Since zcash_voting
+/// 3.0.0-rc.3, `VoteShareWire` carries `vote_round_id` itself (a canonical 64-char
+/// lowercase-hex value populated from the persisted recovery bundle), which retired
+/// the rc.5-era app-side injection that used to add the field here. Measured server
+/// contract: the `/shielded-vote/v1/shares` endpoint hex-decodes `vote_round_id`
+/// (unlike the delegate-vote and cast-vote endpoints, which accept base64 for the
+/// same field name — asymmetry confirmed live 2026-08-12), and the crate emits
+/// exactly that hex form, so nothing is added or rewritten app-side.
+func sharePostBody(for payload: SharePayload) -> [String: Any] {
     let data = Data(payload.wireJson.utf8)
-    guard var body = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+    guard let body = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
         return [:]
     }
-    guard let roundIdData = strictHexData(roundIdHex), roundIdData.count == 32 else {
-        LoggerProxy.error("sharePostBody: invalid roundIdHex (expected 64 hex chars, got \(roundIdHex.count))")
-        return body
-    }
-    body["vote_round_id"] = roundIdHex
     return body
 }
 
@@ -459,7 +451,6 @@ private func applyShareAttemptOutcome(
 
 func delegateSharePayloads(
     _ payloads: [SharePayload],
-    roundIdHex: String,
     proposalId: UInt32,
     initialServerURLs: [String],
     postShare: @escaping SharePost,
@@ -491,7 +482,7 @@ func delegateSharePayloads(
                         do {
                             // Build body inside the task: [String: Any] isn't Sendable, but SharePayload is —
                             // recompute per task so the sending closure only captures Sendable values.
-                            let body = sharePostBody(for: payload, roundIdHex: roundIdHex)
+                            let body = sharePostBody(for: payload)
                             try await postShare(server, body)
                             return (server, .success(()))
                         } catch {
@@ -548,7 +539,6 @@ func delegateSharePayloads(
 
 func resubmitSharePayload(
     _ payload: SharePayload,
-    roundIdHex: String,
     configuredServerURLs: [String],
     sentToURLs: [String],
     postShare: @escaping SharePost,
@@ -557,7 +547,7 @@ func resubmitSharePayload(
     let sentSet = Set(sentToURLs)
     let untried = orderServers(configuredServerURLs.filter { !sentSet.contains($0) })
     let alreadySent = orderServers(configuredServerURLs.filter { sentSet.contains($0) })
-    let body = sharePostBody(for: payload, roundIdHex: roundIdHex)
+    let body = sharePostBody(for: payload)
 
     for server in untried + alreadySent {
         do {
@@ -1030,7 +1020,7 @@ extension VotingAPIClient: DependencyKey {
                     }
                 }
             },
-            delegateShares: { payloads, roundIdHex, proposalId, serverURLs in
+            delegateShares: { payloads, proposalId, serverURLs in
                 @Dependency(\.transactionGuard) var transactionGuard
                 return try await transactionGuard.withSubmission {
                     // Active foreground delivery uses the submission-local server set.
@@ -1041,7 +1031,6 @@ extension VotingAPIClient: DependencyKey {
                     let tracker = ServerHealthTracker.shared
                     return try await delegateSharePayloads(
                         payloads,
-                        roundIdHex: roundIdHex,
                         proposalId: proposalId,
                         initialServerURLs: serverURLs,
                         postShare: { server, body in
@@ -1086,12 +1075,11 @@ extension VotingAPIClient: DependencyKey {
                     return .pending
                 }
             },
-            resubmitShare: { payload, roundIdHex, excludeURLs in
+            resubmitShare: { payload, excludeURLs in
                 let configuredServerURLs = try await SvAPIConfigStore.shared.configuredVoteServerURLs()
                 let tracker = ServerHealthTracker.shared
                 return await resubmitSharePayload(
                     payload,
-                    roundIdHex: roundIdHex,
                     configuredServerURLs: configuredServerURLs,
                     sentToURLs: excludeURLs,
                     postShare: { server, body in

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientInterface.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientInterface.swift
@@ -94,6 +94,9 @@ struct VotingCryptoClient {
     var extractPcztSighash: @Sendable (_ pcztBytes: Data) throws -> Data
     /// Resolve the round PIR endpoint, fetch ZKP #1 IMT proofs, and cache them in the voting DB.
     /// Requires `buildVotingPczt` to have stored delegation data for this bundle first.
+    /// `polyLen` is the dynamic config's `pir_layout.poly_len` (YPIR RLWE polynomial degree,
+    /// 2048 or 4096) — load-bearing since `zcash_voting` 3.0, which validates it locally and
+    /// re-checks it against the PIR server at connect.
     var precomputeDelegationPir: @Sendable (
         _ roundId: String,
         _ bundleIndex: UInt32,
@@ -103,7 +106,8 @@ struct VotingCryptoClient {
         _ networkId: UInt32,
         _ pirDepth: UInt32,
         _ tier0Layers: UInt32,
-        _ tier1Layers: UInt32
+        _ tier1Layers: UInt32,
+        _ polyLen: UInt32
     ) async throws -> DelegationPirPrecomputeResult
     /// Build and prove the real delegation ZKP (#1). Long-running.
     /// Loads data from voting DB and wallet DB, fetches IMT proofs from server,
@@ -130,9 +134,10 @@ struct VotingCryptoClient {
         _ expectedSnapshotHeight: UInt64,
         _ pirDepth: UInt32,
         _ tier0Layers: UInt32,
-        _ tier1Layers: UInt32
+        _ tier1Layers: UInt32,
+        _ polyLen: UInt32
     ) -> AsyncThrowingStream<ProofEvent, Error>
-        = { _, _, _, _, _, _, _, _, _, _, _, _, _ in AsyncThrowingStream { $0.finish() } }
+        = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in AsyncThrowingStream { $0.finish() } }
     /// Extract Orchard FVK bytes from a UFVK string.
     var extractOrchardFvkFromUfvk: @Sendable (_ ufvkStr: String, _ networkId: UInt32) throws -> Data
     /// Build, sign, and persist the cast-vote commitment for one proposal in a single call.

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
@@ -277,7 +277,8 @@ extension VotingCryptoClient: DependencyKey {
             extractPcztSighash: { pcztBytes in
                 Data(try VotingRustBackend.extractPcztSighash(pczt: [UInt8](pcztBytes)))
             },
-            precomputeDelegationPir: { roundId, bundleIndex, bundleNotes, pirEndpoints, expectedSnapshotHeight, networkId, pirDepth, tier0Layers, tier1Layers in
+            // swiftlint:disable:next line_length
+            precomputeDelegationPir: { roundId, bundleIndex, bundleNotes, pirEndpoints, expectedSnapshotHeight, networkId, pirDepth, tier0Layers, tier1Layers, polyLen in
                 let backend = try await dbActor.backend()
                 let sdkNotes = bundleNotes.map { $0.toSDK() }
                 let result = try await backend.precomputeDelegationPir(
@@ -286,7 +287,12 @@ extension VotingCryptoClient: DependencyKey {
                     notes: sdkNotes,
                     pirEndpoints: pirEndpoints,
                     expectedSnapshotHeight: expectedSnapshotHeight,
-                    pirLayout: VotingPirLayout(pirDepth: pirDepth, tier0Layers: tier0Layers, tier1Layers: tier1Layers)
+                    pirLayout: VotingPirLayout(
+                        pirDepth: pirDepth,
+                        tier0Layers: tier0Layers,
+                        tier1Layers: tier1Layers,
+                        polyLen: polyLen
+                    )
                 )
                 return DelegationPirPrecomputeResult(
                     cachedCount: result.cachedCount,
@@ -294,7 +300,7 @@ extension VotingCryptoClient: DependencyKey {
                 )
             },
             // swiftlint:disable:next line_length
-            buildAndProveDelegation: { roundId, bundleIndex, bundleNotes, senderSeed, hotkeyStoredSecret, networkId, accountIndex, roundName, pirEndpoints, expectedSnapshotHeight, pirDepth, tier0Layers, tier1Layers in
+            buildAndProveDelegation: { roundId, bundleIndex, bundleNotes, senderSeed, hotkeyStoredSecret, networkId, accountIndex, roundName, pirEndpoints, expectedSnapshotHeight, pirDepth, tier0Layers, tier1Layers, polyLen in
                 AsyncThrowingStream<ProofEvent, Error> { continuation in
                     Task.detached {
                         do {
@@ -323,7 +329,12 @@ extension VotingCryptoClient: DependencyKey {
                                 params,
                                 pirEndpoints: pirEndpoints,
                                 expectedSnapshotHeight: expectedSnapshotHeight,
-                                pirLayout: VotingPirLayout(pirDepth: pirDepth, tier0Layers: tier0Layers, tier1Layers: tier1Layers),
+                                pirLayout: VotingPirLayout(
+                                    pirDepth: pirDepth,
+                                    tier0Layers: tier0Layers,
+                                    tier1Layers: tier1Layers,
+                                    polyLen: polyLen
+                                ),
                                 progress: { progress in
                                     continuation.yield(.progress(progress))
                                 }

--- a/secant/Sources/Dependencies/VotingModels/VotingServiceConfig.swift
+++ b/secant/Sources/Dependencies/VotingModels/VotingServiceConfig.swift
@@ -20,11 +20,12 @@ struct VotingServiceConfig: Codable, Equatable, Sendable {
         let pirDepth: UInt32
         let tier0Layers: UInt32
         let tier1Layers: UInt32
-        /// YPIR RLWE polynomial degree (2048/4096) introduced by chain v1.3.0. Parsed for
-        /// forward-compatibility and diagnostics; NOT consumed by `zcash_voting` 2.0.0-rc.5 (our
-        /// pin) — becomes load-bearing at the crate bump that carries `PirLayout.poly_len`
-        /// (Vizor reference: chainapsis/vizor-wallet#506). No behavior may key off this value
-        /// until then.
+        /// YPIR RLWE polynomial degree (2048/4096) introduced by chain v1.3.0. Load-bearing
+        /// since the `zcash_voting` 3.0 bump (MOB-1678): it feeds the delegation FFI's
+        /// `PirLayout.poly_len` and the round-auth v2 signing payload. Kept decode-optional so
+        /// cached pre-3.0 configs still decode; consumers fail closed when this is nil at
+        /// threading time (crate parity — 3.0's dynamic-config resolution requires the field
+        /// and rejects `poly_len ∉ {2048, 4096}`).
         let polyLen: UInt32?
 
         enum CodingKeys: String, CodingKey {

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -1795,6 +1795,12 @@ extension VotingCoordFlow {
             // --- Delegation (ZKP #1) — run inline if not already done ---
             if !delegationDone {
                 do {
+                    // Fail closed before any FFI call when the dynamic config predates
+                    // `pir_layout.poly_len` (see `missingPolyLenConfigError`). Votes on an
+                    // already-delegated round never reach this branch and stay unaffected.
+                    guard let polyLen = pirLayout.polyLen else {
+                        throw Self.missingPolyLenConfigError
+                    }
                     let senderPhrase = try walletStorage.exportWallet().seedPhrase.value()
                     let senderSeed = try mnemonic.toSeed(senderPhrase)
                     try await Self.runDelegationPipeline(
@@ -1810,6 +1816,7 @@ extension VotingCoordFlow {
                         pirDepth: pirLayout.pirDepth,
                         tier0Layers: pirLayout.tier0Layers,
                         tier1Layers: pirLayout.tier1Layers,
+                        polyLen: polyLen,
                         delegationPrepared: delegationPrepared,
                         seedFingerprint: seedFingerprint,
                         votingCrypto: votingCrypto,
@@ -2069,6 +2076,15 @@ extension VotingCoordFlow {
         else {
             return .none
         }
+        // Fail closed before any FFI call when the dynamic config predates
+        // `pir_layout.poly_len` (see `missingPolyLenConfigError`).
+        guard let polyLen = pirLayout.polyLen else {
+            LoggerProxy.error("Delegation precompute refused: dynamic config lacks pir_layout.poly_len")
+            return .send(.delegationPrecomputeFailed(
+                roundId: roundId,
+                error: Self.missingPolyLenConfigError.localizedDescription
+            ))
+        }
 
         mutateSession(&state, roundId: roundId) { roundSession in
             roundSession.delegationPrecomputeStatus = .inProgress
@@ -2130,7 +2146,8 @@ extension VotingCoordFlow {
                     networkId,
                     pirLayout.pirDepth,
                     pirLayout.tier0Layers,
-                    pirLayout.tier1Layers
+                    pirLayout.tier1Layers,
+                    polyLen
                 )
                 totalCached += result.cachedCount
                 totalFetched += result.fetchedCount
@@ -2841,6 +2858,15 @@ extension VotingCoordFlow {
             LoggerProxy.error("serviceConfig/selectedAccount unexpectedly nil during Keystone delegation proof")
             return .none
         }
+        // Fail closed before any FFI call when the dynamic config predates
+        // `pir_layout.poly_len` (see `missingPolyLenConfigError`).
+        guard let polyLen = pirLayout.polyLen else {
+            LoggerProxy.error("Keystone delegation proof refused: dynamic config lacks pir_layout.poly_len")
+            return .send(.delegationProofFailed(
+                roundId: roundId,
+                error: VotingErrorMapper.userFriendlyMessage(from: Self.missingPolyLenConfigError.localizedDescription)
+            ))
+        }
         let bundleCount = session.bundleCount
         let roundName = activeSession.title
         let storedSignatures = session.keystoneBundleSignatures.sorted { $0.bundleIndex < $1.bundleIndex }
@@ -2917,7 +2943,8 @@ extension VotingCoordFlow {
                         expectedSnapshotHeight,
                         pirLayout.pirDepth,
                         pirLayout.tier0Layers,
-                        pirLayout.tier1Layers
+                        pirLayout.tier1Layers,
+                        polyLen
                     ) {
                         switch event {
                         case .progress(let progress):
@@ -3605,6 +3632,16 @@ extension VotingCoordFlow {
 
     // MARK: - Delegation pipeline (Zashi inline)
 
+    /// 3.0 bump (MOB-1678): `pir_layout.poly_len` is load-bearing — `zcash_voting` 3.0
+    /// validates it locally (`poly_len ∈ {2048, 4096}`) and the PIR connect handshake
+    /// re-checks it against the server. A dynamic config without the field predates the
+    /// 3.0 service, so every delegation entry point fails closed *before any FFI call*
+    /// rather than fabricating a value. Reuses the existing localized
+    /// `coinVote.configError.decodeFailed` copy — no new strings in this wave.
+    static let missingPolyLenConfigError = VotingConfigError.decodeFailed(
+        "pir_layout.poly_len is required for delegation"
+    )
+
     /// Mirrors `Voting.runDelegationPipeline` but sends back to
     /// `VotingCoordFlow.Action`. The legacy version targets `Voting.Action`,
     /// so cross-type dispatching is the only reason we duplicate this here.
@@ -3622,6 +3659,7 @@ extension VotingCoordFlow {
         pirDepth: UInt32,
         tier0Layers: UInt32,
         tier1Layers: UInt32,
+        polyLen: UInt32,
         delegationPrepared: Bool = false,
         seedFingerprint: Data? = nil,
         votingCrypto: VotingCryptoClient,
@@ -3699,9 +3737,20 @@ extension VotingCoordFlow {
                 }
 
                 for try await event in votingCrypto.buildAndProveDelegation(
-                    roundId, bundleIndex, bundleNotes,
-                    senderSeed, hotkeySeed, networkId, accountIndex, roundName,
-                    pirEndpoints, expectedSnapshotHeight, pirDepth, tier0Layers, tier1Layers
+                    roundId,
+                    bundleIndex,
+                    bundleNotes,
+                    senderSeed,
+                    hotkeySeed,
+                    networkId,
+                    accountIndex,
+                    roundName,
+                    pirEndpoints,
+                    expectedSnapshotHeight,
+                    pirDepth,
+                    tier0Layers,
+                    tier1Layers,
+                    polyLen
                 ) {
                     switch event {
                     case .progress(let progress):

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -1984,7 +1984,6 @@ extension VotingCoordFlow {
                         }
                         let batchDelegationResult = try await Voting.delegateSharesWithFallback(
                             payloads,
-                            roundId: roundId,
                             proposalId: proposalId,
                             votingAPI: votingAPI,
                             serverURLs: shareServerURLs
@@ -2230,7 +2229,6 @@ extension VotingCoordFlow {
                         let payload = SharePayload(wireJson: wireJson, shareIndex: share.shareIndex)
                         let acceptedServers = try await votingAPI.resubmitShare(
                             payload,
-                            roundId,
                             share.sentToURLs
                         )
                         let newServers = acceptedServers.filter {
@@ -3595,7 +3593,6 @@ extension VotingCoordFlow {
 
         let recoveryResult = try await Voting.delegateSharesWithFallback(
             payloads,
-            roundId: roundId,
             proposalId: proposalId,
             votingAPI: votingAPI,
             serverURLs: shareServerURLs

--- a/secant/Sources/Features/Voting/VotingHelpers.swift
+++ b/secant/Sources/Features/Voting/VotingHelpers.swift
@@ -311,7 +311,6 @@ enum Voting {
     @discardableResult
     static func delegateSharesWithFallback(
         _ payloads: [SharePayload],
-        roundId: String,
         proposalId: UInt32,
         votingAPI: VotingAPIClient,
         serverURLs: [String],
@@ -324,7 +323,7 @@ enum Voting {
         var lastExhaustionError: ShareDelegationError?
         for attempt in 1...3 {
             do {
-                return try await votingAPI.delegateShares(payloads, roundId, proposalId, serverURLs)
+                return try await votingAPI.delegateShares(payloads, proposalId, serverURLs)
             } catch let error as ShareDelegationError where error == .noReachableVoteServers {
                 lastExhaustionError = error
                 LoggerProxy.warn("delegateShares attempt \(attempt)/3 exhausted vote servers")

--- a/secant/Sources/Features/Voting/VotingHelpers.swift
+++ b/secant/Sources/Features/Voting/VotingHelpers.swift
@@ -449,8 +449,37 @@ enum VotingErrorMapper {
         if rawError.contains("No PIR server matches") {
             return String(localizable: .coinVoteStoreUserErrorPirSnapshotMismatch)
         }
+        if rawError.contains("PIR poly_len mismatch") {
+            // 3.0-bump fingerprint (MOB-1678): pir-client 0.4.0-rc.7's connect handshake
+            // refuses when the config's advertised poly_len disagrees with what the PIR
+            // server serves ("PIR poly_len mismatch: expected N, server advertised M") —
+            // a config/server generation split, same class as a snapshot mismatch:
+            // out-of-sync service, retry later once the operators converge.
+            return String(localizable: .coinVoteStoreUserErrorPirSnapshotMismatch)
+        }
+        if rawError.contains("unsupported PIR layout") {
+            // 3.0-bump fingerprint (MOB-1678): local layout validation
+            // (`pir_types::PirLayout::validate_supported`, e.g. "unsupported PIR layout
+            // poly_len 1024") — the config advertises a geometry this build cannot query.
+            // Not transient; the update-the-app remedy of the config-class message is the
+            // closest existing copy.
+            return String(localizable: .coinVoteStoreUserErrorPirEndpointsMissing)
+        }
         if rawError.contains("No PIR endpoints are configured") {
             return String(localizable: .coinVoteStoreUserErrorPirEndpointsMissing)
+        }
+        if rawError.contains("does not match its synced vote-tree leaf") {
+            // 3.0-bump fingerprint (MOB-1678): `VoteTreeSync::sync` now verifies confirmed
+            // VAN entries against the synced tree; a mismatch resets the round's tree client
+            // so the next attempt re-syncs from scratch — the existing retryable
+            // out-of-sync copy fits exactly.
+            return String(localizable: .coinVoteStoreUserErrorInvalidAnchorHeight)
+        }
+        if rawError.contains("is absent from the synced vote tree") {
+            // 3.0-bump fingerprint (MOB-1678): a confirmed delegation's position hasn't
+            // appeared in the synced vote tree yet; incremental sync state is kept and the
+            // next sync resumes — the wait-for-confirmation copy matches the semantics.
+            return String(localizable: .coinVoteStoreUserErrorCommitmentTreeNotGrown)
         }
         if rawError.contains("Commitment tree did not grow") {
             return String(localizable: .coinVoteStoreUserErrorCommitmentTreeNotGrown)

--- a/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -757,6 +757,7 @@ import Testing
             pirDepth: 1,
             tier0Layers: 1,
             tier1Layers: 1,
+            polyLen: 4096,
             votingCrypto: votingCrypto,
             votingAPI: votingAPI,
             send: Send<VotingCoordFlow.Action>(send: { _ in }),
@@ -815,6 +816,7 @@ import Testing
             pirDepth: 1,
             tier0Layers: 1,
             tier1Layers: 1,
+            polyLen: 4096,
             votingCrypto: votingCrypto,
             votingAPI: votingAPI,
             send: Send<VotingCoordFlow.Action>(send: { _ in }),
@@ -861,7 +863,7 @@ import Testing
             }
             return Self.makeDelegationRegistration()
         }
-        votingCrypto.buildAndProveDelegation = { _, _, _, _, _, _, _, _, _, _, _, _, _ in
+        votingCrypto.buildAndProveDelegation = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
             recorder.record("prove")
             return AsyncThrowingStream { continuation in
                 continuation.yield(.progress(1))
@@ -898,6 +900,7 @@ import Testing
             pirDepth: 1,
             tier0Layers: 1,
             tier1Layers: 1,
+            polyLen: 4096,
             votingCrypto: votingCrypto,
             votingAPI: votingAPI,
             send: Send<VotingCoordFlow.Action>(send: { _ in }),
@@ -944,7 +947,7 @@ import Testing
             recorder.record("registration")
             return Self.makeDelegationRegistration()
         }
-        votingCrypto.buildAndProveDelegation = { _, _, _, _, _, _, _, _, _, _, _, _, _ in
+        votingCrypto.buildAndProveDelegation = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
             recorder.record("prove")
             return AsyncThrowingStream { continuation in
                 continuation.yield(.progress(1))
@@ -981,6 +984,7 @@ import Testing
             pirDepth: 1,
             tier0Layers: 1,
             tier1Layers: 1,
+            polyLen: 4096,
             votingCrypto: votingCrypto,
             votingAPI: votingAPI,
             send: Send<VotingCoordFlow.Action>(send: { _ in }),
@@ -1020,7 +1024,7 @@ import Testing
             recorder.record("registration")
             return Self.makeDelegationRegistration()
         }
-        votingCrypto.buildAndProveDelegation = { _, _, _, _, _, _, _, _, _, _, _, _, _ in
+        votingCrypto.buildAndProveDelegation = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
             recorder.record("prove")
             return AsyncThrowingStream { continuation in
                 continuation.finish()
@@ -1056,6 +1060,7 @@ import Testing
             pirDepth: 1,
             tier0Layers: 1,
             tier1Layers: 1,
+            polyLen: 4096,
             votingCrypto: votingCrypto,
             votingAPI: votingAPI,
             send: Send<VotingCoordFlow.Action>(send: { _ in }),
@@ -1071,6 +1076,93 @@ import Testing
             "fetch:proof-complete-tx",
             "van:0:9"
         ])
+    }
+
+    // 3.0 bump (MOB-1678): the config's PIR layout — poly_len included — must arrive at the
+    // prove FFI byte-for-byte. `zcash_voting` 3.0 validates poly_len locally and the PIR
+    // connect handshake re-checks it against the server, so a dropped or reordered value
+    // turns into a hard connect failure in production.
+    @Test func delegationPipelineThreadsConfigPolyLenIntoProveFFI() async throws {
+        let recorder = EventRecorder()
+        var votingCrypto = VotingCryptoClient()
+        votingCrypto.getDelegationTxHash = { _, _ in .notFound }
+        votingCrypto.buildVotingPczt = { _, _, _, _, _, _, _, _, _, _ in
+            Self.makeVotingPcztResult()
+        }
+        votingCrypto.signDelegationRequest = { _, _, _, _, _, _, _ in
+            (signature: Data(repeating: 0x09, count: 64), sighash: Data(repeating: 0x0A, count: 32))
+        }
+        votingCrypto.getDelegationSubmission = { _, _, _, _ in
+            // Cache probe fails once (no proof persisted yet) so the pipeline must prove.
+            if recorder.recordAndCount("registration") == 1 {
+                throw TestError.delegationProofMissing
+            }
+            return Self.makeDelegationRegistration()
+        }
+        votingCrypto.buildAndProveDelegation = { _, _, _, _, _, _, _, _, _, _, pirDepth, tier0Layers, tier1Layers, polyLen in
+            recorder.record("prove:\(pirDepth)/\(tier0Layers)/\(tier1Layers)/\(polyLen)")
+            return AsyncThrowingStream { continuation in
+                continuation.yield(.progress(1))
+                continuation.finish()
+            }
+        }
+        votingCrypto.storeDelegationTxHash = { _, _, _ in }
+        votingCrypto.storeVanPosition = { _, _, _ in }
+
+        var votingAPI = VotingAPIClient()
+        votingAPI.submitDelegation = { _ in TxResult(txHash: "poly-tx", code: 0) }
+        votingAPI.fetchTxConfirmation = { _ in Self.makeDelegationConfirmation(position: 3) }
+
+        try await VotingCoordFlow.runDelegationPipeline(
+            roundId: "aabb",
+            cachedNotes: [note(value: ballotDivisor, position: 0)],
+            senderSeed: [],
+            hotkeySeed: [],
+            networkId: 1,
+            accountIndex: 0,
+            roundName: "Round",
+            pirEndpoints: ["https://pir.example.com"],
+            expectedSnapshotHeight: 1,
+            pirDepth: 19,
+            tier0Layers: 12,
+            tier1Layers: 7,
+            polyLen: 4096,
+            votingCrypto: votingCrypto,
+            votingAPI: votingAPI,
+            send: Send<VotingCoordFlow.Action>(send: { _ in }),
+            delegationConfirmationTimeout: 0,
+            delegationConfirmationRetryDelay: .zero
+        )
+
+        #expect(recorder.events().contains("prove:19/12/7/4096"))
+    }
+
+    // 3.0 bump (MOB-1678): a dynamic config that predates `pir_layout.poly_len` must refuse
+    // the Keystone delegation flow before ANY voting-crypto call — fabricating a poly_len
+    // would send a doomed or wrong-generation PIR query. The recorder staying empty proves
+    // the refusal fires ahead of even the cached-bundle recovery probes.
+    @MainActor
+    @Test func keystoneAuthorizationRefusesBeforeFFIWhenConfigLacksPolyLen() async {
+        let recorder = EventRecorder()
+        let sig = signature(byte: 2, bundleIndex: 1)
+        let expectedError = VotingErrorMapper.userFriendlyMessage(
+            from: VotingCoordFlow.missingPolyLenConfigError.localizedDescription
+        )
+        let store = Store(
+            initialState: authorizationState(signatures: [sig], completedBundles: [], polyLen: nil)
+        ) {
+            VotingCoordFlow()
+        } withDependencies: {
+            self.configureKeystoneAuthorizationDependencies(&$0, recorder: recorder)
+        }
+
+        store.send(.keystoneAllBundlesSigned(roundId: activeRoundId))
+        await waitForStore {
+            store.state.roundCache[self.activeRoundId]?.batchSubmissionStatus
+                == .authorizationFailed(error: expectedError)
+        }
+
+        #expect(recorder.events().isEmpty)
     }
 
     // Task 8P (CHP.md 2026-08-13, 8O adversarial finding): a share the servers already
@@ -1287,7 +1379,8 @@ import Testing
 
     private func authorizationState(
         signatures: [KeystoneBundleSignature],
-        completedBundles: Set<UInt32>
+        completedBundles: Set<UInt32>,
+        polyLen: UInt32? = 4096
     ) -> VotingCoordFlow.State {
         var session = roundSession(
             roundId: activeRoundId,
@@ -1310,7 +1403,7 @@ import Testing
             pirEndpoints: [.init(url: "https://pir.example.com", label: "pir")],
             supportedVersions: .init(pir: ["v0"], voteProtocol: "v0", tally: "v0", voteServer: "v1"),
             rounds: [:],
-            pirLayout: .init(pirDepth: 1, tier0Layers: 1, tier1Layers: 1)
+            pirLayout: .init(pirDepth: 1, tier0Layers: 1, tier1Layers: 1, polyLen: polyLen)
         )
         state.isKeystoneUser = true
         state.$selectedWalletAccount.withLock { $0 = keystoneWalletAccount() }
@@ -1427,7 +1520,7 @@ import Testing
             }
             return .notFound
         }
-        dependencies.votingCrypto.buildAndProveDelegation = { _, bundleIndex, _, _, _, _, _, _, _, _, _, _, _ in
+        dependencies.votingCrypto.buildAndProveDelegation = { _, bundleIndex, _, _, _, _, _, _, _, _, _, _, _, _ in
             recorder.record("prove:\(bundleIndex)")
             return AsyncThrowingStream { continuation in
                 if bundleIndex == failingProofBundleIndex {

--- a/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -1194,7 +1194,7 @@ import Testing
 
         var votingAPI = VotingAPIClient()
         votingAPI.fetchTxConfirmation = { _ in TxConfirmation(height: 100, code: 0) }
-        votingAPI.delegateShares = { _, _, _, serverURLs in
+        votingAPI.delegateShares = { _, _, serverURLs in
             ShareDelegationResult(
                 delegatedShares: [
                     DelegatedShareInfo(shareIndex: 0, proposalId: 1, acceptedByServers: serverURLs),
@@ -1247,7 +1247,7 @@ import Testing
 
         var votingAPI = VotingAPIClient()
         votingAPI.fetchTxConfirmation = { _ in TxConfirmation(height: 100, code: 0) }
-        votingAPI.delegateShares = { _, _, _, serverURLs in
+        votingAPI.delegateShares = { _, _, serverURLs in
             ShareDelegationResult(
                 delegatedShares: [
                     DelegatedShareInfo(shareIndex: 0, proposalId: 1, acceptedByServers: serverURLs),

--- a/zodlTests/VotingTests/VotingHelpersTests.swift
+++ b/zodlTests/VotingTests/VotingHelpersTests.swift
@@ -21,6 +21,42 @@ import Testing
         #expect(message == String(localizable: .coinVoteStoreUserErrorPirInvalidProofData))
     }
 
+    // 3.0-bump fingerprints (MOB-1678): the four new crate message shapes must land on
+    // existing copy, not leak crate internals. Raw strings mirror pir-client 0.4.0-rc.7's
+    // connect ensure, pir-types' validate_supported, and tree_sync.rs's VAN checks.
+
+    @Test func votingErrorMapperMapsPolyLenMismatchToSnapshotMismatch() {
+        let message = VotingErrorMapper.userFriendlyMessage(
+            from: "Invalid input: PIR poly_len mismatch: expected 4096, server advertised 2048"
+        )
+
+        #expect(message == String(localizable: .coinVoteStoreUserErrorPirSnapshotMismatch))
+    }
+
+    @Test func votingErrorMapperMapsUnsupportedPirLayoutToConfigMessage() {
+        let message = VotingErrorMapper.userFriendlyMessage(
+            from: "unsupported PIR layout poly_len 1024; expected 2048 or 4096"
+        )
+
+        #expect(message == String(localizable: .coinVoteStoreUserErrorPirEndpointsMissing))
+    }
+
+    @Test func votingErrorMapperMapsVanLeafMismatchToRetryableOutOfSync() {
+        let message = VotingErrorMapper.userFriendlyMessage(
+            from: "Invalid input: confirmed delegation bundle 0 does not match its synced vote-tree leaf"
+        )
+
+        #expect(message == String(localizable: .coinVoteStoreUserErrorInvalidAnchorHeight))
+    }
+
+    @Test func votingErrorMapperMapsVanAbsentFromTreeToNotYetConfirmed() {
+        let message = VotingErrorMapper.userFriendlyMessage(
+            from: "Invalid input: confirmed delegation bundle 1 is absent from the synced vote tree"
+        )
+
+        #expect(message == String(localizable: .coinVoteStoreUserErrorCommitmentTreeNotGrown))
+    }
+
     @Test func smartBundlesUsesRustOrderingAndPerBundleQuantization() {
         let notes = [
             note(value: 31_568_000, position: 0),

--- a/zodlTests/VotingTests/VotingServiceConfigTests.swift
+++ b/zodlTests/VotingTests/VotingServiceConfigTests.swift
@@ -33,7 +33,8 @@ import Testing
         #expect(config.pirEndpoints.first?.label == "pir-1")
         #expect(config.supportedVersions.voteServer == "v1")
         #expect(config.supportedVersions.pir == ["v0", "v1"])
-        // v1.3.0 chain field (MOB-1678): parsed for forward-compat, unconsumed on the rc.5 pin.
+        // v1.3.0 chain field (MOB-1678): load-bearing since the zcash_voting 3.0 bump —
+        // it feeds the delegation FFI and the round-auth v2 payload.
         #expect(config.pirLayout.polyLen == 4096)
     }
 
@@ -281,140 +282,259 @@ import Testing
 
 @Suite struct RoundAuthenticatorTests {
     private let roundId = "58d9319ac86933b81769a7c0972444fa39212ad3790646398de6ce6534de2225"
+    private let otherRoundId = "0000000000000000000000000000000000000000000000000000000000000002"
     private let eaPK = Data(base64Encoded: "N72oXeIF96QwWBtChaCwde3tjTt75ZfAs455V4usYwM=")!
-    private let adminPubkey = Data(base64Encoded: "rKDbmhkoW9ja7dMiCV+1uTao7wXWV6xN/57erkrOuiQ=")!
-    private let adminSignature = Data(
-        base64Encoded: "rnll+KsHIFt73GpyNoWrX57dlcX8hTi8GU5X/xpwg3vcE+jCARUXpD7LsK+OLw6R5q1kU/zccwNgzsmclt4WAg=="
-    )!
+    /// Layout mirroring the crate's `test_pir_layout()` (config/mod.rs tests): 19/12/7/4096.
+    private let pirLayout = VotingServiceConfig.PirLayout(
+        pirDepth: 19,
+        tier0Layers: 12,
+        tier1Layers: 7,
+        polyLen: 4096
+    )
+    /// Fresh per-test admin key; entries are signed the way the crate's tests do —
+    /// ed25519 over the constructed v2 payload (round_auth.rs test recipe).
+    private let adminKey = Curve25519.Signing.PrivateKey()
 
-    @Test func authenticateAcceptsFixtureFromDynamicConfig() {
-        #expect(
-            RoundAuthenticator.authenticate(
-                chainEaPK: eaPK,
-                roundIdHex: roundId,
-                rounds: [roundId: makeEntry()],
-                trustedKeys: [makeTrustedKey()]
-            ) == .authenticated
+    // Golden vector from zcash_voting 3.0.0-rc.2
+    // (`dynamic_resolution_accepts_vote_sdk_ui_signed_round_entry`, config/mod.rs):
+    // a vote-sdk admin-UI / Keplr-derived key signing the poly_len-bound v2 preimage
+    // (tag || round_id || ea_pk || 19/12/7/4096). Passing pins byte-for-byte
+    // compatibility with the crate's verifier.
+    @Test func authenticateAcceptsCrateGoldenVector() {
+        let goldenRoundId = "06aae723e42cf615d174f338e8f30a72d2bf3275eb9d9e835cc894f197904b20"
+        let goldenKeyId = "keplr:sv1mqts0klc9768rns9h2ykeaka5tve6ts39c2zu3"
+        let goldenEaPK = Data(base64Encoded: "GpYa1sCGIMe2bp1O9UgrThrwkCdxu6oHDmhoBTw6EZ8=")!
+        let goldenPubkey = Data(base64Encoded: "NDygCpG+Y4T4uu8M1Sb/YG+74lUVj9XgYypUoMQMXT8=")!
+        let goldenSig = Data(
+            base64Encoded: "RHbpnj2a1VA+wadIQT3JM/r6ADH11VeA8UgT5dhwhixMcS5Bw5ispndM/ZYH/d2vxNBxTRtZwnLyXZjxcVD+Dg=="
+        )!
+        let entry = VotingServiceConfig.RoundEntry(
+            authVersion: 2,
+            eaPk: goldenEaPK,
+            signatures: [.init(keyId: goldenKeyId, alg: "ed25519", sig: goldenSig)]
         )
-    }
-
-    @Test func authenticateReportsMissingRound() {
-        #expect(
-            RoundAuthenticator.authenticate(
-                chainEaPK: eaPK,
-                roundIdHex: roundId,
-                rounds: [:],
-                trustedKeys: [makeTrustedKey()]
-            ) == .missingRound
-        )
-    }
-
-    @Test func authenticateReportsUnknownAuthVersion() {
-        #expect(
-            RoundAuthenticator.authenticate(
-                chainEaPK: eaPK,
-                roundIdHex: roundId,
-                rounds: [roundId: makeEntry(authVersion: 2)],
-                trustedKeys: [makeTrustedKey()]
-            ) == .unknownAuthVersion
-        )
-    }
-
-    @Test func authenticateReportsInvalidSignatures() {
-        var badSig = adminSignature
-        badSig[0] ^= 0xFF
-
-        #expect(
-            RoundAuthenticator.authenticate(
-                chainEaPK: eaPK,
-                roundIdHex: roundId,
-                rounds: [roundId: makeEntry(signature: badSig)],
-                trustedKeys: [makeTrustedKey()]
-            ) == .invalidSignatures
-        )
-    }
-
-    @Test func authenticateReportsEaPKMismatch() {
-        var chainEaPK = eaPK
-        chainEaPK[0] ^= 0xFF
-
-        #expect(
-            RoundAuthenticator.authenticate(
-                chainEaPK: chainEaPK,
-                roundIdHex: roundId,
-                rounds: [roundId: makeEntry()],
-                trustedKeys: [makeTrustedKey()]
-            ) == .eaPKMismatch
-        )
-    }
-
-    @Test func authenticateReportsInvalidSignaturesWhenEntryEaPKIsShort() {
-        #expect(
-            RoundAuthenticator.authenticate(
-                chainEaPK: eaPK,
-                roundIdHex: roundId,
-                rounds: [roundId: makeEntry(eaPK: Data(repeating: 0x01, count: 31))],
-                trustedKeys: [makeTrustedKey()]
-            ) == .invalidSignatures
-        )
-    }
-
-    @Test func verifyEntrySignaturesRejectsUnknownKeyId() {
-        let entry = makeEntry(keyId: "unknown-key")
-
-        #expect(!RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
-    }
-
-    @Test func verifyEntrySignaturesRejectsSignatureAlgMismatch() {
-        let entry = makeEntry(signatureAlg: "ed448")
-
-        #expect(!RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
-    }
-
-    @Test func verifyEntrySignaturesRejectsTrustedKeyAlgMismatch() {
         let trustedKey = StaticVotingConfig.TrustedKey(
-            keyId: "valar-test",
-            alg: "ed448",
-            pubkey: adminPubkey,
+            keyId: goldenKeyId,
+            alg: "ed25519",
+            pubkey: goldenPubkey,
             notes: nil
         )
 
-        #expect(!RoundAuthenticator.verifyEntrySignatures(entry: makeEntry(), trustedKeys: [trustedKey]))
+        let status = authenticate(
+            chainEaPK: goldenEaPK,
+            roundIdHex: goldenRoundId,
+            rounds: [goldenRoundId: entry],
+            trustedKeys: [trustedKey]
+        )
+        #expect(status == .authenticated)
     }
 
-    @Test func verifyEntrySignaturesRejectsShortSignature() {
-        let entry = makeEntry(signature: Data(repeating: 0x01, count: 63))
+    // Golden byte layout from zcash_voting 3.0.0-rc.2
+    // (`encoding_matches_round_auth_v2_wire_format`, round_auth.rs): round_id [1u8; 32],
+    // ea_pk [2u8; 32], layout 19/12/7/4096, every u32 little-endian.
+    @Test func signingPayloadV2MatchesCrateWireFormat() throws {
+        let payload = try #require(RoundAuthenticator.signingPayloadV2(
+            roundIdHex: String(repeating: "01", count: 32),
+            eaPk: Data(repeating: 0x02, count: 32),
+            pirLayout: pirLayout
+        ))
 
-        #expect(!RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
+        var expected = Data("zcash-shielded-vote:round-auth:v2".utf8)
+        expected.append(Data(repeating: 0x01, count: 32))
+        expected.append(Data(repeating: 0x02, count: 32))
+        expected.append(Data([19, 0, 0, 0]))
+        expected.append(Data([12, 0, 0, 0]))
+        expected.append(Data([7, 0, 0, 0]))
+        expected.append(Data([0x00, 0x10, 0x00, 0x00]))
+        let matches = payload == expected
+        #expect(matches)
+        #expect(payload.count == 113)
     }
 
-    @Test func verifyEntrySignaturesAcceptsWhenAnySignatureIsValid() {
+    @Test func authenticateAcceptsV2EntrySignedOverV2Payload() throws {
+        let entry = try makeSignedEntry()
+
+        let status = authenticate(rounds: [roundId: entry])
+        #expect(status == .authenticated)
+    }
+
+    @Test func authenticateReportsMissingRound() {
+        let status = authenticate(rounds: [:])
+        #expect(status == .missingRound)
+    }
+
+    // v1 policy pin (MOB-1678, deliberate + overturnable — see `RoundAuthenticator`):
+    // a *valid* v1-style signature over the raw `ea_pk` must no longer authenticate,
+    // matching the crate's `dynamic_resolution_skips_legacy_auth_version_1_rounds`.
+    @Test func authenticateRejectsLegacyV1Entry() throws {
+        let v1Signature = try adminKey.signature(for: eaPK)
         let entry = VotingServiceConfig.RoundEntry(
             authVersion: 1,
             eaPk: eaPK,
+            signatures: [.init(keyId: "valar-test", alg: "ed25519", sig: v1Signature)]
+        )
+
+        let status = authenticate(rounds: [roundId: entry])
+        #expect(status == .unknownAuthVersion)
+    }
+
+    @Test func authenticateReportsInvalidSignatures() throws {
+        var badSig = try makeSignedEntry().signatures[0].sig
+        badSig[0] ^= 0xFF
+        let entry = VotingServiceConfig.RoundEntry(
+            authVersion: 2,
+            eaPk: eaPK,
+            signatures: [.init(keyId: "valar-test", alg: "ed25519", sig: badSig)]
+        )
+
+        let status = authenticate(rounds: [roundId: entry])
+        #expect(status == .invalidSignatures)
+    }
+
+    @Test func authenticateReportsEaPKMismatch() throws {
+        var chainEaPK = eaPK
+        chainEaPK[0] ^= 0xFF
+        let entry = try makeSignedEntry()
+
+        let status = authenticate(chainEaPK: chainEaPK, rounds: [roundId: entry])
+        #expect(status == .eaPKMismatch)
+    }
+
+    @Test func authenticateReportsInvalidSignaturesWhenEntryEaPKIsShort() {
+        let shortEaPK = Data(repeating: 0x01, count: 31)
+        let entry = VotingServiceConfig.RoundEntry(
+            authVersion: 2,
+            eaPk: shortEaPK,
+            signatures: [.init(keyId: "valar-test", alg: "ed25519", sig: Data(repeating: 0x01, count: 64))]
+        )
+
+        let status = authenticate(chainEaPK: shortEaPK, rounds: [roundId: entry])
+        #expect(status == .invalidSignatures)
+    }
+
+    // The v2 signature binds the round id: the crate's replay test
+    // (`dynamic_resolution_skips_round_entry_replayed_under_different_round_id`).
+    @Test func authenticateRejectsEntryReplayedUnderDifferentRoundId() throws {
+        let entry = try makeSignedEntry() // signed for `roundId`
+
+        let status = authenticate(roundIdHex: otherRoundId, rounds: [otherRoundId: entry])
+        #expect(status == .invalidSignatures)
+    }
+
+    // The v2 signature binds the full PIR layout: a config host swapping poly_len (or any
+    // tier) after signing invalidates the attestation
+    // (`dynamic_resolution_skips_rounds_when_pir_layout_changed_after_signing`).
+    @Test func authenticateRejectsWhenPolyLenChangedAfterSigning() throws {
+        let entry = try makeSignedEntry() // signed over poly_len 4096
+        let swappedLayout = VotingServiceConfig.PirLayout(
+            pirDepth: 19,
+            tier0Layers: 12,
+            tier1Layers: 7,
+            polyLen: 2048
+        )
+
+        let status = authenticate(rounds: [roundId: entry], pirLayout: swappedLayout)
+        #expect(status == .invalidSignatures)
+    }
+
+    // A config that predates `pir_layout.poly_len` cannot carry v2 attestations: the
+    // payload is unconstructible, so nothing authenticates (fail closed).
+    @Test func authenticateRejectsWhenConfigLacksPolyLen() throws {
+        let entry = try makeSignedEntry()
+        let preBumpLayout = VotingServiceConfig.PirLayout(pirDepth: 19, tier0Layers: 12, tier1Layers: 7)
+
+        let status = authenticate(rounds: [roundId: entry], pirLayout: preBumpLayout)
+        #expect(status == .invalidSignatures)
+    }
+
+    // Crate parity (`verify_round_entry` decodes defensively): a round id that does not
+    // strict-hex-decode to exactly 32 bytes can never authenticate.
+    @Test func authenticateRejectsRoundIdsThatDoNotDecodeTo32Bytes() throws {
+        let thirtyOneByteId = String(repeating: "ab", count: 31)
+        let nonHexId = String(repeating: "zz", count: 32)
+        for badId in [thirtyOneByteId, nonHexId] {
+            let entry = try makeSignedEntry(roundIdHex: badId)
+
+            let status = authenticate(roundIdHex: badId, rounds: [badId: entry])
+            #expect(status == .invalidSignatures, "round id \(badId) must never authenticate")
+        }
+    }
+
+    @Test func verifyEntrySignaturesRejectsUnknownKeyId() throws {
+        let entry = try makeSignedEntry(keyId: "unknown-key")
+
+        #expect(!verify(entry))
+    }
+
+    @Test func verifyEntrySignaturesRejectsSignatureAlgMismatch() throws {
+        let entry = try makeSignedEntry(signatureAlg: "ed448")
+
+        #expect(!verify(entry))
+    }
+
+    @Test func verifyEntrySignaturesRejectsTrustedKeyAlgMismatch() throws {
+        let trustedKey = StaticVotingConfig.TrustedKey(
+            keyId: "valar-test",
+            alg: "ed448",
+            pubkey: adminKey.publicKey.rawRepresentation,
+            notes: nil
+        )
+        let entry = try makeSignedEntry()
+
+        let valid = RoundAuthenticator.verifyEntrySignatures(
+            entry: entry,
+            roundIdHex: roundId,
+            pirLayout: pirLayout,
+            trustedKeys: [trustedKey]
+        )
+        #expect(!valid)
+    }
+
+    @Test func verifyEntrySignaturesRejectsShortSignature() {
+        let entry = VotingServiceConfig.RoundEntry(
+            authVersion: 2,
+            eaPk: eaPK,
+            signatures: [.init(keyId: "valar-test", alg: "ed25519", sig: Data(repeating: 0x01, count: 63))]
+        )
+
+        #expect(!verify(entry))
+    }
+
+    @Test func verifyEntrySignaturesAcceptsWhenAnySignatureIsValid() throws {
+        let validSignature = try makeSignedEntry().signatures[0].sig
+        let entry = VotingServiceConfig.RoundEntry(
+            authVersion: 2,
+            eaPk: eaPK,
             signatures: [
                 .init(keyId: "valar-test", alg: "ed25519", sig: Data(repeating: 0x01, count: 64)),
-                .init(keyId: "valar-test", alg: "ed25519", sig: adminSignature)
+                .init(keyId: "valar-test", alg: "ed25519", sig: validSignature)
             ]
         )
 
-        #expect(RoundAuthenticator.verifyEntrySignatures(entry: entry, trustedKeys: [makeTrustedKey()]))
+        #expect(verify(entry))
     }
 
-    @Test func serviceConfigDropsOnlyRoundsWithoutValidSignatures() {
-        var badSignature = adminSignature
-        badSignature[0] ^= 0xFF
-        let invalidRoundId = String(repeating: "b", count: 64)
+    @Test func serviceConfigDropsOnlyRoundsWithoutValidSignatures() throws {
+        // One entry validly signed for its own id; the same entry replayed verbatim under
+        // another id (signature binds the round id → dropped); one legacy v1 entry (dropped).
+        let validEntry = try makeSignedEntry()
+        let v1Entry = VotingServiceConfig.RoundEntry(
+            authVersion: 1,
+            eaPk: eaPK,
+            signatures: [.init(keyId: "valar-test", alg: "ed25519", sig: try adminKey.signature(for: eaPK))]
+        )
+        let v1RoundId = String(repeating: "b", count: 64)
         let config = VotingServiceConfig(
             configVersion: 1,
             voteServers: [.init(url: "https://vote.example.com", label: "vote")],
             pirEndpoints: [.init(url: "https://pir.example.com", label: "pir")],
             supportedVersions: .init(pir: ["v0"], voteProtocol: "v0", tally: "v0", voteServer: "v1"),
             rounds: [
-                roundId: makeEntry(),
-                invalidRoundId: makeEntry(signature: badSignature)
+                roundId: validEntry,
+                otherRoundId: validEntry,
+                v1RoundId: v1Entry
             ],
-            pirLayout: .init(pirDepth: 1, tier0Layers: 1, tier1Layers: 1)
+            pirLayout: pirLayout
         )
 
         let filtered = serviceConfigRetainingRoundsWithValidSignatures(config, trustedKeys: [makeTrustedKey()])
@@ -422,24 +542,58 @@ import Testing
         #expect(Set(filtered.rounds.keys) == [roundId])
     }
 
-    private func makeEntry(
-        authVersion: Int = 1,
-        eaPK: Data? = nil,
+    /// Builds a registry entry signed exactly the way the crate's tests sign theirs:
+    /// ed25519 over `signingPayloadV2` for this suite's round, ea_pk, and layout.
+    private func makeSignedEntry(
+        roundIdHex: String? = nil,
         keyId: String = "valar-test",
-        signatureAlg: String = "ed25519",
-        signature: Data? = nil
-    ) -> VotingServiceConfig.RoundEntry {
-        .init(
-            authVersion: authVersion,
-            eaPk: eaPK ?? self.eaPK,
-            signatures: [
-                .init(keyId: keyId, alg: signatureAlg, sig: signature ?? adminSignature)
-            ]
+        signatureAlg: String = "ed25519"
+    ) throws -> VotingServiceConfig.RoundEntry {
+        // For undecodable round ids the canonical payload cannot exist; sign a stand-in so
+        // the entry still carries a well-formed 64-byte signature for the verifier to refuse.
+        let payload = RoundAuthenticator.signingPayloadV2(
+            roundIdHex: roundIdHex ?? roundId,
+            eaPk: eaPK,
+            pirLayout: pirLayout
+        ) ?? Data("undecodable-round-id-stand-in".utf8)
+        return VotingServiceConfig.RoundEntry(
+            authVersion: 2,
+            eaPk: eaPK,
+            signatures: [.init(keyId: keyId, alg: signatureAlg, sig: try adminKey.signature(for: payload))]
+        )
+    }
+
+    /// `RoundAuthenticator.authenticate` with this suite's fixtures defaulted in.
+    /// Kept as a plain function returning a local so `#expect` only ever compares
+    /// two simple values — inlining the full call into the macro blows past the
+    /// type-checker's expression budget.
+    private func authenticate(
+        chainEaPK: Data? = nil,
+        roundIdHex: String? = nil,
+        rounds: [String: VotingServiceConfig.RoundEntry],
+        trustedKeys: [StaticVotingConfig.TrustedKey]? = nil,
+        pirLayout: VotingServiceConfig.PirLayout? = nil
+    ) -> RoundAuthStatus {
+        RoundAuthenticator.authenticate(
+            chainEaPK: chainEaPK ?? eaPK,
+            roundIdHex: roundIdHex ?? roundId,
+            rounds: rounds,
+            trustedKeys: trustedKeys ?? [makeTrustedKey()],
+            pirLayout: pirLayout ?? self.pirLayout
+        )
+    }
+
+    private func verify(_ entry: VotingServiceConfig.RoundEntry) -> Bool {
+        RoundAuthenticator.verifyEntrySignatures(
+            entry: entry,
+            roundIdHex: roundId,
+            pirLayout: pirLayout,
+            trustedKeys: [makeTrustedKey()]
         )
     }
 
     private func makeTrustedKey() -> StaticVotingConfig.TrustedKey {
-        .init(keyId: "valar-test", alg: "ed25519", pubkey: adminPubkey, notes: nil)
+        .init(keyId: "valar-test", alg: "ed25519", pubkey: adminKey.publicKey.rawRepresentation, notes: nil)
     }
 }
 

--- a/zodlTests/VotingTests/VotingServiceConfigTests.swift
+++ b/zodlTests/VotingTests/VotingServiceConfigTests.swift
@@ -794,13 +794,44 @@ import Testing
     }
 }
 
+// MOB-1678: since zcash_voting 3.0.0-rc.3, `VoteShareWire` carries `vote_round_id`
+// itself (canonical lowercase hex), which retired the app-side injection that used
+// to add the field to the share POST body. These two tests pin the surviving wire
+// contract from its new source: the field still reaches the server, still as
+// lowercase hex, but verbatim from the crate JSON — the app adds nothing.
+@Suite struct SharePostBodyWireContractTests {
+    @Test func shareBodyCarriesCrateProvidedVoteRoundIdVerbatim() {
+        let roundIdHex = String(repeating: "01", count: 32)
+        let payload = SharePayload(
+            wireJson: "{\"vote_round_id\":\"\(roundIdHex)\",\"share_index\":3,\"submit_at\":99}",
+            shareIndex: 3
+        )
+
+        let body = sharePostBody(for: payload)
+
+        #expect(body["vote_round_id"] as? String == roundIdHex)
+        #expect(body["share_index"] as? Int == 3)
+        #expect(body["submit_at"] as? Int == 99)
+    }
+
+    @Test func shareBodyIsTheWireJsonVerbatimWithNothingInjected() {
+        let payload = makeRecoverySharePayload()
+
+        let body = sharePostBody(for: payload)
+
+        // The fixture wire JSON has no vote_round_id, and none may appear in the
+        // body: the crate is the only source of the field now.
+        #expect(body["vote_round_id"] == nil)
+        #expect(Set(body.keys) == Set(["share_index", "submit_at"]))
+    }
+}
+
 @Suite struct ShareResubmissionFallbackTests {
     @Test func resubmissionTriesUntriedHelpersFirst() async {
         let recorder = SharePostRecorder()
 
         let acceptedServers = await resubmitSharePayload(
             makeRecoverySharePayload(),
-            roundIdHex: "aabb",
             configuredServerURLs: [
                 "https://already-sent.example.com",
                 "https://untried.example.com"
@@ -822,7 +853,6 @@ import Testing
 
         let acceptedServers = await resubmitSharePayload(
             makeRecoverySharePayload(),
-            roundIdHex: "aabb",
             configuredServerURLs: [
                 "https://already-sent.example.com",
                 "https://untried.example.com"
@@ -850,7 +880,6 @@ import Testing
 
         let acceptedServers = await resubmitSharePayload(
             makeRecoverySharePayload(),
-            roundIdHex: "aabb",
             configuredServerURLs: [
                 "https://already-sent.example.com",
                 "https://untried.example.com"
@@ -879,7 +908,6 @@ import Testing
 
         let result = try await delegateSharePayloads(
             [payload],
-            roundIdHex: "aabb",
             proposalId: 1,
             initialServerURLs: [
                 "https://online-one.example.com",
@@ -918,7 +946,6 @@ import Testing
 
         let result = try await delegateSharePayloads(
             payloads,
-            roundIdHex: "aabb",
             proposalId: 1,
             initialServerURLs: [
                 "https://offline.example.com",
@@ -952,7 +979,6 @@ import Testing
 
         let result = try await delegateSharePayloads(
             [payload],
-            roundIdHex: "aabb",
             proposalId: 1,
             initialServerURLs: [
                 "https://offline-one.example.com",
@@ -983,7 +1009,6 @@ import Testing
         await #expect(throws: ShareDelegationError.noReachableVoteServers) {
             _ = try await delegateSharePayloads(
                 [makeRecoverySharePayload()],
-                roundIdHex: "aabb",
                 proposalId: 1,
                 initialServerURLs: [
                     "https://offline-one.example.com",
@@ -1008,7 +1033,6 @@ import Testing
         let error = await #expect(throws: SvAPIError.self) {
             _ = try await delegateSharePayloads(
                 [payload],
-                roundIdHex: "aabb",
                 proposalId: 1,
                 initialServerURLs: [
                     "https://rejecting.example.com",
@@ -1043,7 +1067,6 @@ import Testing
 
         let result = try await delegateSharePayloads(
             [payload],
-            roundIdHex: "aabb",
             proposalId: 1,
             initialServerURLs: [
                 "https://degraded.example.com",
@@ -1070,7 +1093,6 @@ import Testing
 
         let result = try await delegateSharePayloads(
             [payload],
-            roundIdHex: "aabb",
             proposalId: 1,
             initialServerURLs: [
                 "https://timing-out.example.com",
@@ -1097,7 +1119,7 @@ import Testing
     @Test func delegateSharesWithFallbackRetriesReachabilityExhaustion() async throws {
         let attempts = AttemptCounter()
         var votingAPI = VotingAPIClient()
-        votingAPI.delegateShares = { _, _, _, serverURLs in
+        votingAPI.delegateShares = { _, _, serverURLs in
             let attempt = await attempts.increment()
             if attempt < 3 {
                 throw ShareDelegationError.noReachableVoteServers
@@ -1107,7 +1129,6 @@ import Testing
 
         let result = try await Voting.delegateSharesWithFallback(
             [],
-            roundId: "aabb",
             proposalId: 1,
             votingAPI: votingAPI,
             serverURLs: ["https://vote.example.com"],
@@ -1122,7 +1143,7 @@ import Testing
     @Test func delegateSharesWithFallbackRethrowsUnexpectedErrorWithoutRetry() async {
         let attempts = AttemptCounter()
         var votingAPI = VotingAPIClient()
-        votingAPI.delegateShares = { _, _, _, _ in
+        votingAPI.delegateShares = { _, _, _ in
             _ = await attempts.increment()
             throw SharePostFailure()
         }
@@ -1130,7 +1151,6 @@ import Testing
         await #expect(throws: SharePostFailure.self) {
             _ = try await Voting.delegateSharesWithFallback(
                 [],
-                roundId: "aabb",
                 proposalId: 1,
                 votingAPI: votingAPI,
                 serverURLs: ["https://vote.example.com"],
@@ -1148,7 +1168,7 @@ import Testing
     @Test func delegateSharesWithFallbackRethrowsHttpRejectionWithoutRetry() async {
         let attempts = AttemptCounter()
         var votingAPI = VotingAPIClient()
-        votingAPI.delegateShares = { _, _, _, _ in
+        votingAPI.delegateShares = { _, _, _ in
             _ = await attempts.increment()
             throw SvAPIError.httpError(statusCode: 400, message: "vote_round_id: expected 32 bytes, got 0")
         }
@@ -1156,7 +1176,6 @@ import Testing
         let error = await #expect(throws: SvAPIError.self) {
             _ = try await Voting.delegateSharesWithFallback(
                 [],
-                roundId: "aabb",
                 proposalId: 1,
                 votingAPI: votingAPI,
                 serverURLs: ["https://vote.example.com"],

--- a/zodlTests/VotingTests/VotingServiceConfigTests.swift
+++ b/zodlTests/VotingTests/VotingServiceConfigTests.swift
@@ -143,6 +143,30 @@ import Testing
         }
     }
 
+    /// The bundled anchor is a hand-edited string literal carrying a 64-char hash,
+    /// and `PinnedConfigSource.sha256` is optional by design — a source without a
+    /// `?checksum=` is legal and parses fine (see
+    /// `pinnedConfigSourceParseAcceptsMissingChecksum`). `decodeAndVerify` only
+    /// checks the digest `if let expectedSHA256`, so a pin that loses its checksum
+    /// to a typo, a bad merge, or a truncated edit does not fail — it silently
+    /// accepts whatever the host returns, turning the anchor into plain trust in
+    /// the transport. Nothing else in the suite pins the bundled constant itself.
+    @Test func bundledPinnedSourceCarriesAChecksumSoVerificationCannotSilentlyNoOp() throws {
+        let source = try PinnedConfigSource.parse(StaticVotingConfig.bundledPinnedSource)
+
+        #expect(source.url.scheme == "https")
+        let digest = try #require(
+            source.sha256,
+            "bundled pin carries no checksum — decodeAndVerify would accept any bytes the host serves"
+        )
+        #expect(digest.count == 32)
+
+        // The digest is the pin; it must not also travel to the server as a query
+        // the host could key behaviour off.
+        let sentQuery = URLComponents(url: source.url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        #expect(!sentQuery.contains { $0.name == "checksum" })
+    }
+
     @Test func staticConfigDecodeAndVerifyAcceptsMatchingSHA256() throws {
         let config = makeStaticConfig()
         let data = try JSONEncoder().encode(config)

--- a/zodlTests/VotingTests/VotingServiceConfigTests.swift
+++ b/zodlTests/VotingTests/VotingServiceConfigTests.swift
@@ -1193,6 +1193,110 @@ import Testing
     }
 }
 
+/// A vote commitment's 16 shares each carry that share's `primary_blind` in the
+/// clear, alongside the full `share_comms` vector. A helper that receives every
+/// share therefore learns every blind against every commitment and can solve for
+/// the share values — recovering the voter's exact balance. `zcash_voting` 3.0.0
+/// closes this in its own planner by omitting the server at index
+/// `share_index % 16` from that share's initial targets; ZODL drives its own
+/// fan-out, so the same guarantee is enforced here.
+@Suite struct ShareDelegationSpreadTests {
+    @Test func noHelperReceivesEveryShareOnInitialSubmission() async throws {
+        let recorder = ShareTargetRecorder()
+        let payloads = (0..<16).map { makeRecoverySharePayload(index: UInt32($0)) }
+        let servers = [
+            "https://helper-a.example.com",
+            "https://helper-b.example.com",
+            "https://helper-c.example.com"
+        ]
+
+        _ = try await delegateSharePayloads(
+            payloads,
+            proposalId: 1,
+            initialServerURLs: servers,
+            postShare: { server, body in
+                await recorder.record(server: server, shareIndex: body["share_index"] as? Int ?? -1)
+            },
+            // Worst case on purpose: a selector with no spread of its own hands
+            // the same prefix to every share. The omission rule is what has to
+            // break the correlation, not the selector's randomness.
+            selectTargets: { candidates, targetCount in Array(candidates.prefix(targetCount)) }
+        )
+
+        for server in servers {
+            let received = await recorder.shareIndices(for: server)
+            #expect(received.count < 16, "\(server) received all 16 shares — it can recover the voter's balance")
+        }
+    }
+
+    /// The omitted server for a share is fixed by its position in the *configured*
+    /// helper list. `delegateSharePayloads` prunes failed helpers from its working
+    /// set mid-commitment, and if the omission were computed against that shrinking
+    /// list the indices would shift: a helper whose omitted share moves backwards
+    /// past the share already being sent never comes due again, and can collect the
+    /// entire remainder of the commitment.
+    @Test func helperOmissionFollowsConfiguredOrderWhenAnotherHelperIsPruned() async throws {
+        let recorder = ShareTargetRecorder()
+        let helperA = "https://helper-a.example.com"
+        let helperB = "https://helper-b.example.com"
+        let helperC = "https://helper-c.example.com"
+        let helperD = "https://helper-d.example.com"
+
+        // B fails on its first attempt (share 0) and is pruned, so every later share
+        // is planned against a 3-helper working set while the configured list stays 4.
+        _ = try await delegateSharePayloads(
+            (0..<16).map { makeRecoverySharePayload(index: UInt32($0)) },
+            proposalId: 1,
+            initialServerURLs: [helperA, helperB, helperC, helperD],
+            postShare: { server, body in
+                await recorder.record(server: server, shareIndex: body["share_index"] as? Int ?? -1)
+                if server == helperB { throw SharePostFailure() }
+            },
+            selectTargets: { candidates, targetCount in Array(candidates.prefix(targetCount)) }
+        )
+
+        // C sits at configured index 2, so share 2 is the one it must miss — and
+        // share 1 (B's index) must still reach it. Indexing the pruned list instead
+        // swaps these two.
+        let received = await recorder.shareIndices(for: helperC)
+        #expect(received.contains(1), "share 1 belongs to the pruned helper's index — C must not inherit its omission")
+        #expect(!received.contains(2), "C sits at configured index 2, so share 2 must stay omitted after pruning")
+    }
+
+    @Test func fallbackStillReachesTheOmittedHelperWhenTheOthersFail() async throws {
+        let recorder = ShareTargetRecorder()
+        // Share 0 omits the server at index 0 from its initial targets.
+        let omitted = "https://helper-a.example.com"
+        let failing = "https://helper-b.example.com"
+
+        _ = try? await delegateSharePayloads(
+            [makeRecoverySharePayload(index: 0)],
+            proposalId: 1,
+            initialServerURLs: [omitted, failing],
+            postShare: { server, body in
+                await recorder.record(server: server, shareIndex: body["share_index"] as? Int ?? -1)
+                if server == failing { throw SharePostFailure() }
+            },
+            selectTargets: { candidates, targetCount in Array(candidates.prefix(targetCount)) }
+        )
+
+        let reached = await recorder.shareIndices(for: omitted)
+        #expect(reached.contains(0), "initial-submission omission must not survive into fallback — the share would be lost")
+    }
+}
+
+private actor ShareTargetRecorder {
+    private var byServer: [String: Set<Int>] = [:]
+
+    func record(server: String, shareIndex: Int) {
+        byServer[server, default: []].insert(shareIndex)
+    }
+
+    func shareIndices(for server: String) -> Set<Int> {
+        byServer[server] ?? []
+    }
+}
+
 private actor SharePostRecorder {
     private var postedServers: [String] = []
 


### PR DESCRIPTION
Stacked on #1988 (base `chp-re-enable`). Rides the companion SDK branch `chp-30-bump` (`zcash_voting 3.0.0-rc.3`).

## Why this exists

Valar's v1.3.0 rollout intentionally broke the 2.0-family clients: the stage PIR dataset moved to `poly_len: 4096` on Aug 13 (2.0 clients hardcode 2048 → every tier1 query 502s), round attestations moved to auth v2 (v1-only verifiers drop the new rounds as `missingRound`), and **prod upgrades Friday with no dual-serving**. A 2.0-family build cannot vote in the scheduled session; this branch is the client half of the migration, built and live-verified the same day the ground moved.

## What this is

- **`polyLen` threading**: the dynamic config's `pir_layout.poly_len` (parsed forward-compatibly since `14d4cdd7`, now load-bearing) flows config → `VotingCryptoClient` → the delegation FFI. A config without it fails closed with existing copy before any FFI call.
- **Auth v2**: `RoundAuthenticator` rewritten for the v2 attestation payload (domain tag ‖ round id ‖ ea_pk ‖ the full PIR layout as four u32 LE — each round's signature now binds the geometry it will be queried with). v1 entries are rejected outright (crate parity, deliberate; documented at `authVersionV2`). Fixture vectors are built the way the crate's own tests build them, plus crate golden vectors.
- **`vote_round_id` injection retired**: 3.0.0-rc.3's `VoteShareWire` carries the field itself (32 bytes lowercase hex — the exact measured `/shares` contract). `sharePostBody` is a verbatim wire-JSON parse again; a new wire-contract suite pins that nothing is injected app-side.
- Error-mapper fingerprints for the new crate failure shapes (poly mismatch, layout rejection, tree-sync VAN checks) — existing copy only.

## Evidence

- Suite green on this head: `━ Test run with 1301 tests in 188 suites passed` (0 failures), testnet build clean, lint zero-new.
- **Live on stage v1.3.0 (2026-08-14): full end-to-end vote** — v2 rounds authenticate (app's poll list matched the config's v2-signed population exactly, 5/5), delegation PIR queries return 200 on the 4096 dataset, delegation + vote + shares all accepted.
- The finding-#10 resume path and all write-once guards survive 3.0 unchanged (verified in the campaign map; the resume was separately live-verified on Aug 13).
- **2026-08-14: restacked onto the post-3.9.3 base** (3/3 patches byte-equal by range-diff; app version resolves to 3.10.0 over the shipped 3.9.3). Re-measured on this head: `━ Test run with 1301 tests in 188 suites passed` + testnet device build 0 errors, against the rebased SDK carrying #1971's broadcast-readback fix.

## Where to look

- `secant/Sources/Dependencies/VotingAPIClient/RoundAuthenticator.swift` — the v2 verifier.
- `secant/Sources/Dependencies/VotingCryptoClient|VotingModels/` — `polyLen` threading.
- `secant/Sources/Features/CoordFlows/VotingCoordFlow/` — fail-closed guards + pass-throughs.
- The campaign record (out-of-tree per the `.plans/` convention) documents the environment forensics, the crate-diff map, and every gate.

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes?
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
