### PR TITLE
[MOB-1678] Use resilient voting config pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [Ironwood] Warn before confirming a send that has to spend Orchard funds: the confirmation screen now shows a sheet recommending migration first, with the option to continue or cancel.
 
 ### Changed
+- [MOB-1678] Coinholder Polling now loads its trusted configuration through the resilient voting config gateway, so a GitHub outage no longer blocks configuration loading while the mirrored copy is available.
 - [MOB-1466] Starting a migration now holds you on a "Scheduling…" screen while the schedule is confirmed and the first step is prepared, instead of leaving you on the plan under a spinning button for up to half a minute. The summary fills in with your real numbers the moment it is ready.
 - [MOB-1466] The migration split details sheet now scrolls when a split has more than five steps, so long splits stay readable and the sheet's total and "Got it" button stay reachable. Shorter splits are unchanged.
 - [MOB-1466] "Restart Migration" appears in Advanced Settings only while a migration is actually in progress, and no longer lingers once one has finished.

--- a/docs/voting-service-discovery.md
+++ b/docs/voting-service-discovery.md
@@ -4,10 +4,10 @@ How zodl-ios discovers vote servers and PIR endpoints at runtime. The wallet imp
 
 ## Resolution order
 
-1. **Static config** — fetched from a hash-pinned URL embedded in the signed app binary using `URL?checksum=sha256:HEX`. It carries the `dynamic_config_url` and trusted voting admin keys.
-2. **Dynamic config** — fetched from the verified static config's `dynamic_config_url`, currently [`https://voting.valargroup.org/prod/dynamic-voting-config.json`](https://voting.valargroup.org/prod/dynamic-voting-config.json), served through the Cloudflare-managed config host from [`valargroup/token-holder-voting-config`](https://github.com/valargroup/token-holder-voting-config).
+1. **Static config** — fetched from an immutable `voting.valargroup.dev/pins/prod/...` URL embedded in the signed app binary using `URL?checksum=sha256:HEX`. It carries the `dynamic_config_url` and trusted voting admin keys.
+2. **Dynamic config** — fetched from the verified static config's `dynamic_config_url`, currently [`https://voting.valargroup.dev/prod/dynamic-voting-config.json`](https://voting.valargroup.dev/prod/dynamic-voting-config.json). The gateway reads from [`valargroup/token-holder-voting-config`](https://github.com/valargroup/token-holder-voting-config) normally and serves the automatically published Cloudflare copy when GitHub is unavailable.
 
-There is no silent fallback. If the pinned static config source is malformed, the static config fetch fails, the SHA-256 does not match, or the dynamic config is unreachable, returns non-200, decodes to an unsupported shape, or advertises a version the wallet doesn't speak, the wallet routes to the `.configError` screen (`VotingConfigErrorView`) and voting is blocked for the session.
+The wallet does not choose between origins or accept different static config bytes during failover. GitHub-to-Cloudflare fallback happens behind the same gateway URL, and the embedded SHA-256 must still match. If the pinned static config source is malformed, the static config fetch fails, the SHA-256 does not match, or the dynamic config is unreachable, returns non-200, decodes to an unsupported shape, or advertises a version the wallet doesn't speak, the wallet routes to the `.configError` screen (`VotingConfigErrorView`) and voting is blocked for the session.
 
 Implementation lives in [`VotingAPIClientLiveKey.swift`](../secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift) (`fetchServiceConfig`).
 

--- a/secant/Sources/Dependencies/VotingModels/StaticVotingConfig.swift
+++ b/secant/Sources/Dependencies/VotingModels/StaticVotingConfig.swift
@@ -8,9 +8,9 @@ import Foundation
 struct StaticVotingConfig: Codable, Equatable, Sendable {
     static let supportedVersion = 1
     static let algEd25519 = "ed25519"
+    private static let bundledSHA256 = "fb62a56fae28debfdaa092f163cda0dab13295f87d25bbc4d0064d6ccdeb6943"
     static let bundledPinnedSource =
-        "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/2785311d45758e85567d70a1f13709fa01b62c6b/prod/static-voting-config.json" +
-        "?checksum=sha256:bed0116f961226b256a574b52461ce81d9f5294a57e190987dc155f07eb1e431"
+        "https://voting.valargroup.dev/pins/prod/\(bundledSHA256)/static-voting-config.json?checksum=sha256:\(bundledSHA256)"
 
     let staticConfigVersion: Int
     let dynamicConfigURL: URL


### PR DESCRIPTION
Before, the bundled production voting trust anchor fetched directly from raw GitHub, making configuration loading depend on GitHub availability.

After, it uses the immutable voting.valargroup.dev production pin. The gateway reads GitHub normally and serves the automatically published Cloudflare copy during a GitHub outage, while ZODL still enforces the embedded SHA-256. ZODL has no separate bundled stage anchor, so this PR intentionally changes only production.